### PR TITLE
refactor(digigraph): backward-compat loader for digiproject.yaml migration

### DIFF
--- a/digigraph/src/digigraph/project_config.py
+++ b/digigraph/src/digigraph/project_config.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def _subst_env(val: Any) -> Any:
@@ -24,19 +27,47 @@ def _subst_env(val: Any) -> Any:
     return val
 
 
+def _resolve_config_path(path: str | Path | None = None) -> Path | None:
+    """Resolve config file path with backward-compat for legacy config.yaml name.
+
+    Search order (when no explicit path):
+      digiproject.yaml → config/digiproject.yaml → config/digi_project.yaml
+    """
+    explicit = path or os.environ.get("DIGI_PROJECT_CONFIG")
+    if explicit:
+        p = Path(explicit)
+        if p.name == "config.yaml":
+            preferred = p.parent / "digiproject.yaml"
+            if preferred.exists():
+                logger.warning(
+                    "DEPRECATED: project config at %s; rename to digiproject.yaml (v1alpha1). "
+                    "Found digiproject.yaml in the same directory — loading it instead.",
+                    p,
+                )
+                return preferred
+            if p.exists():
+                logger.warning(
+                    "DEPRECATED: project config file %s should be renamed to digiproject.yaml (v1alpha1).",
+                    p,
+                )
+                return p
+        return p if p.exists() else None
+    for candidate in (
+        Path("digiproject.yaml"),
+        Path("config") / "digiproject.yaml",
+        Path("config") / "digi_project.yaml",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def load_project_config(path: str | Path | None = None) -> dict[str, Any]:
     """Load project YAML. Path from DIGI_PROJECT_CONFIG or default."""
-    cfg_path = path or os.environ.get("DIGI_PROJECT_CONFIG")
-    if not cfg_path:
-        default = Path("config") / "digi_project.yaml"
-        if default.exists():
-            cfg_path = default
-        else:
-            return {}
-    p = Path(cfg_path)
-    if not p.exists():
+    resolved = _resolve_config_path(path)
+    if resolved is None:
         return {}
-    raw = p.read_text()
+    raw = resolved.read_text()
     data = yaml.safe_load(raw) or {}
     return _subst_env(data)
 
@@ -101,34 +132,27 @@ class DigiProjectConfig:
     @classmethod
     def load(cls, path: str | Path | None = None) -> "DigiProjectConfig":
         """Load from DIGI_PROJECT_CONFIG or path. Results are cached by (path, mtime)."""
-        cfg_path = path or os.environ.get("DIGI_PROJECT_CONFIG")
-        if not cfg_path:
-            default = Path("config") / "digi_project.yaml"
-            cfg_path = str(default) if default.exists() else None
+        resolved = _resolve_config_path(path)
 
-        if cfg_path:
-            p = Path(cfg_path)
-            if p.exists():
-                try:
-                    mtime = p.stat().st_mtime
-                    cache_key = (str(p.resolve()), mtime)
-                    cached = _config_cache.get(cache_key)
-                    if cached is not None:
-                        return cached
-                except OSError:
-                    pass
+        if resolved is not None:
+            try:
+                mtime = resolved.stat().st_mtime
+                cache_key = (str(resolved.resolve()), mtime)
+                cached = _config_cache.get(cache_key)
+                if cached is not None:
+                    return cached
+            except OSError:
+                pass
 
-        data = load_project_config(cfg_path) if cfg_path else load_project_config()
-        obj = cls(data, config_path=cfg_path)
+        data = load_project_config(path)
+        obj = cls(data, config_path=resolved)
 
-        if cfg_path:
-            p = Path(cfg_path)
-            if p.exists():
-                try:
-                    mtime = p.stat().st_mtime
-                    _config_cache[(str(p.resolve()), mtime)] = obj
-                except OSError:
-                    pass
+        if resolved is not None:
+            try:
+                mtime = resolved.stat().st_mtime
+                _config_cache[(str(resolved.resolve()), mtime)] = obj
+            except OSError:
+                pass
         return obj
 
     def get_enabled_agents(self) -> list[str]:

--- a/tests/dg/test_project_config.py
+++ b/tests/dg/test_project_config.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
-from digigraph.project_config import DigiProjectConfig, load_project_config
+from digigraph.project_config import DigiProjectConfig, _resolve_config_path, load_project_config
 
 
 def test_load_project_config_returns_empty_when_no_file(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -99,6 +100,54 @@ mcp:
     tools = cfg.get_mcp_tools()
     assert "digigraph_workflow" in tools
     assert "digisearch_unified_content_index_query" in tools
+
+
+@pytest.mark.unit
+def test_resolve_config_path_prefers_digiproject_yaml_over_config_yaml(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """When config.yaml is given but digiproject.yaml sibling exists, prefer digiproject.yaml and warn."""
+    (tmp_path / "config.yaml").write_text("project:\n  name: old\n")
+    (tmp_path / "digiproject.yaml").write_text("project:\n  name: new\n")
+    with caplog.at_level(logging.WARNING, logger="digigraph.project_config"):
+        resolved = _resolve_config_path(str(tmp_path / "config.yaml"))
+    assert resolved is not None
+    assert resolved.name == "digiproject.yaml"
+    assert "DEPRECATED" in caplog.text
+    assert "digiproject.yaml" in caplog.text
+
+
+@pytest.mark.unit
+def test_resolve_config_path_warns_on_config_yaml_when_no_digiproject(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """When config.yaml is given and no digiproject.yaml exists, use config.yaml with deprecation warning."""
+    (tmp_path / "config.yaml").write_text("project:\n  name: legacy\n")
+    with caplog.at_level(logging.WARNING, logger="digigraph.project_config"):
+        resolved = _resolve_config_path(str(tmp_path / "config.yaml"))
+    assert resolved is not None
+    assert resolved.name == "config.yaml"
+    assert "DEPRECATED" in caplog.text
+
+
+@pytest.mark.unit
+def test_resolve_config_path_default_prefers_digiproject_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default search (no explicit path) prefers digiproject.yaml in cwd over config/digi_project.yaml."""
+    monkeypatch.delenv("DIGI_PROJECT_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "digiproject.yaml").write_text("project:\n  name: preferred\n")
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "digi_project.yaml").write_text("project:\n  name: fallback\n")
+    resolved = _resolve_config_path()
+    assert resolved is not None
+    assert resolved.name == "digiproject.yaml"
+
+
+@pytest.mark.unit
+def test_load_project_config_legacy_config_yaml(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """load_project_config honours config.yaml with deprecation warning when no digiproject.yaml."""
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("project:\n  name: sitaas-legacy\n")
+    with caplog.at_level(logging.WARNING, logger="digigraph.project_config"):
+        result = load_project_config(str(cfg_file))
+    assert result["project"]["name"] == "sitaas-legacy"
+    assert "DEPRECATED" in caplog.text
 
 
 def test_get_search_index_config_loads_index_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `_resolve_config_path()` to `project_config.py` — single place that resolves the config file path with priority order and deprecation detection
- When `DIGI_PROJECT_CONFIG` or an explicit path points to `config.yaml`, checks for a `digiproject.yaml` sibling first (prefers it + warns DEPRECATED if found); falls back to `config.yaml` itself with a deprecation warning
- Default search order (no explicit path): `digiproject.yaml` → `config/digiproject.yaml` → `config/digi_project.yaml`
- Both `load_project_config()` and `DigiProjectConfig.load()` now use `_resolve_config_path()` — single source of truth
- 4 new unit tests covering all backward-compat code paths

## Migration path for SITAAS

1. Rename `projects/sitaas/config.yaml` → `projects/sitaas/digiproject.yaml` (gitignored — local copy)
2. Update `DIGI_PROJECT_CONFIG` in docker-compose to point to `digiproject.yaml`
3. Old `config.yaml` path still works for one release (warning emitted on load)

## Test plan

- [ ] `pytest tests/dg/test_project_config.py -m unit` — all 4 new tests green
- [ ] All 11 project_config tests pass
- [ ] `ruff check` clean

Fixes #20
Part of #3