### PR TITLE
refactor(digigraph): converge env resolvers into shared env_utils

### DIFF
--- a/digigraph/src/digigraph/env_utils.py
+++ b/digigraph/src/digigraph/env_utils.py
@@ -1,0 +1,83 @@
+"""Shared environment-variable substitution helper for DigiGraph.
+
+Resolves ``${VAR}`` and ``${VAR:-default}`` references in strings and arbitrarily
+nested dicts/lists.
+
+Behaviour on a missing variable (no default):
+- ``errors`` is ``None`` (silent mode, used by ``project_config``): returns ``""``
+- ``errors`` is a list (tracked mode, used by ``project_validate``): preserves the
+  original ``${VAR}`` literal and appends a human-readable message to ``errors``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+# Matches ${VAR} or ${VAR:-default}.  VAR must be a valid env-var identifier.
+_ENV_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+def resolve_env_refs(
+    value: Any,
+    *,
+    env: dict[str, str] | None = None,
+    errors: list[str] | None = None,
+    path: str = "$",
+) -> Any:
+    """Walk *value* substituting ``${VAR}`` / ``${VAR:-default}`` in strings.
+
+    Parameters
+    ----------
+    value:
+        A string, dict, list, or any other type.  Non-string scalars are returned
+        unchanged.
+    env:
+        Mapping of environment variables.  Defaults to ``os.environ``.
+    errors:
+        When provided (tracked mode), unresolved references (no default, not set)
+        cause the original ``${VAR}`` to be preserved in the output and an error
+        message to be appended here.  When ``None`` (silent mode), unresolved
+        references are replaced with ``""``.
+    path:
+        JSONPath-style string used in error messages when *errors* is provided.
+
+    Returns
+    -------
+    Any
+        The same type as *value* with all env refs resolved.
+    """
+    _env = os.environ if env is None else env
+
+    if isinstance(value, str):
+
+        def _sub(match: re.Match[str]) -> str:
+            var = match.group(1)
+            default = match.group(2)
+            if var in _env:
+                return _env[var]
+            if default is not None:
+                return default
+            # Variable is missing and has no default.
+            if errors is not None:
+                errors.append(
+                    f"{path}: unresolved environment variable '${{{var}}}' "
+                    "(no default and not set in environment)"
+                )
+                return match.group(0)  # preserve literal in tracked mode
+            return ""  # silent mode
+
+        return _ENV_REF.sub(_sub, value)
+
+    if isinstance(value, dict):
+        return {
+            k: resolve_env_refs(v, env=_env, errors=errors, path=f"{path}.{k}")
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            resolve_env_refs(v, env=_env, errors=errors, path=f"{path}[{i}]")
+            for i, v in enumerate(value)
+        ]
+    return value

--- a/digigraph/src/digigraph/project_config.py
+++ b/digigraph/src/digigraph/project_config.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import warnings
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from digigraph.env_utils import resolve_env_refs
 
 logger = logging.getLogger(__name__)
 
@@ -17,17 +18,12 @@ SUPPORTED_PROJECT_VERSIONS: frozenset[str] = frozenset({"v1alpha1"})
 
 
 def _subst_env(val: Any) -> Any:
-    """Replace ${VAR_NAME} with os.environ value."""
-    if isinstance(val, str):
-        for m in re.finditer(r"\$\{([^}]+)\}", val):
-            key = m.group(1)
-            val = val.replace(m.group(0), os.environ.get(key, ""))
-        return val
-    if isinstance(val, dict):
-        return {k: _subst_env(v) for k, v in val.items()}
-    if isinstance(val, list):
-        return [_subst_env(v) for v in val]
-    return val
+    """Replace ${VAR_NAME} / ${VAR:-default} with os.environ value.
+
+    Delegates to the shared :func:`digigraph.env_utils.resolve_env_refs` helper
+    in silent mode (missing vars → ``""``).
+    """
+    return resolve_env_refs(val)
 
 
 def _resolve_config_path(path: str | Path | None = None) -> Path | None:

--- a/digigraph/src/digigraph/project_validate.py
+++ b/digigraph/src/digigraph/project_validate.py
@@ -9,8 +9,6 @@ Used by the ``digi project validate`` CLI; callable as a library for programmati
 
 from __future__ import annotations
 
-import os
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -18,10 +16,8 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator, FormatChecker
 
+from digigraph.env_utils import resolve_env_refs
 from digigraph.schemas import DIGIPROJECT_V1ALPHA1, load_schema
-
-# Matches ${VAR} or ${VAR:-default}. VAR must match env-var identifier rules.
-_ENV_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
 
 
 @dataclass
@@ -54,39 +50,13 @@ def _resolve_env_refs(
 
     Appends a human-readable error to ``errors`` for each unresolved ``${VAR}``
     (no default and env unset). Returns the substituted structure.
+
+    Delegates to :func:`digigraph.env_utils.resolve_env_refs` in tracked mode
+    (``errors`` list provided).
     """
     if errors is None:
         errors = []
-    env = os.environ if env is None else env
-
-    if isinstance(value, str):
-
-        def _sub(match: re.Match[str]) -> str:
-            var = match.group(1)
-            default = match.group(2)
-            if var in env:
-                return env[var]
-            if default is not None:
-                return default
-            errors.append(
-                f"{path}: unresolved environment variable '${{{var}}}' "
-                "(no default and not set in environment)"
-            )
-            return match.group(0)
-
-        return _ENV_REF.sub(_sub, value)
-
-    if isinstance(value, dict):
-        return {
-            k: _resolve_env_refs(v, env=env, path=f"{path}.{k}", errors=errors)
-            for k, v in value.items()
-        }
-    if isinstance(value, list):
-        return [
-            _resolve_env_refs(v, env=env, path=f"{path}[{i}]", errors=errors)
-            for i, v in enumerate(value)
-        ]
-    return value
+    return resolve_env_refs(value, env=env, errors=errors, path=path)
 
 
 def _format_schema_error_path(abs_path: Any) -> str:

--- a/tests/dg/test_env_utils.py
+++ b/tests/dg/test_env_utils.py
@@ -1,0 +1,143 @@
+"""Unit tests for digigraph.env_utils.resolve_env_refs."""
+
+from __future__ import annotations
+
+import pytest
+
+from digigraph.env_utils import resolve_env_refs
+
+
+# ---------------------------------------------------------------------------
+# ${VAR} — present in environment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_var_present_returns_env_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${MY_VAR} and MY_VAR set, When resolved, Then the value replaces the reference."""
+    monkeypatch.setenv("MY_VAR", "hello")
+    result = resolve_env_refs("prefix_${MY_VAR}_suffix")
+    assert result == "prefix_hello_suffix"
+
+
+# ---------------------------------------------------------------------------
+# ${VAR} — absent, no errors list (silent mode → "")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_var_absent_silent_returns_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${UNSET_VAR} with no default and errors=None, When resolved, Then returns empty string silently."""
+    monkeypatch.delenv("UNSET_VAR", raising=False)
+    result = resolve_env_refs("${UNSET_VAR}")
+    assert result == ""
+
+
+@pytest.mark.unit
+def test_var_absent_silent_no_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given errors=None (default), When a var is missing, Then no errors list is mutated."""
+    monkeypatch.delenv("UNSET_VAR2", raising=False)
+    # Just confirm no exception is raised and result is ""
+    result = resolve_env_refs("${UNSET_VAR2}")
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# ${VAR} — absent, with errors list (tracked mode → preserve literal + append error)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_var_absent_tracked_preserves_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${UNSET_TRACK} absent and errors list provided, When resolved, Then literal ref is preserved."""
+    monkeypatch.delenv("UNSET_TRACK", raising=False)
+    errors: list[str] = []
+    result = resolve_env_refs("${UNSET_TRACK}", errors=errors)
+    assert "${UNSET_TRACK}" in result
+
+
+@pytest.mark.unit
+def test_var_absent_tracked_appends_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${UNSET_TRACK} absent and errors list provided, When resolved, Then error referencing the var is appended."""
+    monkeypatch.delenv("UNSET_TRACK2", raising=False)
+    errors: list[str] = []
+    resolve_env_refs("${UNSET_TRACK2}", errors=errors)
+    assert len(errors) == 1
+    assert "UNSET_TRACK2" in errors[0]
+    assert "unresolved" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# ${VAR:-default} — env set: env wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_var_with_default_env_set_returns_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${MY_VAR:-fallback} and MY_VAR set, When resolved, Then env value wins over default."""
+    monkeypatch.setenv("MY_VAR2", "from-env")
+    result = resolve_env_refs("${MY_VAR2:-fallback}")
+    assert result == "from-env"
+
+
+# ---------------------------------------------------------------------------
+# ${VAR:-default} — env absent: default wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_var_with_default_env_absent_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${MISSING:-my-default} and MISSING unset, When resolved, Then default value is used."""
+    monkeypatch.delenv("MISSING", raising=False)
+    result = resolve_env_refs("${MISSING:-my-default}")
+    assert result == "my-default"
+
+
+@pytest.mark.unit
+def test_var_with_default_env_absent_no_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given ${MISSING2:-fallback} with errors list and MISSING2 unset, When resolved, Then no error appended."""
+    monkeypatch.delenv("MISSING2", raising=False)
+    errors: list[str] = []
+    result = resolve_env_refs("${MISSING2:-fallback}", errors=errors)
+    assert result == "fallback"
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Nested strings within dict / list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_nested_dict_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a nested dict containing ${VAR} refs, When resolved, Then all refs are substituted."""
+    monkeypatch.setenv("SVC_HOST", "myhost")
+    value = {"services": {"url": "http://${SVC_HOST}:8000"}, "other": 42}
+    result = resolve_env_refs(value)
+    assert result == {"services": {"url": "http://myhost:8000"}, "other": 42}
+
+
+@pytest.mark.unit
+def test_nested_list_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Given a list containing ${VAR} refs, When resolved, Then all list elements are substituted."""
+    monkeypatch.setenv("TAG", "prod")
+    value = ["item_${TAG}", "plain", 99]
+    result = resolve_env_refs(value)
+    assert result == ["item_prod", "plain", 99]
+
+
+# ---------------------------------------------------------------------------
+# Non-string passthrough (int, None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_string_passthrough_int() -> None:
+    """Given an integer value, When resolved, Then it is returned unchanged."""
+    assert resolve_env_refs(42) == 42  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_non_string_passthrough_none() -> None:
+    """Given None, When resolved, Then None is returned unchanged."""
+    assert resolve_env_refs(None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Extract `resolve_env_refs(value, *, env, errors, path)` into new `digigraph/src/digigraph/env_utils.py` with the stricter `\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}` regex
- `project_config._subst_env` delegates to the helper in silent mode (missing vars → `""`)
- `project_validate._resolve_env_refs` delegates in tracked mode (missing vars → preserve literal + append error)
- 12 unit tests in `tests/dg/test_env_utils.py` covering all scenarios: present, absent (both modes), default (present/absent), nested dict/list, non-string passthrough

## Test plan

- [x] `pytest -m unit -k "env_utils or project_config or project_validate" -v` — 34 passed
- [x] `make score` — Security 10/10, Quality 9/10, Optimization 10/10, Accuracy 10/10 (all above thresholds)
- [x] `ruff check` + `ruff format --check` on all modified files — clean

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)