### PR TITLE
feat(ci): PR quality gate — enforce /simplify and /review before merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,13 @@ Fixes #
 - [ ] test — tests only
 - [ ] chore — build, CI, deps
 
+## Agent Quality Gates
+
+> Agents: check these **before** opening the PR. Both are required for `task/*` branches — CI will block merge if unchecked.
+
+- [ ] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
+- [ ] `/review` completed — PR reviewed against scoring rubric; findings addressed
+
 ---
 
 ## Summary

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,0 +1,69 @@
+name: PR quality gate
+
+# Blocks merge on task/* branches if /simplify and /review checkboxes are unchecked.
+# Non-task branches (bot/*, docs/*, chore/*, dependabot/*) are exempt.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  quality-gate:
+    name: Require /simplify and /review for task branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check quality gates
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Only enforce on task/* branches.
+          if [[ ! "$PR_BRANCH" =~ ^task/ ]]; then
+            echo "Branch '$PR_BRANCH' is not a task branch — skipping quality gate."
+            exit 0
+          fi
+
+          FAIL=0
+          body="${PR_BODY:-}"
+
+          # [x] must precede /simplify (backtick-quoted in template, bare accepted too).
+          if printf '%s' "$body" | grep -Eqi '\[x\][[:space:]]*/`?simplify`?'; then
+            echo "✅ /simplify: checked"
+          else
+            echo "❌ /simplify: not checked in PR body"
+            FAIL=1
+          fi
+
+          # [x] must precede /review (backtick-quoted in template, bare accepted too).
+          if printf '%s' "$body" | grep -Eqi '\[x\][[:space:]]*/`?review`?'; then
+            echo "✅ /review: checked"
+          else
+            echo "❌ /review: not checked in PR body"
+            FAIL=1
+          fi
+
+          if [[ "$FAIL" -eq 1 ]]; then
+            cat <<MSG >&2
+
+          ❌ This task/* PR is missing required quality gate sign-offs.
+
+          Before merging, run both steps in Claude Code and check the boxes in the PR body:
+
+            /simplify   — 3-agent code review pass (reuse, quality, efficiency)
+            /review     — PR review against the scoring rubric
+
+          Then edit the PR body to check the boxes:
+            - [x] \`/simplify\` run — code reviewed for reuse, quality, and efficiency; issues fixed
+            - [x] \`/review\` completed — PR reviewed against scoring rubric; findings addressed
+
+          MSG
+            exit 1
+          fi
+
+          echo "All quality gates passed. ✅"

--- a/docs/agents/AGENT_WORKFLOW.md
+++ b/docs/agents/AGENT_WORKFLOW.md
@@ -131,6 +131,20 @@ Before opening a PR, score the change honestly using the four rubrics in `docs/s
 
 ---
 
+## 6. Pre-PR Checklist (task/* branches)
+
+Before pushing and opening a PR, run these steps in order:
+
+1. **`make test-unit`** — all unit tests pass
+2. **`make score`** — Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9
+3. **`/simplify`** — 3-agent code review pass; fix any findings
+4. **`/review`** — PR review against scoring rubric; address findings
+5. **Check both boxes** in the PR body — CI will block merge if unchecked
+
+CI enforces steps 4–5 via `.github/workflows/pr-quality-gate.yml`.
+
+---
+
 ## 7. Opening the PR
 
 1. Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — fill every section.


### PR DESCRIPTION
## Summary

- New **Agent Quality Gates** section in the PR template with two required checkboxes for `task/*` branches: `/simplify` and `/review`
- New `pr-quality-gate.yml` CI job blocks merge if either checkbox is unchecked; bot/*, docs/*, chore/*, dependabot/* branches are exempt
- `AGENT_WORKFLOW.md` updated with a numbered Pre-PR Checklist: test-unit → score → /simplify → /review → check boxes → open PR

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `/simplify` run on changed code — minor efficiency fix applied (extracted `body` variable to avoid double expansion)
- [x] `/review` completed — patterns mirror `pr-linkage.yml` correctly

## Agent Quality Gates

- [x] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] `/review` completed — PR reviewed against scoring rubric; findings addressed

Fixes #129