### PR TITLE
feat(digisearch): DigiThings-guide project indexing ecosystem docs

### DIFF
--- a/.github/workflows/reindex-digithings-guide.yml
+++ b/.github/workflows/reindex-digithings-guide.yml
@@ -1,0 +1,79 @@
+# Reindex the DigiThings-guide `docs` index on merge to develop.
+#
+# Keep the `paths:` filter below in sync with `sources:` in
+# docs/projects/digithings-guide/indexes/docs.yaml.
+#
+# Today this runs a DRY-RUN (resolves globs, parses + chunks in-process via
+# the DigiSearch stub backend). When DigiSearch exposes a service-less ingest
+# entry point, swap the script call to `--apply` (see scripts/reindex_digithings_guide.py).
+# Follow-up (tracked under issue #23): wire real ingest once DigiSearch
+# exposes a service-less ingest entry point.
+name: Reindex DigiThings-guide
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - README.md
+      - ROADMAP.md
+      - ARCHITECTURE.md
+      - AGENTS.md
+      - CONTRIBUTING.md
+      - RELEASES.md
+      - SECURITY.md
+      - BRANCHING.md
+      - docs/VISION.md
+      - docs/adr/*.md
+      - digibase/ARCHITECTURE.md
+      - digibase/AGENTS.md
+      - digibase/README.md
+      - digibase/DIGI*.md
+      - digichat/ARCHITECTURE.md
+      - digichat/AGENTS.md
+      - digichat/README.md
+      - digichat/DIGI*.md
+      - digiclaw/ARCHITECTURE.md
+      - digiclaw/AGENTS.md
+      - digiclaw/DIGI*.md
+      - digigraph/ARCHITECTURE.md
+      - digigraph/AGENTS.md
+      - digigraph/DIGI*.md
+      - digikey/ARCHITECTURE.md
+      - digikey/AGENTS.md
+      - digikey/README.md
+      - digikey/DIGI*.md
+      - digiquant/ARCHITECTURE.md
+      - digiquant/AGENTS.md
+      - digiquant/DIGI*.md
+      - digisearch/ARCHITECTURE.md
+      - digisearch/AGENTS.md
+      - digisearch/DIGI*.md
+      - digismith/ARCHITECTURE.md
+      - digismith/AGENTS.md
+      - digismith/DIGI*.md
+      - docs/projects/digithings-guide/**
+      - scripts/reindex_digithings_guide.py
+      - .github/workflows/reindex-digithings-guide.yml
+  workflow_dispatch:
+
+jobs:
+  reindex:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install DigiSearch (editable) + yaml
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+          # Editable install of DigiSearch gives the script its parsers + chunkers.
+          python -m pip install -e digisearch
+
+      - name: Reindex (dry-run)
+        env:
+          DIGISEARCH_ALLOW_STUB: "1"
+        run: python scripts/reindex_digithings_guide.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ venv/
 projects/*/.env
 
 # Confidential: project configs and deployments (never share)
-projects/
+# Anchored to repo root so docs/projects/ (public dogfooding projects) is not captured.
+/projects/
 *.pyc
 __pycache__/
 .pytest_cache/

--- a/docs/projects/digithings-guide/README.md
+++ b/docs/projects/digithings-guide/README.md
@@ -1,0 +1,26 @@
+# DigiThings-guide
+
+A DigiThings Project that indexes the DigiThings ecosystem's own documentation — ARCHITECTURE files, ADRs, VISION, ROADMAP, and each component's AGENTS / README / DIGI\*.md — so the future "Chat with DigiThings" surface can retrieve from them. This is dogfooding: DigiSearch indexing DigiThings.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `digiproject.yaml` | v1alpha1 project config. Declares the project and points at `indexes/` for discovery. |
+| `indexes/docs.yaml` | Index manifest for the `docs` index — lists `sources` globs, backend, description. |
+
+## Reindex
+
+A GitHub Action at [`.github/workflows/reindex-digithings-guide.yml`](../../../.github/workflows/reindex-digithings-guide.yml) triggers on pushes to `develop` that touch any tracked source file. It invokes [`scripts/reindex_digithings_guide.py`](../../../scripts/reindex_digithings_guide.py), which today does a dry-run (resolves the glob set and chunks in-process via the DigiSearch stub backend) and will call a service-less ingest entry point once that lands in DigiSearch.
+
+## Convention note
+
+Conventional DigiThings Projects live under `projects/<name>/` which is gitignored for confidentiality. This one is public and lives under `docs/projects/digithings-guide/` so it can be tracked without carving a `.gitignore` exception. At runtime a deploy may symlink or copy this into the expected `projects/` layout.
+
+## Related
+
+- Spec: [`docs/spec/project-spec-v1alpha1.md`](../../spec/project-spec-v1alpha1.md)
+- Schema: `digigraph/src/digigraph/schemas/digiproject.v1alpha1.json` (landed via PR #84)
+- Template: [`docs/templates/project/`](../../templates/project/)
+- Epic: [#3 Project Spec](https://github.com/digithings-ai/digithings/issues/3)
+- Issue: [#23](https://github.com/digithings-ai/digithings/issues/23)

--- a/docs/projects/digithings-guide/digiproject.yaml
+++ b/docs/projects/digithings-guide/digiproject.yaml
@@ -1,0 +1,45 @@
+# digiproject.yaml — v1alpha1
+# DigiThings-guide: dogfooding project that indexes the DigiThings ecosystem's
+# own documentation so the future "Chat with DigiThings" surface can retrieve
+# from ARCHITECTURE.md, ADRs, VISION, ROADMAP, and component docs.
+#
+# Spec: docs/spec/project-spec-v1alpha1.md
+# Schema: digigraph/src/digigraph/schemas/digiproject.v1alpha1.json (landed via PR #84)
+#
+# Location note: conventional projects live under `projects/<name>/` (gitignored
+# for confidentiality). This dogfooding project is public and lives under
+# `docs/projects/digithings-guide/` so it can be tracked without carving a
+# .gitignore exception. A runtime deploy may symlink or copy this into the
+# expected `projects/` layout.
+
+project:
+  name: digithings-guide
+  description: "Dogfooding index of DigiThings ecosystem documentation (ARCHITECTURE, ADRs, VISION, ROADMAP, component docs)."
+  version: "0.1.0"
+
+agents:
+  enabled:
+    - research
+  llm_mode: test
+  allowed_tools:
+    - digisearch
+  research_system_prompt: |
+    You are the DigiThings guide. Answer questions about the DigiThings
+    ecosystem by retrieving from the `docs` index and citing the source
+    files (path + heading). When a question has no grounded answer in the
+    index, say so and point the user to ROADMAP.md or the relevant
+    component's AGENTS.md rather than guessing.
+
+# Multi-index discovery: each *.yaml file under indexes/ becomes one DigiSearch
+# index tool. We ship exactly one: `docs`.
+indexes_dir: indexes
+
+mcp:
+  enabled: false
+  port: 8765
+  tools:
+    - digigraph_workflow
+
+services:
+  digisearch_url: ${DIGISEARCH_URL:-http://digisearch:8002}
+  litellm_url: ${OPENAI_API_BASE:-http://litellm:4000/v1}

--- a/docs/projects/digithings-guide/indexes/docs.yaml
+++ b/docs/projects/digithings-guide/indexes/docs.yaml
@@ -1,0 +1,72 @@
+# indexes/docs.yaml — DigiSearch index manifest for the DigiThings-guide project.
+#
+# Discovered by digigraph.project_config._discover_indexes_from_dir: each *.yaml
+# under indexes/ becomes one index tool (digisearch_<index_name>_query).
+#
+# `sources` is a v1alpha1 forward-looking extension. The current
+# `_discover_indexes_from_dir` reads only `index_name` + `backend`; the
+# `sources` globs below are consumed by scripts/reindex_digithings_guide.py and
+# by the reindex-digithings-guide GitHub Action's `paths:` filter. When a
+# service-less ingest entry point lands in DigiSearch, it should consume this
+# same block.
+
+index_name: docs
+backend: azure_search
+
+# Human-readable description used by the research node when routing.
+description: |
+  The DigiThings ecosystem documentation: root README, ROADMAP, VISION,
+  ADRs, component ARCHITECTURE + AGENTS + DIGI*.md files. Use for
+  questions about how DigiThings works, what each component does, or
+  why a design decision was made.
+
+# Source globs (relative to repo root). Keep in sync with the `paths:` filter
+# in .github/workflows/reindex-digithings-guide.yml.
+sources:
+  # Root-level docs
+  - README.md
+  - ROADMAP.md
+  - ARCHITECTURE.md
+  - AGENTS.md
+  - CONTRIBUTING.md
+  - RELEASES.md
+  - SECURITY.md
+  - BRANCHING.md
+  # VISION lives under docs/ in this repo (not root)
+  - docs/VISION.md
+  # Architecture decision records
+  - docs/adr/*.md
+  # Component ARCHITECTURE / AGENTS / README / DIGI*.md
+  # (DIGI*.md glob matches when components add top-level DIGI named docs;
+  # no-ops today for components that don't.)
+  - digibase/ARCHITECTURE.md
+  - digibase/AGENTS.md
+  - digibase/README.md
+  - digibase/DIGI*.md
+  - digichat/ARCHITECTURE.md
+  - digichat/AGENTS.md
+  - digichat/README.md
+  - digichat/DIGI*.md
+  - digiclaw/ARCHITECTURE.md
+  - digiclaw/AGENTS.md
+  - digiclaw/DIGI*.md
+  - digigraph/ARCHITECTURE.md
+  - digigraph/AGENTS.md
+  - digigraph/DIGI*.md
+  - digikey/ARCHITECTURE.md
+  - digikey/AGENTS.md
+  - digikey/README.md
+  - digikey/DIGI*.md
+  - digiquant/ARCHITECTURE.md
+  - digiquant/AGENTS.md
+  - digiquant/DIGI*.md
+  - digisearch/ARCHITECTURE.md
+  - digisearch/AGENTS.md
+  - digisearch/DIGI*.md
+  - digismith/ARCHITECTURE.md
+  - digismith/AGENTS.md
+  - digismith/DIGI*.md
+
+# Chunking / embedding intentionally omitted — inherit DigiSearch defaults
+# (recursive 512/64 chunker; backend-configured embeddings). Override only
+# after an ADR documents the reason.

--- a/scripts/reindex_digithings_guide.py
+++ b/scripts/reindex_digithings_guide.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Reindex the DigiThings-guide `docs` index.
+
+Reads the index manifest at docs/projects/digithings-guide/indexes/docs.yaml,
+expands the `sources` globs against the repo root, and (today) performs a
+DRY-RUN chunk count via the in-process DigiSearch stub. Swap to a real
+service-less ingest call once DigiSearch exposes one.
+
+Exit codes:
+  0 — success (all resolved files ingested/dry-run-chunked without error)
+  1 — manifest missing or malformed
+  2 — ingest error
+
+Usage:
+  python scripts/reindex_digithings_guide.py              # dry-run
+  python scripts/reindex_digithings_guide.py --apply      # wire to real ingest when available
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "docs" / "projects" / "digithings-guide" / "indexes" / "docs.yaml"
+
+
+def resolve_sources(manifest_path: Path) -> tuple[str, list[Path]]:
+    """Return (index_name, resolved file paths) from the manifest's `sources` globs."""
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"manifest not found: {manifest_path}")
+    data = yaml.safe_load(manifest_path.read_text()) or {}
+    index_name = (data.get("index_name") or "").strip()
+    if not index_name:
+        raise ValueError(f"manifest missing index_name: {manifest_path}")
+    patterns = data.get("sources") or []
+    seen: set[Path] = set()
+    resolved: list[Path] = []
+    for pattern in patterns:
+        for match in sorted(REPO_ROOT.glob(pattern)):
+            if not match.is_file():
+                continue
+            rp = match.resolve()
+            if rp in seen:
+                continue
+            seen.add(rp)
+            resolved.append(match)
+    return index_name, resolved
+
+
+def dry_run(index_name: str, paths: list[Path]) -> int:
+    """Parse + chunk each file in-process; print a summary. Uses the DigiSearch stub backend."""
+    try:
+        from digisearch.ingestion.chunkers.recursive import RecursiveChunker
+        from digisearch.ingestion.registry import ParserRegistry
+    except ImportError as exc:
+        print(f"digisearch not importable: {exc}", file=sys.stderr)
+        print(
+            "Install with: pip install -e digisearch  (or run the real ingest once the CLI supports service-less mode)",
+            file=sys.stderr,
+        )
+        return 2
+
+    registry = ParserRegistry()
+    chunker = RecursiveChunker(chunk_size=512, chunk_overlap=64)
+    total_chunks = 0
+    skipped: list[tuple[Path, str]] = []
+    for path in paths:
+        parser = registry.get_parser(str(path))
+        if parser is None:
+            skipped.append((path, "no parser"))
+            continue
+        try:
+            doc = registry.parse(path)
+            chunks = chunker.chunk(doc)
+            total_chunks += len(chunks)
+            print(f"  {path.relative_to(REPO_ROOT)}: {len(chunks)} chunks")
+        except Exception as exc:  # noqa: BLE001 — dry-run surfaces parser errors
+            skipped.append((path, str(exc)))
+
+    print(f"\nindex={index_name} files={len(paths)} chunks={total_chunks} skipped={len(skipped)}")
+    for path, reason in skipped:
+        print(f"  SKIP {path.relative_to(REPO_ROOT)}: {reason}", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Ingest into the configured backend (not yet supported — runs dry-run with warning).",
+    )
+    args = parser.parse_args()
+
+    try:
+        index_name, paths = resolve_sources(MANIFEST)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"manifest error: {exc}", file=sys.stderr)
+        return 1
+
+    if not paths:
+        print("no source files resolved — nothing to index", file=sys.stderr)
+        return 0
+
+    if args.apply:
+        # Follow-up (tracked under issue #23): invoke service-less ingest once it
+        # lands in DigiSearch. Until then, dry-run still proves the file set
+        # parses and chunks cleanly.
+        print("--apply: service-less ingest not yet available; running dry-run", file=sys.stderr)
+
+    print(f"Resolving {len(paths)} source files for index '{index_name}'...")
+    return dry_run(index_name, paths)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_digithings_guide_project.py
+++ b/tests/scripts/test_digithings_guide_project.py
@@ -1,0 +1,113 @@
+"""Unit tests for the DigiThings-guide project config.
+
+Validates that:
+  1. digiproject.yaml parses as valid YAML and conforms to the v1alpha1
+     JSON Schema that is documented in docs/spec/project-spec-v1alpha1.md.
+  2. The index manifest at indexes/docs.yaml has the fields that
+     digigraph.project_config._discover_indexes_from_dir expects.
+  3. The reindex script resolves at least one source file from the
+     manifest globs (catches regressions where a rename silently empties
+     the source list).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_DIR = REPO_ROOT / "docs" / "projects" / "digithings-guide"
+PROJECT_CONFIG = PROJECT_DIR / "digiproject.yaml"
+INDEX_MANIFEST = PROJECT_DIR / "indexes" / "docs.yaml"
+SPEC_MD = REPO_ROOT / "docs" / "spec" / "project-spec-v1alpha1.md"
+
+
+pytestmark = pytest.mark.unit
+
+
+def _load_yaml_with_env_substitution(path: Path) -> dict:
+    """Read YAML, stripping ``${VAR:-default}`` defaults so safe_load tolerates them.
+
+    digigraph.project_config performs env substitution before parsing; we do a
+    minimal equivalent here so the test isn't coupled to that module.
+    """
+    raw = path.read_text()
+    # Replace ${NAME:-default} / ${NAME} with the default (or empty string).
+    raw = re.sub(r"\$\{([A-Z_][A-Z0-9_]*):-([^}]*)\}", r"\2", raw)
+    raw = re.sub(r"\$\{([A-Z_][A-Z0-9_]*)\}", "", raw)
+    return yaml.safe_load(raw) or {}
+
+
+def _extract_schema_from_spec() -> dict:
+    """Extract the JSON Schema block from docs/spec/project-spec-v1alpha1.md."""
+    import json
+
+    text = SPEC_MD.read_text()
+    match = re.search(r"```json\n(\{.*?\})\n```", text, re.DOTALL)
+    assert match is not None, "could not find JSON Schema block in project-spec-v1alpha1.md"
+    return json.loads(match.group(1))
+
+
+def test_project_config_is_valid_yaml() -> None:
+    data = _load_yaml_with_env_substitution(PROJECT_CONFIG)
+    assert data["project"]["name"] == "digithings-guide"
+    assert re.match(r"^\d+\.\d+\.\d+", data["project"]["version"])
+
+
+def test_project_config_conforms_to_v1alpha1_schema() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _extract_schema_from_spec()
+    data = _load_yaml_with_env_substitution(PROJECT_CONFIG)
+    # Raises jsonschema.ValidationError on mismatch.
+    jsonschema.validate(instance=data, schema=schema)
+
+
+def test_index_manifest_has_required_fields() -> None:
+    data = yaml.safe_load(INDEX_MANIFEST.read_text())
+    # _discover_indexes_from_dir reads these:
+    assert data["index_name"] == "docs"
+    assert data["backend"] in {"azure_search", "chroma"}
+    # Forward-looking sources extension (consumed by reindex script + GH Action):
+    assert isinstance(data["sources"], list)
+    assert len(data["sources"]) > 0
+
+
+def test_reindex_script_resolves_source_files() -> None:
+    # Import the script as a module.
+    scripts_dir = REPO_ROOT / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    try:
+        import reindex_digithings_guide as rix  # type: ignore[import-not-found]
+    finally:
+        sys.path.pop(0)
+
+    index_name, paths = rix.resolve_sources(INDEX_MANIFEST)
+    assert index_name == "docs"
+    # Sanity: at minimum README.md, ROADMAP.md, ARCHITECTURE.md, docs/VISION.md,
+    # and the ADR index should resolve. If this drops to zero something is very wrong.
+    assert len(paths) >= 5
+    rels = {p.relative_to(REPO_ROOT).as_posix() for p in paths}
+    assert "README.md" in rels
+    assert "ROADMAP.md" in rels
+    assert "ARCHITECTURE.md" in rels
+    assert "docs/VISION.md" in rels
+    assert any(r.startswith("docs/adr/") for r in rels)
+
+
+def test_workflow_paths_match_manifest_sources() -> None:
+    """The GH Action's `paths:` filter should be a superset of the manifest's
+    `sources:` (minus the meta paths that trigger on config changes). Drift here
+    means the Action won't fire when a tracked doc changes."""
+    workflow = REPO_ROOT / ".github" / "workflows" / "reindex-digithings-guide.yml"
+    manifest = yaml.safe_load(INDEX_MANIFEST.read_text())
+    wf = yaml.safe_load(workflow.read_text())
+    # PyYAML parses the `on:` key as the boolean True. Support both spellings.
+    push_cfg = (wf.get("on") or wf.get(True) or {}).get("push", {})
+    wf_paths = set(push_cfg.get("paths", []))
+    missing = [src for src in manifest["sources"] if src not in wf_paths]
+    assert not missing, f"workflow paths missing sources: {missing}"


### PR DESCRIPTION
## Summary

- New DigiThings Project at `docs/projects/digithings-guide/` that dogfoods DigiSearch by indexing the DigiThings ecosystem's own docs (component ARCHITECTURE + AGENTS + README + DIGI*.md, root README/ROADMAP/ARCHITECTURE, `docs/VISION.md`, `docs/adr/*.md`).
- `digiproject.yaml` conforms to the v1alpha1 schema documented in `docs/spec/project-spec-v1alpha1.md`. The index manifest at `indexes/docs.yaml` declares an `docs` index plus a forward-looking `sources:` globs block consumed by the reindex script and the GH Action.
- `scripts/reindex_digithings_guide.py` resolves the globs, parses + chunks in-process via DigiSearch's recursive chunker (dry-run). 35 files resolve today.
- `.github/workflows/reindex-digithings-guide.yml` runs the script on merge to `develop` when any tracked source changes. Also fires on `workflow_dispatch`.
- Unit tests (`tests/scripts/test_digithings_guide_project.py`) validate the config against the v1alpha1 JSON Schema extracted from the spec markdown, check the index manifest fields, confirm the reindex script resolves at least five expected files, and guard against drift between manifest `sources:` and the Action's `paths:` filter.

## Why `docs/projects/` not `projects/`

`projects/` is root-level gitignored for confidential project configs. Rather than carving an un-ignore exception (which the task called out as one of two acceptable options), I placed the dogfooding project under `docs/projects/digithings-guide/`. I also anchored the gitignore pattern to `/projects/` so it no longer captures `docs/projects/` as a side effect. A deploy may symlink/copy this into the runtime-expected `projects/` layout.

## Deferred gaps

- **Real ingest.** DigiSearch has no service-less ingest today; the CLI's `ingest` writes to the in-process stub backend. The workflow runs as a dry-run that proves the file set parses and chunks cleanly. When a service-less ingest lands (or when the Action is taught to POST to a live DigiSearch), switch the script to `--apply`. Tracked as a follow-up.
- **`digi project validate`.** PR #92 (validate CLI) hasn't merged to `develop`. The unit test uses `jsonschema` against the schema embedded in the spec markdown — equivalent validation, no dependency on the un-merged CLI.
- **Top-level `DIGI*.md` component files.** None exist today in the tree; the manifest globs and Action `paths:` include them so they light up automatically when components add them.

## Test plan

- [x] `pytest tests/scripts/test_digithings_guide_project.py -v` — 5/5 pass
- [x] `python3 scripts/check_doc_links.py` — OK (81 markdown files scanned)
- [x] `ruff check` — clean
- [x] `make score` — 10/10 across Security/Quality/Optimization/Accuracy
- [ ] After merge: verify the Reindex DigiThings-guide Action fires on next docs push to develop

Fixes #23