### PR TITLE
docs(backlog): decompose epic #2 hardening into child tasks

### DIFF
--- a/docs/backlog/epic-2-hardening.md
+++ b/docs/backlog/epic-2-hardening.md
@@ -1,0 +1,73 @@
+# Epic #2 — Hardening (cold review) child-task breakdown
+
+## Purpose
+
+Epic [#2](https://github.com/digithings-ai/digithings/issues/2) is a Phase 2
+production-readiness cold review of the entire monorepo after a stretch of
+active feature development. Scope covers secrets handling, auth-path rate
+limiting, CORS tightening, input validation at every HTTP trust boundary, a
+dependency/CVE audit, sensible `httpx` timeout defaults, health-probe vs
+status-endpoint separation, and documented threat-model coverage — all held to
+the PR scoring gate (see [docs/scoring/](../scoring/README.md): Security ≥ 8,
+Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9). The output is a set of small,
+individually-mergeable PRs that close the residual gaps identified after the
+platform-level controls already landed.
+
+## Completed preconditions
+
+Already in place and out of scope for this epic:
+
+- **DigiKey RS256 JWTs + JWKS** protect DigiGraph, DigiQuant, and DigiSearch on
+  non-exempt routes (see [SECURITY.md](../../SECURITY.md) §"Non-negotiable
+  defaults" item 2). No legacy static `DIGI_API_KEY` fallback.
+- **Scoped API keys** issued via DigiKey, with tenant-scope enforcement at the
+  key layer.
+- **Audit redaction** — every `audit.jsonl` writer routes through
+  `digibase.audit.redact_mapping`; prompts, JWTs, API keys, and document bodies
+  are stripped before persistence.
+- **Claude Code guardrails** — `scripts/claude-hooks/` PreToolUse hooks block
+  writes outside the repo root, pushes to non-origin remotes, and edits to
+  protected paths off a `task-N-*` branch (see [AGENTS.md](../../AGENTS.md)).
+- **Pre-push hook** — `scripts/hooks/pre-push.sh` (installed by
+  `make hooks-install`) blocks non-origin pushes, `main` pushes without
+  `ALLOW_MAIN_PUSH=1`, and live-trading-path pushes without a
+  `Human-Approved-By:` trailer.
+- **Loopback binding** — every Compose service binds `127.0.0.1` by default.
+
+## Remaining sub-tasks
+
+Each item below is sized for a single PR under ~120 lines of diff.
+
+- [ ] **Secrets-scan CI config.** Add a `gitleaks` (or `trufflehog`) GitHub
+  Actions job running on every PR + on `develop` pushes. Ship a baseline
+  allowlist for known fixtures under `tests/`. Fail the job on any new finding.
+- [ ] **Rate-limit middleware on auth paths.** Apply a per-IP token-bucket
+  limiter to DigiKey's key-issuance and JWT-mint endpoints, and to DigiGraph's
+  authenticated entry points. Default limits configurable via env; document in
+  [SECURITY.md](../../SECURITY.md).
+- [ ] **CORS allowlist audit.** Enumerate every FastAPI app's CORS config
+  (DigiGraph, DigiSearch, DigiQuant, DigiKey, DigiSmith, DigiChat BFF). Replace
+  any `*` origin with an explicit allowlist driven by env. Add a unit test per
+  service asserting disallowed origins are rejected.
+- [ ] **Pydantic v2 input validation at HTTP boundaries.** Sweep every
+  `@app.post` / `@app.get` handler for untyped `dict` bodies or query params;
+  replace with a Pydantic v2 model. Covers DigiGraph `/workflow`, DigiSearch
+  query/ingest, DigiQuant backtest, and the DigiChat BFF proxy routes.
+- [ ] **Dependency-audit CI (`pip-audit`).** Add a scheduled + PR-triggered
+  `pip-audit` job against each component's lockfile. Fail on `HIGH`/`CRITICAL`;
+  warn on `MEDIUM`. Include Node audit for `digichat/` (`npm audit --omit=dev`).
+- [ ] **`httpx` timeout defaults.** Centralize an `httpx.Timeout(connect=5,
+  read=30, write=10, pool=5)` helper in `digibase`; replace bare
+  `httpx.AsyncClient()` constructions across components. Guarantees no
+  unbounded hangs on upstream LLM or broker calls.
+- [ ] **`/healthz` vs `/v1/status` separation.** Carve a minimal
+  auth-exempt `/healthz` returning `{"ok": true}` for liveness probes on every
+  service; keep `/v1/status` (DigiSmith) for richer, still-secret-free
+  diagnostics. Document the contract so load balancers stop pinging `/v1/status`.
+- [ ] **Documented threat model.** Expand [SECURITY.md](../../SECURITY.md)
+  "Threat model" section into a STRIDE-style table — actor, asset, threat,
+  mitigation, residual risk — cross-linked from [AGENTS.md](../../AGENTS.md)
+  and the [security scoring rubric](../scoring/SECURITY.md).
+
+When every box above is checked, file the `docs/HARDENING_REPORT_2026Q2.md`
+deliverable called out in epic #2 and close the epic.


### PR DESCRIPTION
Refs #2

Adds `docs/backlog/epic-2-hardening.md` breaking the Phase 2 hardening cold-review epic into PR-sized child tasks.

## Contents
- **Purpose recap** — production-readiness sweep held to the PR scoring gate.
- **Completed preconditions** — DigiKey RS256 JWTs + JWKS, scoped API keys, audit redaction via `digibase.audit.redact_mapping`, Claude Code PreToolUse guardrails (`scripts/claude-hooks/`), and the `scripts/hooks/pre-push.sh` hook.
- **8 remaining sub-tasks**, each scoped for a single <120-line PR:
  1. Secrets-scan CI (gitleaks/trufflehog).
  2. Rate-limit middleware on DigiKey + DigiGraph auth paths.
  3. CORS allowlist audit across all FastAPI apps.
  4. Pydantic v2 input validation at every HTTP boundary.
  5. `pip-audit` + `npm audit` CI job.
  6. Centralized `httpx` timeout defaults in `digibase`.
  7. `/healthz` vs `/v1/status` separation.
  8. STRIDE-style threat-model table in `SECURITY.md`.

## Test plan
- [x] `make doc-check` passes (71 markdown files scanned, all links OK).
- Docs-only; no code changes.