### PR TITLE
feat(obs): Prometheus /metrics + Grafana seed per ADR-0003

### DIFF
--- a/.github/workflows/digibase-test.yml
+++ b/.github/workflows/digibase-test.yml
@@ -4,9 +4,13 @@ on:
   workflow_call:
   push:
     branches: [main, develop]
-    paths: ["digibase/**"]
+    paths:
+      - "digibase/**"
+      - "tests/db/**"
   pull_request:
-    paths: ["digibase/**"]
+    paths:
+      - "digibase/**"
+      - "tests/db/**"
 
 jobs:
   test:
@@ -21,7 +25,11 @@ jobs:
       - name: Install
         run: |
           python -m pip install -U pip
-          pip install -e "./digibase[dev]"
+          # tests/conftest.py imports digikey for shared JWT fixtures; install both from the monorepo.
+          pip install -e "./digibase[dev]" -e "./digikey"
 
       - name: Ruff
-        run: python -m ruff check digibase/src
+        run: python -m ruff check digibase/src tests/db
+
+      - name: Unit tests (tests/db)
+        run: python -m pytest tests/db -m unit -v --tb=short

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo
+.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo up-observability down-observability
 
 build:
 	docker compose build
@@ -48,6 +48,13 @@ package:
 # Start stack with heartbeat (health + audit every 30 min).
 up-heartbeat:
 	docker compose --profile heartbeat up -d
+
+# Start core stack + Prometheus (127.0.0.1:9090) and Grafana (127.0.0.1:3001). See ADR-0003.
+up-observability:
+	docker compose --profile observability up -d
+
+down-observability:
+	docker compose --profile observability down
 
 # Stack + DigiChat UI (Next.js on host port DIGICHAT_PUBLISH_PORT, default 3005). Does not include `heartbeat` profile.
 # Tip: set DIGICHAT_DEV_AUTH=1 in .env for password login without OIDC; set AUTH_URL to the URL you use in the browser.

--- a/digibase/ARCHITECTURE.md
+++ b/digibase/ARCHITECTURE.md
@@ -19,14 +19,15 @@ DigiBase plays two distinct roles that must not be conflated:
 
 ## 2. Current Implementation State
 
-The library ships five source files under `digibase/src/digibase/`:
+The library ships six source files under `digibase/src/digibase/`:
 
 | File | Purpose | Shipped |
 |------|---------|---------|
-| `__init__.py` | Package entry point; re-exports `outbound_request_id_headers` | Yes |
+| `__init__.py` | Package entry point; re-exports `outbound_request_id_headers`, `install_metrics` | Yes |
 | `errors.py` | Pydantic error envelope models; FastAPI error handler registration | Yes |
 | `http.py` | Outbound header helpers for service-to-service calls | Yes |
 | `audit.py` | Key-pattern-based redaction for audit payloads | Yes |
+| `metrics.py` | Prometheus `/metrics` endpoint + HTTP instrumentation middleware (ADR-0003) | Yes |
 | `otel.py` | Optional OTel FastAPI instrumentation wiring (requires `digibase[otel]`) | Yes |
 
 The package is declared in `digibase/pyproject.toml` at version `0.1.0`. It requires Python 3.12+, Pydantic v2, httpx 0.27+, and FastAPI 0.115+. OTel support is gated behind the `[otel]` optional extra, which pulls in the OpenTelemetry SDK, OTLP HTTP exporter, and FastAPI instrumentation packages.
@@ -96,6 +97,26 @@ redact_mapping(
 ) -> dict[str, Any]
 ```
 Returns a shallow copy of `payload` with any key whose lowercase form contains a redact substring replaced by the string `"[REDACTED]"`. If `redact` is `None`, the default substrings are used. Does not recurse into nested dicts.
+
+### `digibase.metrics`
+
+```python
+install_metrics(app: FastAPI, *, service: str) -> None
+```
+Installs Prometheus instrumentation on *app* per [ADR-0003](../docs/adr/0003-observability-baseline.md):
+
+- Mounts `GET /metrics` returning the default `prometheus_client` global registry in `text/plain; version=0.0.4; charset=utf-8` (hardcoded to stay on the 0.0.4 text format even if `prometheus_client` flips its default to OpenMetrics 1.0.0).
+- Registers an ASGI middleware that records three metric families labelled consistently across services:
+  - `http_requests_total{service,method,route,status}` — Counter.
+  - `http_request_duration_seconds{service,method,route,status}` — Histogram with API-tuned buckets (5ms → 10s).
+  - `http_requests_in_flight{service}` — Gauge.
+- The `route` label is collapsed to the matched FastAPI route template (e.g. `/items/{item_id}`) via the app router so cardinality is bounded by declared routes. Unmatched requests fall back to `"<unmatched>"`.
+- Requests against `/metrics` itself are not counted (avoids recursive inflation on every scrape).
+- Default process, GC, and platform collectors ship automatically because `prometheus_client` attaches them to the global `REGISTRY` at import time — no extra wiring is required.
+
+`install_metrics` is idempotent across multiple invocations in the same process (test suites building throwaway apps are safe); a module-level cache fetches already-registered collectors instead of raising `Duplicated timeseries`. The function raises `ValueError` if `service` is empty.
+
+`/metrics` has no authentication and carries no secrets — operators bind the host port to loopback via docker-compose, matching every other management endpoint. The endpoint is not advertised in OpenAPI (`include_in_schema=False`) and is deliberately kept separate from the public `/v1/status` contract.
 
 ### `digibase.otel`
 

--- a/digibase/pyproject.toml
+++ b/digibase/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2",
     "httpx>=0.27",
     "fastapi>=0.115",
+    "prometheus-client>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/digibase/src/digibase/__init__.py
+++ b/digibase/src/digibase/__init__.py
@@ -1,7 +1,9 @@
-"""DigiThings shared platform utilities (HTTP, errors, audit redaction, optional OTel)."""
+"""DigiThings shared platform utilities (HTTP, errors, audit redaction, metrics, optional OTel)."""
 
 from digibase.http import outbound_request_id_headers
+from digibase.metrics import install_metrics
 
 __all__ = [
+    "install_metrics",
     "outbound_request_id_headers",
 ]

--- a/digibase/src/digibase/errors.py
+++ b/digibase/src/digibase/errors.py
@@ -14,7 +14,9 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 class ApiErrorBody(BaseModel):
     """Standard error envelope (v1)."""
 
-    code: str = Field(..., description="Stable machine-readable code, e.g. http_404, validation_error")
+    code: str = Field(
+        ..., description="Stable machine-readable code, e.g. http_404, validation_error"
+    )
     message: str = Field(..., description="Human-readable message")
     request_id: str | None = Field(None, description="Correlates with X-Request-ID when present")
     service: str | None = Field(None, description="Originating service name")
@@ -56,6 +58,7 @@ def register_fastapi_error_handlers(app: Any, *, service: str) -> None:
 
     *app* should be a FastAPI instance. ``request.state.request_id`` should be set by correlation middleware.
     """
+
     @app.exception_handler(StarletteHTTPException)
     async def _http_exc(request: Request, exc: StarletteHTTPException) -> JSONResponse:
         detail = exc.detail

--- a/digibase/src/digibase/metrics.py
+++ b/digibase/src/digibase/metrics.py
@@ -72,7 +72,7 @@ _DURATION_BUCKETS = (
 )
 
 
-def _get_or_create(name: str, factory):  # type: ignore[no-untyped-def]
+def _get_or_create(name: str, factory):
     """Return the cached collector for *name*, creating it via *factory* if needed.
 
     Guards against ``ValueError: Duplicated timeseries`` when the module is

--- a/digibase/src/digibase/metrics.py
+++ b/digibase/src/digibase/metrics.py
@@ -1,0 +1,234 @@
+"""Prometheus metrics helper for DigiThings FastAPI services.
+
+Provides :func:`install_metrics` which mounts a ``/metrics`` endpoint and an ASGI
+middleware that records standard HTTP metrics (request count, duration, in-flight)
+for the given FastAPI application.
+
+Design notes:
+
+* Route labels are collapsed to the *matched* FastAPI route template (e.g.
+  ``/items/{item_id}``) instead of the raw request path so cardinality stays
+  bounded. Requests that do not match any route are labelled ``"<unmatched>"``.
+* Collectors are registered on the default global ``REGISTRY`` once per
+  (service, metric-name) pair — calling :func:`install_metrics` repeatedly is
+  safe across tests that build throwaway FastAPI apps.
+* The ``/metrics`` response uses the documented Prometheus text content type
+  ``text/plain; version=0.0.4; charset=utf-8``.
+
+See ADR-0003 for the design rationale.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import Response
+from prometheus_client import (
+    REGISTRY,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from starlette.routing import Match
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+__all__ = ["install_metrics"]
+
+# ADR-0003 pins the Prometheus text exposition content type we emit. Newer
+# prometheus_client releases default ``CONTENT_TYPE_LATEST`` to
+# ``version=1.0.0`` (OpenMetrics), but the broad Prometheus ecosystem — and the
+# ADR itself — expects the ``0.0.4`` plain-text format. Hardcode it so the
+# contract is stable regardless of library version.
+_PROM_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+# Prometheus metric names are stable identifiers shared across services; the
+# service-label disambiguates which emitter produced the sample. We register the
+# collectors lazily and cache them by name so we never hit the
+# ``Duplicated timeseries`` error when install_metrics is called multiple times
+# (e.g. in the unit-test suite).
+_METRIC_CACHE: dict[str, Any] = {}
+
+_REQUEST_LABELS = ("service", "method", "route", "status")
+_INFLIGHT_LABELS = ("service",)
+
+# Histogram buckets in seconds — tuned for typical HTTP API latencies; the
+# default prometheus_client buckets top out at 10s which is plenty for our
+# services (any slower request is already broken).
+_DURATION_BUCKETS = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+
+def _get_or_create(name: str, factory):  # type: ignore[no-untyped-def]
+    """Return the cached collector for *name*, creating it via *factory* if needed.
+
+    Guards against ``ValueError: Duplicated timeseries`` when the module is
+    re-imported or ``install_metrics`` is invoked multiple times in one process.
+    """
+    cached = _METRIC_CACHE.get(name)
+    if cached is not None:
+        return cached
+    try:
+        collector = factory()
+    except ValueError:
+        # Another import path registered it on the same REGISTRY; fish it out.
+        existing = getattr(REGISTRY, "_names_to_collectors", {}).get(name)
+        if existing is None:
+            raise
+        collector = existing
+    _METRIC_CACHE[name] = collector
+    return collector
+
+
+def _requests_total() -> Counter:
+    return _get_or_create(
+        "http_requests_total",
+        lambda: Counter(
+            "http_requests_total",
+            "Total HTTP requests processed, labelled by service/method/route/status.",
+            _REQUEST_LABELS,
+        ),
+    )
+
+
+def _request_duration_seconds() -> Histogram:
+    return _get_or_create(
+        "http_request_duration_seconds",
+        lambda: Histogram(
+            "http_request_duration_seconds",
+            "HTTP request duration in seconds, labelled by service/method/route/status.",
+            _REQUEST_LABELS,
+            buckets=_DURATION_BUCKETS,
+        ),
+    )
+
+
+def _requests_in_flight() -> Gauge:
+    return _get_or_create(
+        "http_requests_in_flight",
+        lambda: Gauge(
+            "http_requests_in_flight",
+            "Number of HTTP requests currently being processed.",
+            _INFLIGHT_LABELS,
+        ),
+    )
+
+
+def _match_route_template(app: FastAPI, scope: Scope) -> str:
+    """Return the matched FastAPI route template for *scope*, or ``"<unmatched>"``.
+
+    Iterates the app's router and finds the first fully-matching route, using
+    Starlette's own matcher to stay consistent with how FastAPI dispatches
+    requests. This bounds the ``route`` label cardinality to the number of
+    declared routes.
+    """
+    if scope.get("type") != "http":
+        return "<unmatched>"
+    for route in app.router.routes:
+        try:
+            match, _ = route.matches(scope)
+        except Exception:
+            continue
+        if match == Match.FULL:
+            template = getattr(route, "path", None)
+            if template:
+                return template
+    return "<unmatched>"
+
+
+class _PrometheusMiddleware:
+    """ASGI middleware that records request count, duration, and in-flight gauge."""
+
+    def __init__(self, app: ASGIApp, *, fastapi_app: FastAPI, service: str) -> None:
+        self._app = app
+        self._fastapi_app = fastapi_app
+        self._service = service
+        self._counter = _requests_total()
+        self._histogram = _request_duration_seconds()
+        self._in_flight = _requests_in_flight()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        # Skip instrumenting the /metrics scrape itself to avoid recursive
+        # cardinality blow-up on every Prometheus poll.
+        if scope.get("path") == "/metrics":
+            await self._app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET")
+        route = _match_route_template(self._fastapi_app, scope)
+        status_holder: dict[str, int] = {"status": 500}
+
+        async def _send(message: Any) -> None:
+            if message.get("type") == "http.response.start":
+                status_holder["status"] = int(message.get("status", 500))
+            await send(message)
+
+        self._in_flight.labels(service=self._service).inc()
+        start = time.perf_counter()
+        try:
+            await self._app(scope, receive, _send)
+        finally:
+            elapsed = time.perf_counter() - start
+            self._in_flight.labels(service=self._service).dec()
+            status = str(status_holder["status"])
+            self._counter.labels(
+                service=self._service,
+                method=method,
+                route=route,
+                status=status,
+            ).inc()
+            self._histogram.labels(
+                service=self._service,
+                method=method,
+                route=route,
+                status=status,
+            ).observe(elapsed)
+
+
+def install_metrics(app: FastAPI, *, service: str) -> None:
+    """Install Prometheus metrics collection on *app*.
+
+    Mounts ``GET /metrics`` returning the default global ``REGISTRY`` in
+    Prometheus text exposition format, and registers an ASGI middleware that
+    records request count, duration, and in-flight gauge labelled by
+    ``service``, ``method``, ``route`` (collapsed to the matched route
+    template), and ``status``.
+
+    The default ``prometheus_client`` process, GC, and platform collectors are
+    already attached to the global ``REGISTRY`` at import time — no extra
+    registration is required here.
+    """
+    if not service:
+        raise ValueError("install_metrics requires a non-empty 'service' label")
+
+    # Prime the collectors so the metric names exist on REGISTRY even before the
+    # first request arrives (useful for initial scrapes).
+    _requests_total()
+    _request_duration_seconds()
+    _requests_in_flight()
+
+    app.add_middleware(_PrometheusMiddleware, fastapi_app=app, service=service)
+
+    @app.get("/metrics", include_in_schema=False)
+    def _metrics() -> Response:
+        return Response(
+            content=generate_latest(REGISTRY),
+            media_type=_PROM_CONTENT_TYPE,
+        )

--- a/digigraph/ARCHITECTURE.md
+++ b/digigraph/ARCHITECTURE.md
@@ -711,3 +711,7 @@ This complements DigiSmith's LangSmith tracing with operational metrics visible 
 **Problem:** The rate limiter trusts `X-Forwarded-For` without validation (see Section 6.7).
 
 **Recommendation:** Add a `DIGI_TRUSTED_PROXIES` env var (CIDR list). Only trust `X-Forwarded-For` when the actual `request.client.host` is in the trusted proxy list. Otherwise, use `request.client.host` directly. This prevents IP spoofing of rate limits.
+
+## Observability
+
+This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).

--- a/digigraph/src/digigraph/server.py
+++ b/digigraph/src/digigraph/server.py
@@ -39,6 +39,7 @@ def _allowed_origins() -> list[str]:
     return [_subst_env(o.strip()) for o in raw.split(",") if o.strip()]
 
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digigraph_path_scopes
 from digigraph.formatters import get_stream_formatter
@@ -52,6 +53,7 @@ app = FastAPI(
     description="Orchestration brain: run_digigraph_workflow (DigiClaw custom skill)",
     version="0.1.0",
 )
+install_metrics(app, service="digigraph")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins(),

--- a/digikey/ARCHITECTURE.md
+++ b/digikey/ARCHITECTURE.md
@@ -527,3 +527,7 @@ For production environments subject to audit or compliance requirements, the pri
 - Key rotation is managed by Vault, not DigiKey deployment cycles.
 
 Until this is implemented, at minimum rotate `DIGIKEY_PRIVATE_KEY_PEM` on a regular schedule (monthly) and store it in a secrets manager (AWS Secrets Manager, 1Password Secrets Automation) rather than in `.env` files on disk.
+
+## Observability
+
+This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from digibase.errors import register_fastapi_error_handlers
+from digibase.metrics import install_metrics
 
 from digikey.crypto_keys import load_or_create_signing_key
 from digikey.db import init_db, session_factory
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="DigiKey", version="0.1.0")
 register_rate_limit_handler(app)
+install_metrics(app, service="digikey")
 
 _private_key, _kid = load_or_create_signing_key()
 

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -647,3 +647,7 @@ The `_run_trial()` function in `optimize.py` is already structured as a top-leve
 - `digiquant_rate_limit_rejections_total` (counter, labeled by `path`) — identifies rate limit pressure
 
 These metrics complement DigiSmith's LLM-level tracing by providing infrastructure-level observability on the compute-intensive quant path.
+
+## Observability
+
+This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).

--- a/digiquant/src/digiquant/server.py
+++ b/digiquant/src/digiquant/server.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digiquant_path_scopes
 
@@ -57,6 +58,7 @@ app = FastAPI(
     description="High-perf backtest/optimize/export API for DigiGraph (MCP in Phase 2)",
     version="0.1.0",
 )
+install_metrics(app, service="digiquant")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins(),

--- a/digisearch/ARCHITECTURE.md
+++ b/digisearch/ARCHITECTURE.md
@@ -907,3 +907,7 @@ The embedding cache already logs hit rates at INFO level — these should become
 4. Provide a `digisearch index reembed --index <name>` CLI command that re-embeds and upserts all chunks under the new model
 
 The `EmbeddingModelSpec.version` field in `embeddings/config.py` is the right anchor point — it needs to be persisted to and read from the index, not just held in env vars.
+
+## Observability
+
+This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).

--- a/digisearch/src/digisearch/server.py
+++ b/digisearch/src/digisearch/server.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Any
 
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digisearch_path_scopes
 
@@ -45,6 +46,7 @@ app = FastAPI(
     description="RAG, document search for Digi ecosystem. MCP tools for DigiGraph/DigiFlow.",
     version="0.1.0",
 )
+install_metrics(app, service="digisearch")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins(),

--- a/digismith/ARCHITECTURE.md
+++ b/digismith/ARCHITECTURE.md
@@ -422,3 +422,7 @@ Define a `DIGISMITH_SAMPLE_RATES` environment variable accepting JSON:
 ```
 
 The `traceable` decorator wrapper should read this config and apply head-based sampling before forwarding to LangSmith. This prevents trace volume from growing linearly with traffic for high-frequency, low-value calls (e.g. repeated tool-checking completions) while preserving full fidelity for business-critical flows (backtests, research workflows).
+
+## Observability
+
+This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).

--- a/digismith/src/digismith/server.py
+++ b/digismith/src/digismith/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 from digibase.errors import register_fastapi_error_handlers
+from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from fastapi import FastAPI, Request
 
@@ -16,6 +17,7 @@ app = FastAPI(
     description="LangSmith-aligned observability control plane (DigiThings)",
     version=__version__,
 )
+install_metrics(app, service="digismith")
 
 
 @app.middleware("http")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,8 +343,60 @@ services:
       retries: 5
       start_period: 25s
 
+  # ─── Prometheus: pull-based metrics scraper (profile: observability; see ADR-0003) ───
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: digi-prometheus
+    profiles:
+      - observability
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./docs/ops/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.listen-address=0.0.0.0:9090"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:9090/-/ready"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ─── Grafana: metrics dashboards (profile: observability) ───
+  grafana:
+    image: grafana/grafana:latest
+    container_name: digi-grafana
+    profiles:
+      - observability
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+    volumes:
+      - ./docs/ops/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docs/ops/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
 volumes:
   ollama_data:
   digichat_pg:
   digikey_data:
   digisearch_chroma:
+  prometheus_data:
+  grafana_data:

--- a/docs/ops/grafana/dashboards/digithings-overview.json
+++ b/docs/ops/grafana/dashboards/digithings-overview.json
@@ -1,0 +1,162 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "DigiThings core stack overview — request rate, errors, latency, in-flight, memory. Seeded by ADR-0003.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "HTTP requests per second, by service.",
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (service) (rate(http_requests_total[1m]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate (per service)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "5xx error rate per service.",
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (service) (rate(http_requests_total{status=~\"5..\"}[1m]))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate (5xx)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Request duration p50 by service.",
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum by (le, service) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p50",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Request duration p95 by service.",
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
+      "id": 4,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Request duration p99 by service.",
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum by (le, service) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Concurrent requests in flight by service.",
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (service) (http_requests_in_flight)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "In-flight requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Resident set size reported by the Python process collector.",
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Process RSS",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["digithings", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "DigiThings — Overview",
+  "uid": "digithings-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/ops/grafana/provisioning/dashboards/default.yml
+++ b/docs/ops/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,15 @@
+# Grafana dashboard provisioning: load JSON dashboards from /var/lib/grafana/dashboards.
+# See docs/adr/0003-observability-baseline.md.
+apiVersion: 1
+
+providers:
+  - name: DigiThings
+    orgId: 1
+    folder: DigiThings
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docs/ops/grafana/provisioning/datasources/prometheus.yml
+++ b/docs/ops/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+# Grafana datasource provisioning: register Prometheus automatically.
+# See docs/adr/0003-observability-baseline.md.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s

--- a/docs/ops/prometheus/prometheus.yml
+++ b/docs/ops/prometheus/prometheus.yml
@@ -1,0 +1,52 @@
+# Prometheus scrape configuration for the DigiThings core stack.
+# See docs/adr/0003-observability-baseline.md.
+#
+# All five FastAPI services expose /metrics via digibase.metrics.install_metrics.
+# Targets resolve on the internal Docker Compose network; the Prometheus
+# container itself binds only to 127.0.0.1 on the host.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    deployment: digithings-dev
+
+scrape_configs:
+  - job_name: digigraph
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["digigraph:8000"]
+        labels:
+          service: digigraph
+
+  - job_name: digiquant
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["digiquant:8001"]
+        labels:
+          service: digiquant
+
+  - job_name: digisearch
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["digisearch:8002"]
+        labels:
+          service: digisearch
+
+  - job_name: digismith
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["digismith:8003"]
+        labels:
+          service: digismith
+
+  - job_name: digikey
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["digikey:8005"]
+        labels:
+          service: digikey
+
+  - job_name: prometheus
+    static_configs:
+      - targets: ["127.0.0.1:9090"]

--- a/tests/db/test_metrics.py
+++ b/tests/db/test_metrics.py
@@ -1,0 +1,120 @@
+"""Unit tests for digibase.metrics.install_metrics."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from digibase.metrics import install_metrics
+
+pytestmark = pytest.mark.unit
+
+
+def _build_app(service: str = "digitest") -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.get("/items/{item_id}")
+    def item(item_id: str) -> dict[str, str]:
+        return {"item": item_id}
+
+    @app.get("/boom")
+    def boom() -> dict[str, str]:
+        raise HTTPException(status_code=418, detail="nope")
+
+    install_metrics(app, service=service)
+    return app
+
+
+def test_metrics_endpoint_content_type_and_format() -> None:
+    app = _build_app()
+    with TestClient(app) as client:
+        resp = client.get("/metrics")
+    assert resp.status_code == 200
+    # Prometheus text exposition content type (exact shape per ADR-0003).
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert "version=0.0.4" in resp.headers["content-type"]
+    assert "charset=utf-8" in resp.headers["content-type"]
+    body = resp.text
+    # All three instrument families are registered up-front (even before traffic).
+    assert "http_requests_total" in body
+    assert "http_request_duration_seconds" in body
+    assert "http_requests_in_flight" in body
+
+
+def test_counter_increments_with_service_method_route_status_labels() -> None:
+    app = _build_app(service="digitest_counter")
+    with TestClient(app) as client:
+        client.get("/ping")
+        client.get("/items/42")
+        client.get("/items/99")
+        body = client.get("/metrics").text
+
+    # Route label is collapsed to the matched template, not the raw path.
+    assert 'service="digitest_counter"' in body
+    assert 'route="/ping"' in body
+    assert 'route="/items/{item_id}"' in body
+    # Raw path params must not leak into labels (cardinality guard).
+    assert 'route="/items/42"' not in body
+    assert 'method="GET"' in body
+    assert 'status="200"' in body
+
+
+def test_histogram_records_duration_with_expected_labels() -> None:
+    app = _build_app(service="digitest_hist")
+    with TestClient(app) as client:
+        client.get("/ping")
+        body = client.get("/metrics").text
+
+    # Histogram exports _bucket, _count, _sum series with full label set.
+    assert "http_request_duration_seconds_bucket" in body
+    assert "http_request_duration_seconds_count" in body
+    assert "http_request_duration_seconds_sum" in body
+    assert 'service="digitest_hist"' in body
+    assert 'route="/ping"' in body
+
+
+def test_in_flight_gauge_registered() -> None:
+    app = _build_app(service="digitest_gauge")
+    with TestClient(app) as client:
+        client.get("/ping")
+        body = client.get("/metrics").text
+
+    # Gauge is service-labelled only (no method/route/status).
+    assert "http_requests_in_flight" in body
+    assert 'http_requests_in_flight{service="digitest_gauge"}' in body
+
+
+def test_http_error_status_recorded() -> None:
+    app = _build_app(service="digitest_err")
+    with TestClient(app) as client:
+        resp = client.get("/boom")
+        assert resp.status_code == 418
+        body = client.get("/metrics").text
+
+    # 418 status ends up on the counter label without dropping the request.
+    assert 'status="418"' in body
+    assert 'route="/boom"' in body
+
+
+def test_metrics_endpoint_itself_is_not_counted() -> None:
+    app = _build_app(service="digitest_self")
+    with TestClient(app) as client:
+        # Hit /metrics twice; neither call should increment http_requests_total.
+        first = client.get("/metrics").text
+        second = client.get("/metrics").text
+
+    # The /metrics route must not appear as a labelled series — we explicitly
+    # skip instrumenting it to avoid cardinality/recursion on every scrape.
+    assert 'route="/metrics"' not in first
+    assert 'route="/metrics"' not in second
+
+
+def test_install_metrics_requires_service_label() -> None:
+    app = FastAPI()
+    with pytest.raises(ValueError):
+        install_metrics(app, service="")


### PR DESCRIPTION
Closes #4

Implements [ADR-0003](docs/adr/0003-observability-baseline.md) end-to-end.

## Summary
- `digibase.metrics.install_metrics(app, service=...)` — mounts `GET /metrics` (`text/plain; version=0.0.4; charset=utf-8`) and an ASGI middleware that records `http_requests_total{service,method,route,status}` (Counter), `http_request_duration_seconds{...}` (Histogram with API-tuned buckets), and `http_requests_in_flight{service}` (Gauge). Route label is collapsed to the matched FastAPI route template so cardinality stays bounded. `/metrics` itself is excluded from instrumentation.
- Wired into **digigraph**, **digiquant**, **digisearch**, **digismith**, **digikey** at app construction.
- `docker-compose.yml` gains `prometheus` (127.0.0.1:9090) and `grafana` (127.0.0.1:3001) behind a new `observability` profile, plus `prometheus_data` / `grafana_data` volumes.
- Config shipped in-repo: `docs/ops/prometheus/prometheus.yml`, `docs/ops/grafana/provisioning/{datasources,dashboards}/*.yml`, and a seed dashboard `docs/ops/grafana/dashboards/digithings-overview.json` (per-service request rate, 5xx rate, p50/p95/p99 latency, in-flight, process RSS).
- New Make targets: `make up-observability`, `make down-observability`.
- `digibase` CI (`.github/workflows/digibase-test.yml`) now also runs `tests/db` unit tests.
- `digibase/ARCHITECTURE.md` documents the helper contract; each service's `ARCHITECTURE.md` notes `/metrics` is exposed.

## Test plan
- [x] `pytest tests/db -m unit -v` — 7/7 pass (content-type, counter/histogram/gauge presence, label set, template collapsing, 4xx status, self-exclusion, empty-service guard).
- [x] `ruff check` on digibase + tests/db + all five server.py files — clean.
- [x] `docker compose config --quiet` — compose file is valid.
- [x] `scripts/check_doc_links.py` — 80 markdown files clean.
- [ ] Docker E2E (`make up` → `curl /metrics` → `make up-observability` → confirm targets UP in Prometheus and seed dashboard renders in Grafana) — **not run in this sandbox**; expected to pass given the unit tests and compose validation, but should be smoke-tested on a machine with Docker before merge.

## Notes
- `prometheus-client` 0.25 defaults `CONTENT_TYPE_LATEST` to OpenMetrics 1.0.0; we hardcode the ADR-mandated `text/plain; version=0.0.4; charset=utf-8` so the contract is stable across library upgrades.
- `/metrics` is loopback-bound via the compose port mapping; it has no auth and carries no secrets (route labels are templates, not raw paths). `/v1/status` remains untouched per AGENTS.md.