### PR TITLE
fix(agent-tooling): correct hook path to component-router-preflight.sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
           { "type": "command", "command": "scripts/claude-hooks/project-root-guard.sh" },
           { "type": "command", "command": "scripts/claude-hooks/protected-path-guard.sh" },
           { "type": "command", "command": "scripts/claude-hooks/branch-warn.sh" },
-          { "type": "command", "command": "scripts/claude-hooks/component-router-guard.sh" }
+          { "type": "command", "command": "scripts/claude-hooks/component-router-preflight.sh" }
         ]
       },
       {


### PR DESCRIPTION
## Summary
- \`.claude/settings.json\` referenced \`component-router-guard.sh\` which doesn't exist in develop
- The actual committed hook file is \`component-router-preflight.sh\` (from PR #123)
- Every Write/Edit tool use was silently invoking a missing script
- One-line fix: update the reference

## Agent Quality Gates
- [x] \`/simplify\` run — single-line path fix, no further reuse opportunities
- [x] \`/review\` completed — bug confirmed, fix is the minimal correction

Fixes #139