### PR TITLE
feat(website): hero CTA linking to chat.digithings.ai

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -40,6 +40,10 @@
                     <p class="description">
                         A composable, platform-agnostic architecture designed for the rapid deployment of autonomous agents. Maintain total control of your stack without vendor lock-in.
                     </p>
+                    <a href="https://chat.digithings.ai" class="hero-cta" target="_blank" rel="noopener noreferrer">
+                        Chat with DigiThings
+                        <span class="hero-cta-arrow" aria-hidden="true">&rarr;</span>
+                    </a>
                 </div>
                 
                 <div class="hero-visual scroll-trigger" data-direction="right">

--- a/website/style.css
+++ b/website/style.css
@@ -204,6 +204,48 @@ p:last-child {
   max-width: 500px;
 }
 
+.hero-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 2rem;
+  padding: 0.9rem 1.6rem;
+  background-color: var(--accent-color);
+  color: var(--bg-primary);
+  font-family: var(--font-family);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  border: 1px solid var(--accent-color);
+  border-radius: 8px;
+  transition: transform 0.2s var(--transition-ease),
+              background-color 0.2s ease,
+              box-shadow 0.2s ease;
+}
+
+.hero-cta:hover,
+.hero-cta:focus-visible {
+  transform: translateY(-2px);
+  background-color: var(--text-primary);
+  box-shadow: 0 10px 30px -10px rgba(255, 255, 255, 0.35);
+  outline: none;
+}
+
+.hero-cta:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 3px;
+}
+
+.hero-cta-arrow {
+  transition: transform 0.2s var(--transition-ease);
+}
+
+.hero-cta:hover .hero-cta-arrow,
+.hero-cta:focus-visible .hero-cta-arrow {
+  transform: translateX(3px);
+}
+
 .hero-divider {
   margin-top: 3rem;
   height: 1px;
@@ -797,5 +839,11 @@ p:last-child {
   .flow-node {
     font-size: 0.95rem;
     padding: 0.75rem 1rem;
+  }
+
+  .hero-cta {
+    font-size: 0.95rem;
+    padding: 0.8rem 1.35rem;
+    margin-top: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary

Adds a prominent above-the-fold "Chat with DigiThings" button in the hero section of `website/index.html`, linking to `https://chat.digithings.ai`. Implements issue #79 (Phase 3a epic #7).

Styled using existing CSS tokens (`--accent-color`, `--bg-primary`, `--transition-ease`, `--font-family`) — no new framework, no new build step, no new dependency. Matches existing nav convention (`target="_blank" rel="noopener noreferrer"`) for the outbound chat link.

## Changes

- `website/index.html` (+4 / -0): insert `<a class="hero-cta">` inside `.hero-text`, immediately after the `.description` paragraph. Includes a decorative right-arrow span marked `aria-hidden`.
- `website/style.css` (+48 / -0): add `.hero-cta` / `.hero-cta-arrow` styles with hover + `:focus-visible` states (lift, shadow, arrow nudge). Add 480px mobile sizing tweak.

## Design notes

- Solid white fill on dark background — highest-contrast affordance, visible above the fold against the starfield.
- `:focus-visible` outline for keyboard accessibility.
- Inline-flex so the arrow lines up on the baseline; `aria-hidden` on the arrow keeps assistive tech focused on the button label.
- Mobile (≤768px): `.hero-text` already gets `align-items: center` on small screens, so the inline-flex button centers naturally — no extra rule needed.
- Smaller padding / font-size at ≤480px to keep the tap target proportionate without overflow.

## Acceptance checklist (from #79)

- [x] Hero-area button labeled "Chat with DigiThings" → `https://chat.digithings.ai`.
- [x] Styled with existing landing aesthetic; no new framework.
- [x] Visible above the fold on desktop (≥1024px) and mobile (≤480px).
- [x] Matches existing nav convention: `target="_blank" rel="noopener noreferrer"`.
- [x] Local smoke: opens `website/index.html`, button renders in hero, clicks through to chat.

## Scoring

`make score` (staged): Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10 — all pass.
`make doc-check`: OK (80 markdown files scanned).

## Test plan

- [ ] Open `website/index.html` in a browser; confirm CTA renders in the hero above the fold.
- [ ] Hover / keyboard-tab to the CTA; confirm lift + focus outline render.
- [ ] Click CTA; confirm it opens `https://chat.digithings.ai` in a new tab.
- [ ] Resize viewport to 480px and 1024px; confirm CTA remains visible above the fold and proportionate.
- [ ] Verify `prefers-reduced-motion` users still see the CTA (existing global `.scroll-trigger` override keeps it fully opaque; CTA itself has no scroll-trigger so it's always visible).

Fixes #79

Related: #7 (Phase 3a epic), ADR-0002 (domain unification).