### PR TITLE
feat(digikey): per-IP rate limit on auth paths

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,25 @@ If you need to reach the stack from outside the host, use **Tailscale** or **Clo
 
 An edge gateway (currently DigiClaw's scope) is the intended single Internet-facing surface: OIDC or mTLS, session binding, global rate limits, with DigiGraph and the verticals kept on loopback or private networks behind it.
 
+## Rate limiting (auth paths)
+
+DigiKey applies a per-IP token-bucket rate limiter to its auth-sensitive
+routes — `POST /v1/admin/keys` (key issuance) and `POST /v1/oauth/token`
+(JWT mint). Defaults: 10 requests/minute sustained, burst 20. Override via
+`DIGIKEY_RL_PER_MIN` and `DIGIKEY_RL_BURST`. On breach the service returns
+HTTP 429 with body `{"detail": "rate_limited", "retry_after": N}` and a
+`Retry-After` header.
+
+Exempt routes (no limiter overhead): `GET /health`,
+`GET /.well-known/jwks.json`, and any future `/healthz`, `/metrics`,
+`/v1/status`. This keeps liveness probes unaffected under load.
+
+The limiter is pure in-process. Cross-process / multi-instance sharing is a
+follow-up — a Redis or DigiBase-backed store would be the upgrade path. For
+today's loopback-bound, single-instance DigiKey deployment, per-process
+buckets are sufficient to blunt brute-force attempts against the bcrypt
+verify path.
+
 ## Revocation
 
 JWT revocation before natural expiry is a roadmap item (tracked under the [DigiKey revocation epic](https://github.com/digithings-ai/digithings/issues/6)). Today, revocation requires rotating the signing key or waiting for token expiry. Design any deployment with token TTLs short enough that this is acceptable.

--- a/digikey/ARCHITECTURE.md
+++ b/digikey/ARCHITECTURE.md
@@ -59,6 +59,7 @@ This architecture means DigiKey sits on the hot path for key exchange but is com
 | `settings.py` | Env-driven constants (`KEY_PREFIX_LEN=16`, `RAW_KEY_PREFIX="dgk_live_"`) |
 | `models.py` | `TokenClaims`, `DigiAuthContext`, `PrincipalKind` Pydantic v2 models |
 | `integrations/service_middleware.py` | `DigiAuthMiddleware`, per-service path-scope tables |
+| `ratelimit.py` | In-process per-IP token-bucket limiter + FastAPI dependency for auth-path routes |
 | `cli.py` | Bootstrap CLI (`digikey issue-key`) |
 
 ---
@@ -426,6 +427,8 @@ DigiChat depends on `digikey` and `digigraph` being healthy.
 | `DIGIKEY_JWT_TTL_SEC` | `900` | No | JWT lifetime in seconds |
 | `DIGIKEY_LITELLM_PROXY_KEY` | — | No | Forwarded as `litellm_proxy_api_key` |
 | `DIGIKEY_JWKS_CACHE_SEC` | `300` | No | Consumer-side JWKS cache TTL |
+| `DIGIKEY_RL_PER_MIN` | `10` | No | Auth-path rate limit: sustained req/min per IP |
+| `DIGIKEY_RL_BURST` | `20` | No | Auth-path rate limit: burst capacity per IP |
 
 Consumer-side variables (set on DigiGraph/DigiQuant/DigiSearch):
 
@@ -468,8 +471,8 @@ Current scopes are per-key. There is no concept of an organization-level policy 
 **Refresh token support**
 The `grant_type` field accepts `api_key` and `bff_session` only. There is no refresh token mechanism. Clients must re-exchange their API key every 15 minutes (default TTL). A `refresh_token` grant would allow silent re-issuance without re-presenting the API key secret.
 
-**Rate limiting on token endpoint**
-`POST /v1/oauth/token` is brute-forceable. A attacker with a leaked key prefix (visible in logs) could attempt bcrypt verification calls in parallel. No rate limiting exists at the DigiKey layer. Rate limiting should be applied at the reverse proxy level or within the service.
+**Rate limiting on token endpoint** — *partially closed in v0.1.1.*
+A per-IP in-process token-bucket limiter (see `ratelimit.py`) is now applied as a FastAPI dependency on `POST /v1/oauth/token` and `POST /v1/admin/keys`. Defaults: 10 req/min sustained, burst 20 — configurable via `DIGIKEY_RL_PER_MIN` / `DIGIKEY_RL_BURST`. Exempt routes (`/health`, `/.well-known/jwks.json`) carry no limiter overhead. The bucket is process-local; cross-process sharing (Redis or a DigiBase-backed store) is the remaining follow-up for multi-instance deployments, and per-API-key-prefix limiting is still a gap. Responses on breach: HTTP 429 with `{"detail":"rate_limited","retry_after":N}` and a `Retry-After` header.
 
 ---
 

--- a/digikey/src/digikey/crypto_keys.py
+++ b/digikey/src/digikey/crypto_keys.py
@@ -62,7 +62,11 @@ def load_or_create_signing_key() -> tuple[RSAPrivateKey, str]:
     kid = (os.environ.get("DIGIKEY_KEY_ID") or "digikey-1").strip() or "digikey-1"
     if pem:
         return load_private_key_from_pem(pem), kid
-    allow = os.environ.get("DIGIKEY_ALLOW_EPHEMERAL_KEY", "0").strip().lower() in ("1", "true", "yes")
+    allow = os.environ.get("DIGIKEY_ALLOW_EPHEMERAL_KEY", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     if not allow:
         raise RuntimeError(
             "DigiKey requires DIGIKEY_PRIVATE_KEY_PEM, or set DIGIKEY_ALLOW_EPHEMERAL_KEY=1 "

--- a/digikey/src/digikey/integrations/service_middleware.py
+++ b/digikey/src/digikey/integrations/service_middleware.py
@@ -30,25 +30,33 @@ def bearer_from_request(request: Request) -> str | None:
 
 
 def digikey_auth_active() -> bool:
-    return bool((os.environ.get("DIGIKEY_JWKS_URL") or "").strip() or (os.environ.get("DIGIKEY_PUBLIC_KEY_PEM") or "").strip())
+    return bool(
+        (os.environ.get("DIGIKEY_JWKS_URL") or "").strip()
+        or (os.environ.get("DIGIKEY_PUBLIC_KEY_PEM") or "").strip()
+    )
 
 
 def _tenant_headers(request: Request) -> str:
     return (
-        (request.headers.get("X-Digi-Tenant") or request.headers.get("X-Digichat-Tenant") or "")
-        .strip()
-    )
+        request.headers.get("X-Digi-Tenant") or request.headers.get("X-Digichat-Tenant") or ""
+    ).strip()
 
 
-def jwt_context(request: Request, raw_bearer: str, required_scopes: list[str]) -> DigiAuthContext | JSONResponse:
+def jwt_context(
+    request: Request, raw_bearer: str, required_scopes: list[str]
+) -> DigiAuthContext | JSONResponse:
     try:
         claims = decode_token(raw_bearer)
     except jwt.exceptions.PyJWTError as e:
         logger.debug("JWT verify failed: %s", e)
-        return JSONResponse(status_code=401, content={"code": "invalid_token", "message": "Invalid token"})
+        return JSONResponse(
+            status_code=401, content={"code": "invalid_token", "message": "Invalid token"}
+        )
     except Exception as e:
         logger.debug("JWT verify error: %s", e)
-        return JSONResponse(status_code=401, content={"code": "invalid_token", "message": "Invalid token"})
+        return JSONResponse(
+            status_code=401, content={"code": "invalid_token", "message": "Invalid token"}
+        )
     if required_scopes and not scope_grants_required(claims.scopes, required_scopes):
         return JSONResponse(
             status_code=403,

--- a/digikey/src/digikey/jwt_issue.py
+++ b/digikey/src/digikey/jwt_issue.py
@@ -40,7 +40,11 @@ def issue_access_token(
     Returns (jwt, jti).
     """
     aud = audience or (os.environ.get("DIGIKEY_AUDIENCE") or DEFAULT_AUDIENCE).strip()
-    ttl = ttl_sec if ttl_sec is not None else int(os.environ.get("DIGIKEY_JWT_TTL_SEC") or DEFAULT_TTL_SEC)
+    ttl = (
+        ttl_sec
+        if ttl_sec is not None
+        else int(os.environ.get("DIGIKEY_JWT_TTL_SEC") or DEFAULT_TTL_SEC)
+    )
     now = datetime.now(timezone.utc)
     jti = uuid.uuid4().hex
     claims: dict[str, Any] = {
@@ -64,7 +68,9 @@ def issue_access_token(
     if key_pub:
         claims["key_pub"] = key_pub
     claims["scope"] = " ".join(scopes)
-    token = jwt.encode(claims, private_key_to_pem(private_key), algorithm="RS256", headers={"kid": kid})
+    token = jwt.encode(
+        claims, private_key_to_pem(private_key), algorithm="RS256", headers={"kid": kid}
+    )
     # PyJWT 2 returns str for str key
     return str(token), jti
 

--- a/digikey/src/digikey/jwt_verify.py
+++ b/digikey/src/digikey/jwt_verify.py
@@ -104,7 +104,9 @@ def _payload_to_claims(payload: dict[str, Any]) -> TokenClaims:
         tenant_slug=str(payload.get("tenant_slug", "") or ""),
         tenant_id=str(payload["tenant_id"]) if payload.get("tenant_id") else None,
         project_id=str(payload["project_id"]) if payload.get("project_id") else None,
-        project_config_ref=str(payload["project_config_ref"]) if payload.get("project_config_ref") else None,
+        project_config_ref=str(payload["project_config_ref"])
+        if payload.get("project_config_ref")
+        else None,
         scopes=scopes,
         key_pub=str(payload["key_pub"]) if payload.get("key_pub") else None,
         principal_kind=pk,

--- a/digikey/src/digikey/ratelimit.py
+++ b/digikey/src/digikey/ratelimit.py
@@ -1,0 +1,190 @@
+"""In-process token-bucket rate limiter for DigiKey auth-sensitive routes.
+
+Applied selectively (via FastAPI dependency) to the key-issuance and
+JWT-mint endpoints. Exempt routes — ``/health``, ``/.well-known/jwks.json``,
+and any future ``/healthz``, ``/metrics``, ``/v1/status`` — do not carry this
+dependency and therefore incur zero overhead.
+
+Design
+------
+* Per-client-IP token bucket. A bucket starts full (``burst`` tokens) and
+  refills at ``per_min / 60`` tokens/second up to ``burst``.
+* ``time.monotonic()`` drives the clock — immune to wall-clock jumps.
+* An :class:`asyncio.Lock` guards bucket mutation so concurrent awaits on
+  the same event loop stay consistent.
+* Pure in-process. Cross-process sharing (multi-worker / multi-instance)
+  is a documented follow-up; a Redis- or DigiBase-backed store is the
+  intended upgrade path (see ``ARCHITECTURE.md`` §"Rate limiting").
+* On breach: HTTP 429, JSON body ``{"detail": "rate_limited",
+  "retry_after": N}``, plus a ``Retry-After: N`` header.
+
+Configuration
+-------------
+* ``DIGIKEY_RL_PER_MIN`` — sustained requests per minute per IP (default 10).
+* ``DIGIKEY_RL_BURST`` — burst capacity per IP (default 20).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass
+
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PER_MIN = 10
+DEFAULT_BURST = 20
+# Cap the bucket table to avoid unbounded memory growth under IP churn / spoofed
+# X-Forwarded-For values. When exceeded we drop the half that has been idle
+# longest — an attacker who cycles IPs effectively resets their own state,
+# which is fine; legitimate callers keep their bucket because recent activity
+# refreshes ``updated_at``.
+MAX_BUCKETS = 10_000
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int; falling back to %d", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    updated_at: float
+
+
+class TokenBucketRateLimiter:
+    """Per-IP token-bucket limiter."""
+
+    def __init__(self, per_min: int | None = None, burst: int | None = None) -> None:
+        self.per_min = (
+            per_min if per_min is not None else _env_int("DIGIKEY_RL_PER_MIN", DEFAULT_PER_MIN)
+        )
+        self.burst = burst if burst is not None else _env_int("DIGIKEY_RL_BURST", DEFAULT_BURST)
+        if self.per_min <= 0:
+            self.per_min = DEFAULT_PER_MIN
+        if self.burst <= 0:
+            self.burst = DEFAULT_BURST
+        self._refill_per_sec = self.per_min / 60.0
+        self._buckets: dict[str, _Bucket] = {}
+        self._lock = asyncio.Lock()
+
+    @staticmethod
+    def client_ip(request: Request) -> str:
+        """Best-effort client IP extraction.
+
+        ``X-Forwarded-For`` is trusted only because DigiKey sits behind a
+        loopback-bound deployment; in production the reverse proxy should be
+        the only thing setting this header.
+        """
+        xff = request.headers.get("x-forwarded-for")
+        if xff:
+            return xff.split(",", 1)[0].strip() or "unknown"
+        real = request.headers.get("x-real-ip")
+        if real:
+            return real.strip() or "unknown"
+        if request.client and request.client.host:
+            return request.client.host
+        return "unknown"
+
+    def reset(self) -> None:
+        """Drop all buckets (test helper)."""
+        self._buckets.clear()
+
+    def _evict_stale(self, now: float) -> None:
+        """Drop the half of buckets that have been idle longest."""
+        items = sorted(self._buckets.items(), key=lambda kv: kv[1].updated_at)
+        drop = len(items) // 2 or 1
+        for k, _ in items[:drop]:
+            self._buckets.pop(k, None)
+
+    async def check(self, key: str) -> tuple[bool, float]:
+        """Consume one token for ``key``.
+
+        Returns ``(allowed, retry_after_seconds)``. When allowed,
+        ``retry_after_seconds`` is 0. When rejected, it is the integer-ceiling
+        seconds until one token refills.
+        """
+        async with self._lock:
+            now = time.monotonic()
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                if len(self._buckets) >= MAX_BUCKETS:
+                    self._evict_stale(now)
+                bucket = _Bucket(tokens=float(self.burst), updated_at=now)
+                self._buckets[key] = bucket
+            elapsed = max(0.0, now - bucket.updated_at)
+            bucket.tokens = min(float(self.burst), bucket.tokens + elapsed * self._refill_per_sec)
+            bucket.updated_at = now
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return True, 0.0
+            needed = 1.0 - bucket.tokens
+            retry_after = needed / self._refill_per_sec if self._refill_per_sec > 0 else 60.0
+            return False, retry_after
+
+
+_limiter: TokenBucketRateLimiter | None = None
+
+
+def get_limiter() -> TokenBucketRateLimiter:
+    """Return the process-wide limiter (lazy init, env-driven)."""
+    global _limiter
+    if _limiter is None:
+        _limiter = TokenBucketRateLimiter()
+    return _limiter
+
+
+def reset_limiter_for_tests() -> None:
+    """Drop the cached limiter so a test can re-read env vars."""
+    global _limiter
+    _limiter = None
+
+
+class RateLimited(Exception):
+    """Raised when a client exceeds the configured rate limit."""
+
+    def __init__(self, retry_after: int) -> None:
+        self.retry_after = retry_after
+        super().__init__(f"rate_limited; retry_after={retry_after}s")
+
+
+async def rate_limit_dependency(request: Request) -> None:
+    """FastAPI dependency — raises :class:`RateLimited` on breach.
+
+    Scoped via ``Depends(rate_limit_dependency)`` on protected routes only.
+    """
+    limiter = get_limiter()
+    key = limiter.client_ip(request)
+    allowed, retry_after = await limiter.check(key)
+    if allowed:
+        return
+    retry_after_s = max(1, int(math.ceil(retry_after)))
+    raise RateLimited(retry_after_s)
+
+
+async def _rate_limited_handler(_request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, RateLimited)
+    return JSONResponse(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        content={"detail": "rate_limited", "retry_after": exc.retry_after},
+        headers={"Retry-After": str(exc.retry_after)},
+    )
+
+
+def register_rate_limit_handler(app: FastAPI) -> None:
+    """Register the 429 JSON response handler on the FastAPI app."""
+    app.add_exception_handler(RateLimited, _rate_limited_handler)

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -7,7 +7,7 @@ import os
 import secrets
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
@@ -18,12 +18,14 @@ from digikey.db import init_db, session_factory
 from digikey.db_schema import ApiKeyRow
 from digikey.jwt_issue import issue_access_token, public_jwks
 from digikey.key_crypto import generate_raw_key, hash_secret, verify_secret
+from digikey.ratelimit import rate_limit_dependency, register_rate_limit_handler
 from digikey.scopes import DEFAULT_BFF_SESSION_SCOPES, scope_grants_required
 from digikey.settings import KEY_PREFIX_LEN, admin_token, allow_dev_global_keys, bff_token
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="DigiKey", version="0.1.0")
+register_rate_limit_handler(app)
 
 _private_key, _kid = load_or_create_signing_key()
 
@@ -34,7 +36,11 @@ def _startup() -> None:
     if not admin_token():
         logger.warning("DIGIKEY_ADMIN_TOKEN is unset — POST /v1/admin/keys returns 503")
     if not (os.environ.get("DIGIKEY_PRIVATE_KEY_PEM") or "").strip():
-        if os.environ.get("DIGIKEY_ALLOW_EPHEMERAL_KEY", "0").strip().lower() in ("1", "true", "yes"):
+        if os.environ.get("DIGIKEY_ALLOW_EPHEMERAL_KEY", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
             logger.warning(
                 "DIGIKEY_ALLOW_EPHEMERAL_KEY=1: ephemeral signing key; set DIGIKEY_PRIVATE_KEY_PEM "
                 "for stable JWKS across restarts",
@@ -75,11 +81,17 @@ class AdminIssueResponse(BaseModel):
     id: str
 
 
-@app.post("/v1/admin/keys", response_model=AdminIssueResponse)
+@app.post(
+    "/v1/admin/keys",
+    response_model=AdminIssueResponse,
+    dependencies=[Depends(rate_limit_dependency)],
+)
 def admin_issue_key(body: AdminIssueBody, request: Request) -> AdminIssueResponse:
     _require_admin(request)
     if body.kind == "dev_global" and not allow_dev_global_keys():
-        raise HTTPException(status_code=403, detail="dev_global keys disabled (set DIGIKEY_ALLOW_DEV_GLOBAL=1)")
+        raise HTTPException(
+            status_code=403, detail="dev_global keys disabled (set DIGIKEY_ALLOW_DEV_GLOBAL=1)"
+        )
     raw, prefix = generate_raw_key()
     scopes = body.scopes
     if body.kind == "dev_global" and (not scopes or scopes == ["*"]):
@@ -126,13 +138,20 @@ def _jwt_ttl() -> int:
     return int(os.environ.get("DIGIKEY_JWT_TTL_SEC") or "900")
 
 
-@app.post("/v1/oauth/token", response_model=TokenResponse, response_model_exclude_none=True)
+@app.post(
+    "/v1/oauth/token",
+    response_model=TokenResponse,
+    response_model_exclude_none=True,
+    dependencies=[Depends(rate_limit_dependency)],
+)
 def oauth_token(body: TokenRequest, request: Request) -> TokenResponse:
     ttl = _jwt_ttl()
     if body.grant_type == "bff_session":
         btok = bff_token()
         if not btok:
-            raise HTTPException(status_code=503, detail="bff_session grant not configured (DIGIKEY_BFF_TOKEN)")
+            raise HTTPException(
+                status_code=503, detail="bff_session grant not configured (DIGIKEY_BFF_TOKEN)"
+            )
         auth = request.headers.get("Authorization") or ""
         if not secrets.compare_digest(auth, f"Bearer {btok}"):
             raise HTTPException(status_code=401, detail="bff unauthorized")
@@ -141,7 +160,9 @@ def oauth_token(body: TokenRequest, request: Request) -> TokenResponse:
         scopes = list(DEFAULT_BFF_SESSION_SCOPES)
         if body.requested_scopes:
             if not scope_grants_required(scopes, body.requested_scopes):
-                raise HTTPException(status_code=400, detail="requested_scopes not allowed for bff session")
+                raise HTTPException(
+                    status_code=400, detail="requested_scopes not allowed for bff session"
+                )
             scopes = body.requested_scopes
         token, _jti = issue_access_token(
             _private_key,

--- a/tests/dk/test_jwt_roundtrip.py
+++ b/tests/dk/test_jwt_roundtrip.py
@@ -1,6 +1,5 @@
 """JWT issue/decode roundtrip (RS256)."""
 
-
 import pytest
 
 jwt = pytest.importorskip("jwt")

--- a/tests/dk/test_ratelimit.py
+++ b/tests/dk/test_ratelimit.py
@@ -1,0 +1,138 @@
+"""Unit tests for DigiKey per-IP token-bucket rate limiter."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from digikey.ratelimit import (
+    TokenBucketRateLimiter,
+    rate_limit_dependency,
+    register_rate_limit_handler,
+    reset_limiter_for_tests,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    register_rate_limit_handler(app)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/v1/status")
+    def status_route() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/oauth/token", dependencies=[Depends(rate_limit_dependency)])
+    def token() -> dict[str, str]:
+        return {"access_token": "stub"}
+
+    return app
+
+
+@pytest.fixture()
+def rl_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # per_min=60 (1/sec refill), burst=20 — matches task spec for burst test.
+    monkeypatch.setenv("DIGIKEY_RL_PER_MIN", "60")
+    monkeypatch.setenv("DIGIKEY_RL_BURST", "20")
+    reset_limiter_for_tests()
+    yield
+    reset_limiter_for_tests()
+
+
+def test_burst_allows_up_to_burst_then_429(rl_env: None) -> None:
+    app = _build_app()
+    client = TestClient(app)
+
+    for i in range(20):
+        r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.1"})
+        assert r.status_code != 429, f"unexpected 429 at request {i + 1}"
+
+    r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.1"})
+    assert r.status_code == 429
+    body = r.json()
+    assert body["detail"] == "rate_limited"
+    assert isinstance(body["retry_after"], int)
+    assert body["retry_after"] >= 1
+    assert "retry-after" in {k.lower() for k in r.headers.keys()}
+    assert int(r.headers["Retry-After"]) == body["retry_after"]
+
+
+def test_window_recovery_after_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After enough monotonic time elapses, new requests are allowed again."""
+    monkeypatch.setenv("DIGIKEY_RL_PER_MIN", "60")
+    monkeypatch.setenv("DIGIKEY_RL_BURST", "5")
+    reset_limiter_for_tests()
+
+    app = _build_app()
+    client = TestClient(app)
+
+    # Drive a fake monotonic clock.
+    now = {"t": 1000.0}
+
+    def fake_monotonic() -> float:
+        return now["t"]
+
+    monkeypatch.setattr("digikey.ratelimit.time.monotonic", fake_monotonic)
+
+    for _ in range(5):
+        r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.2"})
+        assert r.status_code != 429
+
+    r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.2"})
+    assert r.status_code == 429
+    retry_after = r.json()["retry_after"]
+    assert retry_after >= 1
+
+    # Advance past retry_after; refill allows a new request.
+    now["t"] += retry_after + 0.1
+    r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.2"})
+    assert r.status_code != 429
+
+    reset_limiter_for_tests()
+
+
+def test_per_ip_isolation(rl_env: None) -> None:
+    app = _build_app()
+    client = TestClient(app)
+
+    # Exhaust IP A.
+    for _ in range(20):
+        client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.3"})
+    r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.3"})
+    assert r.status_code == 429
+
+    # IP B still has a full bucket.
+    r = client.post("/v1/oauth/token", headers={"X-Forwarded-For": "10.0.0.4"})
+    assert r.status_code != 429
+
+
+def test_exempt_routes_not_rate_limited(rl_env: None) -> None:
+    app = _build_app()
+    client = TestClient(app)
+
+    # Hammer /health and /v1/status well past the burst.
+    for _ in range(100):
+        assert client.get("/health", headers={"X-Forwarded-For": "10.0.0.5"}).status_code == 200
+        assert client.get("/v1/status", headers={"X-Forwarded-For": "10.0.0.5"}).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_refill_and_consume() -> None:
+    """Direct async bucket check: consume burst, exhaust, refill."""
+    limiter = TokenBucketRateLimiter(per_min=60, burst=3)
+
+    # Three tokens available immediately.
+    for _ in range(3):
+        allowed, retry = await limiter.check("ip")
+        assert allowed
+        assert retry == 0.0
+
+    allowed, retry = await limiter.check("ip")
+    assert not allowed
+    assert retry > 0

--- a/tests/dk/test_ratelimit.py
+++ b/tests/dk/test_ratelimit.py
@@ -122,17 +122,20 @@ def test_exempt_routes_not_rate_limited(rl_env: None) -> None:
         assert client.get("/v1/status", headers={"X-Forwarded-For": "10.0.0.5"}).status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_token_bucket_refill_and_consume() -> None:
+def test_token_bucket_refill_and_consume() -> None:
     """Direct async bucket check: consume burst, exhaust, refill."""
-    limiter = TokenBucketRateLimiter(per_min=60, burst=3)
+    import asyncio
 
-    # Three tokens available immediately.
-    for _ in range(3):
+    async def _run() -> None:
+        limiter = TokenBucketRateLimiter(per_min=60, burst=3)
+
+        for _ in range(3):
+            allowed, retry = await limiter.check("ip")
+            assert allowed
+            assert retry == 0.0
+
         allowed, retry = await limiter.check("ip")
-        assert allowed
-        assert retry == 0.0
+        assert not allowed
+        assert retry > 0
 
-    allowed, retry = await limiter.check("ip")
-    assert not allowed
-    assert retry > 0
+    asyncio.run(_run())


### PR DESCRIPTION
Refs #2 — epic-2 hardening sub-task.

## Summary

- New `digikey/ratelimit.py`: in-process per-IP token-bucket limiter with `asyncio.Lock`, `time.monotonic()` clock, and a bounded bucket table with stale-eviction.
- Applied via `Depends(rate_limit_dependency)` only on auth-sensitive routes: `POST /v1/admin/keys` and `POST /v1/oauth/token`. `/health` and `/.well-known/jwks.json` carry no limiter overhead.
- On breach: HTTP 429 with JSON body `{"detail":"rate_limited","retry_after":N}` and a `Retry-After` header, via a registered exception handler.
- Defaults: 10 req/min sustained, burst 20. Overridable via `DIGIKEY_RL_PER_MIN` / `DIGIKEY_RL_BURST`.
- Pure in-process; cross-process sharing (Redis / DigiBase-backed) documented as a follow-up.
- Docs updated: `SECURITY.md` (new "Rate limiting (auth paths)" section), `digikey/ARCHITECTURE.md` (env vars, file map, §12(e) closure note).

## Test plan

- [x] `pytest tests/dk/ -m unit -v` — 6/6 pass, including burst→429, monotonic-clock window recovery, per-IP isolation, exempt-route bypass.
- [x] `ruff check .` + `ruff format --check` clean.
- [ ] Local smoke (reviewer): run DigiKey, burst 25 requests to `/v1/oauth/token` → confirm 429 at the 21st; `/health` stays 200 under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)