### PR TITLE
feat(agent-tooling): score-delta regression reporter vs develop baseline

### DIFF
--- a/.claude/skills/score-and-fix/SKILL.md
+++ b/.claude/skills/score-and-fix/SKILL.md
@@ -19,12 +19,13 @@ Runner: `make score` (wraps `python3 scripts/score.py --staged`).
 
 ## Workflow
 
-1. Run `make score`. If exit 0 — done, changes are PR-eligible; tell the user.
-2. If any dimension fails, for each failing dimension:
+1. Run `make score-delta` first. This compares staged changes against the `origin/develop` baseline per dimension and exits non-zero if any dimension regressed (even if still above the pass threshold). Fix any regression before continuing.
+2. Run `make score`. If exit 0 — done, changes are PR-eligible; tell the user.
+3. If any dimension fails, for each failing dimension:
    a. Read the corresponding `docs/scoring/<DIMENSION>.md` rubric.
    b. For each finding (file + line + description), propose the **narrowest** fix that satisfies the rubric. Do not bundle unrelated refactors.
    c. Apply the fix, re-stage, re-run `make score`.
-3. If score still fails after two iterations, stop and escalate per `docs/agents/AGENT_WORKFLOW.md`. Do not keep trying — repeated failures mean the change is structurally wrong or the rubric needs discussion.
+4. If score still fails after two iterations, stop and escalate per `docs/agents/AGENT_WORKFLOW.md`. Do not keep trying — repeated failures mean the change is structurally wrong or the rubric needs discussion.
 
 ## Common false positives
 
@@ -39,5 +40,6 @@ Any true-positive finding in dimension **Security** that the user wants to overr
 
 ## Related
 
+- `make score-delta` — regression detector; run first to catch slippage vs develop.
 - `/score` — slash-command shortcut.
 - `pr-reviewer` subagent — use after scoring passes for a second-pass review before opening the PR.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo up-observability down-observability
+.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo up-observability down-observability
 
 build:
 	docker compose build
@@ -120,6 +120,11 @@ agents-init:
 # Self-score staged changes against 4-dimension rubrics (Security ≥8, Quality ≥8, Optimization ≥7, Accuracy ≥9)
 score:
 	python3 scripts/score.py --staged
+
+# Compare staged score vs origin/develop baseline per dimension; exits 1 if any dimension regressed.
+# Run this before `make score` to catch incremental quality slippage early.
+score-delta:
+	python3 scripts/score_delta.py
 
 # Detect unused Python imports with ruff (dry-run by default; set APPLY=1 to fix in-place)
 clean-imports:

--- a/agents/sources/skills/score-and-fix/SKILL.md
+++ b/agents/sources/skills/score-and-fix/SKILL.md
@@ -18,12 +18,13 @@ Runner: `make score` (wraps `python3 scripts/score.py --staged`).
 
 ## Workflow
 
-1. Run `make score`. If exit 0 — done, changes are PR-eligible; tell the user.
-2. If any dimension fails, for each failing dimension:
+1. Run `make score-delta` first. This compares staged changes against the `origin/develop` baseline per dimension and exits non-zero if any dimension regressed (even if still above the pass threshold). Fix any regression before continuing.
+2. Run `make score`. If exit 0 — done, changes are PR-eligible; tell the user.
+3. If any dimension fails, for each failing dimension:
    a. Read the corresponding `docs/scoring/<DIMENSION>.md` rubric.
    b. For each finding (file + line + description), propose the **narrowest** fix that satisfies the rubric. Do not bundle unrelated refactors.
    c. Apply the fix, re-stage, re-run `make score`.
-3. If score still fails after two iterations, stop and escalate per `docs/agents/AGENT_WORKFLOW.md`. Do not keep trying — repeated failures mean the change is structurally wrong or the rubric needs discussion.
+4. If score still fails after two iterations, stop and escalate per `docs/agents/AGENT_WORKFLOW.md`. Do not keep trying — repeated failures mean the change is structurally wrong or the rubric needs discussion.
 
 ## Common false positives
 
@@ -38,5 +39,6 @@ Any true-positive finding in dimension **Security** that the user wants to overr
 
 ## Related
 
+- `make score-delta` — regression detector; run first to catch slippage vs develop.
 - `/score` — slash-command shortcut.
 - `pr-reviewer` subagent — use after scoring passes for a second-pass review before opening the PR.

--- a/scripts/score_delta.py
+++ b/scripts/score_delta.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+score_delta.py — Compare per-dimension scores between staged changes and origin/develop baseline.
+
+Usage:
+  python3 scripts/score_delta.py [--baseline BASELINE_REF] [--format text|json]
+
+Semantics:
+  Baseline  = diff score of the full branch vs BASELINE_REF (origin/develop by default),
+              i.e. "what does the whole branch add on top of develop?"
+  Current   = diff score of staged changes only.
+
+A regression is any dimension where current score < baseline score, regardless of
+whether both scores are above the pass threshold.
+
+Exit code:
+  0 — no regression detected, or nothing staged to compare
+  1 — one or more dimensions regressed (current < baseline)
+
+Run `make score` for the absolute threshold check; `make score-delta` for regression detection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Allow importing score.py from the same directory
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_SCRIPTS_DIR))
+import score as _score  # noqa: E402
+
+REPO_ROOT = _SCRIPTS_DIR.parent
+DIMENSIONS = ("security", "quality", "optimization", "accuracy")
+
+
+def _score_for_ref(diff_ref: str) -> dict[str, int]:
+    """Return per-dimension scores for a git diff ref, defaulting absent dims to 10."""
+    diff = _score.get_diff(diff_ref)
+    if not diff.strip():
+        return {dim: 10 for dim in DIMENSIONS}
+    results = _score.scan(diff)
+    return {dim: results[dim].score for dim in DIMENSIONS}
+
+
+def _score_staged() -> dict[str, int]:
+    """Return per-dimension scores for staged changes, defaulting to 10 if nothing staged."""
+    diff = _score.get_diff("staged")
+    if not diff.strip():
+        return {dim: 10 for dim in DIMENSIONS}
+    results = _score.scan(diff)
+    return {dim: results[dim].score for dim in DIMENSIONS}
+
+
+def _compute_regressions(baseline: dict[str, int], current: dict[str, int]) -> list[str]:
+    return [dim for dim in DIMENSIONS if current[dim] < baseline[dim]]
+
+
+def format_table(baseline: dict[str, int], current: dict[str, int]) -> str:
+    regressions = _compute_regressions(baseline, current)
+    lines = [
+        "",
+        "── Score Delta Report ────────────────────────────────────────────────",
+        "  Dimension     Baseline   Current   Delta   Status",
+        "  ─────────────────────────────────────────────────────────────────",
+    ]
+    for dim in DIMENSIONS:
+        delta = current[dim] - baseline[dim]
+        if delta < 0:
+            status = "REGRESSED"
+        elif delta == 0:
+            status = "unchanged"
+        else:
+            status = "improved"
+        lines.append(
+            f"  {dim.capitalize():<14s}  {baseline[dim]:>5d}/10   {current[dim]:>5d}/10"
+            f"  {delta:>+5d}   {status}"
+        )
+    lines.append("  ─────────────────────────────────────────────────────────────────")
+    if regressions:
+        lines.append(f"\n  REGRESSION detected in: {', '.join(regressions)}")
+        lines.append("  Staged changes score lower than the develop baseline on these dimensions.")
+        lines.append("  Run `make score` for the full threshold check and finding details.")
+    else:
+        lines.append("\n  No regression — staged changes match or improve the develop baseline.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_json_output(baseline: dict[str, int], current: dict[str, int]) -> str:
+    regressions = _compute_regressions(baseline, current)
+    return json.dumps(
+        {
+            "regression": bool(regressions),
+            "regressed_dimensions": regressions,
+            "dimensions": {
+                dim: {
+                    "baseline": baseline[dim],
+                    "current": current[dim],
+                    "delta": current[dim] - baseline[dim],
+                    "regressed": current[dim] < baseline[dim],
+                }
+                for dim in DIMENSIONS
+            },
+        },
+        indent=2,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--baseline",
+        metavar="REF",
+        default="origin/develop",
+        help="Git ref to use as baseline (default: origin/develop)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
+    args = parser.parse_args()
+
+    # Refresh baseline ref; warn but continue on failure (offline / no remote).
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", "develop"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    if fetch.returncode != 0:
+        print(
+            f"score-delta: warning: git fetch origin develop failed: {fetch.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+    # Nothing staged → nothing to compare.
+    has_staged = subprocess.run(
+        ["git", "diff", "--staged", "--quiet"], cwd=REPO_ROOT
+    ).returncode != 0
+
+    if not has_staged:
+        if args.format == "json":
+            print(json.dumps({"regression": False, "message": "nothing staged to compare", "dimensions": {}}))
+        else:
+            print("score-delta: nothing staged — no delta to report (exit 0)")
+        return 0
+
+    baseline = _score_for_ref(args.baseline)
+    current = _score_staged()
+
+    if args.format == "json":
+        print(format_json_output(baseline, current))
+    else:
+        print(format_table(baseline, current))
+
+    return 1 if _compute_regressions(baseline, current) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `make score-delta` target backed by `scripts/score_delta.py`
- Compares per-dimension scores (Security/Quality/Optimization/Accuracy) between staged changes and `origin/develop` baseline
- Exits non-zero if any dimension regresses, even when above the pass threshold — catches incremental slippage before it compounds
- Imports `score.py` directly (no subprocess double-spawn) for efficiency
- Updates `score-and-fix` skill to run `make score-delta` before `make score`

## Implementation notes

Baseline = `get_diff("origin/develop")` scored via `score.scan()` — represents what the whole branch adds on top of develop.
Current = `get_diff("staged")` scored the same way.
Regression = any dimension where `current < baseline`.
Clean tree → exits 0 with "nothing staged" message (e2e test passes).

## Test plan

- [x] `make score-delta` with nothing staged exits 0 and prints "nothing staged"
- [x] `make score-delta` with staged changes prints delta table, exits 0 (no regression in this PR)
- [x] `make score` — all 4 dimensions 10/10
- [x] `make doc-check` — 81 files, OK
- [x] `make agents-init` — 14 files generated

Fixes #111
Refs #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)