### PR TITLE
docs(security): STRIDE threat-model table in SECURITY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Before taking any non-trivial action, read:
 - **Orchestration:** LangGraph, supervisor + sub-graph pattern only.
 - **LLM routing:** LiteLLM. Caching is mandatory.
 - **Structured outputs:** Pydantic v2 everywhere, never raw dicts across service boundaries.
-- **Security:** Follow [SECURITY.md](SECURITY.md) exactly — loopback-only defaults, least privilege, human gates for every live trade.
+- **Security:** Follow [SECURITY.md](SECURITY.md) exactly — loopback-only defaults, least privilege, human gates for every live trade. The [STRIDE threat model](SECURITY.md#threat-model) enumerates the actors, assets, and controls you are expected to respect.
 - **Performance targets:** Backtests < 2 s for 10 M rows; token reduction ≥ 70 % vs naive prompts.
 - **Python:** 3.12+, strict typing, ruff-compliant (line length 100).
 - **MCP-first:** every capability exposed as a discoverable tool.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,43 @@ DigiThings is designed to run on a single host or private network. The primary t
 
 We are **not** designing for public internet exposure by default. Running DigiThings on a public endpoint without a dedicated gateway and hardened auth is out of scope.
 
+### STRIDE table
+
+Controls cited in the Mitigation column are already landed on `develop`; see the
+[Non-negotiable defaults](#non-negotiable-defaults), [Rate limiting](#rate-limiting-auth-paths),
+[CORS policy](#cors-policy), [Secrets scanning](#secrets-scanning), and
+[Dependency-audit policy](#dependency-audit-policy) sections for implementation detail.
+STRIDE categories: **S**poofing, **T**ampering, **R**epudiation, **I**nformation disclosure,
+**D**enial of service, **E**levation of privilege.
+
+| Actor | Asset | Threat (STRIDE) | Mitigation (current) | Residual risk |
+|-------|-------|-----------------|----------------------|---------------|
+| External unauthenticated attacker | DigiChat BFF / leaked service endpoint | S — forge identity, replay tokens | RS256 JWTs with JWKS rotation; DigiChat session binding; CORS allowlist (no `*`) via `digibase.cors`. | JWKS cached 300 s — revocation propagation delayed; no WAF / bot-management layer. |
+| External unauthenticated attacker | Auth paths (`/v1/oauth/token`, `/v1/admin/keys`) | D — brute-force / credential stuffing against bcrypt verify | Per-IP token-bucket limiter in `digikey.ratelimit` (10 rpm, burst 20); `/healthz` / JWKS exempt so probes stay live under load. | Pure in-process bucket — no cross-instance sharing; no global DDoS protection beyond per-IP. |
+| External unauthenticated attacker | All FastAPI services | T/I — malformed payloads, parser abuse, unbounded bodies | Pydantic v2 models with `extra="forbid"` at every HTTP handler; bounded `httpx` timeouts via `digibase.http_client`; loopback binding keeps the attack surface off the public Internet by default. | No explicit request body-size cap at the ASGI layer; relies on upstream gateway for byte limits. |
+| External unauthenticated attacker | `/healthz`, `/.well-known/jwks.json` | I — fingerprint service versions | Endpoints are deliberately minimal and secret-free; `/v1/status` on DigiSmith is audited for secret leakage. | Version / stack fingerprinting is possible from response shape; acceptable given public-by-design contract. |
+| Compromised DigiKey API key holder | Tenant data in DigiSearch / DigiQuant | E — widen blast radius beyond issued scopes | Scoped API keys with per-route scope enforcement (`service_middleware`); tenant scope bound at the key layer. | Storage-layer tenant isolation is a roadmap item — today, isolation is key-scope-only (see `digibase/ARCHITECTURE.md`). |
+| Compromised DigiKey API key holder | Live-trading paths (IB/Alpaca/QuantConnect adapters) | E — submit real orders | Broker adapters raise `NotImplementedError`; any code change touching them requires a `Human-Approved-By:` commit trailer enforced by `scripts/hooks/pre-push.sh`; criterion 5/8 in `docs/scoring/SECURITY.md`. | No runtime circuit-breaker yet — the gate is source-tree + commit-trailer, not a runtime interlock. |
+| Compromised DigiKey API key holder | Audit trail | R — deny actions taken | Immutable JSONL audit via `digibase.audit.redact_mapping`; spans carry `workflow_id`, `request_id`, `session_id`. | Audit log is local per-host; no append-only remote sink or signed chain. |
+| Compromised DigiKey API key holder | Rate-limited endpoints | D — exhaust quota for co-tenants | Per-IP limiter today; key issuance gated by admin scope. | No per-key / per-tenant quotas on orchestration or search paths yet. |
+| Malicious LLM output (prompt injection) | Tool-calls from DigiGraph agents | E — coerce agent into unintended tool use | Pydantic v2 structured outputs across tool boundaries; MCP tool allowlist in `digigraph/orchestration/registry.py`; debug/thread endpoints off by default; live-trading adapters stubbed. | Prompt-injection from retrieved DigiSearch documents is not systematically defended — no content-level sanitizer or trust-tier tagging on retrieved context. |
+| Malicious LLM output (prompt injection) | Outbound HTTP from tools | I — data exfiltration via crafted tool args | `digibase.http_client` enforces bounded timeouts; `.claude/settings.json` PreToolUse hooks block network calls to non-allowlisted hosts during agent development. | No runtime egress allowlist for service-to-service traffic in production paths. |
+| Malicious LLM output (prompt injection) | Audit / span payloads | I — smuggle user secrets into observability | `digibase.audit.redact_mapping` strips prompts, JWTs, keys, doc bodies before persistence; `/v1/status` kept secret-free by contract. | Redaction is pattern-based — novel secret formats may pass through until a rule is added. |
+| Insider / developer with repo write access | `SECURITY.md`, `.github/workflows/`, live-trading code | T/E — silently weaken controls | `.claude/settings.json` PreToolUse hooks block edits to protected paths off a `task-N-*` branch; pre-push hook blocks live-trading pushes without `Human-Approved-By:` trailer; CI PR-linkage workflow rejects orphan commits. | Hooks run in the developer's local environment — a determined insider bypassing the harness still needs to clear PR review and branch protection. |
+| Insider / developer with repo write access | Client / pilot material | I — accidental commit of confidential data | `projects/` is gitignored and never pushed to public remotes; `gitleaks` CI on every PR and push with pinned SHA. | `gitleaks` allowlist entries require discipline — an incorrectly scoped entry could mask a real leak. |
+| Insider / developer with repo write access | `main` branch | T — unreviewed merge | `main` pushes require `ALLOW_MAIN_PUSH=1`; branch protection + PR scoring gate (Security ≥ 8, Accuracy ≥ 9). | Relies on GitHub branch protection being correctly configured — audited out-of-band. |
+| Compromised dependency (supply-chain) | Any Python component | T/E — malicious transitive package | `pip-audit` workflow on every PR, every `develop`/`main` push, and weekly; fails merge on HIGH/CRITICAL (CVSS ≥ 7); acceptances require a justified `pip-audit-ignore.txt` entry. | MEDIUM/LOW findings are warn-only; `digiquant[nautilus]` is excluded (tracked in #42); `digichat/` Node audit is a sibling follow-up job. |
+| Compromised dependency (supply-chain) | GitHub Actions runners | T — malicious action version | `gitleaks` and other third-party actions are pinned to commit SHAs in `.github/workflows/`. | Not every action in the repo is SHA-pinned — audited on change to any workflow file. |
+| Co-tenant on shared host (Atlas Phase 5) | Another tenant's index / audit / backtest output | I/E — cross-tenant read or privilege escalation | DigiKey scoped keys enforce tenant scope at the auth layer; audit events are redacted per tenant. | No storage-layer tenant isolation yet; no per-tenant resource quotas; multi-tenant deployment is explicitly a Phase 5 roadmap item. |
+| Co-tenant on shared host (Atlas Phase 5) | Shared LiteLLM proxy | D — exhaust shared LLM budget | LiteLLM caching enabled; `LITELLM_MASTER_KEY` + virtual keys required beyond loopback dev. | No per-tenant token/cost budget enforcement at the proxy layer. |
+
+### Review cadence
+
+This table is re-reviewed at the start of each phase (Phase 3, Phase 4, Phase 5)
+and after any new public-facing endpoint ships. Update the Mitigation column
+when a control lands on `develop`; move items out of the Residual-risk column
+only once a concrete mitigation is merged and exercised by tests.
+
 ## Non-negotiable defaults
 
 These are enforced in code and reviewed on every PR:

--- a/docs/backlog/epic-2-hardening.md
+++ b/docs/backlog/epic-2-hardening.md
@@ -64,7 +64,7 @@ Each item below is sized for a single PR under ~120 lines of diff.
   auth-exempt `/healthz` returning `{"ok": true}` for liveness probes on every
   service; keep `/v1/status` (DigiSmith) for richer, still-secret-free
   diagnostics. Document the contract so load balancers stop pinging `/v1/status`.
-- [ ] **Documented threat model.** Expand [SECURITY.md](../../SECURITY.md)
+- [x] **Documented threat model.** Expand [SECURITY.md](../../SECURITY.md)
   "Threat model" section into a STRIDE-style table — actor, asset, threat,
   mitigation, residual risk — cross-linked from [AGENTS.md](../../AGENTS.md)
   and the [security scoring rubric](../scoring/SECURITY.md).

--- a/docs/scoring/SECURITY.md
+++ b/docs/scoring/SECURITY.md
@@ -4,6 +4,11 @@
 
 Score one point per criterion you fully satisfy. Partial credit is not allowed — either you pass or you don't.
 
+Reviewers: the [STRIDE threat model in SECURITY.md](../../SECURITY.md#threat-model)
+is the anchor checklist for this rubric. If a PR introduces a new actor, asset,
+or endpoint, confirm the table still covers it — update SECURITY.md in the same
+PR if not.
+
 ---
 
 ## Criteria


### PR DESCRIPTION
Closes epic #2 last item

Refs #2

## Summary

Expands the Threat model section of `SECURITY.md` into a STRIDE-style
table covering six actors:

- External unauthenticated attacker
- Compromised DigiKey API key holder
- Malicious LLM output (prompt injection)
- Insider / developer with repo write access
- Compromised dependency (supply chain)
- Co-tenant on shared host (Atlas Phase 5)

Each row cites a concrete mitigation already on `develop` (RS256 JWTs,
`digikey.ratelimit`, `digibase.cors`, Pydantic `extra=\"forbid\"`,
`digibase.http_client` timeouts, `/healthz` exempt, `redact_mapping`,
`pip-audit` CI, `gitleaks` CI, live-trading `Human-Approved-By:`
trailer, loopback binding, `.claude/settings.json` PreToolUse hooks)
and names the residual risk honestly (JWKS 300 s revocation delay,
no WAF, no per-tenant quotas, retrieved-doc prompt-injection not
systematically defended, etc.).

Adds a Review cadence note: re-review at the start of Phase 3, 4, 5
and after any new public-facing endpoint ships.

Cross-linked from `AGENTS.md` §security rules and from
`docs/scoring/SECURITY.md` as the reviewer's anchor checklist. Checks
off the last open item in `docs/backlog/epic-2-hardening.md`.

## Test plan

- [x] `make doc-check` clean (80 markdown files scanned)
- [x] All anchors resolve to real sections
- [x] Docs-only diff — no code paths touched