### PR TITLE
feat(hardening): /healthz liveness endpoint on all services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,26 @@ Each component has its own `ARCHITECTURE.md` (reference) and `AGENTS.md` (pre-fl
 - **digisearch/** — RAG and document search. Use Polars for CSV parsing.
 - **digichat/** — Next.js BFF + chat UI. Follow Next.js conventions; strict TypeScript.
 - **digikey/** — JWT + scoped API keys. Python services integrate via `digikey.integrations.service_middleware`.
-- **digismith/** — Tracing helpers + `/v1/status`. Keep `/v1/status` secret-free.
+- **digismith/** — Tracing helpers + `/v1/status`. Keep `/v1/status` secret-free. See "Liveness vs status" below for the `/healthz` vs `/v1/status` contract.
 - **digiclaw/** — Heartbeat, audit, MCP skill → DigiGraph.
 - **digibase/** — Shared HTTP/audit library.
+
+## Liveness vs status
+
+Every FastAPI service exposes **two** diagnostic endpoints with distinct
+contracts. Do not merge them.
+
+- **`GET /healthz`** — liveness probe. Auth-exempt, rate-limit-exempt,
+  secret-free. Always returns HTTP 200 with `{"ok": true}`. Intended for
+  load balancers, Kubernetes liveness probes, and Docker healthchecks.
+  Must not depend on downstream services, databases, or LLMs.
+- **`GET /v1/status`** (DigiSmith) — human-readable diagnostic surface.
+  Still public and secret-free, but may report tracing configuration,
+  SDK availability, and non-sensitive versioning. Intended for operators
+  and on-call debugging. Load balancers should **not** probe this path.
+
+The legacy `/health` route remains on every service for back-compat, but
+new integrations should target `/healthz`.
 
 ## Agent operations (backlog, playbooks, skills)
 

--- a/digigraph/ARCHITECTURE.md
+++ b/digigraph/ARCHITECTURE.md
@@ -65,7 +65,8 @@ The following is built and functional as of this architecture review (March 2026
 
 | Method | Path | Auth | Rate Limit | Notes |
 |--------|------|------|------------|-------|
-| `GET` | `/health` | None | Unlimited | Docker / DigiClaw health check |
+| `GET` | `/health` | None | Unlimited | Legacy health check (back-compat; prefer `/healthz`) |
+| `GET` | `/healthz` | None | Unlimited | Liveness probe — returns `{"ok": true}`; see AGENTS.md "Liveness vs status" |
 | `POST` | `/workflow` | DigiKey JWT (optional) | 10 req/min/IP | DigiClaw custom skill; body: `WorkflowRequest` |
 | `GET` | `/v1/models` | DigiKey JWT (optional) | 30 req/min/IP | OpenAI model list; returns `sitaas-rag` |
 | `GET` | `/v1/model-info` | DigiKey JWT (optional) | 30 req/min/IP | Current model + mode |

--- a/digigraph/src/digigraph/server.py
+++ b/digigraph/src/digigraph/server.py
@@ -84,7 +84,7 @@ _RATE_LIMITS: dict[str, tuple[int, int]] = {
     "/v1/chat/completions": (10, 60),
 }
 _DEFAULT_RATE_LIMIT = (30, 60)
-_UNLIMITED_PATHS = {"/health"}
+_UNLIMITED_PATHS = {"/health", "/healthz"}
 
 
 @app.middleware("http")
@@ -140,8 +140,19 @@ v1 = APIRouter(prefix="/v1", tags=["openai-compatible"])
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    """Health check for Docker and DigiClaw."""
+    """Legacy health check for Docker and DigiClaw (kept for back-compat)."""
     return {"status": "ok", "service": "digigraph"}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, rate-limit-exempt, secret-free.
+
+    Contract: returns HTTP 200 with ``{"ok": true}``. Intended for load
+    balancers and k8s probes. For richer diagnostics, see DigiSmith's
+    ``/v1/status``.
+    """
+    return {"ok": True}
 
 
 def _digi_fields_from_request(http_request: Request) -> dict[str, str | None]:

--- a/digikey/ARCHITECTURE.md
+++ b/digikey/ARCHITECTURE.md
@@ -68,8 +68,8 @@ This architecture means DigiKey sits on the hot path for key exchange but is com
 
 ### DigiKey-owned endpoints
 
-**`GET /health`**
-Returns `{"status": "ok", "service": "digikey"}`. Always public. Used by Docker healthcheck.
+**`GET /health`** and **`GET /healthz`**
+`/health` returns `{"status": "ok", "service": "digikey"}` (legacy, kept for back-compat). `/healthz` returns `{"ok": true}` — the preferred liveness probe. Both are always public, rate-limit-exempt, and secret-free. Docker healthcheck targets `/healthz`. See AGENTS.md "Liveness vs status".
 
 **`GET /.well-known/jwks.json`**
 Public. Returns the RSA public key as a JWKS document. Consumers cache this with a TTL (default 300 seconds, configurable via `DIGIKEY_JWKS_CACHE_SEC`). No authentication required — the public key is safe to expose.

--- a/digikey/src/digikey/integrations/service_middleware.py
+++ b/digikey/src/digikey/integrations/service_middleware.py
@@ -118,7 +118,7 @@ def attach_digi_auth_middleware(app: FastAPI, *, service: str, path_scopes: Path
 
 
 def digigraph_path_scopes(method: str, path: str) -> list[str] | None:
-    if path == "/health":
+    if path in ("/health", "/healthz"):
         return None
     if path in ("/docs", "/redoc", "/openapi.json"):
         return None
@@ -138,7 +138,7 @@ def digigraph_path_scopes(method: str, path: str) -> list[str] | None:
 
 
 def digiquant_path_scopes(method: str, path: str) -> list[str] | None:
-    if path == "/health":
+    if path in ("/health", "/healthz"):
         return None
     if path in ("/docs", "/redoc", "/openapi.json"):
         return None
@@ -156,7 +156,7 @@ def digiquant_path_scopes(method: str, path: str) -> list[str] | None:
 
 
 def digisearch_path_scopes(method: str, path: str) -> list[str] | None:
-    if path == "/health":
+    if path in ("/health", "/healthz"):
         return None
     if path in ("/docs", "/redoc", "/openapi.json"):
         return None

--- a/digikey/src/digikey/ratelimit.py
+++ b/digikey/src/digikey/ratelimit.py
@@ -1,9 +1,9 @@
 """In-process token-bucket rate limiter for DigiKey auth-sensitive routes.
 
 Applied selectively (via FastAPI dependency) to the key-issuance and
-JWT-mint endpoints. Exempt routes — ``/health``, ``/.well-known/jwks.json``,
-and any future ``/healthz``, ``/metrics``, ``/v1/status`` — do not carry this
-dependency and therefore incur zero overhead.
+JWT-mint endpoints. Exempt routes — ``/health``, ``/healthz``,
+``/.well-known/jwks.json``, and any future ``/metrics``, ``/v1/status`` — do
+not carry this dependency and therefore incur zero overhead.
 
 Design
 ------

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -51,7 +51,19 @@ def _startup() -> None:
 
 @app.get("/health")
 def health() -> dict[str, str]:
+    """Legacy health check (kept for back-compat)."""
     return {"status": "ok", "service": "digikey"}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, rate-limit-exempt, secret-free.
+
+    Returns HTTP 200 with ``{"ok": true}``. Intended for load-balancer and
+    k8s liveness checks. For richer cross-service diagnostics, call DigiSmith's
+    ``/v1/status``.
+    """
+    return {"ok": True}
 
 
 @app.get("/.well-known/jwks.json")

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -141,7 +141,8 @@ All endpoints bind on `127.0.0.1:8001` by default. Auth is enforced by `DigiAuth
 
 | Method | Path | Auth Scope | Description |
 |---|---|---|---|
-| `GET` | `/health` | None | Liveness probe; returns `{"status": "ok", "service": "digiquant"}` |
+| `GET` | `/health` | None | Legacy health check; returns `{"status": "ok", "service": "digiquant"}` (back-compat; prefer `/healthz`) |
+| `GET` | `/healthz` | None | Liveness probe; returns `{"ok": true}` (auth-exempt, rate-limit-exempt; see AGENTS.md "Liveness vs status") |
 | `GET` | `/strategies` | `digiquant:backtest` | List registered strategies (name, aliases, description, default_params) |
 | `GET` | `/check_drift` | `digiquant:backtest` | ADDM drift check for a strategy; query params: `strategy_id`, `baseline_run_id` |
 | `POST` | `/run_backtest` | `digiquant:backtest` | Synchronous NautilusTrader backtest; returns `BacktestResult` |

--- a/digiquant/src/digiquant/server.py
+++ b/digiquant/src/digiquant/server.py
@@ -84,7 +84,7 @@ _RATE_LIMITS: dict[str, tuple[int, int]] = {
     "/v1/orchestrator_invoke": (10, 60),
 }
 _DEFAULT_RATE_LIMIT = (30, 60)
-_UNLIMITED_PATHS = {"/health"}
+_UNLIMITED_PATHS = {"/health", "/healthz"}
 
 
 def _rl_check(request: Request, max_req: int, window: int) -> JSONResponse | None:
@@ -207,8 +207,18 @@ def _pipeline_requires_export(req: PipelineRequest) -> bool:
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    """Health check for Docker and DigiGraph."""
+    """Legacy health check for Docker and DigiGraph (kept for back-compat)."""
     return {"status": "ok", "service": "digiquant"}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, rate-limit-exempt, secret-free.
+
+    Returns HTTP 200 with ``{"ok": true}``. Pair with DigiSmith's ``/v1/status``
+    for richer diagnostics.
+    """
+    return {"ok": True}
 
 
 @app.get("/strategies")

--- a/digisearch/ARCHITECTURE.md
+++ b/digisearch/ARCHITECTURE.md
@@ -129,11 +129,11 @@ As of the March 2026 codebase snapshot, the following modules are implemented an
 
 All paths under the FastAPI app in `server.py`. Base URL: `http://digisearch:8002`.
 
-#### `GET /health`
+#### `GET /health` and `GET /healthz`
 
-Public (no auth). Returns `{"status": "ok", "service": "digisearch"}`. Used by Docker healthcheck and DigiGraph startup dependency.
+Public (no auth). Both endpoints are rate-limit-exempt. `/health` returns `{"status": "ok", "service": "digisearch"}` (legacy, kept for back-compat). `/healthz` returns `{"ok": true}` — the preferred liveness probe for load balancers and k8s (see AGENTS.md "Liveness vs status"). Used by Docker healthcheck and DigiGraph startup dependency.
 
-**Gap:** Does not probe backend connectivity. A backend can be offline and `/health` returns 200. See [Redesign Recommendations](#12-redesign-recommendations).
+**Gap:** Does not probe backend connectivity. A backend can be offline and both endpoints return 200. See [Redesign Recommendations](#12-redesign-recommendations).
 
 #### `GET /azure_status`
 

--- a/digisearch/src/digisearch/server.py
+++ b/digisearch/src/digisearch/server.py
@@ -92,7 +92,7 @@ _RATE_LIMITS: dict[str, tuple[int, int]] = {
     "/v1/orchestrator_invoke": (10, 60),
 }
 _DEFAULT_RATE_LIMIT = (30, 60)
-_UNLIMITED_PATHS = {"/health"}
+_UNLIMITED_PATHS = {"/health", "/healthz"}
 
 
 def _rl_check(request: Request, max_req: int, window: int) -> JSONResponse | None:
@@ -225,8 +225,18 @@ class ResearchTurnRequest(BaseModel):
 
 @app.get("/health")
 def health() -> dict[str, str]:
-    """Health check for Docker and DigiGraph."""
+    """Legacy health check for Docker and DigiGraph (kept for back-compat)."""
     return {"status": "ok", "service": "digisearch"}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, rate-limit-exempt, secret-free.
+
+    Returns HTTP 200 with ``{"ok": true}``. Pair with DigiSmith's ``/v1/status``
+    for richer diagnostics.
+    """
+    return {"ok": True}
 
 
 @app.get("/azure_status")

--- a/digismith/ARCHITECTURE.md
+++ b/digismith/ARCHITECTURE.md
@@ -37,13 +37,13 @@ There is no database, no background worker, no queue, and no internal LangGraph 
 
 ## 3. API Surface
 
-### `GET /health`
+### `GET /health` and `GET /healthz`
 
-Liveness probe. Returns `{"status": "ok"}` unconditionally. Used by Docker Compose healthcheck (`curl -f http://127.0.0.1:8003/health`).
+Liveness probes. `/healthz` is the preferred endpoint (returns `{"ok": true}`); `/health` is retained for back-compat (returns `{"status": "ok"}`). Docker Compose healthcheck targets `/healthz`. See AGENTS.md "Liveness vs status" for the contract that distinguishes `/healthz` (liveness) from `/v1/status` (richer diagnostics).
 
 ```
 HTTP 200 OK
-{"status": "ok"}
+{"ok": true}
 ```
 
 No authentication required. No secrets in response. Safe to expose to any internal load balancer.

--- a/digismith/src/digismith/server.py
+++ b/digismith/src/digismith/server.py
@@ -31,7 +31,18 @@ async def correlation_id(request: Request, call_next):
 
 @app.get("/health")
 def health() -> dict[str, str]:
+    """Legacy health check (kept for back-compat)."""
     return {"status": "ok"}
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, secret-free.
+
+    Returns HTTP 200 with ``{"ok": true}``. For richer diagnostics (tracing
+    configuration, LangSmith host), see ``/v1/status``.
+    """
+    return {"ok": True}
 
 
 @app.get("/v1/status", response_model=SmithStatus)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - digikey_data:/data
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8005/health"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8005/healthz"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -63,7 +63,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8003/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8003/healthz"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -112,7 +112,7 @@ services:
       litellm:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/healthz"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -148,7 +148,7 @@ services:
       digikey:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8001/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8001/healthz"]
       interval: 15s
       timeout: 5s
       retries: 3
@@ -180,7 +180,7 @@ services:
       digikey:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8002/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8002/healthz"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/tests/dg/test_healthz.py
+++ b/tests/dg/test_healthz.py
@@ -1,0 +1,39 @@
+"""DigiGraph ``/healthz`` liveness contract.
+
+Contract (see AGENTS.md "Liveness vs status"):
+* returns HTTP 200 with ``{"ok": true}``
+* requires no ``Authorization`` header
+* is rate-limit-exempt (burst of requests all succeed)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from digigraph.server import app
+
+
+@pytest.fixture
+def unauth_client() -> TestClient:
+    """Client WITHOUT any Authorization header — liveness must not require one."""
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthz:
+    def test_returns_200_ok_true(self, unauth_client: TestClient) -> None:
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_no_authorization_header_required(self, unauth_client: TestClient) -> None:
+        # Explicitly assert no Authorization header is sent.
+        assert "Authorization" not in unauth_client.headers
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+
+    def test_not_rate_limited_under_burst(self, unauth_client: TestClient) -> None:
+        for _ in range(100):
+            r = unauth_client.get("/healthz")
+            assert r.status_code == 200

--- a/tests/dk/test_healthz.py
+++ b/tests/dk/test_healthz.py
@@ -1,0 +1,51 @@
+"""DigiKey ``/healthz`` liveness contract.
+
+Contract (see AGENTS.md "Liveness vs status"):
+* returns HTTP 200 with ``{"ok": true}``
+* requires no ``Authorization`` header (admin scopes are NOT required)
+* is rate-limit-exempt — the token-bucket dependency is NOT attached to the
+  route, so a burst of requests must not trigger HTTP 429.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Signing key loads at digikey.server import — allow ephemeral RS256 for unit tests.
+if not (os.environ.get("DIGIKEY_PRIVATE_KEY_PEM") or "").strip():
+    os.environ.setdefault("DIGIKEY_ALLOW_EPHEMERAL_KEY", "1")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from digikey.ratelimit import reset_limiter_for_tests
+from digikey.server import app
+
+
+@pytest.fixture
+def unauth_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # Tiny bucket: if /healthz were rate-limited the burst test would fail fast.
+    monkeypatch.setenv("DIGIKEY_RL_PER_MIN", "1")
+    monkeypatch.setenv("DIGIKEY_RL_BURST", "2")
+    reset_limiter_for_tests()
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthz:
+    def test_returns_200_ok_true(self, unauth_client: TestClient) -> None:
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_no_authorization_header_required(self, unauth_client: TestClient) -> None:
+        assert "Authorization" not in unauth_client.headers
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+
+    def test_not_rate_limited_under_burst(self, unauth_client: TestClient) -> None:
+        # Burst of 100 — far above DIGIKEY_RL_BURST=2. All must return 200
+        # because the rate-limit dependency is NOT attached to /healthz.
+        for _ in range(100):
+            r = unauth_client.get("/healthz")
+            assert r.status_code == 200

--- a/tests/dq/test_healthz.py
+++ b/tests/dq/test_healthz.py
@@ -1,0 +1,40 @@
+"""DigiQuant ``/healthz`` liveness contract.
+
+Contract (see AGENTS.md "Liveness vs status"):
+* returns HTTP 200 with ``{"ok": true}``
+* requires no ``Authorization`` header
+* is rate-limit-exempt (burst of requests all succeed)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nautilus_trader")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from digiquant.server import app  # noqa: E402
+
+
+@pytest.fixture
+def unauth_client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthz:
+    def test_returns_200_ok_true(self, unauth_client: TestClient) -> None:
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_no_authorization_header_required(self, unauth_client: TestClient) -> None:
+        assert "Authorization" not in unauth_client.headers
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+
+    def test_not_rate_limited_under_burst(self, unauth_client: TestClient) -> None:
+        for _ in range(100):
+            r = unauth_client.get("/healthz")
+            assert r.status_code == 200

--- a/tests/ds/test_healthz.py
+++ b/tests/ds/test_healthz.py
@@ -1,0 +1,37 @@
+"""DigiSearch ``/healthz`` liveness contract.
+
+Contract (see AGENTS.md "Liveness vs status"):
+* returns HTTP 200 with ``{"ok": true}``
+* requires no ``Authorization`` header
+* is rate-limit-exempt (burst of requests all succeed)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from digisearch.server import app
+
+
+@pytest.fixture
+def unauth_client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthz:
+    def test_returns_200_ok_true(self, unauth_client: TestClient) -> None:
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_no_authorization_header_required(self, unauth_client: TestClient) -> None:
+        assert "Authorization" not in unauth_client.headers
+        r = unauth_client.get("/healthz")
+        assert r.status_code == 200
+
+    def test_not_rate_limited_under_burst(self, unauth_client: TestClient) -> None:
+        for _ in range(100):
+            r = unauth_client.get("/healthz")
+            assert r.status_code == 200

--- a/tests/dsm/test_healthz.py
+++ b/tests/dsm/test_healthz.py
@@ -1,0 +1,37 @@
+"""DigiSmith ``/healthz`` liveness contract.
+
+Contract (see AGENTS.md "Liveness vs status"): ``/healthz`` is the minimal
+liveness probe; ``/v1/status`` remains the richer diagnostic surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from digismith.server import app
+
+_client = TestClient(app)
+
+
+@pytest.mark.unit
+class TestHealthz:
+    def test_returns_200_ok_true(self) -> None:
+        r = _client.get("/healthz")
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_no_authorization_header_required(self) -> None:
+        assert "Authorization" not in _client.headers
+        r = _client.get("/healthz")
+        assert r.status_code == 200
+
+    def test_not_rate_limited_under_burst(self) -> None:
+        for _ in range(100):
+            r = _client.get("/healthz")
+            assert r.status_code == 200
+
+    def test_v1_status_still_available(self) -> None:
+        """Contract: ``/healthz`` does not replace ``/v1/status`` — both must work."""
+        r = _client.get("/v1/status")
+        assert r.status_code == 200


### PR DESCRIPTION
Refs #2

## Summary

- Adds auth-exempt, rate-limit-exempt `GET /healthz` returning `{"ok": true}` to DigiGraph, DigiQuant, DigiSearch, DigiSmith, and DigiKey.
- Registers `/healthz` as auth-exempt in `digikey.integrations.service_middleware` (`digigraph_path_scopes`, `digiquant_path_scopes`, `digisearch_path_scopes`) and in each service's per-IP `_UNLIMITED_PATHS` set. DigiKey's dependency-scoped rate limiter is not attached to the route.
- Legacy `/health` endpoints preserved for back-compat.
- Documents the `/healthz` (liveness) vs `/v1/status` (richer, still-secret-free diagnostics) contract in a new "Liveness vs status" section in AGENTS.md and in each component's ARCHITECTURE.md.
- Switches all `docker-compose.yml` service healthchecks from `/health` to `/healthz`.

## Test plan

- [x] `pytest tests/*/test_healthz.py -m unit -v` — 13 passed, 1 skipped (DigiQuant skips locally when `nautilus_trader` is not installed; runs in CI).
- [x] Each `/healthz` test asserts HTTP 200, body `{"ok": true}`, no `Authorization` header, and burst of 100 requests all return 200 (rate-limit-exempt).
- [x] DigiSmith test additionally asserts `/v1/status` continues to work unchanged.
- [x] `ruff check` passes on all touched files.
- [ ] E2E verification (stack up): `for p in 18000 18001 18002 18003 8005; do curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:$p/healthz; done` expect 200 from each.

## Out of scope (parallel Batch-3 units)

- CORS configuration
- `httpx.AsyncClient` timeout defaults
- Pydantic v2 model tightening