### PR TITLE
feat(docs): create project template starter (docs/templates/project/)

### DIFF
--- a/docs/templates/project/.env.example
+++ b/docs/templates/project/.env.example
@@ -1,0 +1,22 @@
+# .env.example — copy to .env and fill in values
+# Never commit .env to version control.
+
+# LLM proxy (required)
+OPENAI_API_BASE=http://litellm:4000/v1
+LITELLM_PROXY_API_KEY=your-litellm-key-here
+
+# DigiSearch (optional — enables document RAG)
+DIGISEARCH_URL=http://digisearch:8002
+DIGISEARCH_INDEX=default
+
+# DigiQuant (optional — enables quant backtest tools)
+DIGIQUANT_URL=http://digiquant:8001
+
+# DigiKey (optional — enables JWT auth)
+DIGIKEY_JWKS_URL=http://digikey:8005/.well-known/jwks.json
+
+# LLM mode override (test | medium | best). Overrides digiproject.yaml.
+# DIGI_LLM_MODE=test
+
+# Enable code execution in data_engineer_agent (requires run_data_dir set)
+# DIGI_ALLOW_CODE_EXEC=1

--- a/docs/templates/project/README.md
+++ b/docs/templates/project/README.md
@@ -1,0 +1,42 @@
+# Project Template
+
+Starter for a new DigiThings project. Copy this directory to `projects/<your-project>/` and customise.
+
+## Quick start
+
+```bash
+cp -r docs/templates/project projects/my-project
+cd projects/my-project
+cp .env.example .env
+# Edit digiproject.yaml and .env for your use-case
+docker compose -f ../../docker-compose.yml -f docker-compose.yml up
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `digiproject.yaml` | Project config (agents, indexes, MCP, services). All fields optional. |
+| `docker-compose.yml` | Compose override — mounts `digiproject.yaml` into digigraph. |
+| `.env.example` | Required env vars. Copy to `.env` and fill values. |
+
+## Capabilities
+
+Enable capabilities by setting fields in `digiproject.yaml`:
+
+| Capability | How to enable |
+|---|---|
+| Custom research prompt (document RAG) | Set `agents.research_system_prompt` |
+| Digistore + delegate tools | Set `run_data_dir` |
+| DigiSearch tool | Set `DIGISEARCH_URL` env var |
+| Multi-index discovery | Set `indexes_dir` pointing to a directory of `*.yaml` index files |
+| MCP server | `mcp.enabled: true` |
+| Restrict available tools | `agents.allowed_tools: [...]` |
+
+See `docs/spec/project-spec-v1alpha1.md` for the full schema and environment variable contract.
+
+## Notes
+
+- `projects/` is gitignored — project configs are local-only (never push to public remotes).
+- `.env` is gitignored — never commit secrets.
+- Rename `digiproject.yaml` from `config.yaml` if migrating from the legacy filename (digigraph will warn and still load it).

--- a/docs/templates/project/digiproject.yaml
+++ b/docs/templates/project/digiproject.yaml
@@ -1,0 +1,35 @@
+# digiproject.yaml — v1alpha1
+# Minimal starter for a new DigiThings project.
+# Copy this directory to projects/<your-project>/ and customise below.
+# All fields are optional; defaults shown in comments.
+# Full spec: docs/spec/project-spec-v1alpha1.md
+
+project:
+  name: my-project        # short identifier, e.g. "sitaas"
+  description: ""         # human-readable description
+  version: "0.1.0"        # SemVer
+
+agents:
+  enabled:
+    - research            # only "research" is supported in Phase 1
+  llm_mode: test          # "test" | "medium" | "best"
+  # planning_mode: false  # enable plan-then-execute flow
+  # allowed_tools:        # restrict tool names (default: all)
+  #   - digisearch
+  # research_system_prompt: |
+  #   Custom system prompt for the research node. When set, enables document-mode RAG.
+
+# run_data_dir: /data/run  # enable Digistore + delegate agent tools
+
+# indexes_dir: indexes      # directory of index *.yaml files (relative to this file)
+
+mcp:
+  enabled: false           # expose an MCP server
+  port: 8765
+  tools:
+    - digigraph_workflow
+
+services:
+  digisearch_url: ${DIGISEARCH_URL:-http://digisearch:8002}
+  litellm_url: ${OPENAI_API_BASE:-http://litellm:4000/v1}
+  digiquant_url: ${DIGIQUANT_URL:-http://digiquant:8001}

--- a/docs/templates/project/docker-compose.yml
+++ b/docs/templates/project/docker-compose.yml
@@ -1,0 +1,18 @@
+# docker-compose.yml — project override
+# Extends the root compose stack for this project.
+# Usage: docker compose -f ../../docker-compose.yml -f docker-compose.yml up
+#
+# Set DIGI_PROJECT_CONFIG to the path of your digiproject.yaml.
+# In Docker: mount a named volume at run_data_dir when Digistore is enabled.
+
+services:
+  digigraph:
+    environment:
+      DIGI_PROJECT_CONFIG: /project/digiproject.yaml
+    volumes:
+      - ./digiproject.yaml:/project/digiproject.yaml:ro
+      # Uncomment below when run_data_dir is set in digiproject.yaml:
+      # - run_data:/data/run
+
+# volumes:
+#   run_data:


### PR DESCRIPTION
## Summary

- Adds `docs/templates/project/` — a tracked starter kit to copy into `projects/<name>/` (which is gitignored)
- `digiproject.yaml`: minimal valid v1alpha1 config with all optional fields commented, env-var substitution examples for all services
- `docker-compose.yml`: compose override pattern — mounts `digiproject.yaml` into digigraph; includes commented volume stanza for Digistore
- `.env.example`: all required and optional env vars with placeholder values (force-added; `.env*` gitignore excludes real secrets but this is a template)
- `README.md`: quickstart, capability enable/disable table, migration notes for `config.yaml` → `digiproject.yaml` rename

## Usage

```bash
cp -r docs/templates/project projects/my-project
cd projects/my-project
cp .env.example .env
# Edit digiproject.yaml and .env
docker compose -f ../../docker-compose.yml -f docker-compose.yml up
```

## Test plan

- [ ] `make doc-check` passes
- [ ] Template YAML is valid (no parse errors)

Fixes #21
Part of #3