### PR TITLE
feat(digigraph): digi project migrate legacy config → digiproject.yaml

### DIFF
--- a/digigraph/src/digigraph/cli.py
+++ b/digigraph/src/digigraph/cli.py
@@ -1,7 +1,7 @@
 """``digi`` command-line interface.
 
-Minimal surface for Phase 1: ``digi project validate <path>``. Additional subcommands
-(``render``, ``migrate``) are tracked as separate backlog items.
+Phase 1 surface: ``digi project validate`` and ``digi project migrate``. The
+``render`` subcommand is tracked as a separate backlog item.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ import argparse
 import sys
 from typing import Sequence
 
+from digigraph.project_migrate import migrate_project_file
 from digigraph.project_validate import validate_project_file
 
 
@@ -29,11 +30,28 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     validate.add_argument("path", help="Path to the digiproject.yaml file.")
 
+    migrate = project_sub.add_parser(
+        "migrate",
+        help="Migrate a pre-spec config.yaml to a v1alpha1 digiproject.yaml.",
+    )
+    migrate.add_argument("path", help="Path to the legacy config.yaml file.")
+    migrate.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Destination path (default: digiproject.yaml next to the source).",
+    )
+    migrate.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite destination if it already exists.",
+    )
+
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """CLI entry point. Returns the process exit code (0 = ok, 1 = validation error)."""
+    """CLI entry point. Returns the process exit code (0 = ok, 1 = error)."""
     parser = _build_parser()
     args = parser.parse_args(argv)
 
@@ -41,6 +59,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         report = validate_project_file(args.path)
         print(f"{args.path}: {report.render()}")
         return 0 if report.ok else 1
+
+    if args.group == "project" and args.command == "migrate":
+        try:
+            dest, mig_report, _val_report = migrate_project_file(
+                args.path, args.output, force=args.force
+            )
+        except (FileNotFoundError, FileExistsError, ValueError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        print(f"{args.path} -> {dest}: {mig_report.render()}")
+        return 0
 
     parser.error(f"unknown command: {args.group} {args.command}")
     return 2  # unreachable — argparse.error exits

--- a/digigraph/src/digigraph/project_migrate.py
+++ b/digigraph/src/digigraph/project_migrate.py
@@ -1,0 +1,173 @@
+"""Migrate a pre-spec ``config.yaml`` to a v1alpha1 ``digiproject.yaml``.
+
+Applies the field renames and section-nesting changes documented in the migration
+table of ``docs/spec/project-spec-v1alpha1.md``. Unknown top-level keys are surfaced
+to stderr as ``UserWarning`` rather than silently dropped, so migration reports are
+auditable. The resulting structure is re-validated via
+:mod:`digigraph.project_validate` before the file is written — migrate + validate
+stay in lockstep.
+
+Used by the ``digi project migrate`` CLI; callable as a library for programmatic use.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from digigraph.project_validate import ValidationReport, validate_project_file
+
+# Top-level keys that v1alpha1 recognises (in the schema). Anything else is either
+# migrated below or flagged as unknown.
+_KNOWN_V1ALPHA1_TOP_LEVEL: frozenset[str] = frozenset(
+    {"project", "agents", "run_data_dir", "indexes_dir", "mcp", "services"}
+)
+
+# Legacy top-level keys that migrate into the v1alpha1 shape. Their handling is
+# explicit (see :func:`migrate_mapping`), so we don't warn on them.
+_LEGACY_HANDLED_TOP_LEVEL: frozenset[str] = frozenset({"run_storage", "graph", "indexes"})
+
+
+@dataclass
+class MigrationReport:
+    """Outcome of a migration run. ``warnings`` captures unknown/dropped keys."""
+
+    warnings: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        if not self.warnings:
+            return "migrated cleanly"
+        lines = [f"migrated with {len(self.warnings)} warning(s):"]
+        for w in self.warnings:
+            lines.append(f"  - {w}")
+        return "\n".join(lines)
+
+
+def migrate_mapping(data: dict[str, Any]) -> tuple[dict[str, Any], MigrationReport]:
+    """Apply legacy→v1alpha1 migrations in-memory.
+
+    Returns the migrated mapping alongside a :class:`MigrationReport`. Emits a
+    ``UserWarning`` for every unknown top-level key so the message surfaces on
+    stderr when the caller does not capture warnings.
+    """
+    report = MigrationReport()
+    out: dict[str, Any] = {}
+
+    # Preserve passthrough sections/fields verbatim when present.
+    for key in ("project", "agents", "mcp", "services"):
+        if key in data and isinstance(data[key], dict):
+            out[key] = dict(data[key])
+
+    # run_data_dir: explicit field wins; else lift run_storage.dir.
+    if "run_data_dir" in data:
+        out["run_data_dir"] = data["run_data_dir"]
+    elif isinstance(data.get("run_storage"), dict) and "dir" in data["run_storage"]:
+        out["run_data_dir"] = data["run_storage"]["dir"]
+        extra = {k: v for k, v in data["run_storage"].items() if k != "dir"}
+        if extra:
+            msg = (
+                f"run_storage subkeys dropped (not in v1alpha1): {sorted(extra)}. "
+                "Only 'dir' is migrated (→ run_data_dir)."
+            )
+            report.warnings.append(msg)
+            warnings.warn(msg, UserWarning, stacklevel=2)
+
+    if "indexes_dir" in data:
+        out["indexes_dir"] = data["indexes_dir"]
+
+    # graph.workflow_profile → agents.workflow_profile (agents wins if both set).
+    graph_cfg = data.get("graph")
+    if isinstance(graph_cfg, dict):
+        wp = graph_cfg.get("workflow_profile")
+        if wp is not None:
+            agents_out = out.setdefault("agents", {})
+            if "workflow_profile" not in agents_out:
+                agents_out["workflow_profile"] = wp
+        extra = {k: v for k, v in graph_cfg.items() if k != "workflow_profile"}
+        if extra:
+            msg = (
+                f"graph subkeys dropped (not in v1alpha1): {sorted(extra)}. "
+                "Only 'workflow_profile' is migrated (→ agents.workflow_profile)."
+            )
+            report.warnings.append(msg)
+            warnings.warn(msg, UserWarning, stacklevel=2)
+
+    # Legacy top-level `indexes:` list has no v1alpha1 equivalent — indexes are now
+    # discovered from `indexes_dir`. Flag it so the user knows to migrate manually.
+    if "indexes" in data:
+        msg = (
+            "Top-level 'indexes' list is not part of v1alpha1 — use 'indexes_dir' "
+            "pointing at a directory of per-index YAML files instead. Original value "
+            "dropped; migrate each entry into its own file under that directory."
+        )
+        report.warnings.append(msg)
+        warnings.warn(msg, UserWarning, stacklevel=2)
+
+    # Unknown top-level keys → warn and drop.
+    for key in data:
+        if key in _KNOWN_V1ALPHA1_TOP_LEVEL or key in _LEGACY_HANDLED_TOP_LEVEL:
+            continue
+        msg = f"unknown top-level key '{key}' has no v1alpha1 mapping; dropped."
+        report.warnings.append(msg)
+        warnings.warn(msg, UserWarning, stacklevel=2)
+
+    return out, report
+
+
+def migrate_project_file(
+    src: str | Path,
+    dest: str | Path | None = None,
+    *,
+    force: bool = False,
+) -> tuple[Path, MigrationReport, ValidationReport]:
+    """Migrate ``src`` to ``dest`` (default: ``digiproject.yaml`` next to src).
+
+    Raises :class:`FileNotFoundError`, :class:`FileExistsError`, or
+    :class:`ValueError` on failure. Returns the destination path, the migration
+    report, and the final validation report (which will be ``ok`` — otherwise a
+    :class:`ValueError` is raised before any write).
+    """
+    src_path = Path(src)
+    if not src_path.exists():
+        raise FileNotFoundError(f"source config not found: {src_path}")
+
+    dest_path = Path(dest) if dest else src_path.parent / "digiproject.yaml"
+    # Resolve for comparison (handle relative equivalence).
+    if dest_path.resolve() == src_path.resolve() and not force:
+        raise FileExistsError(f"refusing to overwrite source file {src_path} without --force")
+    if dest_path.exists() and not force:
+        raise FileExistsError(f"destination {dest_path} already exists; pass --force to overwrite")
+
+    raw = src_path.read_text()
+    try:
+        data = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"cannot parse YAML at {src_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"top-level YAML at {src_path} must be a mapping (got {type(data).__name__})"
+        )
+
+    migrated, mig_report = migrate_mapping(data)
+
+    # Write to a temp file first, validate that, then move into place. Keeps the
+    # destination untouched on validation failure.
+    tmp_path = dest_path.with_suffix(dest_path.suffix + ".tmp")
+    tmp_path.write_text(yaml.safe_dump(migrated, sort_keys=False, default_flow_style=False))
+    try:
+        val_report = validate_project_file(tmp_path)
+        if not val_report.ok:
+            raise ValueError(f"migrated output failed validation:\n{val_report.render()}")
+        tmp_path.replace(dest_path)
+    finally:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+    return dest_path, mig_report, val_report

--- a/docs/spec/project-spec-v1alpha1.md
+++ b/docs/spec/project-spec-v1alpha1.md
@@ -162,6 +162,27 @@ DigiGraph reads the project config on every request (cached by mtime). No restar
 
 ---
 
+## Migration from Pre-Spec `config.yaml`
+
+Legacy projects used an ad-hoc `config.yaml` shape that predates v1alpha1. Run
+`digi project migrate <old-config.yaml>` to convert it to a valid
+`digiproject.yaml`. The tool applies the field renames and section-nesting
+changes below; unknown top-level keys emit a `UserWarning` to stderr rather than
+being silently dropped.
+
+| Legacy path | v1alpha1 path | Notes |
+|---|---|---|
+| `run_storage.dir` | `run_data_dir` | Other `run_storage.*` subkeys are dropped with a warning. |
+| `graph.workflow_profile` | `agents.workflow_profile` | Other `graph.*` subkeys are dropped with a warning. |
+| top-level `indexes:` list | — (use `indexes_dir`) | No direct mapping: split each legacy entry into its own file under `indexes_dir`. Dropped with a warning. |
+| `project`, `agents`, `mcp`, `services`, `run_data_dir`, `indexes_dir` | unchanged | Passthrough sections are copied verbatim. |
+
+The migrated file is re-validated against the v1alpha1 JSON Schema before it is
+written — if validation fails, the migration aborts without touching the
+destination.
+
+---
+
 ## Versioning Policy
 
 - **v1alpha1** (current): schema is unstable; breaking changes possible without notice.

--- a/tests/dg/test_project_migrate.py
+++ b/tests/dg/test_project_migrate.py
@@ -1,0 +1,207 @@
+"""Unit tests for ``digi project migrate`` CLI and migration library."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from digigraph.cli import main as cli_main
+from digigraph.project_migrate import migrate_mapping, migrate_project_file
+from digigraph.project_validate import validate_project_file
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("DIGISEARCH_URL", "OPENAI_API_BASE", "DIGIQUANT_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+LEGACY_CONFIG: dict[str, object] = {
+    "project": {"name": "legacy", "description": "old config", "version": "0.1.0"},
+    "agents": {"enabled": ["research"], "llm_mode": "test"},
+    "run_storage": {"dir": "/data/run", "backend": "local"},
+    "graph": {"workflow_profile": "research_rag", "extra": "ignored"},
+    "mcp": {"enabled": False, "port": 8765, "tools": ["digigraph_workflow"]},
+    "services": {"digisearch_url": "http://ds:8002"},
+    "unknown_top": {"foo": "bar"},
+}
+
+EXPECTED_MIGRATED: dict[str, object] = {
+    "project": {"name": "legacy", "description": "old config", "version": "0.1.0"},
+    "agents": {
+        "enabled": ["research"],
+        "llm_mode": "test",
+        "workflow_profile": "research_rag",
+    },
+    "mcp": {"enabled": False, "port": 8765, "tools": ["digigraph_workflow"]},
+    "services": {"digisearch_url": "http://ds:8002"},
+    "run_data_dir": "/data/run",
+}
+
+
+@pytest.mark.unit
+def test_migrate_snapshot_matches_expected_shape() -> None:
+    with pytest.warns(UserWarning):
+        out, report = migrate_mapping(LEGACY_CONFIG)
+    assert out == EXPECTED_MIGRATED
+    # warnings: run_storage extras, graph extras, unknown_top
+    joined = "\n".join(report.warnings)
+    assert "run_storage" in joined
+    assert "graph" in joined
+    assert "unknown_top" in joined
+
+
+@pytest.mark.unit
+def test_migrate_unknown_key_warns(recwarn: pytest.WarningsRecorder) -> None:
+    out, report = migrate_mapping({"project": {"name": "x"}, "mystery": 42})
+    assert "mystery" not in out
+    assert any("mystery" in w for w in report.warnings)
+    assert any("mystery" in str(w.message) for w in recwarn.list)
+
+
+@pytest.mark.unit
+def test_migrate_legacy_indexes_list_warns() -> None:
+    with pytest.warns(UserWarning, match="indexes"):
+        out, report = migrate_mapping(
+            {"project": {"name": "x"}, "indexes": [{"name": "a", "backend": "azure_search"}]}
+        )
+    assert "indexes" not in out
+    assert any("indexes" in w for w in report.warnings)
+
+
+@pytest.mark.unit
+def test_migrate_agents_workflow_profile_wins_over_graph() -> None:
+    out, _ = migrate_mapping(
+        {
+            "agents": {"workflow_profile": "plan_execute"},
+            "graph": {"workflow_profile": "research_rag"},
+        }
+    )
+    assert out["agents"]["workflow_profile"] == "plan_execute"
+
+
+@pytest.mark.unit
+def test_migrate_file_writes_valid_digiproject(tmp_path: Path, _clean_env: None) -> None:
+    src = tmp_path / "config.yaml"
+    src.write_text(yaml.safe_dump(LEGACY_CONFIG))
+
+    with pytest.warns(UserWarning):
+        dest, mig_report, val_report = migrate_project_file(src)
+
+    assert dest == tmp_path / "digiproject.yaml"
+    assert dest.exists()
+    assert val_report.ok, val_report.render()
+    assert mig_report.warnings  # at least one warning emitted
+
+    # Parse YAML rather than comparing raw text to avoid whitespace flakes.
+    written = yaml.safe_load(dest.read_text())
+    assert written == EXPECTED_MIGRATED
+
+    # Output passes the validator module end-to-end.
+    post = validate_project_file(dest)
+    assert post.ok, post.render()
+
+
+@pytest.mark.unit
+def test_migrate_file_explicit_output(tmp_path: Path, _clean_env: None) -> None:
+    src = tmp_path / "config.yaml"
+    src.write_text(yaml.safe_dump({"project": {"name": "x", "version": "0.1.0"}}))
+    dest = tmp_path / "out" / "custom.yaml"
+    dest.parent.mkdir()
+
+    result, _, val_report = migrate_project_file(src, dest)
+    assert result == dest
+    assert dest.exists()
+    assert val_report.ok
+
+
+@pytest.mark.unit
+def test_migrate_file_refuses_existing_without_force(tmp_path: Path, _clean_env: None) -> None:
+    src = tmp_path / "config.yaml"
+    src.write_text(yaml.safe_dump({"project": {"name": "x", "version": "0.1.0"}}))
+    dest = tmp_path / "digiproject.yaml"
+    dest.write_text("# existing\n")
+
+    with pytest.raises(FileExistsError):
+        migrate_project_file(src, dest)
+
+    # --force overwrites.
+    result, _, val_report = migrate_project_file(src, dest, force=True)
+    assert result == dest
+    assert val_report.ok
+    assert "existing" not in dest.read_text()
+
+
+@pytest.mark.unit
+def test_migrate_file_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        migrate_project_file(tmp_path / "nope.yaml")
+
+
+@pytest.mark.unit
+def test_migrate_file_aborts_on_invalid_result(tmp_path: Path, _clean_env: None) -> None:
+    # A legacy file whose migration produces a still-invalid shape: bogus llm_mode
+    # passes through untouched and trips the schema.
+    src = tmp_path / "config.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {
+                "project": {"name": "x", "version": "0.1.0"},
+                "agents": {"llm_mode": "bogus"},
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="failed validation"):
+        migrate_project_file(src)
+
+    # Destination must not be written on failure.
+    assert not (tmp_path / "digiproject.yaml").exists()
+
+
+@pytest.mark.unit
+def test_cli_migrate_happy_path(
+    tmp_path: Path, _clean_env: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "config.yaml"
+    src.write_text(yaml.safe_dump(LEGACY_CONFIG))
+
+    rc = cli_main(["project", "migrate", str(src)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "digiproject.yaml" in out
+
+    dest = tmp_path / "digiproject.yaml"
+    assert dest.exists()
+    # And the produced file passes the validate subcommand.
+    assert cli_main(["project", "validate", str(dest)]) == 0
+
+
+@pytest.mark.unit
+def test_cli_migrate_sad_path_missing_source(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = cli_main(["project", "migrate", str(tmp_path / "nope.yaml")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "error" in err.lower()
+
+
+@pytest.mark.unit
+def test_cli_migrate_sad_path_existing_dest(
+    tmp_path: Path, _clean_env: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "config.yaml"
+    src.write_text(yaml.safe_dump({"project": {"name": "x", "version": "0.1.0"}}))
+    dest = tmp_path / "digiproject.yaml"
+    dest.write_text("# existing\n")
+
+    rc = cli_main(["project", "migrate", str(src)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "already exists" in err
+
+    # --force succeeds.
+    rc2 = cli_main(["project", "migrate", str(src), "--force"])
+    assert rc2 == 0


### PR DESCRIPTION
## Summary
- Adds `digi project migrate <old-config.yaml>` subcommand that converts pre-spec `config.yaml` files into valid v1alpha1 `digiproject.yaml` output.
- Applies the field-rename and section-nesting migrations documented in a new **Migration from Pre-Spec `config.yaml`** table in `docs/spec/project-spec-v1alpha1.md` (`run_storage.dir` → `run_data_dir`, `graph.workflow_profile` → `agents.workflow_profile`, top-level `indexes:` flagged for manual split).
- Unknown top-level keys surface as `UserWarning` to stderr (not silently dropped) so migration reports are auditable; removed subkeys under handled legacy sections warn too.
- Re-validates the migrated output via `digigraph.project_validate` before writing — migrate and validate stay in lockstep; destination is only replaced on a successful validation.
- Supports `-o/--output` and `--force` flags; default destination is `digiproject.yaml` next to the source.

## Test plan
- [x] `pytest -m unit -k "migrate or cli or validate or schema_sync or project_config" -v` — 42 passed.
- [x] Snapshot test: canonical legacy config → expected new shape (compared as parsed YAML, not raw text).
- [x] Unknown-key test: `UserWarning` emitted and key dropped.
- [x] Migrated output passes `validate_project_file` end-to-end.
- [x] CLI happy path (`rc == 0`, validator accepts output) and sad paths (missing source, existing destination without `--force`).
- [x] `make score` — Security 10, Quality 9, Optimization 10, Accuracy 10.
- [x] `ruff check` / `ruff format --check` clean.

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)