### PR TITLE
test(scripts): reverse drift-guard — workflow paths ⊆ manifest sources

### DIFF
--- a/tests/scripts/test_digithings_guide_project.py
+++ b/tests/scripts/test_digithings_guide_project.py
@@ -111,3 +111,29 @@ def test_workflow_paths_match_manifest_sources() -> None:
     wf_paths = set(push_cfg.get("paths", []))
     missing = [src for src in manifest["sources"] if src not in wf_paths]
     assert not missing, f"workflow paths missing sources: {missing}"
+
+
+def test_manifest_sources_match_workflow_paths() -> None:
+    """Every workflow `paths:` entry must correspond to a manifest source (or a
+    known meta path). An orphan `paths:` entry that doesn't map to any source
+    means the Action triggers on files that won't actually be reindexed.
+
+    Reverse of test_workflow_paths_match_manifest_sources — together they ensure
+    the two lists stay in sync (paths ⊆ sources ∪ META_PATHS and sources ⊆ paths).
+    """
+    # These workflow paths legitimately have no matching manifest source — they
+    # exist to trigger the Action when project config or the script itself changes.
+    META_PATHS = {
+        "docs/projects/digithings-guide/**",
+        "scripts/reindex_digithings_guide.py",
+        ".github/workflows/reindex-digithings-guide.yml",
+    }
+    workflow = REPO_ROOT / ".github" / "workflows" / "reindex-digithings-guide.yml"
+    manifest = yaml.safe_load(INDEX_MANIFEST.read_text())
+    wf = yaml.safe_load(workflow.read_text())
+    # PyYAML parses the `on:` key as the boolean True. Support both spellings.
+    push_cfg = (wf.get("on") or wf.get(True) or {}).get("push", {})
+    wf_paths = set(push_cfg.get("paths", []))
+    sources = set(manifest["sources"])
+    orphans = [p for p in wf_paths if p not in sources and p not in META_PATHS]
+    assert not orphans, f"workflow paths not covered by manifest sources: {orphans}"


### PR DESCRIPTION
## Summary

- Adds `test_manifest_sources_match_workflow_paths` as the reverse direction of the existing `test_workflow_paths_match_manifest_sources` test
- Together the two tests enforce equality between `paths:` in the GitHub Actions workflow and `sources:` in the index manifest (with a `META_PATHS` allowlist for the three non-source trigger paths)
- An orphan `paths:` entry that doesn't map to any manifest source would now be caught, preventing the Action from firing on files that won't be reindexed

## Direction clarification

- Existing test: `sources ⊆ paths` (every source has a workflow trigger)
- New test: `paths ⊆ sources ∪ META_PATHS` (every workflow trigger either maps to a source or is an allowed meta path)
- Meta paths allowlist: `docs/projects/digithings-guide/**`, `scripts/reindex_digithings_guide.py`, `.github/workflows/reindex-digithings-guide.yml`

## Test plan

- [x] `pytest tests/scripts/test_digithings_guide_project.py -v` — all 6 tests pass
- [x] `pytest tests/scripts/ -v` — all 9 tests pass
- [x] `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)