### PR TITLE
chore(deps): pin curl-cffi>=0.15.0 to address CVE-2026-33752

### DIFF
--- a/digiquant/pyproject.toml
+++ b/digiquant/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 nautilus = ["nautilus_trader>=1.190,<2", "requests>=2.28"]
 visualization = ["plotly>=6.3.1"]
-data = ["yfinance>=0.2"]
+data = ["yfinance>=0.2", "curl-cffi>=0.15.0"]
 optimize = ["optuna>=3.0"]
 all = ["digiquant[nautilus]"]
 dev = ["pytest>=8", "pytest-cov>=4", "ruff>=0.8"]


### PR DESCRIPTION
## Summary

- Pins `curl-cffi>=0.15.0` as an explicit constraint in `digiquant[data]` optional extra
- `curl-cffi 0.13.0` (previously pulled in transitively via `yfinance`) has CVE-2026-33752; fix version is 0.15.0

## CVE audit results

### Python (pip-audit --local)

| Package | Version | CVE | Fix |
|---|---|---|---|
| curl-cffi | 0.13.0 | CVE-2026-33752 | 0.15.0 (pinned in this PR) |

No other CVEs in direct Python dependencies.

### npm (digichat — separate repo, not tracked here)

`npm audit` finds 12 vulnerabilities in `digichat`:
- **`drizzle-orm <0.45.2`** (high) — SQL injection via improperly escaped SQL identifiers — run `npm audit fix` in the digichat repo
- **`brace-expansion`** (moderate) — DoS via zero-step sequence
- **`esbuild <=0.24.2`** (moderate) — dev-server CORS bypass (dev only)
- **`hono <=4.12.13`** (moderate) — cookie/IP/path validation bypasses

Action: run `npm audit fix` in the digichat repository.

## Test plan

- [x] `pytest tests/dq/ -m unit` — passes
- [x] Score gate: 10/10 all dimensions

Fixes #18