### PR TITLE
feat(digigraph): digi project validate CLI + extracted JSON Schema

### DIFF
--- a/digigraph/pyproject.toml
+++ b/digigraph/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langgraph>=0.2",
     "openai>=1.0",
     "pyyaml>=6",
+    "jsonschema>=4.21",
     "tabulate>=0.9",
     "matplotlib>=3.8",
     "plotly>=5.0",
@@ -35,8 +36,14 @@ mcp = ["mcp>=1.2"]
 checkpoint-sqlite = ["langgraph-checkpoint-sqlite>=2.0"]
 checkpoint-postgres = ["langgraph-checkpoint-postgres>=2.0"]
 
+[project.scripts]
+digi = "digigraph.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+digigraph = ["schemas/*.json"]
 
 [tool.ruff]
 line-length = 100

--- a/digigraph/src/digigraph/cli.py
+++ b/digigraph/src/digigraph/cli.py
@@ -1,0 +1,50 @@
+"""``digi`` command-line interface.
+
+Minimal surface for Phase 1: ``digi project validate <path>``. Additional subcommands
+(``render``, ``migrate``) are tracked as separate backlog items.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from digigraph.project_validate import validate_project_file
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="digi",
+        description="DigiThings CLI.",
+    )
+    sub = parser.add_subparsers(dest="group", required=True)
+
+    project = sub.add_parser("project", help="Project-level commands")
+    project_sub = project.add_subparsers(dest="command", required=True)
+
+    validate = project_sub.add_parser(
+        "validate",
+        help="Validate a digiproject.yaml file against the v1alpha1 schema.",
+    )
+    validate.add_argument("path", help="Path to the digiproject.yaml file.")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code (0 = ok, 1 = validation error)."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.group == "project" and args.command == "validate":
+        report = validate_project_file(args.path)
+        print(f"{args.path}: {report.render()}")
+        return 0 if report.ok else 1
+
+    parser.error(f"unknown command: {args.group} {args.command}")
+    return 2  # unreachable — argparse.error exits
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/digigraph/src/digigraph/project_validate.py
+++ b/digigraph/src/digigraph/project_validate.py
@@ -1,0 +1,145 @@
+"""DigiProject v1alpha1 validator.
+
+Loads a project YAML, resolves ``${VAR}`` / ``${VAR:-default}`` environment-variable
+references, and validates the result against the packaged JSON Schema
+(``digigraph/schemas/digiproject.v1alpha1.json``).
+
+Used by the ``digi project validate`` CLI; callable as a library for programmatic use.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+from digigraph.schemas import DIGIPROJECT_V1ALPHA1, load_schema
+
+# Matches ${VAR} or ${VAR:-default}. VAR must match env-var identifier rules.
+_ENV_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate validation outcome. ``ok`` is False when any error was collected."""
+
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def render(self) -> str:
+        if self.ok:
+            return "OK"
+        lines = [f"Found {len(self.errors)} error(s):"]
+        for err in self.errors:
+            lines.append(f"  - {err}")
+        return "\n".join(lines)
+
+
+def _resolve_env_refs(
+    value: Any,
+    *,
+    env: dict[str, str] | None = None,
+    path: str = "$",
+    errors: list[str] | None = None,
+) -> Any:
+    """Walk ``value`` resolving ``${VAR}`` / ``${VAR:-default}`` in strings.
+
+    Appends a human-readable error to ``errors`` for each unresolved ``${VAR}``
+    (no default and env unset). Returns the substituted structure.
+    """
+    if errors is None:
+        errors = []
+    env = os.environ if env is None else env
+
+    if isinstance(value, str):
+
+        def _sub(match: re.Match[str]) -> str:
+            var = match.group(1)
+            default = match.group(2)
+            if var in env:
+                return env[var]
+            if default is not None:
+                return default
+            errors.append(
+                f"{path}: unresolved environment variable '${{{var}}}' "
+                "(no default and not set in environment)"
+            )
+            return match.group(0)
+
+        return _ENV_REF.sub(_sub, value)
+
+    if isinstance(value, dict):
+        return {
+            k: _resolve_env_refs(v, env=env, path=f"{path}.{k}", errors=errors)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _resolve_env_refs(v, env=env, path=f"{path}[{i}]", errors=errors)
+            for i, v in enumerate(value)
+        ]
+    return value
+
+
+def _format_schema_error_path(abs_path: Any) -> str:
+    parts: list[str] = ["$"]
+    for seg in abs_path:
+        if isinstance(seg, int):
+            parts.append(f"[{seg}]")
+        else:
+            parts.append(f".{seg}")
+    return "".join(parts)
+
+
+def validate_project_file(
+    path: str | Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> ValidationReport:
+    """Validate a project YAML file and return a :class:`ValidationReport`."""
+    report = ValidationReport()
+    p = Path(path)
+
+    if not p.exists():
+        report.errors.append(f"{p}: file not found")
+        return report
+
+    try:
+        raw = p.read_text()
+    except OSError as exc:
+        report.errors.append(f"{p}: cannot read file: {exc}")
+        return report
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        report.errors.append(f"{p}: YAML parse error: {exc}")
+        return report
+
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        report.errors.append(
+            f"{p}: top-level YAML document must be a mapping (got {type(data).__name__})"
+        )
+        return report
+
+    env_errors: list[str] = []
+    resolved = _resolve_env_refs(data, env=env, errors=env_errors)
+    report.errors.extend(env_errors)
+
+    schema = load_schema(DIGIPROJECT_V1ALPHA1)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    for err in sorted(validator.iter_errors(resolved), key=lambda e: list(e.absolute_path)):
+        loc = _format_schema_error_path(err.absolute_path)
+        report.errors.append(f"{loc}: {err.message}")
+
+    return report

--- a/digigraph/src/digigraph/schemas/__init__.py
+++ b/digigraph/src/digigraph/schemas/__init__.py
@@ -1,0 +1,23 @@
+"""Packaged JSON Schemas for digigraph (e.g. DigiProject v1alpha1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_SCHEMA_DIR = Path(__file__).parent
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    """Load a packaged JSON Schema by filename (e.g. 'digiproject.v1alpha1.json')."""
+    path = _SCHEMA_DIR / name
+    return json.loads(path.read_text())
+
+
+def schema_path(name: str) -> Path:
+    """Return the on-disk path of a packaged schema file."""
+    return _SCHEMA_DIR / name
+
+
+DIGIPROJECT_V1ALPHA1 = "digiproject.v1alpha1.json"

--- a/digigraph/src/digigraph/schemas/digiproject.v1alpha1.json
+++ b/digigraph/src/digigraph/schemas/digiproject.v1alpha1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DigiProject v1alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string" },
+        "description": { "type": "string" },
+        "version":     { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+" }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled":               { "type": "array",  "items": { "type": "string" } },
+        "llm_mode":              { "type": "string",  "enum": ["test", "medium", "best"] },
+        "planning_mode":         { "type": "boolean" },
+        "workflow_profile":      { "type": "string" },
+        "allowed_tools":         { "type": "array",  "items": { "type": "string" } },
+        "research_system_prompt":{ "type": "string" }
+      }
+    },
+    "run_data_dir": { "type": ["string", "null"] },
+    "indexes_dir":  { "type": ["string", "null"] },
+    "mcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port":    { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "tools":   { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "services": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "digisearch_url": { "type": "string", "format": "uri" },
+        "litellm_url":    { "type": "string", "format": "uri" },
+        "digiquant_url":  { "type": "string", "format": "uri" }
+      }
+    }
+  }
+}

--- a/tests/dg/test_project_validate.py
+++ b/tests/dg/test_project_validate.py
@@ -1,0 +1,150 @@
+"""Unit tests for the ``digi project validate`` CLI and validator library."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digigraph.cli import main as cli_main
+from digigraph.project_validate import ValidationReport, validate_project_file
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_PATH = REPO_ROOT / "docs" / "templates" / "project" / "digiproject.yaml"
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset env vars the template references, so default-resolution is exercised."""
+    for var in ("DIGISEARCH_URL", "OPENAI_API_BASE", "DIGIQUANT_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.unit
+def test_template_validates_clean(_clean_env: None) -> None:
+    report = validate_project_file(TEMPLATE_PATH)
+    assert report.ok, report.render()
+
+
+@pytest.mark.unit
+def test_invalid_llm_mode_fails(tmp_path: Path, _clean_env: None) -> None:
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "project": {"name": "x", "version": "0.1.0"},
+                "agents": {"enabled": ["research"], "llm_mode": "bogus"},
+            }
+        )
+    )
+    report = validate_project_file(cfg)
+    assert not report.ok
+    assert any("llm_mode" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_bad_version_pattern_fails(tmp_path: Path, _clean_env: None) -> None:
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(yaml.safe_dump({"project": {"name": "x", "version": "not-semver"}}))
+    report = validate_project_file(cfg)
+    assert not report.ok
+    assert any("version" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_additional_properties_rejected(tmp_path: Path, _clean_env: None) -> None:
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(yaml.safe_dump({"project": {"name": "x"}, "nonsense_key": 1}))
+    report = validate_project_file(cfg)
+    assert not report.ok
+    assert any("nonsense_key" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_unresolved_env_ref_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGI_DOES_NOT_EXIST", raising=False)
+    cfg = tmp_path / "digiproject.yaml"
+    # No default → must error; also not a URI so schema would fail anyway, but env
+    # error must surface first with a clear message.
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "services": {"digisearch_url": "${DIGI_DOES_NOT_EXIST}"},
+            }
+        )
+    )
+    report = validate_project_file(cfg)
+    assert not report.ok
+    assert any("DIGI_DOES_NOT_EXIST" in e and "unresolved" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_env_ref_with_default_resolves(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGI_UNSET_VAR", raising=False)
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "digisearch_url": "${DIGI_UNSET_VAR:-http://fallback:8002}",
+                }
+            }
+        )
+    )
+    report = validate_project_file(cfg)
+    assert report.ok, report.render()
+
+
+@pytest.mark.unit
+def test_env_ref_reads_from_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_TEST_URL", "http://set-in-env:9999")
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(yaml.safe_dump({"services": {"digisearch_url": "${DIGI_TEST_URL}"}}))
+    report = validate_project_file(cfg)
+    assert report.ok, report.render()
+
+
+@pytest.mark.unit
+def test_missing_file_reported(tmp_path: Path) -> None:
+    report = validate_project_file(tmp_path / "nope.yaml")
+    assert not report.ok
+    assert any("not found" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_yaml_parse_error_reported(tmp_path: Path) -> None:
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text("project:\n  name: [unterminated\n")
+    report = validate_project_file(cfg)
+    assert not report.ok
+    assert any("YAML parse error" in e for e in report.errors)
+
+
+@pytest.mark.unit
+def test_report_render_ok_and_errors() -> None:
+    assert ValidationReport().render() == "OK"
+    r = ValidationReport(errors=["a", "b"])
+    rendered = r.render()
+    assert "2 error(s)" in rendered
+    assert "- a" in rendered and "- b" in rendered
+
+
+@pytest.mark.unit
+def test_cli_exits_zero_on_template(_clean_env: None, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = cli_main(["project", "validate", str(TEMPLATE_PATH)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OK" in out
+
+
+@pytest.mark.unit
+def test_cli_exits_nonzero_on_invalid(
+    tmp_path: Path, _clean_env: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg = tmp_path / "digiproject.yaml"
+    cfg.write_text(yaml.safe_dump({"agents": {"llm_mode": "bogus"}}))
+    rc = cli_main(["project", "validate", str(cfg)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "llm_mode" in out

--- a/tests/dg/test_schema_sync.py
+++ b/tests/dg/test_schema_sync.py
@@ -1,0 +1,52 @@
+"""Guard: the JSON Schema embedded in ``docs/spec/project-spec-v1alpha1.md`` must
+match the extracted file at ``digigraph/src/digigraph/schemas/digiproject.v1alpha1.json``.
+
+The JSON file is the single source of truth at runtime; the spec doc copy is for
+humans. This test catches drift between the two.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from digigraph.schemas import DIGIPROJECT_V1ALPHA1, load_schema, schema_path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC_DOC = REPO_ROOT / "docs" / "spec" / "project-spec-v1alpha1.md"
+
+# Match a fenced ```json ... ``` block that contains the DigiProject title.
+_JSON_BLOCK = re.compile(
+    r"```json\s*\n(?P<body>\{.*?\"title\"\s*:\s*\"DigiProject v1alpha1\".*?\})\s*\n```",
+    re.DOTALL,
+)
+
+
+def _extract_embedded_schema() -> dict:
+    text = SPEC_DOC.read_text()
+    match = _JSON_BLOCK.search(text)
+    assert match, (
+        f"Could not locate DigiProject v1alpha1 JSON Schema block in {SPEC_DOC}. "
+        "Expected a ```json fenced code block containing the schema."
+    )
+    return json.loads(match.group("body"))
+
+
+@pytest.mark.unit
+def test_spec_doc_contains_schema_block() -> None:
+    embedded = _extract_embedded_schema()
+    assert embedded.get("title") == "DigiProject v1alpha1"
+
+
+@pytest.mark.unit
+def test_extracted_schema_matches_spec_doc() -> None:
+    """Parsed-equality check: embedded block == extracted JSON file (ignores formatting)."""
+    embedded = _extract_embedded_schema()
+    extracted = load_schema(DIGIPROJECT_V1ALPHA1)
+    assert embedded == extracted, (
+        f"Schema drift detected. Update either {SPEC_DOC} or {schema_path(DIGIPROJECT_V1ALPHA1)} "
+        "so they match."
+    )


### PR DESCRIPTION
## Summary
- Extracts the draft-2020-12 JSON Schema from `docs/spec/project-spec-v1alpha1.md` into `digigraph/src/digigraph/schemas/digiproject.v1alpha1.json` as the single runtime source of truth.
- Ships `digi project validate <path>` (new `digigraph.cli` + `digigraph.project_validate`): YAML load, `${VAR}` / `${VAR:-default}` env-ref resolution, schema validation with URI format checking, aggregated human-readable report, non-zero exit on any error.
- Adds a schema-sync pytest (`tests/dg/test_schema_sync.py`) that parses the embedded ```json block and diffs it against the extracted JSON file — drift caught in CI.
- Adds `jsonschema>=4.21` dep and `digi = digigraph.cli:main` console script; packages `schemas/*.json` as package data.

Unblocks #85, #83, #23 (part of epic #3).

Fixes #84

## Test plan
- [x] `pytest tests/dg/test_project_validate.py tests/dg/test_schema_sync.py -v` — 14 passed
- [x] `pytest tests/dg/test_project_config.py -m unit` — existing loader tests still green
- [x] `ruff check` + `ruff format --check` clean on new files
- [x] `make score` — Security 10 / Quality 8 / Optimization 10 / Accuracy 10 (all thresholds met)
- [x] Template (`docs/templates/project/digiproject.yaml`) validates clean
- [x] Invalid `llm_mode`, bad version pattern, additional-properties → non-zero exit
- [x] Unresolved `${VAR}` → non-zero exit with clear location
- [x] `${VAR:-default}` resolves to default when var unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)