### PR TITLE
docs(digigraph): document SITAAS tool set and multi-turn capabilities

### DIFF
--- a/digigraph/AGENTS.md
+++ b/digigraph/AGENTS.md
@@ -69,6 +69,31 @@ curl http://localhost:8000/test_llm
 
 ---
 
+## SITAAS / Project-Mode Capabilities
+
+When a `digiproject.yaml` (or `config.yaml`) sets `run_data_dir`, DigiGraph operates in **project mode**. The `sitaas_rag` skill is activated, exposing additional tools beyond the base `search` skill.
+
+### Full tool set (sitaas_rag skill)
+
+| Tool | Skill | Condition | Description |
+|---|---|---|---|
+| `digisearch` | search | `DIGISEARCH_URL` set | Semantic/keyword search over indexed documents |
+| `digisearch_fetch_all` | search | `DIGISEARCH_URL` set | Paginated full-result fetch with filters |
+| `digistore_list` | sitaas_rag | `run_data_dir` set | List named datasets from current session |
+| `digistore_profile` | sitaas_rag | `run_data_dir` set | Inspect schema, row count, and sample rows of a dataset |
+| `visualization_agent` | sitaas_rag | `run_data_dir` set | Generate charts (ECharts JSON or PNG) from a dataset_ref |
+| `analysis_agent` | sitaas_rag | `run_data_dir` set | Statistical summaries, correlations, histograms |
+| `data_prep_agent` | sitaas_rag | `run_data_dir` set | Filter, sample, sort, export a dataset |
+| `data_manipulation_agent` | sitaas_rag | `run_data_dir` set | Merge, join, reshape, or transform datasets |
+| `data_engineer_agent` | sitaas_rag | `run_data_dir` set + `DIGI_ALLOW_CODE_EXEC=1` | Execute sandboxed Polars code for custom transformations |
+
+### Multi-turn dataset context
+
+When `stored_datasets` is in graph state, the research node prepends a `[Current session datasets: ...]` context block to the user message so the LLM can reference previous search results by `dataset_ref` (e.g. "chart search_1"). The state is persisted across turns when `DIGI_CHECKPOINTER` is set (default `memory`; use `sqlite` or `postgres` for cross-restart persistence).
+
+### ECharts rendering
+
+`visualization_agent` returns ECharts option JSON when the request includes `X-Response-Format: openwebui` or uses the `sitaas-rag` model endpoint. Without this header, it falls back to a PNG path. The frontend must handle the `echarts_option` key in the tool result to render the chart.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **SITAAS / Project-Mode Capabilities** section to `digigraph/AGENTS.md`
- Documents the complete tool set table with activation conditions (search skill vs sitaas_rag skill, `run_data_dir`, `DIGI_ALLOW_CODE_EXEC`)
- Documents multi-turn `stored_datasets` context injection and ECharts rendering behaviour

## Context

Issue #27 tracks drift between the SITAAS project README/config and the actual tool set. The local `projects/sitaas/README.md` and `config.yaml` (gitignored — confidential) were already updated to include `digistore_list`, `digistore_profile`, `digisearch_fetch_all`, `data_manipulation_agent`, `data_engineer_agent`, and ECharts. This PR documents the same information in the tracked `digigraph/AGENTS.md` agent guide so coding agents have a canonical reference.

## Test plan

- [x] `python3 scripts/check_doc_links.py` — 70 files scanned, OK
- [x] `pytest tests/dg/ -m unit` — 152 passed
- [x] Score gate: 10/10 all dimensions

Fixes #27

🤖 Generated with [Claude Code](https://claude.ai/claude-code)