### PR TITLE
feat(scripts): create_issue.sh --project-fields auto-append

### DIFF
--- a/scripts/create_issue.sh
+++ b/scripts/create_issue.sh
@@ -13,6 +13,16 @@
 #   --risk LEVEL       Risk level: low, med, high (default: low)
 #   --draft            Skip confirmation prompt
 #
+# Project-field flags (optional — if omitted, fields are left unset on Project #1):
+#   --phase PHASE      Phase name, e.g. "Phase 2 — Hardening"
+#   --area AREA        Area name, e.g. "Cross-cutting"
+#   --kind KIND        Kind: Epic, Feature, Task, Bug, Chore, Research
+#   --priority PRI     Priority: P0, P1, P2, P3
+#
+# When --phase/--area/--kind/--priority are provided:
+#   - A row is appended to scripts/project_fields.tsv automatically.
+#   - scripts/set_project_fields.sh is called to set the fields live on Project #1.
+#
 # Requires: gh CLI + gh auth login
 # Output: issue URL on success
 
@@ -29,9 +39,17 @@ BODY=""
 RISK="low"
 DRAFT=false
 
+# Project-field defaults (empty = not provided)
+PHASE=""
+AREA=""
+KIND=""
+PRIORITY=""
+
 VALID_COMPONENTS="digigraph digiquant digisearch digismith digiclaw digibase digikey digichat website root"
 VALID_TYPES="feat fix refactor docs test chore style perf"
 VALID_RISKS="low med high"
+VALID_KINDS="Epic Feature Task Bug Chore Research"
+VALID_PRIORITIES="P0 P1 P2 P3"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 die() { echo "ERROR: $*" >&2; exit 1; }
@@ -51,8 +69,12 @@ while [[ $# -gt 0 ]]; do
     --body)      BODY="$2";      shift 2 ;;
     --risk)      RISK="$2";      shift 2 ;;
     --draft)     DRAFT=true;     shift   ;;
+    --phase)     PHASE="$2";     shift 2 ;;
+    --area)      AREA="$2";      shift 2 ;;
+    --kind)      KIND="$2";      shift 2 ;;
+    --priority)  PRIORITY="$2";  shift 2 ;;
     -h|--help)
-      sed -n '2,20p' "$0" | sed 's/^# \?//'
+      sed -n '2,32p' "$0" | sed 's/^# \?//'
       exit 0
       ;;
     *) die "Unknown option: $1" ;;
@@ -90,6 +112,18 @@ if [[ -z "$COMPONENT" && -z "$TITLE" ]]; then
     [[ "$line" == "EOF" ]] && break
     BODY="${BODY}${line}\n"
   done
+
+  # Project-field prompts
+  echo ""
+  echo "=== Project Fields (optional — press Enter to skip) ==="
+  echo "Phase (e.g. 'Phase 2 — Hardening', 'Phase 3 — Domain unification', 'SITAAS pilot'):"
+  read -r PHASE
+  echo "Area (e.g. Cross-cutting, DigiGraph, DigiQuant, DigiSearch, DigiSmith, DigiKey, DigiBase, DigiChat, DigiClaw, Website, Docs, Atlas, SITAAS):"
+  read -r AREA
+  echo "Kind (${VALID_KINDS// /, }):"
+  read -r KIND
+  echo "Priority (${VALID_PRIORITIES// /, }):"
+  read -r PRIORITY
 fi
 
 # ── Validation ────────────────────────────────────────────────────────────────
@@ -106,6 +140,16 @@ if [[ -n "$TYPE" ]]; then
   # shellcheck disable=SC2086
   contains "$TYPE" $VALID_TYPES || \
     die "Invalid type '$TYPE'. Valid: ${VALID_TYPES}"
+fi
+if [[ -n "$KIND" ]]; then
+  # shellcheck disable=SC2086
+  contains "$KIND" $VALID_KINDS || \
+    die "Invalid kind '$KIND'. Valid: ${VALID_KINDS}"
+fi
+if [[ -n "$PRIORITY" ]]; then
+  # shellcheck disable=SC2086
+  contains "$PRIORITY" $VALID_PRIORITIES || \
+    die "Invalid priority '$PRIORITY'. Valid: ${VALID_PRIORITIES}"
 fi
 
 # ── Normalize title ───────────────────────────────────────────────────────────
@@ -132,7 +176,11 @@ if ! $DRAFT; then
   echo "  Labels:    ${LABELS}"
   echo "  Component: ${COMPONENT}"
   echo "  Risk:      ${RISK}"
-  [[ -n "$BODY" ]] && echo "  Body:      (${#BODY} chars)"
+  [[ -n "$PHASE" ]]    && echo "  Phase:     ${PHASE}"
+  [[ -n "$AREA" ]]     && echo "  Area:      ${AREA}"
+  [[ -n "$KIND" ]]     && echo "  Kind:      ${KIND}"
+  [[ -n "$PRIORITY" ]] && echo "  Priority:  ${PRIORITY}"
+  [[ -n "$BODY" ]]     && echo "  Body:      (${#BODY} chars)"
   echo ""
   read -rp "Proceed? [Y/n] " confirm
   [[ "${confirm:-Y}" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
@@ -162,5 +210,39 @@ if [[ -n "$ISSUE_URL" ]]; then
     echo "Added to Project ${PROJECT_OWNER}/${PROJECT_NUMBER}" >&2
   else
     echo "WARN: could not auto-add ${ISSUE_URL} to Project ${PROJECT_OWNER}/${PROJECT_NUMBER} — add manually with: gh project item-add ${PROJECT_NUMBER} --owner ${PROJECT_OWNER} --url ${ISSUE_URL}" >&2
+  fi
+fi
+
+# ── Append TSV row + set live Project fields (if project fields provided) ──────
+_HAS_FIELDS=false
+[[ -n "$PHASE" || -n "$AREA" || -n "$KIND" || -n "$PRIORITY" ]] && _HAS_FIELDS=true
+
+if $_HAS_FIELDS; then
+  # Parse issue number from URL: .../issues/42 → 42
+  ISSUE_NUMBER="$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')"
+
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    TSV="scripts/project_fields.tsv"
+
+    # Append row if not already present
+    if ! grep -q "^${ISSUE_NUMBER}	" "$TSV" 2>/dev/null; then
+      printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$ISSUE_NUMBER" "${PHASE}" "${AREA}" "${KIND}" "${PRIORITY}" \
+        >> "$TSV"
+      echo "Appended TSV row for #${ISSUE_NUMBER} → ${TSV}" >&2
+    else
+      echo "TSV row for #${ISSUE_NUMBER} already exists — skipping append." >&2
+    fi
+
+    # Set Project fields live
+    if [[ -f "scripts/set_project_fields.sh" ]]; then
+      echo "Setting Project fields for #${ISSUE_NUMBER}..." >&2
+      bash scripts/set_project_fields.sh \
+        --owner "$PROJECT_OWNER" \
+        --project "$PROJECT_NUMBER" \
+        --tsv "$TSV" 2>&1 | grep "#${ISSUE_NUMBER}" >&2 || true
+    fi
+  else
+    echo "WARN: could not parse issue number from URL '${ISSUE_URL}' — TSV not updated." >&2
   fi
 fi


### PR DESCRIPTION
## Summary

- Adds `--phase`, `--area`, `--kind`, `--priority` flags to `scripts/create_issue.sh`.
- After successful issue creation, parses the issue number from the returned URL, appends a TSV row to `scripts/project_fields.tsv`, then calls `scripts/set_project_fields.sh` to set Project #1 fields live.
- Interactive mode prompts for all four fields after the existing inputs.
- All flags are optional — existing callers unchanged.
- Validation for `--kind` (Epic/Feature/Task/Bug/Chore/Research) and `--priority` (P0/P1/P2/P3).

## Test plan

- [x] `scripts/create_issue.sh --help` shows updated flag docs.
- [x] Existing call without project-field flags produces identical output (no regression).
- [x] `--kind Foo` exits with validation error.
- [ ] End-to-end: create an issue with `--phase "Phase 2 — Hardening" --area Cross-cutting --kind Task --priority P1` → TSV row appended + Project field set live.

Fixes #40
Part of #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)