### PR TITLE
docs(adr): ratify ADR-0004 Atlas pricing

### DIFF
--- a/docs/adr/0004-atlas-pricing.md
+++ b/docs/adr/0004-atlas-pricing.md
@@ -1,7 +1,9 @@
 # ADR 0004: Atlas Pricing — Seat Tier + Metered Unit Cost
 
-**Status:** proposed
-**Date:** 2026-04-18
+**Status:** accepted
+**Date:** 2026-04-19
+
+**Rationale for accepting:** All open questions in this ADR are deferred to post-GA validation rather than blocking — none require resolution before Phase 4/5 work (epics #10–13) can start. The two-axis pricing structure (seat + metered units), entitlement flow via DigiKey JWTs, and Stripe as billing provider are stable engineering decisions that downstream work can build against. Dollar figures and free-tier limits are explicitly illustrative and will be tuned once real usage data exists. Accepting unblocks billing integration, entitlement middleware, and Atlas UI copy.
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Changes `docs/adr/0004-atlas-pricing.md` status from `proposed` → `accepted`
- Updates date to 2026-04-19
- Adds rationale-for-accepting note confirming no open questions block Phase 4/5 work
- Two-axis pricing (seat + metered units), DigiKey entitlement flow, and Stripe as billing provider are stable engineering decisions downstream can build against

Fixes #28

## Test plan

- [x] `make doc-check` passes (84 markdown files scanned, OK)
- [x] No code changes — doc-only ADR status update

🤖 Generated with [Claude Code](https://claude.com/claude-code)