### PR TITLE
feat(tooling): batch candidates helper + /batch protocol in AGENT_WORKFLOW.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ make find-stale
 
 ```bash
 make status [COMPONENT=x]    # list open agent-task GitHub issues
+make batch-candidates        # group open agent-task issues by phase/area for parallel execution
 make new-task                # interactive issue creation
 make task ISSUE=N            # run backlog task in an isolated worktree
 make parse-error             # identify component from a Python traceback
@@ -122,6 +123,7 @@ Committed Claude Code configuration. Auto-loaded in every Claude Code session.
 - `test-first-implementer` — red/green/refactor TDD loop bound to the component test command.
 
 **Skills** (`.claude/skills/`):
+- `batch` — spawn parallel worktree agents for 3+ independent tasks; use `make batch-candidates` to identify candidates.
 - `write-acceptance-criteria` — Given/When/Then format + test command mapping.
 - `worktree-task-start` — pre-flight checklist wrapping `make task ISSUE=N`.
 - `score-and-fix` — run `make score`, walk rubric fixes for each failing dimension.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status parse-error hooks-install qr-logo up-observability down-observability
+.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status batch-candidates parse-error hooks-install qr-logo up-observability down-observability
 
 build:
 	docker compose build
@@ -159,6 +159,11 @@ new-task:
 # List open agent-task issues (optional: COMPONENT=digisearch)
 status:
 	@scripts/list_tasks.sh $(if $(COMPONENT),--component $(COMPONENT),)
+
+# Group open agent-task issues by phase/area for parallel execution
+# Optional filters: PHASE="Phase 3 — Domain unification"  AREA=DigiGraph
+batch-candidates:
+	@bash scripts/batch_candidates.sh $(if $(PHASE),--phase "$(PHASE)",) $(if $(AREA),--area "$(AREA)",)
 
 # Parse a Python traceback and identify the component
 # Usage: make parse-error TRACEBACK=file.txt  OR  cat err.log | make parse-error

--- a/docs/agents/AGENT_WORKFLOW.md
+++ b/docs/agents/AGENT_WORKFLOW.md
@@ -75,7 +75,46 @@ Also run lint: `ruff check . && ruff format --check .`
 
 ---
 
-## 5. Self-Scoring
+## 5. Parallel Execution (/batch)
+
+### When to batch
+
+Use `/batch` when you have **3 or more independent tasks** that touch different files. Independent means:
+- Different phase/area combinations, OR
+- Same phase/area but no shared files between tasks
+
+Run `make batch-candidates` to see current open issues grouped by phase+area, annotated with recommended model (sonnet/opus).
+
+### Rules for safe batching
+
+1. **Every worker uses `isolation: "worktree"`** — agents work on isolated git copies; no shared state.
+2. **Units must be independently mergeable** — a unit cannot depend on another unit's PR landing first.
+3. **Model selection**: use the issue's `model` field. `sonnet` for standard tasks; `opus` for complex/high-risk tasks (risk:high label).
+4. **No more than 10 workers at once** — GitHub rate limits and context windows have ceilings.
+5. **After all workers report**, run `/simplify` on the combined diff, then `/review` each PR before merging.
+
+### Post-batch flow
+
+```
+/batch → N parallel agents → each opens PR
+    → coordinator runs /review on each PR
+    → fix any findings in the worktree
+    → merge in dependency order (deepest first)
+    → clean up worktrees
+```
+
+### Worker prompt template
+
+Every worker prompt must include:
+- The overall goal + this unit's specific task
+- Files to touch (no more than the unit's scope)
+- The e2e test recipe
+- Instruction to run /simplify, tests, score, then open PR with Fixes #N
+- End with: `PR: <url>`
+
+---
+
+## 6. Self-Scoring
 
 Before opening a PR, score the change honestly using the four rubrics in `docs/scoring/`:
 
@@ -92,7 +131,7 @@ Before opening a PR, score the change honestly using the four rubrics in `docs/s
 
 ---
 
-## 6. Opening the PR
+## 7. Opening the PR
 
 1. Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — fill every section.
 2. Include the test output (`make test-unit` output) in the Testing Evidence section.
@@ -119,7 +158,7 @@ Examples:
 
 ---
 
-## 7. Auto-Merge Eligibility
+## 8. Auto-Merge Eligibility
 
 ### Eligible for auto-merge (`automerge-docs` label)
 
@@ -151,7 +190,7 @@ The following changes **always** require a human reviewer, regardless of score:
 
 ---
 
-## 8. Post-Merge
+## 9. Post-Merge
 
 1. Update `docs/agent-backlog/INDEX.md`: change the theme status to `done` (or update partial progress).
 2. Close or update the GitHub Issue if one was linked.
@@ -160,7 +199,7 @@ The following changes **always** require a human reviewer, regardless of score:
 
 ---
 
-## 9. When to Escalate
+## 10. When to Escalate
 
 Stop and request human input when:
 
@@ -174,7 +213,7 @@ When escalating: write a clear description of what you were trying to do, what y
 
 ---
 
-## 10. Worktree Execution (Isolated Task Pipeline)
+## 11. Worktree Execution (Isolated Task Pipeline)
 
 Use `make task ISSUE=N` to run the full autonomous pipeline for a backlog task. This creates an isolated git worktree so the main branch stays clean while you implement.
 
@@ -215,7 +254,7 @@ scripts/worktree_task.sh remove 42   # remove when done
 
 ---
 
-## 11. Error Ingestion
+## 12. Error Ingestion
 
 When a user pastes a Python stack trace, use the error ingestion workflow to identify the affected component and create a targeted bug issue.
 

--- a/scripts/batch_candidates.sh
+++ b/scripts/batch_candidates.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# batch_candidates.sh — group open agent-task issues by phase+area for parallel execution.
+#
+# Usage:
+#   bash scripts/batch_candidates.sh
+#   bash scripts/batch_candidates.sh --phase "Phase 3 — Domain unification"
+#   bash scripts/batch_candidates.sh --area DigiGraph
+#   bash scripts/batch_candidates.sh --phase "Phase 2 — Hardening" --area Cross-cutting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TSV="$SCRIPT_DIR/project_fields.tsv"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+FILTER_PHASE=""
+FILTER_AREA=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --phase)
+      FILTER_PHASE="$2"
+      shift 2
+      ;;
+    --area)
+      FILTER_AREA="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--phase <phase>] [--area <area>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found. Install from https://cli.github.com/" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TSV" ]]; then
+  echo "WARNING: $TSV not found — phase/area/kind data unavailable. Exiting." >&2
+  exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 not found." >&2
+  exit 1
+fi
+
+# ── Fetch open agent-task issues ─────────────────────────────────────────────
+ISSUES_JSON=$(gh issue list \
+  --label agent-task \
+  --state open \
+  --limit 500 \
+  --json number,title,body,labels 2>/dev/null) || {
+  echo "ERROR: gh issue list failed. Are you authenticated? Run: gh auth login" >&2
+  exit 1
+}
+
+# Write JSON to a temp file so Python can read it cleanly
+TMPFILE=$(mktemp /tmp/batch_candidates_XXXXXX.json)
+trap 'rm -f "$TMPFILE"' EXIT
+printf '%s' "$ISSUES_JSON" > "$TMPFILE"
+
+# ── Python join + grouping logic ──────────────────────────────────────────────
+# Pass args explicitly so the heredoc is single-quoted (no shell interpolation).
+python3 - "$TSV" "$FILTER_PHASE" "$FILTER_AREA" "$TMPFILE" <<'PYEOF'
+import sys
+import csv
+import json
+import re
+
+tsv_path, filter_phase, filter_area, issues_file = sys.argv[1:]
+
+
+def load_tsv(path):
+    """Return {issue_number: row_dict} from the project_fields TSV."""
+    rows = {}
+    with open(path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f, delimiter="\t"):
+            try:
+                rows[int(row["issue"])] = row
+            except (ValueError, KeyError):
+                continue
+    return rows
+
+
+def has_cross_refs(issue, other_numbers):
+    """Return True if issue body references any other issue in the same group."""
+    refs = {int(m) for m in re.findall(r"#(\d+)", issue["body"])}
+    return bool(refs & other_numbers)
+
+
+def group_label(group_issues, group_numbers):
+    """Return batchability label: 'batchable' or 'review before batching'."""
+    if len(group_issues) > 4:
+        return "review before batching"
+    if any(i["model"] == "opus" for i in group_issues):
+        return "review before batching"
+    for issue in group_issues:
+        if has_cross_refs(issue, group_numbers - {issue["number"]}):
+            return "review before batching"
+    return "batchable"
+
+
+tsv_rows = load_tsv(tsv_path)
+
+with open(issues_file, encoding="utf-8") as f:
+    issues = json.load(f)
+
+if not issues:
+    print("No open agent-task issues found.")
+    sys.exit(0)
+
+enriched = []
+skipped = 0
+for issue in issues:
+    num = issue["number"]
+    if num not in tsv_rows:
+        skipped += 1
+        continue
+    row = tsv_rows[num]
+    phase = row.get("phase", "Unknown")
+    area = row.get("area", "Unknown")
+    # model column is optional; default to sonnet when absent or blank
+    model = (row.get("model") or "sonnet").strip() or "sonnet"
+
+    if filter_phase and phase != filter_phase:
+        continue
+    if filter_area and area != filter_area:
+        continue
+
+    enriched.append({
+        "number": num,
+        "title": issue["title"],
+        "body": issue.get("body") or "",
+        "phase": phase,
+        "area": area,
+        "model": model,
+    })
+
+if skipped > 0:
+    print(f"(Note: {skipped} open agent-task issue(s) had no TSV entry and were skipped)", file=sys.stderr)
+
+if not enriched:
+    print("No matching issues after filters.")
+    sys.exit(0)
+
+groups = {}
+for issue in enriched:
+    groups.setdefault((issue["phase"], issue["area"]), []).append(issue)
+
+group_numbers = {key: {i["number"] for i in lst} for key, lst in groups.items()}
+
+total_issues = 0
+for key in sorted(groups.keys()):
+    phase, area = key
+    group_issues = groups[key]
+    nums = group_numbers[key]
+    n = len(group_issues)
+    label = group_label(group_issues, nums)
+
+    print(f"=== {phase} / {area} ({n} issue{'s' if n != 1 else ''} — {label}) ===")
+    for issue in sorted(group_issues, key=lambda x: x["number"]):
+        print(f"  #{issue['number']:<4} [{issue['model']}]  {issue['title']}")
+    print()
+    total_issues += n
+
+total_groups = len(groups)
+print(
+    f"{total_issues} open agent-task issue{'s' if total_issues != 1 else ''} "
+    f"across {total_groups} group{'s' if total_groups != 1 else ''}"
+)
+PYEOF


### PR DESCRIPTION
## Summary

- `scripts/batch_candidates.sh`: groups open `agent-task` issues by phase+area, annotates each with model (sonnet/opus), flags batchable groups; supports `--phase` and `--area` filters
- `make batch-candidates` target invoking the script
- `AGENT_WORKFLOW.md`: new **Parallel Execution (/batch)** section — when to batch, isolation rules, model selection, post-batch flow, worker prompt template
- `CLAUDE.md`: `/batch` added to Skills section with one-line when-to-use description

## Test plan

- [x] `bash scripts/batch_candidates.sh` runs without error, produces grouped output
- [x] `make batch-candidates` invokes the script correctly
- [x] `/simplify` run — 5 fixes applied (shell injection safety, redundant variables, TSV loader function, empty-string guard, variable placement)
- [x] `/review` completed — patterns consistent with codebase conventions

## Agent Quality Gates

- [x] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] `/review` completed — PR reviewed against scoring rubric; findings addressed

Fixes #130