### PR TITLE
feat(hardening): env-driven CORS allowlist across all services

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,47 @@ today's loopback-bound, single-instance DigiKey deployment, per-process
 buckets are sufficient to blunt brute-force attempts against the bcrypt
 verify path.
 
+## CORS policy
+
+Every FastAPI service (DigiGraph, DigiQuant, DigiSearch, DigiSmith, DigiKey)
+installs CORS middleware via the shared helper
+[`digibase.cors.install_cors`](digibase/src/digibase/cors.py). The helper reads
+an **explicit allowlist** from the environment — there is no wildcard
+(`*`) default, and there is no default that accepts arbitrary browser origins.
+
+**Precedence** (first non-empty wins):
+
+1. `<SERVICE>_CORS_ORIGINS` — per-service override
+   (`DIGIGRAPH_CORS_ORIGINS`, `DIGIQUANT_CORS_ORIGINS`,
+   `DIGISEARCH_CORS_ORIGINS`, `DIGISMITH_CORS_ORIGINS`,
+   `DIGIKEY_CORS_ORIGINS`).
+2. `DIGI_CORS_ORIGINS` — global allowlist shared by every service.
+3. `DIGI_ALLOWED_ORIGINS` — legacy global allowlist (back-compat; deprecated,
+   will be removed after downstream configs migrate).
+4. *(unset)* — the allowlist is **empty**. Browsers are denied the
+   `Access-Control-Allow-Origin` header; no cross-origin script can call the
+   service. Loopback server-to-server traffic is unaffected because CORS is a
+   browser-enforced policy.
+
+All four env vars accept a comma-separated list of origins. Each origin may
+contain `${VAR}` / `$VAR` references that are expanded from the process
+environment at startup, e.g. `https://${UI_HOST}`.
+
+**Fixed middleware profile** (not configurable — keeps the attack surface
+predictable):
+
+- `allow_credentials=True` — required for cookie/session-based bearer flow
+  from DigiChat.
+- `allow_methods=["GET","POST","PUT","DELETE","OPTIONS"]` — no `TRACE`,
+  `CONNECT`, or wildcard.
+- `allow_headers=["Authorization","Content-Type","X-Request-ID"]` — the
+  minimum set used across the stack.
+- `max_age=600` — browser caches the preflight response for 10 minutes.
+
+Deployments that serve a browser UI **must** set at least one of the env vars
+above. `scripts/run_stack_local.sh` defaults to localhost origins for dev
+ergonomics; production deployments set the exact DigiChat origin.
+
 ## Revocation
 
 JWT revocation before natural expiry is a roadmap item (tracked under the [DigiKey revocation epic](https://github.com/digithings-ai/digithings/issues/6)). Today, revocation requires rotating the signing key or waiting for token expiry. Design any deployment with token TTLs short enough that this is acceptable.

--- a/digibase/src/digibase/__init__.py
+++ b/digibase/src/digibase/__init__.py
@@ -1,5 +1,6 @@
 """DigiThings shared platform utilities (HTTP, errors, audit redaction, metrics, optional OTel)."""
 
+from digibase.cors import install_cors, resolve_cors_origins
 from digibase.http import outbound_request_id_headers
 from digibase.http_client import DEFAULT_TIMEOUT, async_client, sync_client
 from digibase.metrics import install_metrics
@@ -7,7 +8,9 @@ from digibase.metrics import install_metrics
 __all__ = [
     "DEFAULT_TIMEOUT",
     "async_client",
+    "install_cors",
     "install_metrics",
     "outbound_request_id_headers",
+    "resolve_cors_origins",
     "sync_client",
 ]

--- a/digibase/src/digibase/cors.py
+++ b/digibase/src/digibase/cors.py
@@ -1,0 +1,77 @@
+"""Shared CORS middleware installer for DigiThings FastAPI services.
+
+Exposes :func:`install_cors` which reads an explicit allowlist from the
+environment and applies Starlette's :class:`CORSMiddleware` with a fixed,
+minimal method/header profile.
+
+Precedence (first non-empty wins):
+
+1. ``<SERVICE>_CORS_ORIGINS`` — per-service override (e.g. ``DIGIGRAPH_CORS_ORIGINS``).
+2. ``DIGI_CORS_ORIGINS``      — global allowlist.
+3. ``DIGI_ALLOWED_ORIGINS``   — legacy global allowlist (back-compat; deprecated).
+4. ``[]``                     — empty (most restrictive). Deployments must set
+   one of the above; without it, no browser origin is accepted.
+
+Each origin may contain ``${VAR}`` / ``$VAR`` references expanded from the
+current environment at call time, e.g. ``http://${API_HOST}:3000``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+__all__ = ["install_cors", "resolve_cors_origins"]
+
+_VAR_PATTERN = re.compile(r"\$\{(\w+)\}|\$(\w+)")
+
+_ALLOWED_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+_ALLOWED_HEADERS = ["Authorization", "Content-Type", "X-Request-ID"]
+_MAX_AGE = 600
+
+
+def _subst_env(s: str) -> str:
+    """Expand ``${VAR}`` / ``$VAR`` patterns using the current environment."""
+    return _VAR_PATTERN.sub(lambda m: os.environ.get(m.group(1) or m.group(2), ""), s)
+
+
+def _parse(raw: str) -> list[str]:
+    return [_subst_env(o.strip()) for o in raw.split(",") if o.strip()]
+
+
+def resolve_cors_origins(service: str) -> list[str]:
+    """Resolve the CORS allowlist for *service* using the documented precedence.
+
+    Returns an empty list when no env var is set — the most restrictive default.
+    """
+    per_service = os.environ.get(f"{service.upper()}_CORS_ORIGINS", "").strip()
+    if per_service:
+        return _parse(per_service)
+    global_new = os.environ.get("DIGI_CORS_ORIGINS", "").strip()
+    if global_new:
+        return _parse(global_new)
+    legacy = os.environ.get("DIGI_ALLOWED_ORIGINS", "").strip()
+    if legacy:
+        return _parse(legacy)
+    return []
+
+
+def install_cors(app: FastAPI, service: str) -> None:
+    """Install CORS middleware on *app* using the allowlist for *service*.
+
+    The allowlist is resolved at call time via :func:`resolve_cors_origins`.
+    ``allow_credentials=True`` is set because DigiChat forwards the DigiKey
+    bearer cookie/session on cross-origin fetches; methods/headers are the
+    minimum set used across the stack.
+    """
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=resolve_cors_origins(service),
+        allow_credentials=True,
+        allow_methods=_ALLOWED_METHODS,
+        allow_headers=_ALLOWED_HEADERS,
+        max_age=_MAX_AGE,
+    )

--- a/digigraph/ARCHITECTURE.md
+++ b/digigraph/ARCHITECTURE.md
@@ -599,7 +599,7 @@ digigraph:
 | `DIGI_ALLOW_CODE_EXEC` | (empty) | Enable `data_engineer_agent` code execution: `1` / `true` |
 | `DIGI_RUN_DATA_DIR` | (empty) | Session dataset storage; enables `sitaas_rag` skill |
 | `DIGI_DISABLE_RATE_LIMIT` | (empty) | Disable rate limiting for tests/dev |
-| `DIGI_ALLOWED_ORIGINS` | `localhost:3000,8000,11434` | CORS allowed origins (comma-separated) |
+| `DIGI_CORS_ORIGINS` / `DIGIGRAPH_CORS_ORIGINS` | (empty) | CORS allowlist — applied via shared `digibase.cors.install_cors`. `DIGI_ALLOWED_ORIGINS` still honored as legacy fallback. See `SECURITY.md` §"CORS policy". |
 | `DIGI_TOOL_MESSAGE_MAX_CHARS` | `12000` | Max chars per tool result message to LLM |
 | `DIGI_LLM_CACHE_TTL_SECONDS` | `3600` | LLM response cache TTL |
 | `DIGI_INTERRUPT_AFTER_RESEARCH` | (empty) | Interrupt graph after research for HITL: `1` |

--- a/digigraph/src/digigraph/server.py
+++ b/digigraph/src/digigraph/server.py
@@ -17,27 +17,9 @@ _DEBUG_REQUEST_LOG: list[dict] = []
 _DEBUG_REQUEST_LOG_MAX = 5
 
 from fastapi import APIRouter, FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
-
-def _subst_env(s: str) -> str:
-    """Expand ${VAR} or $VAR patterns in *s* using current environment variables."""
-    import re
-    return re.sub(r"\$\{(\w+)\}|\$(\w+)", lambda m: os.environ.get(m.group(1) or m.group(2), ""), s)
-
-
-def _allowed_origins() -> list[str]:
-    """Read DIGI_ALLOWED_ORIGINS (comma-separated). Defaults to localhost origins when unset.
-
-    Each origin may contain ``${VAR}`` references that are expanded from the environment,
-    e.g. ``http://${API_HOST}:3000``.
-    """
-    raw = os.environ.get("DIGI_ALLOWED_ORIGINS", "").strip()
-    if not raw:
-        return ["http://localhost:3000", "http://localhost:8000", "http://localhost:11434"]
-    return [_subst_env(o.strip()) for o in raw.split(",") if o.strip()]
-
+from digibase.cors import install_cors, resolve_cors_origins
 from digibase.errors import json_error_response, register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
@@ -48,18 +30,28 @@ from digigraph.models import ChatCompletionRequest, WorkflowRequest, WorkflowRes
 from digigraph.policy import debug_endpoints_enabled, thread_api_enabled
 from digigraph.workflow import run_digigraph_workflow, run_digigraph_workflow_streaming
 
+
+def _allowed_origins() -> list[str]:
+    """Back-compat shim — resolves the digigraph CORS allowlist.
+
+    Kept for older tests / external callers. New code should use
+    :func:`digibase.cors.resolve_cors_origins`. Falls back to the historical
+    localhost defaults when *nothing* is configured so legacy callers that
+    expected a non-empty list continue to work.
+    """
+    origins = resolve_cors_origins("digigraph")
+    if origins:
+        return origins
+    return ["http://localhost:3000", "http://localhost:8000", "http://localhost:11434"]
+
+
 app = FastAPI(
     title="DigiGraph",
     description="Orchestration brain: run_digigraph_workflow (DigiClaw custom skill)",
     version="0.1.0",
 )
 install_metrics(app, service="digigraph")
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_allowed_origins(),
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+install_cors(app, service="digigraph")
 app.add_middleware(DigiAuthMiddleware, service="digigraph", path_scopes=digigraph_path_scopes)
 
 
@@ -320,12 +312,16 @@ def get_thread_history(thread_id: str):
         return JSONResponse(status_code=400, content={"detail": str(e)})
     out = []
     for snapshot in history:
-        out.append({
-            "values": _safe_state_values(snapshot.values if hasattr(snapshot, "values") else None),
-            "next": getattr(snapshot, "next", ()),
-            "metadata": getattr(snapshot, "metadata", None),
-            "created_at": getattr(snapshot, "created_at", None),
-        })
+        out.append(
+            {
+                "values": _safe_state_values(
+                    snapshot.values if hasattr(snapshot, "values") else None
+                ),
+                "next": getattr(snapshot, "next", ()),
+                "metadata": getattr(snapshot, "metadata", None),
+                "created_at": getattr(snapshot, "created_at", None),
+            }
+        )
     return {"thread_id": thread_id, "history": out}
 
 
@@ -344,6 +340,7 @@ def resume_thread(thread_id: str, body: dict | None = None):
         if resume_value is not None:
             try:
                 from langgraph.types import Command
+
                 result = graph.invoke(Command(resume=resume_value), config=config)
             except ImportError:
                 result = graph.invoke(None, config=config)
@@ -416,9 +413,7 @@ def list_models() -> dict:
     }
 
 
-def _build_completion(
-    req: ChatCompletionRequest, content: str, prompt: str
-) -> dict:
+def _build_completion(req: ChatCompletionRequest, content: str, prompt: str) -> dict:
     """Build OpenAI-compatible completion response."""
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
@@ -462,15 +457,15 @@ def _sse_chunk(
     if finish_reason is not None:
         if not content and not reasoning_content and digigraph_trace is None:
             delta = {}
-    return json.dumps({
-        "id": cid,
-        "object": "chat.completion.chunk",
-        "created": created,
-        "model": model,
-        "choices": [
-            {"index": 0, "delta": delta, "finish_reason": finish_reason}
-        ],
-    })
+    return json.dumps(
+        {
+            "id": cid,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+    )
 
 
 def _sse_stream(completion: dict) -> str:
@@ -524,7 +519,9 @@ def _stream_completions_progressive(
         """Emit reasoning buffer as a single <thinking> block for Open WebUI tag detection."""
         if not reasoning_buffer:
             return ""
-        block = "<thinking>\n" + "".join(str(x) for x in reasoning_buffer).strip() + "\n</thinking>\n\n"
+        block = (
+            "<thinking>\n" + "".join(str(x) for x in reasoning_buffer).strip() + "\n</thinking>\n\n"
+        )
         reasoning_buffer.clear()
         return block
 
@@ -564,13 +561,17 @@ def _stream_completions_progressive(
                 thinking_block = flush_reasoning_as_thinking()
                 if thinking_block:
                     yield f"data: {_sse_chunk(cid, created, model, thinking_block, None)}\n\n"
-                raw = data if isinstance(data, str) else (data or {}).get("delta", (data or {}).get("content", ""))
+                raw = (
+                    data
+                    if isinstance(data, str)
+                    else (data or {}).get("delta", (data or {}).get("content", ""))
+                )
                 content = (raw or "").replace("<", "&lt;").replace(">", "&gt;")
                 if content:
                     yield f"data: {_sse_chunk(cid, created, model, content, None)}\n\n"
     except Exception as e:
         logger.exception("stream_completions error")
-        yield f"data: {_sse_chunk(cid, created, model, f"Error: {e!s}", None)}\n\n"
+        yield f"data: {_sse_chunk(cid, created, model, f'Error: {e!s}', None)}\n\n"
 
     yield f"data: {_sse_chunk(cid, created, model, '', 'stop')}\n\n"
     yield "data: [DONE]\n\n"
@@ -636,7 +637,7 @@ def _log_and_store_request_summary(summary: dict) -> None:
         summary["session_id"],
     )
     global _DEBUG_REQUEST_LOG
-    _DEBUG_REQUEST_LOG = [summary] + _DEBUG_REQUEST_LOG[:_DEBUG_REQUEST_LOG_MAX - 1]
+    _DEBUG_REQUEST_LOG = [summary] + _DEBUG_REQUEST_LOG[: _DEBUG_REQUEST_LOG_MAX - 1]
 
 
 @v1.post("/chat/completions")

--- a/digikey/ARCHITECTURE.md
+++ b/digikey/ARCHITECTURE.md
@@ -531,3 +531,7 @@ Until this is implemented, at minimum rotate `DIGIKEY_PRIVATE_KEY_PEM` on a regu
 ## Observability
 
 This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).
+
+## CORS
+
+CORS is installed via the shared `digibase.cors.install_cors(app, service="digikey")` helper; allowlist precedence is `DIGIKEY_CORS_ORIGINS` → `DIGI_CORS_ORIGINS` → legacy `DIGI_ALLOWED_ORIGINS`, defaulting to empty. See `SECURITY.md` §"CORS policy".

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -11,6 +11,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
+from digibase.cors import install_cors
 from digibase.errors import register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="DigiKey", version="0.1.0")
 register_rate_limit_handler(app)
 install_metrics(app, service="digikey")
+install_cors(app, service="digikey")
 
 _private_key, _kid = load_or_create_signing_key()
 

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -392,7 +392,7 @@ All three broker adapters are stubs with no implementation. There is no credenti
 
 ### CORS Wildcard Risk
 
-CORS is configured via `_allowed_origins()`. When `DIGI_ALLOWED_ORIGINS` is not set, the default origins are `http://localhost:3000`, `http://localhost:8000`, and `http://localhost:11434`. This is appropriate for local development. In production, `DIGI_ALLOWED_ORIGINS` must be set to the exact DigiChat/DigiGraph origins. The `allow_methods=["*"]` and `allow_headers=["*"]` settings are permissive; restricting these to the minimum required set would reduce the attack surface.
+CORS is configured via the shared `digibase.cors.install_cors(app, service="digiquant")` helper. The allowlist is read from `DIGIQUANT_CORS_ORIGINS` → `DIGI_CORS_ORIGINS` → legacy `DIGI_ALLOWED_ORIGINS`, defaulting to **empty** (most restrictive). Methods and headers are restricted to `GET/POST/PUT/DELETE/OPTIONS` and `Authorization/Content-Type/X-Request-ID` respectively. See `SECURITY.md` §"CORS policy".
 
 ### Audit Log Secret Redaction
 
@@ -522,7 +522,7 @@ The data volume is mounted **read-only** (`/app/data:ro`), preventing strategies
 
 | Variable | Default | Description |
 |---|---|---|
-| `DIGI_ALLOWED_ORIGINS` | (localhost origins) | Comma-separated CORS origins; supports `${VAR}` expansion |
+| `DIGI_CORS_ORIGINS` / `DIGIQUANT_CORS_ORIGINS` | (empty) | Comma-separated CORS origins (supports `${VAR}` expansion). Legacy `DIGI_ALLOWED_ORIGINS` still honored. |
 | `DIGI_DISABLE_RATE_LIMIT` | `""` | Set to `1`/`true`/`yes` to disable rate limiting |
 | `DIGIQUANT_ALLOW_EXPORT` | `"1"` | Set to `0`/`false` to disable export node globally |
 | `DIGIQUANT_OPTIMIZE_WORKERS` | `os.cpu_count()` | Parallel processes for grid/random optimization |

--- a/digiquant/src/digiquant/server.py
+++ b/digiquant/src/digiquant/server.py
@@ -13,34 +13,16 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from digibase.cors import install_cors
 from digibase.errors import json_error_response, register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digiquant_path_scopes
 
 from fastapi import APIRouter, FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 
 logger = logging.getLogger(__name__)
-
-
-def _subst_env(s: str) -> str:
-    """Expand ${VAR} or $VAR patterns in *s* using current environment variables."""
-    import re
-    return re.sub(r"\$\{(\w+)\}|\$(\w+)", lambda m: os.environ.get(m.group(1) or m.group(2), ""), s)
-
-
-def _allowed_origins() -> list[str]:
-    """Read DIGI_ALLOWED_ORIGINS (comma-separated). Defaults to localhost origins when unset.
-
-    Each origin may contain ``${VAR}`` references that are expanded from the environment,
-    e.g. ``http://${API_HOST}:3000``.
-    """
-    raw = os.environ.get("DIGI_ALLOWED_ORIGINS", "").strip()
-    if not raw:
-        return ["http://localhost:3000", "http://localhost:8000", "http://localhost:11434"]
-    return [_subst_env(o.strip()) for o in raw.split(",") if o.strip()]
 
 from digiquant.addm import AddmResult, check_drift
 from digiquant.audit import audit_log as dq_audit_log
@@ -59,12 +41,7 @@ app = FastAPI(
     version="0.1.0",
 )
 install_metrics(app, service="digiquant")
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_allowed_origins(),
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+install_cors(app, service="digiquant")
 app.add_middleware(DigiAuthMiddleware, service="digiquant", path_scopes=digiquant_path_scopes)
 
 
@@ -91,7 +68,9 @@ def _rl_check(request: Request, max_req: int, window: int) -> JSONResponse | Non
     if os.environ.get("DIGI_DISABLE_RATE_LIMIT", "").lower() in ("1", "true", "yes"):
         return None
     xff = request.headers.get("X-Forwarded-For")
-    ip = xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")
+    ip = (
+        xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")
+    )
     if ip == "testclient":
         return None
     now = _time.monotonic()
@@ -142,14 +121,21 @@ class BacktestRequest(BaseModel):
 
     strategy_name: str = Field(..., description="Strategy name (required)")
     symbols: list[str] = Field(..., min_length=1, description="Instruments (required)")
-    data_path: str | None = Field(default=None, description="Path to single OHLCV CSV (overrides data_dir)")
+    data_path: str | None = Field(
+        default=None, description="Path to single OHLCV CSV (overrides data_dir)"
+    )
     data_dir: str | None = Field(default=None, description="Directory with {symbol}.csv files")
     strategy_params: dict[str, float | int | str] | None = Field(
         default=None,
         description="Optional strategy parameters (e.g. fast_ema_period, slow_ema_period)",
     )
-    tearsheet_path: str | None = Field(default=None, description="Write HTML tearsheet to this path")
-    full_tearsheet: bool = Field(default=True, description="Include extended charts (distributions, rolling metrics). Set false for faster results.")
+    tearsheet_path: str | None = Field(
+        default=None, description="Write HTML tearsheet to this path"
+    )
+    full_tearsheet: bool = Field(
+        default=True,
+        description="Include extended charts (distributions, rolling metrics). Set false for faster results.",
+    )
 
 
 class OptimizeRequest(BaseModel):
@@ -157,11 +143,15 @@ class OptimizeRequest(BaseModel):
 
     strategy_name: str = Field(..., description="Strategy name (required)")
     symbols: list[str] = Field(..., min_length=1, description="Instruments (required)")
-    param_grid: list[dict[str, float | int | str]] | None = Field(default=None, description="Explicit param grid (overrides auto)")
+    param_grid: list[dict[str, float | int | str]] | None = Field(
+        default=None, description="Explicit param grid (overrides auto)"
+    )
     method: str = Field(default="grid", description="grid | bayesian | random")
     n_trials: int = Field(default=50, description="Trials for bayesian/random")
     objective: str = Field(default="sharpe", description="sharpe | return | pnl")
-    constraints: OptimizationConstraints | None = Field(default=None, description="Hard limits (min_trades, max_drawdown_pct, etc.)")
+    constraints: OptimizationConstraints | None = Field(
+        default=None, description="Hard limits (min_trades, max_drawdown_pct, etc.)"
+    )
     data_path: str | None = Field(default=None, description="Path to single OHLCV CSV")
     data_dir: str | None = Field(default=None, description="Directory with {symbol}.csv files")
 
@@ -170,7 +160,9 @@ class ExportRequest(BaseModel):
     """Request body for /run_export."""
 
     strategy_name: str = Field(..., description="Strategy label")
-    params: dict[str, float | int | str] = Field(default_factory=dict, description="Best params from optimize")
+    params: dict[str, float | int | str] = Field(
+        default_factory=dict, description="Best params from optimize"
+    )
     target: str = Field(
         default="nautilus",
         description="nautilus | nautilus_bundle | tradingview | alpaca | quantconnect",
@@ -190,7 +182,9 @@ class PipelineRequest(BaseModel):
         description="Optional params for the initial backtest before optimize",
     )
     run_optimize: bool = Field(default=True, description="Run optimize after backtest")
-    run_export: bool = Field(default=True, description="Run export after optimize (if policy allows)")
+    run_export: bool = Field(
+        default=True, description="Run export after optimize (if policy allows)"
+    )
     method: str = Field(default="grid", description="Optimization method")
     n_trials: int = Field(default=50, ge=1, description="Max trials / grid size hint")
     constraints: OptimizationConstraints | None = Field(
@@ -228,7 +222,9 @@ def api_list_strategies() -> list[dict]:
 
 
 @app.get("/check_drift", response_model=AddmResult)
-def api_check_drift(strategy_id: str = "mean_reversion_tech", baseline_run_id: str | None = None) -> AddmResult:
+def api_check_drift(
+    strategy_id: str = "mean_reversion_tech", baseline_run_id: str | None = None
+) -> AddmResult:
     """Check ADDM drift for strategy. Phase 3: heartbeat calls this; if drift_detected, trigger re-optimize."""
     return check_drift(strategy_id=strategy_id, baseline_run_id=baseline_run_id)
 
@@ -255,7 +251,15 @@ def api_run_backtest(req: BacktestRequest) -> BacktestResult:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except RuntimeError as e:
         raise HTTPException(status_code=503, detail=str(e)) from e
-    dq_audit_log("run_backtest", agent_id="digiquant", payload={"strategy_name": req.strategy_name, "symbols": req.symbols, "run_id": result.run_id})
+    dq_audit_log(
+        "run_backtest",
+        agent_id="digiquant",
+        payload={
+            "strategy_name": req.strategy_name,
+            "symbols": req.symbols,
+            "run_id": result.run_id,
+        },
+    )
     return result
 
 
@@ -272,7 +276,16 @@ def _run_backtest_job(job_id: str, req: "BacktestRequest") -> None:
     """Run backtest in background thread; publish SSE events to the job queue."""
     q: Queue = _backtest_jobs[job_id]["queue"]
     try:
-        q.put(json.dumps({"event": "start", "job_id": job_id, "strategy": req.strategy_name, "symbols": req.symbols}))
+        q.put(
+            json.dumps(
+                {
+                    "event": "start",
+                    "job_id": job_id,
+                    "strategy": req.strategy_name,
+                    "symbols": req.symbols,
+                }
+            )
+        )
         result = service_run_backtest(
             strategy_name=req.strategy_name,
             symbols=req.symbols,
@@ -283,9 +296,19 @@ def _run_backtest_job(job_id: str, req: "BacktestRequest") -> None:
             full_tearsheet=req.full_tearsheet,
         )
         _backtest_jobs[job_id]["result"] = result
-        q.put(json.dumps({"event": "done", "job_id": job_id, "run_id": result.run_id,
-                          "total_pnl": result.total_pnl, "sharpe_ratio": result.sharpe_ratio,
-                          "num_trades": result.num_trades, "status": result.status}))
+        q.put(
+            json.dumps(
+                {
+                    "event": "done",
+                    "job_id": job_id,
+                    "run_id": result.run_id,
+                    "total_pnl": result.total_pnl,
+                    "sharpe_ratio": result.sharpe_ratio,
+                    "num_trades": result.num_trades,
+                    "status": result.status,
+                }
+            )
+        )
     except Exception as e:
         logger.error("Backtest job %s failed: %s", job_id, e)
         _backtest_jobs[job_id]["error"] = str(e)
@@ -380,7 +403,12 @@ def v1_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
             )
         except (ValueError, RuntimeError) as e:
             return {"ok": False, "error": str(e)}
-        return {"ok": True, "service": "digiquant", "tool": tool, "data": result.model_dump(mode="json")}
+        return {
+            "ok": True,
+            "service": "digiquant",
+            "tool": tool,
+            "data": result.model_dump(mode="json"),
+        }
 
     if tool == "digiquant_run_optimize":
         symbols = _normalize_symbols(args.get("symbols"))
@@ -408,7 +436,12 @@ def v1_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
             )
         except RuntimeError as e:
             return {"ok": False, "error": str(e)}
-        return {"ok": True, "service": "digiquant", "tool": tool, "data": result.model_dump(mode="json")}
+        return {
+            "ok": True,
+            "service": "digiquant",
+            "tool": tool,
+            "data": result.model_dump(mode="json"),
+        }
 
     if tool == "digiquant_run_export":
         if not args.get("strategy_name"):
@@ -422,7 +455,12 @@ def v1_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
             )
         except ValueError as e:
             return {"ok": False, "error": str(e)}
-        return {"ok": True, "service": "digiquant", "tool": tool, "data": result.model_dump(mode="json")}
+        return {
+            "ok": True,
+            "service": "digiquant",
+            "tool": tool,
+            "data": result.model_dump(mode="json"),
+        }
 
     if tool in ("digiquant_run_pipeline", "digiquant_pipeline_delegate"):
         symbols = _normalize_symbols(args.get("symbols"))
@@ -438,19 +476,21 @@ def v1_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
         try:
             if args.get("data_path") is None and args.get("data_dir") is None:
                 return {"ok": False, "error": "data_path or data_dir required"}
-            raw = run_quant_workflow({
-                "strategy_name": strategy,
-                "symbols": symbols,
-                "data_path": args.get("data_path"),
-                "data_dir": args.get("data_dir"),
-                "strategy_params": args.get("strategy_params"),
-                "export_target": str(args.get("export_target") or "nautilus"),
-                "run_optimize": bool(args.get("run_optimize", True)),
-                "run_export": bool(args.get("run_export", True)),
-                "method": str(args.get("method") or "grid"),
-                "n_trials": int(args.get("n_trials") or 50),
-                "constraints": constraints.model_dump(mode="json") if constraints else None,
-            })
+            raw = run_quant_workflow(
+                {
+                    "strategy_name": strategy,
+                    "symbols": symbols,
+                    "data_path": args.get("data_path"),
+                    "data_dir": args.get("data_dir"),
+                    "strategy_params": args.get("strategy_params"),
+                    "export_target": str(args.get("export_target") or "nautilus"),
+                    "run_optimize": bool(args.get("run_optimize", True)),
+                    "run_export": bool(args.get("run_export", True)),
+                    "method": str(args.get("method") or "grid"),
+                    "n_trials": int(args.get("n_trials") or 50),
+                    "constraints": constraints.model_dump(mode="json") if constraints else None,
+                }
+            )
         except (ValueError, RuntimeError) as e:
             return {"ok": False, "error": str(e)}
         if raw.get("error"):
@@ -529,18 +569,23 @@ async def api_backtest_progress(job_id: str) -> StreamingResponse:
         q: Queue = _backtest_jobs[job_id]["queue"]
         while True:
             try:
-                item = await asyncio.get_event_loop().run_in_executor(None, lambda: q.get(timeout=30))
+                item = await asyncio.get_event_loop().run_in_executor(
+                    None, lambda: q.get(timeout=30)
+                )
                 if item is None:
                     break
                 yield f"data: {item}\n\n"
             except Empty:
-                yield "data: {\"event\": \"heartbeat\"}\n\n"
+                yield 'data: {"event": "heartbeat"}\n\n'
             except Exception as e:
-                yield f"data: {{\"event\": \"error\", \"detail\": \"{e}\"}}\n\n"
+                yield f'data: {{"event": "error", "detail": "{e}"}}\n\n'
                 break
 
-    return StreamingResponse(event_generator(), media_type="text/event-stream",
-                              headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 @app.get("/backtest/{job_id}/result", response_model=BacktestResult)
@@ -550,7 +595,9 @@ async def api_backtest_result(job_id: str) -> BacktestResult:
     if job is None:
         raise HTTPException(status_code=404, detail=f"Job not found: {job_id!r}")
     if not job["done"]:
-        raise HTTPException(status_code=202, detail="Job still running. Poll /progress for updates.")
+        raise HTTPException(
+            status_code=202, detail="Job still running. Poll /progress for updates."
+        )
     if job["error"]:
         raise HTTPException(status_code=500, detail=job["error"])
     if job["result"] is None:
@@ -580,7 +627,15 @@ def api_run_optimize(req: OptimizeRequest) -> OptimizeResult:
         )
     except RuntimeError as e:
         raise HTTPException(status_code=503, detail=str(e)) from e
-    dq_audit_log("run_optimize", agent_id="digiquant", payload={"strategy_name": req.strategy_name, "run_id": result.run_id, "num_evaluations": result.num_evaluations})
+    dq_audit_log(
+        "run_optimize",
+        agent_id="digiquant",
+        payload={
+            "strategy_name": req.strategy_name,
+            "run_id": result.run_id,
+            "num_evaluations": result.num_evaluations,
+        },
+    )
     return result
 
 

--- a/digisearch/ARCHITECTURE.md
+++ b/digisearch/ARCHITECTURE.md
@@ -539,7 +539,7 @@ The `OpenAIEmbedder` (and other cloud providers) read API keys from environment 
 
 ### CORS policy
 
-`DIGI_ALLOWED_ORIGINS` controls allowed CORS origins. Default when unset: `localhost:3000`, `localhost:8000`, `localhost:11434`. This is acceptably restrictive for loopback deployments. Production deployments must explicitly set this.
+CORS is installed via the shared `digibase.cors.install_cors(app, service="digisearch")` helper. Allowlist precedence: `DIGISEARCH_CORS_ORIGINS` → `DIGI_CORS_ORIGINS` → legacy `DIGI_ALLOWED_ORIGINS`, defaulting to **empty** (most restrictive) when unset. Production deployments must explicitly set one of these. See `SECURITY.md` §"CORS policy".
 
 ### Rate limiting
 
@@ -747,7 +747,7 @@ docker compose --profile digisearch-mcp up
 | `DIGISEARCH_EMBEDDING_VERSION` | `1` | Logical version for index migration |
 | `OPENAI_API_KEY` | _(unset)_ | OpenAI API key for OpenAIEmbedder |
 | `COHERE_API_KEY` | _(unset)_ | Cohere key for CohereEmbedder / CohereReranker |
-| `DIGI_ALLOWED_ORIGINS` | localhost defaults | Comma-separated CORS allowed origins |
+| `DIGI_CORS_ORIGINS` / `DIGISEARCH_CORS_ORIGINS` | (empty) | Comma-separated CORS allowed origins; legacy `DIGI_ALLOWED_ORIGINS` still honored |
 | `DIGI_DISABLE_RATE_LIMIT` | `0` | Disable per-IP rate limiting (testing) |
 | `DIGIKEY_JWKS_URL` | _(required)_ | DigiKey JWKS endpoint for JWT validation |
 | `DIGIKEY_ISSUER` | _(required)_ | JWT issuer |

--- a/digisearch/src/digisearch/server.py
+++ b/digisearch/src/digisearch/server.py
@@ -7,6 +7,7 @@ import os
 import uuid
 from typing import Any
 
+from digibase.cors import install_cors
 from digibase.errors import json_error_response, register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
@@ -16,29 +17,10 @@ from digisearch.core.models import Query
 from digisearch.search._stub import add_chunks, query_index
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
-
-
-def _subst_env(s: str) -> str:
-    """Expand ${VAR} or $VAR patterns in *s* using current environment variables."""
-    import re
-    return re.sub(r"\$\{(\w+)\}|\$(\w+)", lambda m: os.environ.get(m.group(1) or m.group(2), ""), s)
-
-
-def _allowed_origins() -> list[str]:
-    """Read DIGI_ALLOWED_ORIGINS (comma-separated). Defaults to localhost origins when unset.
-
-    Each origin may contain ``${VAR}`` references that are expanded from the environment,
-    e.g. ``http://${API_HOST}:3000``.
-    """
-    raw = os.environ.get("DIGI_ALLOWED_ORIGINS", "").strip()
-    if not raw:
-        return ["http://localhost:3000", "http://localhost:8000", "http://localhost:11434"]
-    return [_subst_env(o.strip()) for o in raw.split(",") if o.strip()]
 
 
 app = FastAPI(
@@ -47,19 +29,18 @@ app = FastAPI(
     version="0.1.0",
 )
 install_metrics(app, service="digisearch")
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_allowed_origins(),
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+install_cors(app, service="digisearch")
 app.add_middleware(DigiAuthMiddleware, service="digisearch", path_scopes=digisearch_path_scopes)
 
 
 @app.on_event("startup")
 def _require_real_search_backend() -> None:
     """Fail startup unless Azure, Chroma, or DIGISEARCH_ALLOW_STUB=1 (unit tests) is set."""
-    allow_stub = os.environ.get("DIGISEARCH_ALLOW_STUB", "0").strip().lower() in ("1", "true", "yes")
+    allow_stub = os.environ.get("DIGISEARCH_ALLOW_STUB", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     if allow_stub:
         logger.warning("DigiSearch: DIGISEARCH_ALLOW_STUB=1 — in-memory stub allowed (tests only).")
         return
@@ -99,7 +80,9 @@ def _rl_check(request: Request, max_req: int, window: int) -> JSONResponse | Non
     if os.environ.get("DIGI_DISABLE_RATE_LIMIT", "").lower() in ("1", "true", "yes"):
         return None
     xff = request.headers.get("X-Forwarded-For")
-    ip = xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")
+    ip = (
+        xff.split(",")[0].strip() if xff else (request.client.host if request.client else "unknown")
+    )
     if ip == "testclient":
         return None
     now = _time.monotonic()
@@ -152,19 +135,44 @@ class QueryRequest(BaseModel):
     index_name: str = Field(default="default", description="Index/collection name")
     top_k: int = Field(default=10, ge=1, le=100)
     mode: str = Field(default="hybrid", description="keyword | vector | hybrid")
-    format: str = Field(default="default", description="default | table — table returns formatted markdown in response.formatted")
-    filter: str | None = Field(default=None, description="Raw OData filter (when index allow_raw_filter)")
-    filters: list[dict[str, Any]] | None = Field(default=None, description="Structured filters [{field, op, value}]")
+    format: str = Field(
+        default="default",
+        description="default | table — table returns formatted markdown in response.formatted",
+    )
+    filter: str | None = Field(
+        default=None, description="Raw OData filter (when index allow_raw_filter)"
+    )
+    filters: list[dict[str, Any]] | None = Field(
+        default=None, description="Structured filters [{field, op, value}]"
+    )
     columns: list[str] | None = Field(default=None, description="Metadata columns to return")
-    response_mode: str = Field(default="full", description="full | summary — return full rows or data summary")
-    summarize_if_over: int | None = Field(default=None, ge=1, description="If result count > this, return summary instead of full")
-    facets: list[str] | None = Field(default=None, description="Azure: facet expressions e.g. ['sourceType', 'itemType,count:20']")
-    highlight_fields: list[str] | None = Field(default=None, description="Azure: fields to highlight matches in (searchable fields)")
-    highlight_pre_tag: str | None = Field(default=None, description="Azure: tag before highlighted term e.g. '<em>'")
-    highlight_post_tag: str | None = Field(default=None, description="Azure: tag after highlighted term e.g. '</em>'")
-    order_by: list[str] | None = Field(default=None, description="Azure: sort clauses e.g. ['sentDateTime desc', 'search.score() desc']")
+    response_mode: str = Field(
+        default="full", description="full | summary — return full rows or data summary"
+    )
+    summarize_if_over: int | None = Field(
+        default=None, ge=1, description="If result count > this, return summary instead of full"
+    )
+    facets: list[str] | None = Field(
+        default=None,
+        description="Azure: facet expressions e.g. ['sourceType', 'itemType,count:20']",
+    )
+    highlight_fields: list[str] | None = Field(
+        default=None, description="Azure: fields to highlight matches in (searchable fields)"
+    )
+    highlight_pre_tag: str | None = Field(
+        default=None, description="Azure: tag before highlighted term e.g. '<em>'"
+    )
+    highlight_post_tag: str | None = Field(
+        default=None, description="Azure: tag after highlighted term e.g. '</em>'"
+    )
+    order_by: list[str] | None = Field(
+        default=None,
+        description="Azure: sort clauses e.g. ['sentDateTime desc', 'search.score() desc']",
+    )
     skip: int = Field(default=0, ge=0, description="Pagination offset (page size = top_k)")
-    include_total_count: bool = Field(default=False, description="When true, total is full match count for pagination")
+    include_total_count: bool = Field(
+        default=False, description="When true, total is full match count for pagination"
+    )
     workspace_id: str | None = Field(
         default=None,
         description="Optional tenant/workspace id for index isolation or filters (enterprise).",
@@ -178,9 +186,15 @@ class QueryResponse(BaseModel):
     query: str
     index_name: str
     total: int
-    formatted: str | None = Field(default=None, description="When format=table, markdown table string for display")
-    summary: dict[str, Any] | None = Field(default=None, description="Data summary when response_mode=summary or over threshold")
-    facets: dict[str, list[dict[str, Any]]] | None = Field(default=None, description="Facet counts by field when facets requested (Azure)")
+    formatted: str | None = Field(
+        default=None, description="When format=table, markdown table string for display"
+    )
+    summary: dict[str, Any] | None = Field(
+        default=None, description="Data summary when response_mode=summary or over threshold"
+    )
+    facets: dict[str, list[dict[str, Any]]] | None = Field(
+        default=None, description="Facet counts by field when facets requested (Azure)"
+    )
     backend: str | None = Field(
         default=None,
         description="Index backend that served the query: azure_ai_search | chroma | stub",
@@ -246,7 +260,10 @@ def azure_status() -> dict[str, bool | str]:
         from digisearch.indexes.backends.azure_search import is_azure_configured, _get_client
 
         if not is_azure_configured():
-            return {"configured": False, "message": "Set AZURE_SEARCH_ENDPOINT, AZURE_SEARCH_API_KEY, AZURE_SEARCH_INDEX_NAME"}
+            return {
+                "configured": False,
+                "message": "Set AZURE_SEARCH_ENDPOINT, AZURE_SEARCH_API_KEY, AZURE_SEARCH_INDEX_NAME",
+            }
         client = _get_client()
         if client is None:
             return {"configured": True, "reachable": False, "message": "Client init failed"}
@@ -291,7 +308,9 @@ def run_query(req: QueryRequest) -> QueryResponse:
         order_by=req.order_by,
         skip=req.skip,
         include_total_count=req.include_total_count,
-        workspace_id=(req.workspace_id.strip() if req.workspace_id and req.workspace_id.strip() else None),
+        workspace_id=(
+            req.workspace_id.strip() if req.workspace_id and req.workspace_id.strip() else None
+        ),
     )
     response = query_index(q, index_name=req.index_name)
     results = response.results
@@ -342,7 +361,9 @@ class OrchestratorToolsRequest(BaseModel):
 class OrchestratorInvokeRequest(BaseModel):
     """Request for POST /v1/orchestrator_invoke."""
 
-    tool: str = Field(..., description="digisearch | digisearch_fetch_all | digisearch_research_delegate")
+    tool: str = Field(
+        ..., description="digisearch | digisearch_fetch_all | digisearch_research_delegate"
+    )
     arguments: dict[str, Any] = Field(default_factory=dict)
     default_index_name: str | None = Field(
         default=None,
@@ -413,7 +434,9 @@ def api_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
     """Execute one DigiSearch orchestrator tool by name (hub dispatch)."""
     tool = (req.tool or "").strip()
     args = req.arguments if isinstance(req.arguments, dict) else {}
-    default_idx = (req.default_index_name or os.environ.get("DIGISEARCH_INDEX", "default") or "default").strip()
+    default_idx = (
+        req.default_index_name or os.environ.get("DIGISEARCH_INDEX", "default") or "default"
+    ).strip()
 
     if tool == "digisearch":
         top_raw = args.get("top_k", 10)
@@ -429,7 +452,12 @@ def api_orchestrator_invoke(req: OrchestratorInvokeRequest) -> dict[str, Any]:
         if not qreq.text.strip():
             return {"ok": False, "error": "query is required"}
         resp = run_query(qreq)
-        return {"ok": True, "service": "digisearch", "tool": tool, "data": resp.model_dump(mode="json")}
+        return {
+            "ok": True,
+            "service": "digisearch",
+            "tool": tool,
+            "data": resp.model_dump(mode="json"),
+        }
 
     if tool == "digisearch_fetch_all":
         page_size = 500
@@ -541,6 +569,7 @@ def api_research_turn(req: ResearchTurnRequest) -> dict[str, Any]:
 def api_ingest(req: IngestRequest) -> IngestResponse:
     """Ingest a document. Uses parsers + chunkers when available. Returns 503 if ingestion fails."""
     from pathlib import Path
+
     try:
         from digisearch.ingestion.chunkers.recursive import RecursiveChunker
         from digisearch.ingestion.registry import ParserRegistry

--- a/digismith/ARCHITECTURE.md
+++ b/digismith/ARCHITECTURE.md
@@ -426,3 +426,7 @@ The `traceable` decorator wrapper should read this config and apply head-based s
 ## Observability
 
 This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-flight gauge for every HTTP route) via `digibase.metrics.install_metrics`; scraped by the `observability` compose profile per [ADR-0003](../docs/adr/0003-observability-baseline.md).
+
+## CORS
+
+CORS is installed via the shared `digibase.cors.install_cors(app, service="digismith")` helper; allowlist precedence is `DIGISMITH_CORS_ORIGINS` → `DIGI_CORS_ORIGINS` → legacy `DIGI_ALLOWED_ORIGINS`, defaulting to empty. See `SECURITY.md` §"CORS policy".

--- a/digismith/src/digismith/server.py
+++ b/digismith/src/digismith/server.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import uuid
 
+from digibase.cors import install_cors
 from digibase.errors import register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from fastapi import FastAPI, Request
 
 from digismith import __version__
-from digismith.config import SmithStatus, langsmith_host_sanitized, langsmith_sdk_importable, tracing_enabled
+from digismith.config import (
+    SmithStatus,
+    langsmith_host_sanitized,
+    langsmith_sdk_importable,
+    tracing_enabled,
+)
 
 app = FastAPI(
     title="DigiSmith",
@@ -18,6 +24,7 @@ app = FastAPI(
     version=__version__,
 )
 install_metrics(app, service="digismith")
+install_cors(app, service="digismith")
 
 
 @app.middleware("http")

--- a/tests/dg/test_cors.py
+++ b/tests/dg/test_cors.py
@@ -1,0 +1,93 @@
+"""CORS allowlist tests for DigiGraph.
+
+Exercises the shared :func:`digibase.cors.install_cors` helper as wired into
+``digigraph.server``: an allowed origin receives an ``access-control-allow-origin``
+reflection on preflight; a disallowed origin does not.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from digibase.cors import install_cors
+
+SERVICE = "digigraph"
+
+
+def _fresh_client(monkeypatch: pytest.MonkeyPatch, origins: str) -> TestClient:
+    # Clear all three precedence tiers so the test's intent is unambiguous.
+    monkeypatch.delenv("DIGIGRAPH_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", origins)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_allowed_origin_reflected_in_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _fresh_client(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Authorization,Content-Type",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == "https://allowed.example"
+
+
+@pytest.mark.unit
+def test_disallowed_origin_rejected_in_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _fresh_client(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    # Starlette returns 400 for preflight from non-allowlisted origins; regardless,
+    # the reflection header must be absent.
+    assert r.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.unit
+def test_per_service_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", "https://global.example")
+    monkeypatch.setenv("DIGIGRAPH_CORS_ORIGINS", "https://override.example")
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    client = TestClient(app)
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://override.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://override.example"
+
+    r2 = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://global.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r2.headers.get("access-control-allow-origin") is None

--- a/tests/dk/test_cors.py
+++ b/tests/dk/test_cors.py
@@ -1,0 +1,76 @@
+"""CORS allowlist tests for DigiKey (uses shared digibase.cors helper)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from digibase.cors import install_cors
+
+SERVICE = "digikey"
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, origins: str) -> TestClient:
+    monkeypatch.delenv("DIGIKEY_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", origins)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_allowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://allowed.example"
+
+
+@pytest.mark.unit
+def test_disallowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.unit
+def test_var_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIKEY_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("UI_HOST", "ui.example")
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", "https://${UI_HOST}")
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    client = TestClient(app)
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://ui.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://ui.example"

--- a/tests/dq/test_cors.py
+++ b/tests/dq/test_cors.py
@@ -1,0 +1,75 @@
+"""CORS allowlist tests for DigiQuant (uses shared digibase.cors helper)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from digibase.cors import install_cors
+
+SERVICE = "digiquant"
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, origins: str) -> TestClient:
+    monkeypatch.delenv("DIGIQUANT_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", origins)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_allowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://allowed.example"
+
+
+@pytest.mark.unit
+def test_disallowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.unit
+def test_legacy_env_still_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIQUANT_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_ALLOWED_ORIGINS", "https://legacy.example")
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    client = TestClient(app)
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://legacy.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://legacy.example"

--- a/tests/ds/test_cors.py
+++ b/tests/ds/test_cors.py
@@ -1,0 +1,75 @@
+"""CORS allowlist tests for DigiSearch (uses shared digibase.cors helper)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from digibase.cors import install_cors
+
+SERVICE = "digisearch"
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, origins: str) -> TestClient:
+    monkeypatch.delenv("DIGISEARCH_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", origins)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_allowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://allowed.example"
+
+
+@pytest.mark.unit
+def test_disallowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.unit
+def test_empty_default_blocks_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGISEARCH_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.post("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    client = TestClient(app)
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://any.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") is None

--- a/tests/dsm/test_cors.py
+++ b/tests/dsm/test_cors.py
@@ -1,0 +1,52 @@
+"""CORS allowlist tests for DigiSmith (uses shared digibase.cors helper)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from digibase.cors import install_cors
+
+SERVICE = "digismith"
+
+
+def _build(monkeypatch: pytest.MonkeyPatch, origins: str) -> TestClient:
+    monkeypatch.delenv("DIGISMITH_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("DIGI_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DIGI_CORS_ORIGINS", origins)
+    app = FastAPI()
+    install_cors(app, service=SERVICE)
+
+    @app.get("/probe")
+    def _probe() -> dict[str, str]:
+        return {"ok": "1"}
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_allowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://allowed.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") == "https://allowed.example"
+
+
+@pytest.mark.unit
+def test_disallowed_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build(monkeypatch, "https://allowed.example")
+    r = client.options(
+        "/probe",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
Refs #2 — Epic #2 Phase-2 hardening, CORS allowlist audit item.

## Summary

- Adds shared `digibase.cors.install_cors(app, service)` helper with a fixed, minimal CORS profile (`GET/POST/PUT/DELETE/OPTIONS`; `Authorization/Content-Type/X-Request-ID`; `max_age=600`; `allow_credentials=True`).
- Precedence: `<SERVICE>_CORS_ORIGINS` → `DIGI_CORS_ORIGINS` → legacy `DIGI_ALLOWED_ORIGINS` → empty. Default is **empty** (most restrictive); deployments must set one of the env vars to accept browser origins. Legacy `DIGI_ALLOWED_ORIGINS` is still honored for back-compat.
- Wires the helper into all five FastAPI services: DigiGraph, DigiQuant, DigiSearch, DigiSmith, DigiKey. DigiSmith and DigiKey previously had **no CORS middleware at all** — this closes that gap.
- Removes previous `allow_methods=["*"]` / `allow_headers=["*"]` wildcards.
- Keeps a small back-compat shim `digigraph.server._allowed_origins()` (legacy tests in `tests/dg/test_concurrency.py` import it).
- New `SECURITY.md` §"CORS policy" documents the precedence chain, fixed middleware profile, and deployment guidance.
- One-line ARCHITECTURE.md note added to each component.

## Test plan

- [x] `pytest tests/{dg,dq,ds,dsm,dk}/test_cors.py -m unit -v` — 14 new tests pass.
- [x] `pytest tests/dg/test_concurrency.py -m unit -v` — legacy `_allowed_origins` regression tests still pass (shim).
- [x] `pytest tests/dsm/test_server.py -m unit -v` — DigiSmith server still imports cleanly.
- [x] `ruff check .` clean. `ruff format .` clean on touched files.
- [x] `make doc-check` clean.
- [ ] E2E preflight probe against running stack (optional; unit tests cover the contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)