### PR TITLE
feat(ci): pip-audit dependency-audit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
   digigraph:
     uses: ./.github/workflows/digigraph-test.yml
 
+  # ── Dependency CVE audit (pip-audit / OSV) ──────────────────────────────────
+  pip-audit:
+    uses: ./.github/workflows/pip-audit.yml
+
   # Note: digichat/ is gitignored (separate deployment repo). Its CI lives there.
   # The digichat-test.yml workflow is kept for future use when/if digichat moves
   # into this monorepo, but is not orchestrated here.

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -43,11 +43,21 @@ jobs:
           python-version: "3.12"
 
       - name: Install component with [dev] extras
-        # digiquant: intentionally excludes [nautilus] — the Nautilus C++ engine
-        # SIGABRTs on Linux CI (tracked in #42). [dev] alone gives us the
-        # dependency closure we need to audit.
+        # Components reference each other (e.g. digigraph depends on
+        # digismith>=0.1.0) but the digi* packages aren't on PyPI, so we
+        # pre-install every local package editable before resolving the
+        # target component's extras.
+        # digiquant: intentionally excludes [nautilus] — the Nautilus C++
+        # engine SIGABRTs on Linux CI (tracked in #42).
         run: |
           python -m pip install -U pip pip-audit
+          pip install -e ./digibase \
+                      -e ./digikey \
+                      -e ./digismith \
+                      -e ./digiclaw \
+                      -e ./digisearch \
+                      -e ./digigraph \
+                      -e ./digiquant
           pip install -e "./${{ matrix.component }}[dev]"
 
       - name: Build --ignore-vuln args from pip-audit-ignore.txt

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,146 @@
+# Dependency-audit CI — runs pip-audit against each Python component.
+#
+# Epic #2 hardening sub-task: scheduled + PR-triggered CVE audit.
+# Blocks on HIGH/CRITICAL findings (OSV severity); warns on MEDIUM/LOW.
+# Known/accepted CVEs can be listed in `pip-audit-ignore.txt` at the repo root
+# (one vuln ID per line — `GHSA-xxxx-xxxx-xxxx` or `PYSEC-YYYY-NNN` — with
+# `#`-prefixed comments for justification).
+#
+# Scope: Python components only. A sibling `npm audit --omit=dev` job for
+# digichat/ is a follow-up (see docs/backlog/epic-2-hardening.md).
+name: pip-audit
+
+on:
+  workflow_call:
+  pull_request:
+  push:
+    branches: [main, develop]
+  schedule:
+    # Weekly Monday 06:00 UTC — catches newly-disclosed CVEs on a dormant repo.
+    - cron: "0 6 * * 1"
+
+jobs:
+  audit:
+    name: pip-audit (${{ matrix.component }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        component:
+          - digibase
+          - digigraph
+          - digiquant
+          - digisearch
+          - digismith
+          - digikey
+          - digiclaw
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install component with [dev] extras
+        # digiquant: intentionally excludes [nautilus] — the Nautilus C++ engine
+        # SIGABRTs on Linux CI (tracked in #42). [dev] alone gives us the
+        # dependency closure we need to audit.
+        run: |
+          python -m pip install -U pip pip-audit
+          pip install -e "./${{ matrix.component }}[dev]"
+
+      - name: Build --ignore-vuln args from pip-audit-ignore.txt
+        id: ignores
+        run: |
+          args=""
+          if [ -f pip-audit-ignore.txt ]; then
+            while IFS= read -r line; do
+              # strip comments and whitespace
+              id="${line%%#*}"
+              id="$(echo "$id" | tr -d '[:space:]')"
+              [ -z "$id" ] && continue
+              args="$args --ignore-vuln $id"
+            done < pip-audit-ignore.txt
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      - name: Run pip-audit (JSON, non-blocking capture)
+        id: audit
+        # Run against the current interpreter's installed environment so we
+        # cover the real transitive closure rather than a stale lockfile.
+        # --strict causes pip-audit to error on metadata problems; we still
+        # want the JSON so we `|| true` and gate on parsed output below.
+        run: |
+          set +e
+          pip-audit \
+            --vulnerability-service osv \
+            --strict \
+            --format json \
+            ${{ steps.ignores.outputs.args }} \
+            > audit.json
+          rc=$?
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Classify findings (HIGH/CRITICAL block; MEDIUM/LOW warn)
+        # OSV severity lives under dependencies[].vulns[].aliases + .fix_versions;
+        # severity strings come via .vulns[].severity (list of {type,score}) or
+        # .vulns[].aliases. pip-audit flattens this into each vuln entry; we
+        # inspect `severity` (CVSS vector) and a coarse label if present.
+        run: |
+          python - <<'PY'
+          import json, os, sys
+          try:
+              data = json.load(open("audit.json"))
+          except Exception as e:
+              print(f"::error::could not parse pip-audit JSON: {e}")
+              sys.exit(1)
+
+          def severity_label(vuln):
+              # pip-audit (OSV) emits an optional "severity" list with CVSS
+              # vectors. We also accept a plain label if the upstream advisory
+              # exposes one via aliases/summary.
+              sev = (vuln.get("severity") or "").upper() if isinstance(vuln.get("severity"), str) else ""
+              if sev:
+                  return sev
+              for s in vuln.get("severity_list", []) or []:
+                  if isinstance(s, dict) and s.get("type", "").upper() in {"CVSS_V3", "CVSS_V4"}:
+                      score = float(s.get("score", "0") or 0)
+                      if score >= 9.0: return "CRITICAL"
+                      if score >= 7.0: return "HIGH"
+                      if score >= 4.0: return "MEDIUM"
+                      if score > 0:    return "LOW"
+              return "UNKNOWN"
+
+          blockers, warns = [], []
+          deps = data.get("dependencies", []) if isinstance(data, dict) else []
+          for dep in deps:
+              name = dep.get("name", "?")
+              version = dep.get("version", "?")
+              for v in dep.get("vulns", []) or []:
+                  vid = v.get("id", "?")
+                  label = severity_label(v)
+                  entry = f"{name}=={version} {vid} [{label}]"
+                  if label in {"HIGH", "CRITICAL"}:
+                      blockers.append(entry)
+                  elif label in {"MEDIUM", "LOW"}:
+                      warns.append(entry)
+                  else:
+                      # Unknown severity — treat as warn; surfaces in logs
+                      # but doesn't fail the job. Promote to blocker via
+                      # explicit pinning or ignore-list entry if needed.
+                      warns.append(entry + " (severity unknown)")
+
+          for w in warns:
+              print(f"::warning::pip-audit: {w}")
+          for b in blockers:
+              print(f"::error::pip-audit blocker: {b}")
+
+          if blockers:
+              print(f"\nFAIL: {len(blockers)} HIGH/CRITICAL vulnerabilit{'y' if len(blockers)==1 else 'ies'}.")
+              print("Fix by pinning a patched version in the component's pyproject.toml,")
+              print("or add the vuln ID to pip-audit-ignore.txt with a justification comment.")
+              sys.exit(1)
+          print(f"OK: 0 HIGH/CRITICAL vulnerabilities ({len(warns)} MEDIUM/LOW warnings).")
+          PY

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,31 @@ If you believe you have found a security vulnerability in DigiThings:
 
 We'll work with you on an embargo period if appropriate and credit you in the release notes if you'd like.
 
+## Dependency-audit policy
+
+Every Python component is scanned on every PR, every push to `main`/`develop`, and weekly (Monday 06:00 UTC) by the [`pip-audit` workflow](.github/workflows/pip-audit.yml) against the [OSV](https://osv.dev) vulnerability database.
+
+- **Blocks merge:** any finding with OSV severity **HIGH** or **CRITICAL** (CVSS ≥ 7.0).
+- **Warn-only:** findings at **MEDIUM** or **LOW** severity, and findings with unknown severity — surfaced via `::warning::` annotations on the PR, not gated.
+- **Scope:** `digibase`, `digigraph`, `digiquant`, `digisearch`, `digismith`, `digikey`, `digiclaw`. Each component is installed with its `[dev]` extras and audited against the resolved transitive closure. `digiquant[nautilus]` is excluded (tracked in #42). `digichat/` (Node) is audited by a sibling `npm audit --omit=dev` job (follow-up).
+
+### Accepting a CVE
+
+To accept a finding — e.g. because the vulnerable code path is not reachable in our usage, or an upstream patch is imminent — add the vuln ID to [`pip-audit-ignore.txt`](pip-audit-ignore.txt) at the repo root:
+
+```
+# GHSA-xxxx-xxxx-xxxx — justification (why not exploitable for us + review date)
+GHSA-xxxx-xxxx-xxxx
+```
+
+Every entry requires a neighbouring comment documenting the rationale and a re-evaluation trigger (upstream fix version or calendar date). Unjustified entries are review-rejected.
+
+Preferred remediation, in order:
+
+1. Pin a patched version in the component's `pyproject.toml` (and update the lockfile/editable-install contract).
+2. Swap the dependency if no fix is available.
+3. Only then: add to `pip-audit-ignore.txt` with justification.
+
 ## PR security rubric
 
 Every pull request is expected to pass the `docs/scoring/SECURITY.md` rubric at ≥ 8/10 before merge. Doc-only PRs touching `SECURITY.md` itself are excluded from auto-merge (see [docs/agent-backlog/AUTOMERGE.md](docs/agent-backlog/AUTOMERGE.md)).

--- a/pip-audit-ignore.txt
+++ b/pip-audit-ignore.txt
@@ -1,0 +1,15 @@
+# pip-audit accepted-risk list
+# ----------------------------
+# One vulnerability ID per line — `GHSA-xxxx-xxxx-xxxx` or `PYSEC-YYYY-NNN`.
+# `#`-prefixed lines (and inline trailing `# …` comments) are ignored.
+#
+# Every entry MUST include a justification comment on a neighbouring line:
+#   - why the vuln doesn't apply to our usage, and
+#   - when the entry should be re-evaluated (e.g. upstream fix version / date).
+#
+# Policy: see SECURITY.md § "Dependency-audit policy".
+#
+# Example:
+#   # GHSA-aaaa-bbbb-cccc — CVE-2099-0000 in foo; only reachable via the CLI
+#   # entrypoint we don't ship. Re-check when foo 2.0 lands.
+#   GHSA-aaaa-bbbb-cccc


### PR DESCRIPTION
Refs #2 (epic-2 hardening — dependency-audit CI sub-task).

## Summary

- Adds `.github/workflows/pip-audit.yml` — matrix job over the 7 Python components (`digibase`, `digigraph`, `digiquant`, `digisearch`, `digismith`, `digikey`, `digiclaw`). Each row installs the component with its `[dev]` extras and runs `pip-audit` against the resolved environment using the OSV vulnerability service.
- Triggers: every PR, push to `main`/`develop`, and weekly Monday 06:00 UTC schedule. 10-minute per-job timeout.
- **Blocks** on any finding with OSV severity **HIGH** or **CRITICAL** (CVSS ≥ 7.0). **Warns** (`::warning::` annotations) on MEDIUM/LOW/UNKNOWN.
- Accepted-risk file at repo root: `pip-audit-ignore.txt` — one `GHSA-*`/`PYSEC-*` ID per line, `#` comments required for justification. Parsed into `--ignore-vuln` flags.
- `digiquant[nautilus]` is excluded (SIGABRT on Linux CI, #42) — matches existing `digiquant-test.yml` pattern.
- Wired into `.github/workflows/ci.yml` via `workflow_call` so it appears on every PR alongside the per-component suites.
- `digichat/` (Node) is **out of scope** — a sibling `npm audit --omit=dev` job is a follow-up (noted in the workflow header and in `epic-2-hardening.md`).
- `SECURITY.md` gains a "Dependency-audit policy" section documenting what blocks, what warns, and the remediation order (pin patched version → swap dependency → ignore-with-justification).

## Test plan

- [ ] Matrix expands to 7 rows on this PR (one per component).
- [ ] At least one component completes green against the current dependency set.
- [ ] If a real HIGH/CRITICAL surfaces on the baseline, either pin the fix in the relevant `pyproject.toml` or add the CVE to `pip-audit-ignore.txt` with a justification comment — do not merge a broken baseline.
- [ ] `pip-audit-ignore.txt` entries are honoured (empty file today; contents-only template).
- [ ] Scheduled run fires Monday 06:00 UTC (verifiable post-merge via `gh run list --workflow=pip-audit.yml`).