### PR TITLE
feat(tooling): separate GitHub Project for digiQuant issues

### DIFF
--- a/.github/workflows/issue-to-digiquant-project.yml
+++ b/.github/workflows/issue-to-digiquant-project.yml
@@ -1,0 +1,31 @@
+name: Add digiquant issues to digiQuant project
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-digiquant-project:
+    name: Add component:digiquant issue to digiQuant project
+    runs-on: ubuntu-latest
+    if: contains(toJson(github.event.issue.labels.*.name), 'component:digiquant')
+    steps:
+      - name: Check token present
+        id: token
+        env:
+          TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+        run: |
+          if [[ -n "${TOKEN:-}" ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Secret DIGITHINGS_PROJECT_TOKEN not set — skipping auto-add. Create a PAT with 'project' + 'repo' scopes and store it as DIGITHINGS_PROJECT_TOKEN."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.token.outputs.present == 'true' && vars.DIGI_QUANT_PROJECT_NUMBER != ''
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/digithings-ai/projects/${{ vars.DIGI_QUANT_PROJECT_NUMBER }}
+          github-token: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}

--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -23,7 +23,7 @@ jobs:
             echo "::warning::Secret DIGITHINGS_PROJECT_TOKEN not set — skipping auto-add. Create a PAT with 'project' + 'repo' scopes and store it as DIGITHINGS_PROJECT_TOKEN. Default GITHUB_TOKEN cannot write to org projects."
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
-      - if: steps.token.outputs.present == 'true'
+      - if: steps.token.outputs.present == 'true' && !contains(toJson(github.event.issue.labels.*.name), 'component:digiquant')
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/digithings-ai/projects/1

--- a/scripts/create_issue.sh
+++ b/scripts/create_issue.sh
@@ -227,14 +227,28 @@ fi
 ISSUE_URL="$(gh issue create "${CREATE_ARGS[@]}")"
 echo "$ISSUE_URL"
 
-# ── Add to GitHub Project #1 (org: digithings-ai) ─────────────────────────────
-# Keeps the backlog single-pane; idempotent — re-adding an existing item is a no-op.
+# ── Add to the appropriate GitHub Project ─────────────────────────────────────
+# digiquant issues → digiQuant project; all others → Project #1.
+# Idempotent — re-adding an existing item is a no-op.
 PROJECT_OWNER="${DIGI_PROJECT_OWNER:-digithings-ai}"
-PROJECT_NUMBER="${DIGI_PROJECT_NUMBER:-1}"
-if gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" >/dev/null 2>&1; then
-  echo "Added to Project ${PROJECT_OWNER}/${PROJECT_NUMBER}" >&2
+if [[ "$COMPONENT" == "digiquant" ]]; then
+  PROJECT_NUMBER="${DIGI_QUANT_PROJECT_NUMBER:-}"
+  PROJECT_LABEL="digiQuant project"
+  if [[ -z "$PROJECT_NUMBER" ]]; then
+    echo "WARN: DIGI_QUANT_PROJECT_NUMBER not set — skipping auto-add. Set it after running scripts/setup_digiquant_project.sh, then: gh project item-add <N> --owner ${PROJECT_OWNER} --url ${ISSUE_URL}" >&2
+    PROJECT_NUMBER=""
+  fi
 else
-  echo "WARN: could not auto-add ${ISSUE_URL} to Project ${PROJECT_OWNER}/${PROJECT_NUMBER} — add manually with: gh project item-add ${PROJECT_NUMBER} --owner ${PROJECT_OWNER} --url ${ISSUE_URL}" >&2
+  PROJECT_NUMBER="${DIGI_PROJECT_NUMBER:-1}"
+  PROJECT_LABEL="Project ${PROJECT_OWNER}/${PROJECT_NUMBER}"
+fi
+
+if [[ -n "$PROJECT_NUMBER" ]]; then
+  if gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" >/dev/null 2>&1; then
+    echo "Added to ${PROJECT_LABEL}" >&2
+  else
+    echo "WARN: could not auto-add ${ISSUE_URL} to ${PROJECT_LABEL} — add manually with: gh project item-add ${PROJECT_NUMBER} --owner ${PROJECT_OWNER} --url ${ISSUE_URL}" >&2
+  fi
 fi
 
 # ── Append TSV row + set live Project fields (if project fields provided) ──────
@@ -258,8 +272,8 @@ if $_HAS_FIELDS; then
       echo "TSV row for #${ISSUE_NUMBER} already exists — skipping append." >&2
     fi
 
-    # Set Project fields live
-    if [[ -f "scripts/set_project_fields.sh" ]]; then
+    # Set Project fields live (skip if project number is unresolved)
+    if [[ -f "scripts/set_project_fields.sh" && -n "$PROJECT_NUMBER" ]]; then
       echo "Setting Project fields for #${ISSUE_NUMBER}..." >&2
       bash scripts/set_project_fields.sh \
         --owner "$PROJECT_OWNER" \

--- a/scripts/setup_digiquant_project.sh
+++ b/scripts/setup_digiquant_project.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# setup_digiquant_project.sh — One-shot setup for the digiQuant GitHub Project.
+#
+# Creates the project and adds the same five custom fields as Project #1:
+#   Phase, Area, Kind, Priority, Model
+#
+# Usage:
+#   bash scripts/setup_digiquant_project.sh [--org ORG]
+#
+# After running, set the project number as a GitHub Actions variable:
+#   gh variable set DIGI_QUANT_PROJECT_NUMBER --org digithings-ai --body <N>
+#
+# Requires: gh CLI + org-level project write access
+
+set -euo pipefail
+
+ORG="digithings-ai"
+TITLE="digiQuant"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org) ORG="$2"; shift 2 ;;
+    -h|--help) sed -n '2,15p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found." >&2; exit 1
+fi
+if ! gh auth status &>/dev/null; then
+  echo "ERROR: Not authenticated. Run: gh auth login" >&2; exit 1
+fi
+
+echo "Creating project '${TITLE}' under org '${ORG}'..."
+PROJECT_JSON=$(gh project create --owner "$ORG" --title "$TITLE" --format json)
+PROJECT_NUMBER=$(echo "$PROJECT_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['number'])")
+echo "Created project #${PROJECT_NUMBER}"
+
+add_field() {
+  local name="$1"; shift
+  local opts_csv
+  opts_csv=$(IFS=','; echo "$*")
+  echo -n "  Adding field '${name}'..."
+  gh project field-create "$PROJECT_NUMBER" --owner "$ORG" --name "$name" \
+    --data-type SINGLE_SELECT --single-select-options "$opts_csv" > /dev/null
+  echo " done."
+}
+
+add_field "Phase" \
+  "Phase 2 — Hardening" \
+  "Phase 3 — Domain unification" \
+  "Phase 4 — Atlas on DigiGraph" \
+  "Phase 5 — Atlas tiering" \
+  "SITAAS pilot"
+
+add_field "Area" \
+  "Cross-cutting" \
+  "DigiGraph" \
+  "DigiQuant" \
+  "DigiSearch" \
+  "DigiSmith" \
+  "DigiKey" \
+  "DigiChat" \
+  "DigiBase" \
+  "DigiClaw" \
+  "Website" \
+  "SITAAS" \
+  "Docs" \
+  "Atlas"
+
+add_field "Kind" \
+  "Epic" \
+  "Feature" \
+  "Task" \
+  "Bug" \
+  "Chore" \
+  "Research"
+
+add_field "Priority" \
+  "P0" \
+  "P1" \
+  "P2" \
+  "P3"
+
+add_field "Model" \
+  "sonnet" \
+  "opus"
+
+echo ""
+echo "Setup complete. Project URL: https://github.com/orgs/${ORG}/projects/${PROJECT_NUMBER}"
+echo ""
+echo "Next step — store the project number as a GitHub Actions variable:"
+echo "  gh variable set DIGI_QUANT_PROJECT_NUMBER --repo <org/repo> --body ${PROJECT_NUMBER}"
+echo "  (Use --org ${ORG} instead if you have org admin access)"
+echo ""
+echo "Or export locally:"
+echo "  export DIGI_QUANT_PROJECT_NUMBER=${PROJECT_NUMBER}"


### PR DESCRIPTION
## Summary
- Routes \`component:digiquant\` issues to a dedicated digiQuant GitHub Project (for epic #9) instead of the shared Project #1
- New workflow \`issue-to-digiquant-project.yml\` — fires only on \`component:digiquant\` issues
- Existing \`issue-to-project.yml\` now excludes \`component:digiquant\` (no double-add)
- One-shot setup script \`setup_digiquant_project.sh\` creates the project with the same 5 custom fields (Phase, Area, Kind, Priority, Model)
- \`create_issue.sh\` routes \`--component digiquant\` to \`DIGI_QUANT_PROJECT_NUMBER\` env var

## Deployment
After merge:
1. Run \`bash scripts/setup_digiquant_project.sh\`
2. Set \`DIGI_QUANT_PROJECT_NUMBER\` as an org-level GitHub Actions variable: \`gh variable set DIGI_QUANT_PROJECT_NUMBER --org digithings-ai --body <N>\`

## Agent Quality Gates
- [x] \`/simplify\` run earlier — code was already clean
- [x] \`/review\` — bash + yaml syntax validated

Fixes #140
Refs #9