### PR TITLE
test(digigraph): guard mtime-keyed project-config reload contract

### DIFF
--- a/tests/dg/test_project_config.py
+++ b/tests/dg/test_project_config.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import pytest
 
+import digigraph.project_config as project_config_module
 from digigraph.project_config import DigiProjectConfig, _resolve_config_path, load_project_config
 
 
@@ -174,3 +176,48 @@ mcp:
     assert index_config.get("index_name") == "unified-content-index"
     assert "sourceType" in (index_config.get("filterable_fields") or [])
     assert "subject" in (index_config.get("result_metadata_fields") or [])
+
+
+@pytest.mark.unit
+def test_digi_project_config_load_re_reads_on_mtime_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given  a project config file that DigiProjectConfig.load() has already loaded,
+    When   the file content is mutated and the mtime is bumped by ≥1 second,
+    Then   a subsequent DigiProjectConfig.load() call returns the new value without
+           a process restart (mtime-keyed cache invalidation per project-spec-v1alpha1).
+
+    The spec states: "DigiGraph reads the project config on every request (cached by mtime).
+    No restart required for non-secret field changes."
+    """
+    # Isolate: clear the module-level cache so previous tests don't interfere.
+    monkeypatch.setattr(project_config_module, "_config_cache", {})
+
+    cfg_file = tmp_path / "digiproject.yaml"
+    cfg_file.write_text(
+        "project:\n  name: before-reload\nagents:\n  llm_mode: test\n"
+    )
+    # Establish initial mtime explicitly at t=1000 so we can reliably bump it.
+    initial_ts = 1_000_000_000.0
+    os.utime(cfg_file, (initial_ts, initial_ts))
+
+    # First load — populates cache keyed by (path, mtime).
+    cfg_before = DigiProjectConfig.load(str(cfg_file))
+    assert cfg_before.get_llm_mode() == "test"
+    assert cfg_before.project.get("name") == "before-reload"
+
+    # Mutate file and bump mtime by 1 second — simulates an in-place edit on disk.
+    cfg_file.write_text(
+        "project:\n  name: after-reload\nagents:\n  llm_mode: best\n"
+    )
+    bumped_ts = initial_ts + 1.0
+    os.utime(cfg_file, (bumped_ts, bumped_ts))
+
+    # Second load — must see the new values (cache miss due to mtime change).
+    cfg_after = DigiProjectConfig.load(str(cfg_file))
+    assert cfg_after.get_llm_mode() == "best", (
+        "DigiProjectConfig.load() did not pick up the updated file after mtime bump; "
+        "mtime-keyed cache invalidation is broken."
+    )
+    assert cfg_after.project.get("name") == "after-reload"


### PR DESCRIPTION
## Summary

- Adds `test_digi_project_config_load_re_reads_on_mtime_change` to `tests/dg/test_project_config.py`
- Tests `DigiProjectConfig.load()` (not the uncached `load_project_config()` free function), which is the entry point that implements the mtime-keyed cache described in `project-spec-v1alpha1.md`
- Contract being guarded: _"DigiGraph reads the project config on every request (cached by mtime). No restart required for non-secret field changes."_
- The test isolates the module-global `_config_cache` via `monkeypatch.setattr` to prevent cross-test contamination, uses `os.utime` to bump mtime by exactly 1 second (coarse-filesystem safe), and asserts on two fields (`llm_mode` and `project.name`) to confirm the post-bump load sees mutated content

## Implementation notes

- No production code was changed — test-only PR
- The loader already implements mtime-keyed caching correctly, so no `xfail` is needed
- The pre-existing `nautilus_trader` import failure in `tests/contracts/test_openapi_contract.py` is unrelated and pre-dates this branch

## Test plan

- [x] `pytest -m unit -k "project_config" -v` — 7 passed
- [x] `make test-unit` — 510 passed (1 pre-existing fail on missing `nautilus_trader`, 16 skipped)
- [x] `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)