### PR TITLE
chore(root): backfill project_fields.tsv for #33 and #34

### DIFF
--- a/scripts/project_fields.tsv
+++ b/scripts/project_fields.tsv
@@ -29,3 +29,5 @@ issue	phase	area	kind	priority
 29	Phase 3 — Domain unification	DigiChat	Research	P2
 30	Phase 5 — Atlas tiering	Cross-cutting	Research	P3
 31	Phase 2 — Hardening	Cross-cutting	Epic	P0
+33	Phase 3 — Domain unification	Website	Chore	P2
+34	Phase 2 — Hardening	Cross-cutting	Epic	P0


### PR DESCRIPTION
Fixes #36

## Summary

- Record the Phase/Area/Kind/Priority placements already applied on Project #1 for issues #33 and #34 in `scripts/project_fields.tsv`.
- Keeps `scripts/set_project_fields.sh` idempotent and the TSV the reproducible source of truth.

## Placements

- **#33** — Phase 3 — Domain unification / Website / Chore / P2
- **#34** — Phase 2 — Hardening / Cross-cutting / Epic / P0

Note: the Project has no `Phase 0` option (starts at Phase 2). #34 lands under Phase 2 — Hardening since agent-coding discipline is infrastructural hardening. If a dedicated `Phase 0 — Setup` option gets added later, #34 can be re-assigned and the TSV updated.

## Test plan

- [x] `scripts/set_project_fields.sh` still succeeds end-to-end (verified pre-PR)
- [ ] Re-running after merge should produce zero field mutations (pure idempotence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)