### PR TITLE
feat(ci): model field on Project board + expanded issue coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -35,6 +35,16 @@ body:
         - high
     validations:
       required: true
+  - type: dropdown
+    id: model
+    attributes:
+      label: Model
+      description: "sonnet = standard tasks; opus = complex/high-risk tasks requiring deeper reasoning"
+      options:
+        - sonnet
+        - opus
+    validations:
+      required: true
   - type: textarea
     id: goal
     attributes:

--- a/.github/workflows/auto-stub-project-fields.yml
+++ b/.github/workflows/auto-stub-project-fields.yml
@@ -1,17 +1,14 @@
-# Auto-stub scripts/project_fields.tsv when an agent-task label is applied to an issue.
+# Auto-stub scripts/project_fields.tsv when relevant labels are applied to an issue.
 #
-# Fires on `issues.labeled` so it covers both:
-#   - Issues opened with the label already applied (GitHub fires labeled per label at open).
-#   - Labels added retroactively to an existing issue.
+# Job 1 (stub-tsv): fires on `issues.labeled` when `agent-task` is applied.
+#   Infers phase/area/kind/priority/model from existing labels and opens a PR
+#   that appends a row to project_fields.tsv.
 #
-# If the issue number is not already in scripts/project_fields.tsv, the workflow
-# opens a PR that appends a row with values inferred from the issue's labels:
+# Job 2 (stub-tsv-phase): fires on `issues.labeled` when any phase-N label is applied
+#   to an issue that is NOT labeled `housekeeping`. Opens the same kind of stub PR.
+#   Skips if the issue already has `agent-task` (job 1 covers that case).
 #
-#   phase  — derived from the phase-N label (see PHASE_MAP in the step below)
-#   area   — derived from the component:X label (see AREA_MAP in the step below)
-#   kind   — "Epic" if the issue is labeled "epic", else "Feature" for phase-0, else "Task"
-#   priority — "P1" for epics/phase-0, "P2" otherwise
-#
+# Both jobs skip if the issue number is already in project_fields.tsv.
 # See set_project_fields.sh for field-name conventions (exact em-dash strings required).
 name: Auto-stub project fields TSV
 
@@ -102,15 +99,20 @@ jobs:
           PRIORITY="P2"
           if echo "$LABEL_NAMES" | grep -qwE "epic|phase-0"; then PRIORITY="P1"; fi
 
-          printf '%s\t%s\t%s\t%s\t%s\n' "$ISSUE" "$PHASE" "$AREA" "$KIND" "$PRIORITY" >> "$TSV"
+          # Model: opus for risk:high issues; sonnet otherwise.
+          MODEL="sonnet"
+          if echo "$LABEL_NAMES" | grep -qw "risk:high"; then MODEL="opus"; fi
+
+          printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$ISSUE" "$PHASE" "$AREA" "$KIND" "$PRIORITY" "$MODEL" >> "$TSV"
           echo "Appended inferred row for #${ISSUE}:"
           tail -1 "$TSV"
 
           # Surface inferred values for the PR body.
-          echo "phase=$PHASE"    >> "$GITHUB_OUTPUT"
-          echo "area=$AREA"      >> "$GITHUB_OUTPUT"
-          echo "kind=$KIND"      >> "$GITHUB_OUTPUT"
+          echo "phase=$PHASE"       >> "$GITHUB_OUTPUT"
+          echo "area=$AREA"         >> "$GITHUB_OUTPUT"
+          echo "kind=$KIND"         >> "$GITHUB_OUTPUT"
           echo "priority=$PRIORITY" >> "$GITHUB_OUTPUT"
+          echo "model=$MODEL"       >> "$GITHUB_OUTPUT"
 
       - name: Open stub PR
         if: steps.check.outputs.present == 'false'
@@ -132,10 +134,157 @@ jobs:
             | area | `${{ steps.infer.outputs.area }}` | Edit TSV if component label is missing or wrong |
             | kind | `${{ steps.infer.outputs.kind }}` | Epic, Feature, Task, Bug, Chore, or Research |
             | priority | `${{ steps.infer.outputs.priority }}` | P0, P1, P2, or P3 |
+            | model | `${{ steps.infer.outputs.model }}` | sonnet (standard) or opus (complex/high-risk) |
 
             See `scripts/set_project_fields.sh` for exact field-name requirements.
 
             Refs #${{ github.event.issue.number }}
-            Fixes #126
+            Fixes #128
+          labels: "phase-0"
+          add-paths: scripts/project_fields.tsv
+
+  stub-tsv-phase:
+    name: Append inferred row for non-agent-task phase-labeled issues
+    # Fire when a phase-N or sitaas label is applied, but NOT for agent-task (job 1 covers that)
+    # and NOT for housekeeping issues (those are exempt from project-field requirements).
+    if: |
+      github.event.label.name != 'agent-task' &&
+      github.event.label.name != 'housekeeping' &&
+      (
+        startsWith(github.event.label.name, 'phase-') ||
+        github.event.label.name == 'sitaas'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: Guard — skip if already in TSV, housekeeping, or agent-task
+        id: guard
+        env:
+          LABELS: ${{ toJson(github.event.issue.labels) }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          TSV="scripts/project_fields.tsv"
+
+          LABEL_NAMES=$(echo "$LABELS" | python3 -c "
+          import json,sys
+          labels = json.load(sys.stdin)
+          print(' '.join(l['name'] for l in labels))
+          ")
+
+          # Skip if issue is already in TSV.
+          if grep -q "^${ISSUE}	" "$TSV" 2>/dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Row for #${ISSUE} already in ${TSV} — nothing to do."
+            exit 0
+          fi
+
+          # Skip if agent-task label is present (job 1 handles it).
+          if echo "$LABEL_NAMES" | grep -qw "agent-task"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "#${ISSUE} has agent-task label — stub-tsv job handles it."
+            exit 0
+          fi
+
+          # Skip if housekeeping label is present.
+          if echo "$LABEL_NAMES" | grep -qw "housekeeping"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "#${ISSUE} is housekeeping — exempt from project-field requirements."
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "No row for #${ISSUE} — will infer and append."
+
+      - name: Infer and append row
+        if: steps.guard.outputs.skip == 'false'
+        id: infer
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+          LABELS: ${{ toJson(github.event.issue.labels) }}
+        run: |
+          TSV="scripts/project_fields.tsv"
+
+          LABEL_NAMES=$(echo "$LABELS" | python3 -c "
+          import json,sys
+          labels = json.load(sys.stdin)
+          print(' '.join(l['name'] for l in labels))
+          ")
+
+          # Phase mapping.
+          PHASE="Phase 3 — Domain unification"
+          if   echo "$LABEL_NAMES" | grep -qw "phase-0"; then PHASE="Phase 2 — Hardening"
+          elif echo "$LABEL_NAMES" | grep -qw "phase-2"; then PHASE="Phase 2 — Hardening"
+          elif echo "$LABEL_NAMES" | grep -qw "phase-3"; then PHASE="Phase 3 — Domain unification"
+          elif echo "$LABEL_NAMES" | grep -qw "phase-4"; then PHASE="Phase 4 — Atlas on DigiGraph"
+          elif echo "$LABEL_NAMES" | grep -qw "phase-5"; then PHASE="Phase 5 — Atlas tiering"
+          elif echo "$LABEL_NAMES" | grep -qw "sitaas";  then PHASE="SITAAS pilot"
+          fi
+
+          # Area mapping.
+          AREA="Cross-cutting"
+          if   echo "$LABEL_NAMES" | grep -qw "component:website";   then AREA="Website"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digichat";   then AREA="DigiChat"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digisearch"; then AREA="DigiSearch"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digigraph";  then AREA="DigiGraph"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digiquant";  then AREA="DigiQuant"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digikey";    then AREA="DigiKey"
+          elif echo "$LABEL_NAMES" | grep -qw "component:digismith";  then AREA="DigiSmith"
+          elif echo "$LABEL_NAMES" | grep -qw "sitaas";               then AREA="SITAAS"
+          fi
+
+          # Kind.
+          KIND="Task"
+          if echo "$LABEL_NAMES" | grep -qw "epic"; then KIND="Epic"; fi
+
+          # Priority.
+          PRIORITY="P2"
+          if echo "$LABEL_NAMES" | grep -qw "epic"; then PRIORITY="P1"; fi
+
+          # Model: opus for risk:high; sonnet otherwise.
+          MODEL="sonnet"
+          if echo "$LABEL_NAMES" | grep -qw "risk:high"; then MODEL="opus"; fi
+
+          printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$ISSUE" "$PHASE" "$AREA" "$KIND" "$PRIORITY" "$MODEL" >> "$TSV"
+          echo "Appended inferred row for #${ISSUE}:"
+          tail -1 "$TSV"
+
+          echo "phase=$PHASE" >> "$GITHUB_OUTPUT"
+          echo "area=$AREA" >> "$GITHUB_OUTPUT"
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          echo "priority=$PRIORITY" >> "$GITHUB_OUTPUT"
+          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
+
+      - name: Open stub PR
+        if: steps.guard.outputs.skip == 'false'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(ci): auto-stub TSV row for issue #${{ github.event.issue.number }}"
+          branch: "bot/stub-tsv-${{ github.event.issue.number }}"
+          base: develop
+          title: "chore(ci): stub project_fields.tsv row for #${{ github.event.issue.number }}"
+          body: |
+            ## Auto-stub: project_fields.tsv row for #${{ github.event.issue.number }}
+
+            Appended an inferred row for issue #${{ github.event.issue.number }} (`${{ github.event.issue.title }}`).
+
+            **Inferred values — verify before merging:**
+            | Column | Inferred value | Override if wrong |
+            |--------|---------------|-------------------|
+            | phase | `${{ steps.infer.outputs.phase }}` | Edit TSV if phase label is missing or wrong |
+            | area | `${{ steps.infer.outputs.area }}` | Edit TSV if component label is missing or wrong |
+            | kind | `${{ steps.infer.outputs.kind }}` | Epic, Feature, Task, Bug, Chore, or Research |
+            | priority | `${{ steps.infer.outputs.priority }}` | P0, P1, P2, or P3 |
+            | model | `${{ steps.infer.outputs.model }}` | sonnet (standard) or opus (complex/high-risk) |
+
+            See `scripts/set_project_fields.sh` for exact field-name requirements.
+
+            Refs #${{ github.event.issue.number }}
+            Fixes #128
           labels: "phase-0"
           add-paths: scripts/project_fields.tsv

--- a/.github/workflows/project-fields-coverage.yml
+++ b/.github/workflows/project-fields-coverage.yml
@@ -2,7 +2,8 @@ name: Project fields coverage
 
 # Fails if any open issue with the agent-task label is:
 #   (a) missing from scripts/project_fields.tsv, OR
-#   (b) has a placeholder phase value (raw "phase-N" string instead of full name).
+#   (b) has a placeholder phase value (raw "phase-N" string instead of full name), OR
+#   (c) has fewer than 6 columns OR has an invalid model value (not sonnet/opus).
 #
 # Runs on every PR so agents cannot open a PR whose linked issue is uncategorised.
 # Also runs on a daily schedule to catch gaps introduced outside PRs.
@@ -23,7 +24,7 @@ permissions:
 
 jobs:
   coverage:
-    name: All agent-task issues in TSV with real phase
+    name: All agent-task issues in TSV with real phase and valid model
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,28 +64,38 @@ jobs:
               continue
             fi
 
+            # (b) + (c) Extract phase, column count, and model in one awk pass.
+            read -r PHASE COL_COUNT MODEL < <(awk -F'\t' -v n="$NUM" '$1==n {print $2, NF, $6; exit}' "$TSV")
+
             # (b) Placeholder phase: raw phase-N string instead of full name with em-dash.
-            PHASE=$(awk -F'\t' -v n="$NUM" '$1==n {print $2}' "$TSV")
             if echo "$PHASE" | grep -Eqi '^phase-[0-9]+$'; then
               echo "❌  #${NUM} «${TITLE}» — phase is still a placeholder: «${PHASE}»"
               FAIL=1
               continue
             fi
 
-            echo "✅  #${NUM} — phase: ${PHASE}"
+            # (c) Model column: must be present (6 columns) and valid (sonnet or opus).
+            if [[ "$COL_COUNT" -lt 6 || ( "$MODEL" != "sonnet" && "$MODEL" != "opus" ) ]]; then
+              echo "❌  #${NUM} «${TITLE}» — invalid or missing model value: «${MODEL}» (must be sonnet or opus)"
+              FAIL=1
+              continue
+            fi
+
+            echo "✅  #${NUM} — phase: ${PHASE} | model: ${MODEL}"
           done <<< "$OPEN_ISSUES"
 
           echo ""
           if [[ "$FAIL" -eq 1 ]]; then
             cat <<MSG >&2
 
-          One or more open agent-task issues are missing from scripts/project_fields.tsv
-          or still have a placeholder phase value.
+          One or more open agent-task issues are missing from scripts/project_fields.tsv,
+          still have a placeholder phase value, or have an invalid model value.
 
           To fix:
-            1. Add or update the row in scripts/project_fields.tsv (tab-separated):
-                 <issue>  <phase>  <area>  <kind>  <priority>
-               Use the exact strings from set_project_fields.sh (em-dash in phase names).
+            1. Add or update the row in scripts/project_fields.tsv (tab-separated, 6 columns):
+                 <issue>  <phase>  <area>  <kind>  <priority>  <model>
+               Use exact strings from set_project_fields.sh (em-dash in phase names).
+               model must be sonnet (standard tasks) or opus (complex/high-risk tasks).
             2. Run scripts/set_project_fields.sh to sync the live Project board.
             3. Commit and push — this check will re-run on the PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Before taking any non-trivial action, read:
 - **Python:** 3.12+, strict typing, ruff-compliant (line length 100).
 - **MCP-first:** every capability exposed as a discoverable tool.
 - **No orphan code:** every code change must trace to a GitHub Issue on [Project #1](https://github.com/orgs/digithings-ai/projects/1). Use a `task/<N>-<slug>` branch (via `make task ISSUE=N`) or add `Fixes #<N>` / `Closes #<N>` to the PR body. Enforced by `.github/workflows/pr-linkage.yml`. See the epic at #34 for rationale.
+- **`housekeeping` label:** issues labeled `housekeeping` are exempt from project-field requirements (Phase/Area/Kind/Priority/Model in `scripts/project_fields.tsv`). Use only for trivial chores — dependency bumps, typo fixes, README-only updates — that do not require tracking on the board.
 - **Agent surface is generated:** the skills, subagents, and slash commands under `.claude/`, the Cursor rules at `.cursor/rules/digithings.mdc`, and `.github/copilot-instructions.md` are **all generated** by `scripts/agents_init.py` from `agents.yml` + `agents/sources/`. Edit the sources, run `make agents-init`, then commit. CI drift-checks via `scripts/agents_init.py --check`.
 
 ## Workflow (plan → execute → verify)

--- a/scripts/project_fields.tsv
+++ b/scripts/project_fields.tsv
@@ -1,62 +1,62 @@
-issue	phase	area	kind	priority
-2	Phase 2 — Hardening	Cross-cutting	Epic	P0
-3	Phase 2 — Hardening	Cross-cutting	Epic	P0
-4	Phase 2 — Hardening	DigiSmith	Epic	P1
-5	Phase 2 — Hardening	DigiGraph	Epic	P1
-6	Phase 2 — Hardening	DigiKey	Epic	P2
-7	Phase 3 — Domain unification	Website	Epic	P1
-8	Phase 3 — Domain unification	DigiChat	Epic	P1
-9	Phase 3 — Domain unification	DigiQuant	Epic	P2
-10	Phase 4 — Atlas on DigiGraph	Atlas	Epic	P2
-11	Phase 4 — Atlas on DigiGraph	Atlas	Epic	P2
-12	Phase 5 — Atlas tiering	Atlas	Epic	P3
-13	Phase 5 — Atlas tiering	Atlas	Epic	P3
-14	SITAAS pilot	SITAAS	Epic	P1
-15	Phase 2 — Hardening	Cross-cutting	Chore	P2
-16	Phase 2 — Hardening	Cross-cutting	Chore	P2
-17	Phase 2 — Hardening	Cross-cutting	Task	P2
-18	Phase 2 — Hardening	Cross-cutting	Chore	P1
-19	Phase 2 — Hardening	Docs	Task	P0
-20	Phase 2 — Hardening	SITAAS	Task	P1
-21	Phase 2 — Hardening	Cross-cutting	Task	P1
-22	Phase 3 — Domain unification	Website	Task	P1
-23	Phase 3 — Domain unification	DigiSearch	Feature	P1
-24	Phase 3 — Domain unification	DigiChat	Feature	P1
-25	SITAAS pilot	SITAAS	Task	P1
-26	SITAAS pilot	SITAAS	Task	P1
-27	SITAAS pilot	Docs	Chore	P2
-28	Phase 5 — Atlas tiering	Atlas	Research	P3
-29	Phase 3 — Domain unification	DigiChat	Research	P2
-30	Phase 5 — Atlas tiering	Cross-cutting	Research	P3
-31	Phase 2 — Hardening	Cross-cutting	Epic	P0
-33	Phase 3 — Domain unification	Website	Chore	P2
-34	Phase 2 — Hardening	Cross-cutting	Epic	P0
-40	Phase 2 — Hardening	Cross-cutting	Chore	P1
-41	Phase 2 — Hardening	Cross-cutting	Epic	P1
-42	Phase 2 — Hardening	DigiQuant	Bug	P0
-43	Phase 2 — Hardening	Cross-cutting	Chore	P1
-77	Phase 2 — Hardening	Cross-cutting	Chore	P1
-79	Phase 3 — Domain unification	Website	Feature	P2
-80	Phase 3 — Domain unification	Website	Chore	P2
-81	Phase 3 — Domain unification	Website	Feature	P2
-82	Phase 3 — Domain unification	Docs	Chore	P2
-83	Phase 3 — Domain unification	DigiGraph	Task	P2
-84	Phase 3 — Domain unification	DigiGraph	Feature	P2
-85	Phase 3 — Domain unification	DigiGraph	Feature	P2
-86	Phase 3 — Domain unification	DigiGraph	Feature	P2
-87	Phase 3 — Domain unification	DigiGraph	Task	P2
-95	Phase 3 — Domain unification	Docs	Bug	P2
-96	Phase 3 — Domain unification	DigiGraph	Task	P2
-97	Phase 3 — Domain unification	DigiSearch	Task	P2
-98	Phase 3 — Domain unification	Docs	Task	P2
-100	Phase 3 — Domain unification	Website	Task	P2
-101	Phase 3 — Domain unification	Website	Task	P2
-103	Phase 3 — Domain unification	Docs	Chore	P2
-105	Phase 2 — Hardening	Cross-cutting	Feature	P2
-106	SITAAS pilot	DigiGraph	Feature	P1
-108	Phase 2 — Hardening	Cross-cutting	Feature	P2
-109	Phase 2 — Hardening	Cross-cutting	Chore	P2
-110	SITAAS pilot	DigiGraph	Feature	P1
-111	Phase 2 — Hardening	Cross-cutting	Feature	P2
-121	Phase 2 — Hardening	Cross-cutting	Feature	P2
-126	Phase 2 — Hardening	Cross-cutting	Chore	P1
+issue	phase	area	kind	priority	model
+2	Phase 2 — Hardening	Cross-cutting	Epic	P0	sonnet
+3	Phase 2 — Hardening	Cross-cutting	Epic	P0	sonnet
+4	Phase 2 — Hardening	DigiSmith	Epic	P1	sonnet
+5	Phase 2 — Hardening	DigiGraph	Epic	P1	sonnet
+6	Phase 2 — Hardening	DigiKey	Epic	P2	sonnet
+7	Phase 3 — Domain unification	Website	Epic	P1	sonnet
+8	Phase 3 — Domain unification	DigiChat	Epic	P1	sonnet
+9	Phase 3 — Domain unification	DigiQuant	Epic	P2	sonnet
+10	Phase 4 — Atlas on DigiGraph	Atlas	Epic	P2	sonnet
+11	Phase 4 — Atlas on DigiGraph	Atlas	Epic	P2	sonnet
+12	Phase 5 — Atlas tiering	Atlas	Epic	P3	sonnet
+13	Phase 5 — Atlas tiering	Atlas	Epic	P3	sonnet
+14	SITAAS pilot	SITAAS	Epic	P1	sonnet
+15	Phase 2 — Hardening	Cross-cutting	Chore	P2	sonnet
+16	Phase 2 — Hardening	Cross-cutting	Chore	P2	sonnet
+17	Phase 2 — Hardening	Cross-cutting	Task	P2	sonnet
+18	Phase 2 — Hardening	Cross-cutting	Chore	P1	sonnet
+19	Phase 2 — Hardening	Docs	Task	P0	sonnet
+20	Phase 2 — Hardening	SITAAS	Task	P1	sonnet
+21	Phase 2 — Hardening	Cross-cutting	Task	P1	sonnet
+22	Phase 3 — Domain unification	Website	Task	P1	sonnet
+23	Phase 3 — Domain unification	DigiSearch	Feature	P1	sonnet
+24	Phase 3 — Domain unification	DigiChat	Feature	P1	sonnet
+25	SITAAS pilot	SITAAS	Task	P1	sonnet
+26	SITAAS pilot	SITAAS	Task	P1	sonnet
+27	SITAAS pilot	Docs	Chore	P2	sonnet
+28	Phase 5 — Atlas tiering	Atlas	Research	P3	sonnet
+29	Phase 3 — Domain unification	DigiChat	Research	P2	sonnet
+30	Phase 5 — Atlas tiering	Cross-cutting	Research	P3	sonnet
+31	Phase 2 — Hardening	Cross-cutting	Epic	P0	sonnet
+33	Phase 3 — Domain unification	Website	Chore	P2	sonnet
+34	Phase 2 — Hardening	Cross-cutting	Epic	P0	sonnet
+40	Phase 2 — Hardening	Cross-cutting	Chore	P1	sonnet
+41	Phase 2 — Hardening	Cross-cutting	Epic	P1	sonnet
+42	Phase 2 — Hardening	DigiQuant	Bug	P0	opus
+43	Phase 2 — Hardening	Cross-cutting	Chore	P1	sonnet
+77	Phase 2 — Hardening	Cross-cutting	Chore	P1	sonnet
+79	Phase 3 — Domain unification	Website	Feature	P2	sonnet
+80	Phase 3 — Domain unification	Website	Chore	P2	sonnet
+81	Phase 3 — Domain unification	Website	Feature	P2	sonnet
+82	Phase 3 — Domain unification	Docs	Chore	P2	sonnet
+83	Phase 3 — Domain unification	DigiGraph	Task	P2	sonnet
+84	Phase 3 — Domain unification	DigiGraph	Feature	P2	sonnet
+85	Phase 3 — Domain unification	DigiGraph	Feature	P2	sonnet
+86	Phase 3 — Domain unification	DigiGraph	Feature	P2	sonnet
+87	Phase 3 — Domain unification	DigiGraph	Task	P2	sonnet
+95	Phase 3 — Domain unification	Docs	Bug	P2	sonnet
+96	Phase 3 — Domain unification	DigiGraph	Task	P2	sonnet
+97	Phase 3 — Domain unification	DigiSearch	Task	P2	sonnet
+98	Phase 3 — Domain unification	Docs	Task	P2	sonnet
+100	Phase 3 — Domain unification	Website	Task	P2	sonnet
+101	Phase 3 — Domain unification	Website	Task	P2	sonnet
+103	Phase 3 — Domain unification	Docs	Chore	P2	sonnet
+105	Phase 2 — Hardening	Cross-cutting	Feature	P2	sonnet
+106	SITAAS pilot	DigiGraph	Feature	P1	sonnet
+108	Phase 2 — Hardening	Cross-cutting	Feature	P2	sonnet
+109	Phase 2 — Hardening	Cross-cutting	Chore	P2	sonnet
+110	SITAAS pilot	DigiGraph	Feature	P1	sonnet
+111	Phase 2 — Hardening	Cross-cutting	Feature	P2	sonnet
+121	Phase 2 — Hardening	Cross-cutting	Feature	P2	sonnet
+126	Phase 2 — Hardening	Cross-cutting	Chore	P1	sonnet

--- a/scripts/set_project_fields.sh
+++ b/scripts/set_project_fields.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# set_project_fields.sh — bulk-set Phase/Area/Kind/Priority on DigiThings GitHub Project items.
+# set_project_fields.sh — bulk-set Phase/Area/Kind/Priority/Model on DigiThings GitHub Project items.
 #
 # Usage:
 #   scripts/set_project_fields.sh [--tsv PATH] [--owner OWNER] [--project NUM]
@@ -8,9 +8,9 @@
 #
 # TSV format (tab-separated, header required, empty cell = leave field unchanged):
 #
-#   issue<TAB>phase<TAB>area<TAB>kind<TAB>priority
-#   2<TAB>Phase 2 — Hardening<TAB>Cross-cutting<TAB>Epic<TAB>P0
-#   3<TAB>Phase 2 — Hardening<TAB>Cross-cutting<TAB>Epic<TAB>P0
+#   issue<TAB>phase<TAB>area<TAB>kind<TAB>priority<TAB>model
+#   2<TAB>Phase 2 — Hardening<TAB>Cross-cutting<TAB>Epic<TAB>P0<TAB>sonnet
+#   42<TAB>Phase 2 — Hardening<TAB>DigiQuant<TAB>Bug<TAB>P0<TAB>opus
 #
 # Field/option names must match the Project's configuration exactly (em-dash, etc.).
 # Re-runs are idempotent — rows can be added/edited and the script rerun safely.
@@ -50,10 +50,12 @@ PHASE_FID=$(field_id Phase)
 AREA_FID=$(field_id Area)
 KIND_FID=$(field_id Kind)
 PRIO_FID=$(field_id Priority)
+MODEL_FID=$(field_id Model)
 
 for f in "$PHASE_FID" "$AREA_FID" "$KIND_FID" "$PRIO_FID"; do
   [[ -n "$f" ]] || { echo "Missing one of Phase/Area/Kind/Priority fields on Project" >&2; exit 1; }
 done
+[[ -n "$MODEL_FID" ]] || echo "Warning: Model field not found on Project — model column will be skipped." >&2
 
 echo "Fetching project items..."
 ITEMS_JSON=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json --limit 500)
@@ -74,7 +76,7 @@ set_field() {
 }
 
 apply_row() {
-  local issue="$1" phase="$2" area="$3" kind="$4" prio="$5"
+  local issue="$1" phase="$2" area="$3" kind="$4" prio="$5" model="${6:-}"
   local item_id
   item_id=$(item_id_for_issue "$issue")
   if [[ -z "$item_id" ]]; then
@@ -99,14 +101,18 @@ apply_row() {
     local oid; oid=$(option_id Priority "$prio")
     [[ -z "$oid" ]] && { echo "  #$issue: unknown Priority '$prio'" >&2; } || { set_field "$item_id" "$PRIO_FID" "$oid"; changed+=("Priority"); }
   fi
+  if [[ -n "$MODEL_FID" && -n "$model" ]]; then
+    local oid; oid=$(option_id Model "$model")
+    [[ -z "$oid" ]] && { echo "  #$issue: unknown Model '$model'" >&2; } || { set_field "$item_id" "$MODEL_FID" "$oid"; changed+=("Model"); }
+  fi
   echo "  #$issue ← ${changed[*]:-(no changes)}"
 }
 
 echo "Applying $(( $(wc -l < "$TSV") - 1 )) rows from $TSV"
-tail -n +2 "$TSV" | while IFS=$'\t' read -r issue phase area kind prio; do
+tail -n +2 "$TSV" | while IFS=$'\t' read -r issue phase area kind prio model; do
   [[ -z "${issue// }" ]] && continue
   [[ "$issue" =~ ^# ]] && continue
-  apply_row "$issue" "${phase:-}" "${area:-}" "${kind:-}" "${prio:-}"
+  apply_row "$issue" "${phase:-}" "${area:-}" "${kind:-}" "${prio:-}" "${model:-}"
 done
 
 echo "Done. View: https://github.com/orgs/$OWNER/projects/$PROJECT"


### PR DESCRIPTION
## Summary

- **`project_fields.tsv`**: 6th `model` column added; all existing rows backfilled (`risk:high` → `opus`, else `sonnet`)
- **`set_project_fields.sh`**: reads `model` column and syncs the Model single-select field on the GitHub Project board; skips gracefully if field not yet created on the board
- **`auto-stub-project-fields.yml`**: infers `model` from `risk:high`→`opus`/else `sonnet`; second job `stub-tsv-phase` stubs any issue with a `phase-N` label that isn't `agent-task` or `housekeeping`
- **`project-fields-coverage.yml`**: validates 6-column TSV and that `model` is `sonnet` or `opus`; merged 3 separate `awk` passes into one for efficiency
- **`agent_task.yml`** issue template: Model dropdown (sonnet/opus) with guidance note
- **`AGENTS.md`**: `housekeeping` label convention documented

## Test plan

- [x] YAML syntax validated on both workflow files
- [x] TSV column count: all rows have exactly 6 columns
- [x] `/simplify` run — 3 fixes: step rename for accuracy, trailing space cleanup, 3→1 awk pass merge
- [x] `/review` completed — reuse and patterns consistent with codebase

## Agent Quality Gates

- [x] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] `/review` completed — PR reviewed against scoring rubric; findings addressed

Fixes #128