### PR TITLE
test(digigraph): conditional exposure tests for digistore orchestrator tools

### DIFF
--- a/tests/dg/test_digistore_tools.py
+++ b/tests/dg/test_digistore_tools.py
@@ -95,3 +95,41 @@ def test_digistore_profile_handler_not_found_returns_error() -> None:
     assert "content" in out
     data = json.loads(out["content"])
     assert "error" in data
+
+
+@pytest.mark.unit
+def test_digistore_tools_exposed_when_run_data_dir_set() -> None:
+    """digistore_list and digistore_profile appear in get_tools_for_skills when run_data_dir is set."""
+    from digigraph.orchestration.registry import ToolContext
+    from digigraph.skills import get_tools_for_skills
+
+    ctx = ToolContext(
+        session_id="sess-1",
+        run_data_dir="/data/run",
+        index_name="default",
+        index_config={},
+        state={},
+    )
+    tools = get_tools_for_skills(["sitaas_rag"], ctx)
+    names = {t["function"]["name"] for t in tools}
+    assert "digistore_list" in names
+    assert "digistore_profile" in names
+
+
+@pytest.mark.unit
+def test_digistore_tools_absent_without_run_data_dir() -> None:
+    """digistore_list and digistore_profile are not exposed when run_data_dir is None."""
+    from digigraph.orchestration.registry import ToolContext
+    from digigraph.skills import get_tools_for_skills
+
+    ctx = ToolContext(
+        session_id="sess-1",
+        run_data_dir=None,
+        index_name="default",
+        index_config={},
+        state={},
+    )
+    tools = get_tools_for_skills(["sitaas_rag"], ctx)
+    names = {t["function"]["name"] for t in tools}
+    assert "digistore_list" not in names
+    assert "digistore_profile" not in names


### PR DESCRIPTION
## Summary

- Adds two tests to `tests/dg/test_digistore_tools.py` verifying the conditional tool registration behaviour for `digistore_list` and `digistore_profile`
- `test_digistore_tools_exposed_when_run_data_dir_set`: confirms both tools appear in `get_tools_for_skills(["sitaas_rag"], ctx)` when `ctx.run_data_dir` is set
- `test_digistore_tools_absent_without_run_data_dir`: confirms neither tool appears when `ctx.run_data_dir` is None

## Implementation note

The tools were already implemented in `digigraph/src/digigraph/orchestration/builtin.py` via the `sitaas_rag` skill with `when=lambda ctx: ctx.has_run_data_dir`. This PR closes issue #26 with test coverage for the conditional exposure contract.

## Test plan

- [x] `pytest tests/dg/test_digistore_tools.py` — 6 passed
- [x] `pytest tests/dg/ -m unit` — all passed
- [x] Score gate: 10/10 all dimensions

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/claude-code)