### PR TITLE
feat(agent-tooling): parallel-worktree conflict detector

### DIFF
--- a/.claude/skills/worktree-task-start/SKILL.md
+++ b/.claude/skills/worktree-task-start/SKILL.md
@@ -28,9 +28,10 @@ Run these checks and surface any failures to the user before invoking `make task
    If missing the label: ask whether to add it or pick a different issue.
 3. **Component label present?** (one of `digigraph, digiquant, digisearch, digismith, digiclaw, digibase, digikey, digichat`)
    If absent: offer to add based on the issue body.
-4. **Worktree slot free?** (`.claude/worktrees/task-N-*` must not already exist.)
+4. **Worktree slot free?** (`.worktrees/task-N-*` must not already exist.)
    If present: offer to `scripts/worktree_task.sh remove N` first.
 5. **On `develop` or a stable branch?** Tasks should branch off `develop`, not off another task branch.
+6. **Parallel-worktree conflict check.** `make task` automatically runs `scripts/check-worktree-conflicts.sh N` before creating the worktree. The script infers the task's component from the issue title/body and compares changed files in every active `.worktrees/*` branch against that component glob. If overlaps are found a warning table is printed — this is advisory only (exit 0). Review the table and coordinate with any parallel agent touching the same files before proceeding.
 
 ## Required reading (before implementation)
 

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ pr:
 # Usage: make task ISSUE=42
 task:
 	@[ -n "$(ISSUE)" ] || (echo "Usage: make task ISSUE=<number>"; exit 1)
+	@scripts/check-worktree-conflicts.sh $(ISSUE)
 	@scripts/run_task.sh $(ISSUE)
 
 # Create a new GitHub Issue for the agent backlog (interactive)

--- a/agents/sources/skills/worktree-task-start/SKILL.md
+++ b/agents/sources/skills/worktree-task-start/SKILL.md
@@ -27,9 +27,10 @@ Run these checks and surface any failures to the user before invoking `make task
    If missing the label: ask whether to add it or pick a different issue.
 3. **Component label present?** (one of `digigraph, digiquant, digisearch, digismith, digiclaw, digibase, digikey, digichat`)
    If absent: offer to add based on the issue body.
-4. **Worktree slot free?** (`.claude/worktrees/task-N-*` must not already exist.)
+4. **Worktree slot free?** (`.worktrees/task-N-*` must not already exist.)
    If present: offer to `scripts/worktree_task.sh remove N` first.
 5. **On `develop` or a stable branch?** Tasks should branch off `develop`, not off another task branch.
+6. **Parallel-worktree conflict check.** `make task` automatically runs `scripts/check-worktree-conflicts.sh N` before creating the worktree. The script infers the task's component from the issue title/body and compares changed files in every active `.worktrees/*` branch against that component glob. If overlaps are found a warning table is printed — this is advisory only (exit 0). Review the table and coordinate with any parallel agent touching the same files before proceeding.
 
 ## Required reading (before implementation)
 

--- a/scripts/check-worktree-conflicts.sh
+++ b/scripts/check-worktree-conflicts.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# check-worktree-conflicts.sh — Detect file-glob overlaps across active worktrees.
+#
+# Usage:
+#   scripts/check-worktree-conflicts.sh ISSUE_NUMBER
+#
+# Reads the GitHub issue title/body to infer a component glob (e.g. "digigraph/**"),
+# then checks each active .worktrees/* branch to see if any changed files overlap.
+# Prints a warning table when overlaps are found. Always exits 0 (warning only, not blocking).
+#
+# Requires: git (gh CLI optional — gracefully skips when unavailable)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ISSUE="${1:-}"
+[[ -z "$ISSUE" ]] && { echo "Usage: scripts/check-worktree-conflicts.sh ISSUE_NUMBER" >&2; exit 0; }
+ISSUE="${ISSUE#\#}"
+
+WORKTREES_DIR="${REPO_ROOT}/.worktrees"
+
+COMPONENTS="digigraph digiquant digisearch digismith digiclaw digibase digikey digichat"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+header() { echo ""; echo "── $* ──"; }
+
+# Infer component glob from issue metadata
+infer_globs() {
+  local issue="$1"
+  local text=""
+
+  if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+    text="$(gh issue view "$issue" --json title,body --jq '.title + " " + .body' 2>/dev/null || true)"
+  fi
+
+  local matched=""
+  for comp in $COMPONENTS; do
+    if echo "$text" | grep -qi "$comp"; then
+      matched="${matched} ${comp}/**"
+    fi
+  done
+
+  matched="${matched# }"
+
+  if [[ -z "$matched" ]]; then
+    echo "**"  # Broad fallback — no component inferred
+  else
+    echo "$matched"
+  fi
+}
+
+matches_any_glob() {
+  local file="$1"
+  shift
+  local glob
+  for glob in "$@"; do
+    # Strip trailing /** and treat as prefix check
+    local prefix="${glob%/**}"
+    if [[ "$glob" == "**" ]] || [[ "$file" == "$prefix"/* ]] || [[ "$file" == "$prefix" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+header "Worktree conflict check for issue #${ISSUE}"
+
+# Fetch latest origin/develop so diffs are not stale
+git fetch origin develop --quiet 2>/dev/null || true
+
+# Infer globs from issue metadata
+GLOBS_STR="$(infer_globs "$ISSUE")"
+# Disable glob expansion before splitting GLOBS_STR so "digigraph/**" is not expanded
+set -f
+# shellcheck disable=SC2206
+GLOBS=($GLOBS_STR)
+set +f
+
+echo "Issue:  #${ISSUE}"
+echo "Globs:  ${GLOBS[*]}"
+
+# No worktrees directory — nothing to check
+if [[ ! -d "$WORKTREES_DIR" ]]; then
+  echo "No .worktrees/ directory found — nothing to compare."
+  echo ""
+  exit 0
+fi
+
+FOUND_CONFLICT=false
+CONFLICT_ROWS=""
+
+for wt_dir in "$WORKTREES_DIR"/*/; do
+  [[ -d "$wt_dir" ]] || continue
+
+  # Skip the worktree for *this* issue (task-N-* pattern)
+  wt_name="$(basename "$wt_dir")"
+  if echo "$wt_name" | grep -q "^task-${ISSUE}-"; then
+    continue
+  fi
+
+  # Get the branch name from the worktree
+  wt_branch="$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "(detached)")"
+  [[ -z "$wt_branch" ]] && wt_branch="(detached)"
+
+  # Get changed files in this worktree vs origin/develop
+  changed_files="$(git -C "$wt_dir" diff origin/develop...HEAD --name-only 2>/dev/null || true)"
+  [[ -z "$changed_files" ]] && continue
+
+  wt_rows=""
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    if matches_any_glob "$file" "${GLOBS[@]}"; then
+      wt_rows="${wt_rows}  ${file}"$'\n'
+    fi
+  done <<< "$changed_files"
+
+  if [[ -n "$wt_rows" ]]; then
+    FOUND_CONFLICT=true
+    CONFLICT_ROWS="${CONFLICT_ROWS}WORKTREE: ${wt_branch} (${wt_dir})"$'\n'
+    CONFLICT_ROWS="${CONFLICT_ROWS}${wt_rows}"$'\n'
+  fi
+done
+
+if $FOUND_CONFLICT; then
+  echo ""
+  echo "WARNING: Overlapping files detected in active worktrees"
+  echo "────────────────────────────────────────────────────────"
+  echo "$CONFLICT_ROWS"
+  echo "You may be editing files that another parallel task is already touching."
+  echo "Coordinate with the other task or proceed with caution."
+else
+  echo "No overlapping files found across active worktrees."
+fi
+
+echo ""
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check-worktree-conflicts.sh <issue-number>` that infers a task's component glob from its GitHub issue title/body (matching against the 8 known components), diffs every active `.worktrees/*` branch against `origin/develop`, and prints a warning table for any overlapping files
- Hooked into the `Makefile` `task:` target — runs automatically before `scripts/run_task.sh` on every `make task ISSUE=N` invocation; always exits 0 (advisory, never blocking)
- Updates `agents/sources/skills/worktree-task-start/skill.md` (and regenerated `.claude/skills/`) to document the new pre-flight step (item 6 in the checklist)

## Test plan

- [x] `bash scripts/check-worktree-conflicts.sh 99` exits 0 and prints readable output with all six active worktrees scanned
- [x] `bash scripts/check-worktree-conflicts.sh 9999` (nonexistent issue) exits 0, falls back to `**` glob, still exits 0
- [x] No-op when `.worktrees/` does not exist (exits 0 with "nothing to compare" message)
- [x] Glob expansion bug fixed via `set -f` before array split so `digigraph/**` is not shell-expanded
- [x] `make agents-init` — 14 files regenerated cleanly
- [x] `make doc-check` — 172 markdown files scanned OK
- [x] `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10

Fixes #108
Refs #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)