### PR TITLE
chore(website): replace expired QR with self-generated logo QR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score clean-imports find-stale commit pr task new-task status parse-error hooks-install
+.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo
 
 build:
 	docker compose build
@@ -27,6 +27,11 @@ test-e2e:
 # Internal markdown links (agent-facing docs). Same check as CI workflow docs.yml.
 doc-check:
 	python3 scripts/check_doc_links.py
+
+# Regenerate website/assets/qrw.svg from scripts/generate-qr.py.
+# Requires: pip install "qrcode==8.0"
+qr-logo:
+	python3 scripts/generate-qr.py
 
 # Coverage for Phase 1 code (digigraph + digiquant + digismith). Requires: pip install -e "digigraph[dev]" -e "digiquant[dev]" -e "digismith"
 test-cov:

--- a/scripts/generate-qr.py
+++ b/scripts/generate-qr.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate website/assets/qrw.svg — a circular-dot QR code for digithings.ai.
+
+Dependencies:
+    pip install "qrcode==8.0"
+
+Usage:
+    python3 scripts/generate-qr.py
+    make qr-logo
+
+Spec:
+    URL:             https://digithings.ai
+    ECC level:       H (highest — tolerates ~30% damage)
+    Module style:    filled circles (#ffffff, transparent background)
+    Output:          website/assets/qrw.svg (1023×1023 px viewBox)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUT = REPO_ROOT / "website" / "assets" / "qrw.svg"
+URL = "https://digithings.ai"
+
+try:
+    import qrcode
+    import qrcode.constants
+except ModuleNotFoundError:
+    sys.exit("qrcode not installed. Run: pip install 'qrcode==8.0'")
+
+# ── Generate matrix ─────────────────────────────────────────────────────────
+qr = qrcode.QRCode(
+    version=None,
+    error_correction=qrcode.constants.ERROR_CORRECT_H,
+    box_size=1,
+    border=4,
+)
+qr.add_data(URL)
+qr.make(fit=True)
+matrix = qr.get_matrix()
+
+# ── Render SVG with circular modules ────────────────────────────────────────
+SIZE = 1023
+n = len(matrix)
+step = SIZE / n
+r = step * 0.48  # radius fills ~96% of each cell
+
+parts: list[str] = [
+    f'<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve"'
+    f' width="{SIZE}" height="{SIZE}" viewBox="0 0 {SIZE} {SIZE}"'
+    f' style="max-width:100%;height:auto;">',
+    '<g fill="#ffffff">',
+]
+
+for row_idx, row in enumerate(matrix):
+    for col_idx, cell in enumerate(row):
+        if cell:
+            cx = (col_idx + 0.5) * step
+            cy = (row_idx + 0.5) * step
+            parts.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="{r:.2f}"/>')
+
+parts += ["</g>", "</svg>"]
+svg = "\n".join(parts)
+
+OUT.write_text(svg, encoding="utf-8")
+print(f"Written {len(svg):,} chars → {OUT.relative_to(REPO_ROOT)}")

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,31 @@
+# website/
+
+Static landing page for [digithings.ai](https://digithings.ai) — vanilla HTML/CSS/JS with a canvas starfield background. Deployed via GitHub Pages from this directory.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.html` | Landing page markup |
+| `style.css` | Styles |
+| `main.js` | Canvas starfield + scroll animations |
+| `assets/qrw.svg` | Logo QR code — self-generated (see below) |
+| `CNAME` | GitHub Pages custom domain |
+
+## Logo QR code
+
+`assets/qrw.svg` encodes `https://digithings.ai` with ECC level H (30% damage tolerance), circular dot modules, white fill, transparent background. It is **generated** from `scripts/generate-qr.py` and checked in so the site works without running the generator.
+
+To regenerate:
+
+```bash
+pip install "qrcode==8.0"
+make qr-logo
+# → writes website/assets/qrw.svg
+```
+
+The generator script lives at `scripts/generate-qr.py` with a pinned `qrcode==8.0` dependency for reproducibility.
+
+## Deployment
+
+`digithings.ai` is served via GitHub Pages pointing at this directory. `CNAME` contains the custom domain. The `static.yml` workflow deploys on push to `develop`/`main`.

--- a/website/assets/qrw.svg
+++ b/website/assets/qrw.svg
@@ -1,351 +1,446 @@
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" xmlns:xlink="http://www.w3.org/1999/xlink" style="max-width: 100%;height: auto;" width="1023" height="1023" viewBox="0 0 1023 1023">
-<g  fill="#ffffff">
-<g transform="translate(310,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,62) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,93) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,124) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,155) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,155) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,155) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,155) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,155) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,186) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,186) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,186) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,186) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,217) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,248) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,279) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,279) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,279) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,279) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,310) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,341) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,372) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(93,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,403) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,434) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(93,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,465) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(93,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,496) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(93,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,527) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,558) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(93,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,589) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(124,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(217,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,620) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(186,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,651) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(62,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(155,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(248,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(279,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,682) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,713) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,744) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(930,775) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,806) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(403,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(465,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,837) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(310,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(651,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(682,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(775,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(868,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,868) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(434,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(589,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(713,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(837,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(899,899) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(341,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(372,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(496,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(527,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(558,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(620,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(744,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-<g transform="translate(806,930) scale(5.3216666666667)"><circle cx="3" cy="3" r="3"/></g>
-</g><g ><g transform="translate(62,62)"  fill="#ffffff"><g transform="scale(15.5)"><path d="M4.5,14h5.1C12,14,14,12,14,9.6V4.5C14,2,12,0,9.5,0H4.4C2,0,0,2,0,4.4v5.1C0,12,2,14,4.5,14z M12,4.8v4.4 c0,1.5-1.3,2.8-2.8,2.8H4.8C3.2,12,2,10.8,2,9.2V4.8C2,3.3,3.3,2,4.8,2h4.4C10.8,2,12,3.2,12,4.8z"/></g></g>
-<g transform="translate(744,62)"  fill="#ffffff"><g transform="scale(15.5)"><path d="M4.5,14h5.1C12,14,14,12,14,9.6V4.5C14,2,12,0,9.5,0H4.4C2,0,0,2,0,4.4v5.1C0,12,2,14,4.5,14z M12,4.8v4.4 c0,1.5-1.3,2.8-2.8,2.8H4.8C3.2,12,2,10.8,2,9.2V4.8C2,3.3,3.3,2,4.8,2h4.4C10.8,2,12,3.2,12,4.8z"/></g></g>
-<g transform="translate(62,744)"  fill="#ffffff"><g transform="scale(15.5)"><path d="M4.5,14h5.1C12,14,14,12,14,9.6V4.5C14,2,12,0,9.5,0H4.4C2,0,0,2,0,4.4v5.1C0,12,2,14,4.5,14z M12,4.8v4.4 c0,1.5-1.3,2.8-2.8,2.8H4.8C3.2,12,2,10.8,2,9.2V4.8C2,3.3,3.3,2,4.8,2h4.4C10.8,2,12,3.2,12,4.8z"/></g></g>
-<g transform="translate(124,124)"  fill="#ffffff"><g transform="scale(15.5)"><circle cx="3" cy="3" r="3"/></g></g>
-<g transform="translate(806,124)"  fill="#ffffff"><g transform="scale(15.5)"><circle cx="3" cy="3" r="3"/></g></g>
-<g transform="translate(124,806)"  fill="#ffffff"><g transform="scale(15.5)"><circle cx="3" cy="3" r="3"/></g></g></g>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="1023" height="1023" viewBox="0 0 1023 1023" style="max-width:100%;height:auto;">
+<g fill="#ffffff">
+<circle cx="124.42" cy="124.42" r="13.27"/>
+<circle cx="152.07" cy="124.42" r="13.27"/>
+<circle cx="179.72" cy="124.42" r="13.27"/>
+<circle cx="207.36" cy="124.42" r="13.27"/>
+<circle cx="235.01" cy="124.42" r="13.27"/>
+<circle cx="262.66" cy="124.42" r="13.27"/>
+<circle cx="290.31" cy="124.42" r="13.27"/>
+<circle cx="373.26" cy="124.42" r="13.27"/>
+<circle cx="400.91" cy="124.42" r="13.27"/>
+<circle cx="456.20" cy="124.42" r="13.27"/>
+<circle cx="483.85" cy="124.42" r="13.27"/>
+<circle cx="539.15" cy="124.42" r="13.27"/>
+<circle cx="566.80" cy="124.42" r="13.27"/>
+<circle cx="594.45" cy="124.42" r="13.27"/>
+<circle cx="649.74" cy="124.42" r="13.27"/>
+<circle cx="677.39" cy="124.42" r="13.27"/>
+<circle cx="732.69" cy="124.42" r="13.27"/>
+<circle cx="760.34" cy="124.42" r="13.27"/>
+<circle cx="787.99" cy="124.42" r="13.27"/>
+<circle cx="815.64" cy="124.42" r="13.27"/>
+<circle cx="843.28" cy="124.42" r="13.27"/>
+<circle cx="870.93" cy="124.42" r="13.27"/>
+<circle cx="898.58" cy="124.42" r="13.27"/>
+<circle cx="124.42" cy="152.07" r="13.27"/>
+<circle cx="290.31" cy="152.07" r="13.27"/>
+<circle cx="345.61" cy="152.07" r="13.27"/>
+<circle cx="373.26" cy="152.07" r="13.27"/>
+<circle cx="400.91" cy="152.07" r="13.27"/>
+<circle cx="428.55" cy="152.07" r="13.27"/>
+<circle cx="483.85" cy="152.07" r="13.27"/>
+<circle cx="594.45" cy="152.07" r="13.27"/>
+<circle cx="622.09" cy="152.07" r="13.27"/>
+<circle cx="677.39" cy="152.07" r="13.27"/>
+<circle cx="732.69" cy="152.07" r="13.27"/>
+<circle cx="898.58" cy="152.07" r="13.27"/>
+<circle cx="124.42" cy="179.72" r="13.27"/>
+<circle cx="179.72" cy="179.72" r="13.27"/>
+<circle cx="207.36" cy="179.72" r="13.27"/>
+<circle cx="235.01" cy="179.72" r="13.27"/>
+<circle cx="290.31" cy="179.72" r="13.27"/>
+<circle cx="345.61" cy="179.72" r="13.27"/>
+<circle cx="373.26" cy="179.72" r="13.27"/>
+<circle cx="511.50" cy="179.72" r="13.27"/>
+<circle cx="539.15" cy="179.72" r="13.27"/>
+<circle cx="566.80" cy="179.72" r="13.27"/>
+<circle cx="594.45" cy="179.72" r="13.27"/>
+<circle cx="649.74" cy="179.72" r="13.27"/>
+<circle cx="677.39" cy="179.72" r="13.27"/>
+<circle cx="732.69" cy="179.72" r="13.27"/>
+<circle cx="787.99" cy="179.72" r="13.27"/>
+<circle cx="815.64" cy="179.72" r="13.27"/>
+<circle cx="843.28" cy="179.72" r="13.27"/>
+<circle cx="898.58" cy="179.72" r="13.27"/>
+<circle cx="124.42" cy="207.36" r="13.27"/>
+<circle cx="179.72" cy="207.36" r="13.27"/>
+<circle cx="207.36" cy="207.36" r="13.27"/>
+<circle cx="235.01" cy="207.36" r="13.27"/>
+<circle cx="290.31" cy="207.36" r="13.27"/>
+<circle cx="345.61" cy="207.36" r="13.27"/>
+<circle cx="373.26" cy="207.36" r="13.27"/>
+<circle cx="456.20" cy="207.36" r="13.27"/>
+<circle cx="511.50" cy="207.36" r="13.27"/>
+<circle cx="594.45" cy="207.36" r="13.27"/>
+<circle cx="622.09" cy="207.36" r="13.27"/>
+<circle cx="732.69" cy="207.36" r="13.27"/>
+<circle cx="787.99" cy="207.36" r="13.27"/>
+<circle cx="815.64" cy="207.36" r="13.27"/>
+<circle cx="843.28" cy="207.36" r="13.27"/>
+<circle cx="898.58" cy="207.36" r="13.27"/>
+<circle cx="124.42" cy="235.01" r="13.27"/>
+<circle cx="179.72" cy="235.01" r="13.27"/>
+<circle cx="207.36" cy="235.01" r="13.27"/>
+<circle cx="235.01" cy="235.01" r="13.27"/>
+<circle cx="290.31" cy="235.01" r="13.27"/>
+<circle cx="345.61" cy="235.01" r="13.27"/>
+<circle cx="373.26" cy="235.01" r="13.27"/>
+<circle cx="428.55" cy="235.01" r="13.27"/>
+<circle cx="483.85" cy="235.01" r="13.27"/>
+<circle cx="511.50" cy="235.01" r="13.27"/>
+<circle cx="539.15" cy="235.01" r="13.27"/>
+<circle cx="622.09" cy="235.01" r="13.27"/>
+<circle cx="732.69" cy="235.01" r="13.27"/>
+<circle cx="787.99" cy="235.01" r="13.27"/>
+<circle cx="815.64" cy="235.01" r="13.27"/>
+<circle cx="843.28" cy="235.01" r="13.27"/>
+<circle cx="898.58" cy="235.01" r="13.27"/>
+<circle cx="124.42" cy="262.66" r="13.27"/>
+<circle cx="290.31" cy="262.66" r="13.27"/>
+<circle cx="345.61" cy="262.66" r="13.27"/>
+<circle cx="400.91" cy="262.66" r="13.27"/>
+<circle cx="456.20" cy="262.66" r="13.27"/>
+<circle cx="539.15" cy="262.66" r="13.27"/>
+<circle cx="566.80" cy="262.66" r="13.27"/>
+<circle cx="594.45" cy="262.66" r="13.27"/>
+<circle cx="622.09" cy="262.66" r="13.27"/>
+<circle cx="677.39" cy="262.66" r="13.27"/>
+<circle cx="732.69" cy="262.66" r="13.27"/>
+<circle cx="898.58" cy="262.66" r="13.27"/>
+<circle cx="124.42" cy="290.31" r="13.27"/>
+<circle cx="152.07" cy="290.31" r="13.27"/>
+<circle cx="179.72" cy="290.31" r="13.27"/>
+<circle cx="207.36" cy="290.31" r="13.27"/>
+<circle cx="235.01" cy="290.31" r="13.27"/>
+<circle cx="262.66" cy="290.31" r="13.27"/>
+<circle cx="290.31" cy="290.31" r="13.27"/>
+<circle cx="345.61" cy="290.31" r="13.27"/>
+<circle cx="400.91" cy="290.31" r="13.27"/>
+<circle cx="456.20" cy="290.31" r="13.27"/>
+<circle cx="511.50" cy="290.31" r="13.27"/>
+<circle cx="566.80" cy="290.31" r="13.27"/>
+<circle cx="622.09" cy="290.31" r="13.27"/>
+<circle cx="677.39" cy="290.31" r="13.27"/>
+<circle cx="732.69" cy="290.31" r="13.27"/>
+<circle cx="760.34" cy="290.31" r="13.27"/>
+<circle cx="787.99" cy="290.31" r="13.27"/>
+<circle cx="815.64" cy="290.31" r="13.27"/>
+<circle cx="843.28" cy="290.31" r="13.27"/>
+<circle cx="870.93" cy="290.31" r="13.27"/>
+<circle cx="898.58" cy="290.31" r="13.27"/>
+<circle cx="373.26" cy="317.96" r="13.27"/>
+<circle cx="483.85" cy="317.96" r="13.27"/>
+<circle cx="511.50" cy="317.96" r="13.27"/>
+<circle cx="594.45" cy="317.96" r="13.27"/>
+<circle cx="179.72" cy="345.61" r="13.27"/>
+<circle cx="262.66" cy="345.61" r="13.27"/>
+<circle cx="290.31" cy="345.61" r="13.27"/>
+<circle cx="317.96" cy="345.61" r="13.27"/>
+<circle cx="345.61" cy="345.61" r="13.27"/>
+<circle cx="373.26" cy="345.61" r="13.27"/>
+<circle cx="400.91" cy="345.61" r="13.27"/>
+<circle cx="428.55" cy="345.61" r="13.27"/>
+<circle cx="511.50" cy="345.61" r="13.27"/>
+<circle cx="539.15" cy="345.61" r="13.27"/>
+<circle cx="594.45" cy="345.61" r="13.27"/>
+<circle cx="677.39" cy="345.61" r="13.27"/>
+<circle cx="705.04" cy="345.61" r="13.27"/>
+<circle cx="760.34" cy="345.61" r="13.27"/>
+<circle cx="787.99" cy="345.61" r="13.27"/>
+<circle cx="815.64" cy="345.61" r="13.27"/>
+<circle cx="843.28" cy="345.61" r="13.27"/>
+<circle cx="870.93" cy="345.61" r="13.27"/>
+<circle cx="179.72" cy="373.26" r="13.27"/>
+<circle cx="262.66" cy="373.26" r="13.27"/>
+<circle cx="317.96" cy="373.26" r="13.27"/>
+<circle cx="345.61" cy="373.26" r="13.27"/>
+<circle cx="373.26" cy="373.26" r="13.27"/>
+<circle cx="400.91" cy="373.26" r="13.27"/>
+<circle cx="483.85" cy="373.26" r="13.27"/>
+<circle cx="566.80" cy="373.26" r="13.27"/>
+<circle cx="677.39" cy="373.26" r="13.27"/>
+<circle cx="732.69" cy="373.26" r="13.27"/>
+<circle cx="843.28" cy="373.26" r="13.27"/>
+<circle cx="870.93" cy="373.26" r="13.27"/>
+<circle cx="898.58" cy="373.26" r="13.27"/>
+<circle cx="124.42" cy="400.91" r="13.27"/>
+<circle cx="152.07" cy="400.91" r="13.27"/>
+<circle cx="179.72" cy="400.91" r="13.27"/>
+<circle cx="207.36" cy="400.91" r="13.27"/>
+<circle cx="235.01" cy="400.91" r="13.27"/>
+<circle cx="290.31" cy="400.91" r="13.27"/>
+<circle cx="345.61" cy="400.91" r="13.27"/>
+<circle cx="400.91" cy="400.91" r="13.27"/>
+<circle cx="428.55" cy="400.91" r="13.27"/>
+<circle cx="456.20" cy="400.91" r="13.27"/>
+<circle cx="511.50" cy="400.91" r="13.27"/>
+<circle cx="622.09" cy="400.91" r="13.27"/>
+<circle cx="677.39" cy="400.91" r="13.27"/>
+<circle cx="705.04" cy="400.91" r="13.27"/>
+<circle cx="815.64" cy="400.91" r="13.27"/>
+<circle cx="843.28" cy="400.91" r="13.27"/>
+<circle cx="898.58" cy="400.91" r="13.27"/>
+<circle cx="152.07" cy="428.55" r="13.27"/>
+<circle cx="207.36" cy="428.55" r="13.27"/>
+<circle cx="262.66" cy="428.55" r="13.27"/>
+<circle cx="373.26" cy="428.55" r="13.27"/>
+<circle cx="594.45" cy="428.55" r="13.27"/>
+<circle cx="622.09" cy="428.55" r="13.27"/>
+<circle cx="649.74" cy="428.55" r="13.27"/>
+<circle cx="677.39" cy="428.55" r="13.27"/>
+<circle cx="732.69" cy="428.55" r="13.27"/>
+<circle cx="815.64" cy="428.55" r="13.27"/>
+<circle cx="152.07" cy="456.20" r="13.27"/>
+<circle cx="179.72" cy="456.20" r="13.27"/>
+<circle cx="207.36" cy="456.20" r="13.27"/>
+<circle cx="262.66" cy="456.20" r="13.27"/>
+<circle cx="290.31" cy="456.20" r="13.27"/>
+<circle cx="400.91" cy="456.20" r="13.27"/>
+<circle cx="428.55" cy="456.20" r="13.27"/>
+<circle cx="483.85" cy="456.20" r="13.27"/>
+<circle cx="511.50" cy="456.20" r="13.27"/>
+<circle cx="539.15" cy="456.20" r="13.27"/>
+<circle cx="566.80" cy="456.20" r="13.27"/>
+<circle cx="594.45" cy="456.20" r="13.27"/>
+<circle cx="622.09" cy="456.20" r="13.27"/>
+<circle cx="677.39" cy="456.20" r="13.27"/>
+<circle cx="705.04" cy="456.20" r="13.27"/>
+<circle cx="732.69" cy="456.20" r="13.27"/>
+<circle cx="815.64" cy="456.20" r="13.27"/>
+<circle cx="870.93" cy="456.20" r="13.27"/>
+<circle cx="152.07" cy="483.85" r="13.27"/>
+<circle cx="262.66" cy="483.85" r="13.27"/>
+<circle cx="317.96" cy="483.85" r="13.27"/>
+<circle cx="345.61" cy="483.85" r="13.27"/>
+<circle cx="373.26" cy="483.85" r="13.27"/>
+<circle cx="428.55" cy="483.85" r="13.27"/>
+<circle cx="456.20" cy="483.85" r="13.27"/>
+<circle cx="483.85" cy="483.85" r="13.27"/>
+<circle cx="539.15" cy="483.85" r="13.27"/>
+<circle cx="566.80" cy="483.85" r="13.27"/>
+<circle cx="649.74" cy="483.85" r="13.27"/>
+<circle cx="677.39" cy="483.85" r="13.27"/>
+<circle cx="732.69" cy="483.85" r="13.27"/>
+<circle cx="815.64" cy="483.85" r="13.27"/>
+<circle cx="898.58" cy="483.85" r="13.27"/>
+<circle cx="124.42" cy="511.50" r="13.27"/>
+<circle cx="152.07" cy="511.50" r="13.27"/>
+<circle cx="179.72" cy="511.50" r="13.27"/>
+<circle cx="235.01" cy="511.50" r="13.27"/>
+<circle cx="290.31" cy="511.50" r="13.27"/>
+<circle cx="345.61" cy="511.50" r="13.27"/>
+<circle cx="428.55" cy="511.50" r="13.27"/>
+<circle cx="456.20" cy="511.50" r="13.27"/>
+<circle cx="483.85" cy="511.50" r="13.27"/>
+<circle cx="539.15" cy="511.50" r="13.27"/>
+<circle cx="566.80" cy="511.50" r="13.27"/>
+<circle cx="622.09" cy="511.50" r="13.27"/>
+<circle cx="649.74" cy="511.50" r="13.27"/>
+<circle cx="677.39" cy="511.50" r="13.27"/>
+<circle cx="815.64" cy="511.50" r="13.27"/>
+<circle cx="843.28" cy="511.50" r="13.27"/>
+<circle cx="898.58" cy="511.50" r="13.27"/>
+<circle cx="179.72" cy="539.15" r="13.27"/>
+<circle cx="235.01" cy="539.15" r="13.27"/>
+<circle cx="317.96" cy="539.15" r="13.27"/>
+<circle cx="345.61" cy="539.15" r="13.27"/>
+<circle cx="428.55" cy="539.15" r="13.27"/>
+<circle cx="483.85" cy="539.15" r="13.27"/>
+<circle cx="511.50" cy="539.15" r="13.27"/>
+<circle cx="539.15" cy="539.15" r="13.27"/>
+<circle cx="594.45" cy="539.15" r="13.27"/>
+<circle cx="622.09" cy="539.15" r="13.27"/>
+<circle cx="677.39" cy="539.15" r="13.27"/>
+<circle cx="732.69" cy="539.15" r="13.27"/>
+<circle cx="815.64" cy="539.15" r="13.27"/>
+<circle cx="179.72" cy="566.80" r="13.27"/>
+<circle cx="235.01" cy="566.80" r="13.27"/>
+<circle cx="262.66" cy="566.80" r="13.27"/>
+<circle cx="290.31" cy="566.80" r="13.27"/>
+<circle cx="345.61" cy="566.80" r="13.27"/>
+<circle cx="400.91" cy="566.80" r="13.27"/>
+<circle cx="456.20" cy="566.80" r="13.27"/>
+<circle cx="483.85" cy="566.80" r="13.27"/>
+<circle cx="511.50" cy="566.80" r="13.27"/>
+<circle cx="539.15" cy="566.80" r="13.27"/>
+<circle cx="566.80" cy="566.80" r="13.27"/>
+<circle cx="622.09" cy="566.80" r="13.27"/>
+<circle cx="649.74" cy="566.80" r="13.27"/>
+<circle cx="677.39" cy="566.80" r="13.27"/>
+<circle cx="732.69" cy="566.80" r="13.27"/>
+<circle cx="898.58" cy="566.80" r="13.27"/>
+<circle cx="152.07" cy="594.45" r="13.27"/>
+<circle cx="207.36" cy="594.45" r="13.27"/>
+<circle cx="317.96" cy="594.45" r="13.27"/>
+<circle cx="345.61" cy="594.45" r="13.27"/>
+<circle cx="428.55" cy="594.45" r="13.27"/>
+<circle cx="566.80" cy="594.45" r="13.27"/>
+<circle cx="594.45" cy="594.45" r="13.27"/>
+<circle cx="622.09" cy="594.45" r="13.27"/>
+<circle cx="732.69" cy="594.45" r="13.27"/>
+<circle cx="760.34" cy="594.45" r="13.27"/>
+<circle cx="843.28" cy="594.45" r="13.27"/>
+<circle cx="898.58" cy="594.45" r="13.27"/>
+<circle cx="124.42" cy="622.09" r="13.27"/>
+<circle cx="152.07" cy="622.09" r="13.27"/>
+<circle cx="179.72" cy="622.09" r="13.27"/>
+<circle cx="207.36" cy="622.09" r="13.27"/>
+<circle cx="235.01" cy="622.09" r="13.27"/>
+<circle cx="262.66" cy="622.09" r="13.27"/>
+<circle cx="290.31" cy="622.09" r="13.27"/>
+<circle cx="317.96" cy="622.09" r="13.27"/>
+<circle cx="345.61" cy="622.09" r="13.27"/>
+<circle cx="373.26" cy="622.09" r="13.27"/>
+<circle cx="400.91" cy="622.09" r="13.27"/>
+<circle cx="428.55" cy="622.09" r="13.27"/>
+<circle cx="456.20" cy="622.09" r="13.27"/>
+<circle cx="483.85" cy="622.09" r="13.27"/>
+<circle cx="511.50" cy="622.09" r="13.27"/>
+<circle cx="539.15" cy="622.09" r="13.27"/>
+<circle cx="566.80" cy="622.09" r="13.27"/>
+<circle cx="649.74" cy="622.09" r="13.27"/>
+<circle cx="843.28" cy="622.09" r="13.27"/>
+<circle cx="898.58" cy="622.09" r="13.27"/>
+<circle cx="235.01" cy="649.74" r="13.27"/>
+<circle cx="345.61" cy="649.74" r="13.27"/>
+<circle cx="400.91" cy="649.74" r="13.27"/>
+<circle cx="428.55" cy="649.74" r="13.27"/>
+<circle cx="456.20" cy="649.74" r="13.27"/>
+<circle cx="594.45" cy="649.74" r="13.27"/>
+<circle cx="622.09" cy="649.74" r="13.27"/>
+<circle cx="705.04" cy="649.74" r="13.27"/>
+<circle cx="732.69" cy="649.74" r="13.27"/>
+<circle cx="760.34" cy="649.74" r="13.27"/>
+<circle cx="815.64" cy="649.74" r="13.27"/>
+<circle cx="870.93" cy="649.74" r="13.27"/>
+<circle cx="124.42" cy="677.39" r="13.27"/>
+<circle cx="152.07" cy="677.39" r="13.27"/>
+<circle cx="179.72" cy="677.39" r="13.27"/>
+<circle cx="235.01" cy="677.39" r="13.27"/>
+<circle cx="290.31" cy="677.39" r="13.27"/>
+<circle cx="317.96" cy="677.39" r="13.27"/>
+<circle cx="345.61" cy="677.39" r="13.27"/>
+<circle cx="456.20" cy="677.39" r="13.27"/>
+<circle cx="511.50" cy="677.39" r="13.27"/>
+<circle cx="539.15" cy="677.39" r="13.27"/>
+<circle cx="594.45" cy="677.39" r="13.27"/>
+<circle cx="677.39" cy="677.39" r="13.27"/>
+<circle cx="705.04" cy="677.39" r="13.27"/>
+<circle cx="732.69" cy="677.39" r="13.27"/>
+<circle cx="760.34" cy="677.39" r="13.27"/>
+<circle cx="787.99" cy="677.39" r="13.27"/>
+<circle cx="815.64" cy="677.39" r="13.27"/>
+<circle cx="898.58" cy="677.39" r="13.27"/>
+<circle cx="345.61" cy="705.04" r="13.27"/>
+<circle cx="400.91" cy="705.04" r="13.27"/>
+<circle cx="428.55" cy="705.04" r="13.27"/>
+<circle cx="456.20" cy="705.04" r="13.27"/>
+<circle cx="511.50" cy="705.04" r="13.27"/>
+<circle cx="539.15" cy="705.04" r="13.27"/>
+<circle cx="622.09" cy="705.04" r="13.27"/>
+<circle cx="677.39" cy="705.04" r="13.27"/>
+<circle cx="787.99" cy="705.04" r="13.27"/>
+<circle cx="815.64" cy="705.04" r="13.27"/>
+<circle cx="870.93" cy="705.04" r="13.27"/>
+<circle cx="898.58" cy="705.04" r="13.27"/>
+<circle cx="124.42" cy="732.69" r="13.27"/>
+<circle cx="152.07" cy="732.69" r="13.27"/>
+<circle cx="179.72" cy="732.69" r="13.27"/>
+<circle cx="207.36" cy="732.69" r="13.27"/>
+<circle cx="235.01" cy="732.69" r="13.27"/>
+<circle cx="262.66" cy="732.69" r="13.27"/>
+<circle cx="290.31" cy="732.69" r="13.27"/>
+<circle cx="345.61" cy="732.69" r="13.27"/>
+<circle cx="483.85" cy="732.69" r="13.27"/>
+<circle cx="511.50" cy="732.69" r="13.27"/>
+<circle cx="539.15" cy="732.69" r="13.27"/>
+<circle cx="594.45" cy="732.69" r="13.27"/>
+<circle cx="622.09" cy="732.69" r="13.27"/>
+<circle cx="677.39" cy="732.69" r="13.27"/>
+<circle cx="732.69" cy="732.69" r="13.27"/>
+<circle cx="787.99" cy="732.69" r="13.27"/>
+<circle cx="815.64" cy="732.69" r="13.27"/>
+<circle cx="843.28" cy="732.69" r="13.27"/>
+<circle cx="898.58" cy="732.69" r="13.27"/>
+<circle cx="124.42" cy="760.34" r="13.27"/>
+<circle cx="290.31" cy="760.34" r="13.27"/>
+<circle cx="345.61" cy="760.34" r="13.27"/>
+<circle cx="373.26" cy="760.34" r="13.27"/>
+<circle cx="428.55" cy="760.34" r="13.27"/>
+<circle cx="483.85" cy="760.34" r="13.27"/>
+<circle cx="566.80" cy="760.34" r="13.27"/>
+<circle cx="622.09" cy="760.34" r="13.27"/>
+<circle cx="649.74" cy="760.34" r="13.27"/>
+<circle cx="677.39" cy="760.34" r="13.27"/>
+<circle cx="787.99" cy="760.34" r="13.27"/>
+<circle cx="815.64" cy="760.34" r="13.27"/>
+<circle cx="870.93" cy="760.34" r="13.27"/>
+<circle cx="124.42" cy="787.99" r="13.27"/>
+<circle cx="179.72" cy="787.99" r="13.27"/>
+<circle cx="207.36" cy="787.99" r="13.27"/>
+<circle cx="235.01" cy="787.99" r="13.27"/>
+<circle cx="290.31" cy="787.99" r="13.27"/>
+<circle cx="373.26" cy="787.99" r="13.27"/>
+<circle cx="400.91" cy="787.99" r="13.27"/>
+<circle cx="456.20" cy="787.99" r="13.27"/>
+<circle cx="511.50" cy="787.99" r="13.27"/>
+<circle cx="566.80" cy="787.99" r="13.27"/>
+<circle cx="594.45" cy="787.99" r="13.27"/>
+<circle cx="622.09" cy="787.99" r="13.27"/>
+<circle cx="649.74" cy="787.99" r="13.27"/>
+<circle cx="677.39" cy="787.99" r="13.27"/>
+<circle cx="705.04" cy="787.99" r="13.27"/>
+<circle cx="732.69" cy="787.99" r="13.27"/>
+<circle cx="760.34" cy="787.99" r="13.27"/>
+<circle cx="787.99" cy="787.99" r="13.27"/>
+<circle cx="870.93" cy="787.99" r="13.27"/>
+<circle cx="124.42" cy="815.64" r="13.27"/>
+<circle cx="179.72" cy="815.64" r="13.27"/>
+<circle cx="207.36" cy="815.64" r="13.27"/>
+<circle cx="235.01" cy="815.64" r="13.27"/>
+<circle cx="290.31" cy="815.64" r="13.27"/>
+<circle cx="373.26" cy="815.64" r="13.27"/>
+<circle cx="428.55" cy="815.64" r="13.27"/>
+<circle cx="511.50" cy="815.64" r="13.27"/>
+<circle cx="594.45" cy="815.64" r="13.27"/>
+<circle cx="649.74" cy="815.64" r="13.27"/>
+<circle cx="677.39" cy="815.64" r="13.27"/>
+<circle cx="760.34" cy="815.64" r="13.27"/>
+<circle cx="787.99" cy="815.64" r="13.27"/>
+<circle cx="815.64" cy="815.64" r="13.27"/>
+<circle cx="843.28" cy="815.64" r="13.27"/>
+<circle cx="870.93" cy="815.64" r="13.27"/>
+<circle cx="124.42" cy="843.28" r="13.27"/>
+<circle cx="179.72" cy="843.28" r="13.27"/>
+<circle cx="207.36" cy="843.28" r="13.27"/>
+<circle cx="235.01" cy="843.28" r="13.27"/>
+<circle cx="290.31" cy="843.28" r="13.27"/>
+<circle cx="345.61" cy="843.28" r="13.27"/>
+<circle cx="373.26" cy="843.28" r="13.27"/>
+<circle cx="428.55" cy="843.28" r="13.27"/>
+<circle cx="456.20" cy="843.28" r="13.27"/>
+<circle cx="539.15" cy="843.28" r="13.27"/>
+<circle cx="566.80" cy="843.28" r="13.27"/>
+<circle cx="705.04" cy="843.28" r="13.27"/>
+<circle cx="787.99" cy="843.28" r="13.27"/>
+<circle cx="815.64" cy="843.28" r="13.27"/>
+<circle cx="870.93" cy="843.28" r="13.27"/>
+<circle cx="898.58" cy="843.28" r="13.27"/>
+<circle cx="124.42" cy="870.93" r="13.27"/>
+<circle cx="290.31" cy="870.93" r="13.27"/>
+<circle cx="373.26" cy="870.93" r="13.27"/>
+<circle cx="400.91" cy="870.93" r="13.27"/>
+<circle cx="483.85" cy="870.93" r="13.27"/>
+<circle cx="539.15" cy="870.93" r="13.27"/>
+<circle cx="566.80" cy="870.93" r="13.27"/>
+<circle cx="677.39" cy="870.93" r="13.27"/>
+<circle cx="815.64" cy="870.93" r="13.27"/>
+<circle cx="124.42" cy="898.58" r="13.27"/>
+<circle cx="152.07" cy="898.58" r="13.27"/>
+<circle cx="179.72" cy="898.58" r="13.27"/>
+<circle cx="207.36" cy="898.58" r="13.27"/>
+<circle cx="235.01" cy="898.58" r="13.27"/>
+<circle cx="262.66" cy="898.58" r="13.27"/>
+<circle cx="290.31" cy="898.58" r="13.27"/>
+<circle cx="483.85" cy="898.58" r="13.27"/>
+<circle cx="566.80" cy="898.58" r="13.27"/>
+<circle cx="594.45" cy="898.58" r="13.27"/>
+<circle cx="677.39" cy="898.58" r="13.27"/>
+<circle cx="732.69" cy="898.58" r="13.27"/>
+<circle cx="760.34" cy="898.58" r="13.27"/>
+<circle cx="787.99" cy="898.58" r="13.27"/>
+<circle cx="815.64" cy="898.58" r="13.27"/>
+<circle cx="898.58" cy="898.58" r="13.27"/>
+</g>
 </svg>


### PR DESCRIPTION
## Summary

- Generates `website/assets/qrw.svg` from a checked-in `scripts/generate-qr.py` (pinned `qrcode==8.0`).
- New QR encodes `https://digithings.ai` directly with ECC level H, circular dot modules, `#ffffff` fill, transparent background.
- Adds `make qr-logo` target for reproducible regeneration.
- Adds `website/README.md` documenting site layout and QR generation.
- `website/index.html` unchanged — both `<img src="assets/qrw.svg">` references at nav (line 21) and hero (line 36) are already correct.

## Test plan

- [x] `make qr-logo` runs without error and writes `website/assets/qrw.svg`.
- [x] SVG opens correctly in browser (circular dot pattern, white fill, transparent background).
- [x] `make doc-check` passes.
- [ ] Scan with phone camera → resolves to `https://digithings.ai` without redirect.

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)