### PR TITLE
feat(digikey): JWT jti revocation via Redis blocklist

### DIFF
--- a/digikey/pyproject.toml
+++ b/digikey/pyproject.toml
@@ -19,11 +19,12 @@ dependencies = [
     "PyJWT>=2.8",
     "cryptography>=42",
     "httpx>=0.27",
+    "redis>=5",
     "digibase>=0.1.0",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.8"]
+dev = ["pytest>=8", "ruff>=0.8", "fakeredis>=2.20"]
 
 [project.scripts]
 digikey = "digikey.cli:main"

--- a/digikey/src/digikey/blocklist.py
+++ b/digikey/src/digikey/blocklist.py
@@ -1,0 +1,108 @@
+"""Redis-backed jti blocklist for JWT revocation (ADR-0007).
+
+Thin wrapper over redis-py. Keys are named ``jti:<uuid>`` and written with
+per-entry TTL equal to the token's remaining lifetime so Redis self-cleans.
+
+Configuration: ``DIGIKEY_BLOCKLIST_REDIS_URL``. When unset, ``is_blocked()``
+returns ``False`` (feature-flag fallback) and ``write_blocklist_bulk()`` is a
+no-op. This lets deployments without Redis keep the existing behavior.
+
+On a Redis connection/communication failure in ``is_blocked()``, this module
+re-raises ``BlocklistUnavailable``; ``DigiAuthMiddleware`` converts that to an
+HTTP 503 (fail-closed, per ADR-0007).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "jti:"
+
+_client_cache: tuple[str, object] | None = None
+
+
+class BlocklistUnavailable(RuntimeError):
+    """Raised when the Redis blocklist backend is configured but unreachable."""
+
+
+def _redis_url() -> str:
+    return (os.environ.get("DIGIKEY_BLOCKLIST_REDIS_URL") or "").strip()
+
+
+def is_configured() -> bool:
+    return bool(_redis_url())
+
+
+def _get_client():
+    """Return a cached redis client for the current URL, or None if unset."""
+    global _client_cache
+    url = _redis_url()
+    if not url:
+        _client_cache = None
+        return None
+    if _client_cache is not None and _client_cache[0] == url:
+        return _client_cache[1]
+    try:
+        import redis  # local import so digikey loads without redis installed
+    except ImportError as e:  # pragma: no cover - redis is a declared dep
+        raise BlocklistUnavailable(f"redis package not installed: {e}") from e
+    client = redis.Redis.from_url(url, decode_responses=True)
+    _client_cache = (url, client)
+    return client
+
+
+def reset_client_cache() -> None:
+    """Test helper — drop the memoized client so env changes take effect."""
+    global _client_cache
+    _client_cache = None
+
+
+def write_blocklist_bulk(entries: list[tuple[str, int]]) -> int:
+    """Push ``(jti, ttl_sec)`` entries to Redis in a single pipeline.
+
+    Entries with ``ttl_sec <= 0`` are skipped (the token is already expired).
+    Returns the number of entries actually written. No-op if Redis unconfigured.
+    """
+    if not entries:
+        return 0
+    client = _get_client()
+    if client is None:
+        return 0
+    import redis as _redis
+
+    pipe = client.pipeline(transaction=False)
+    written = 0
+    for jti, ttl in entries:
+        if ttl <= 0:
+            continue
+        pipe.setex(_KEY_PREFIX + jti, ttl, "1")
+        written += 1
+    if written == 0:
+        return 0
+    try:
+        pipe.execute()
+    except _redis.RedisError as e:
+        raise BlocklistUnavailable(f"redis pipeline failed: {e}") from e
+    return written
+
+
+def is_blocked(jti: str) -> bool:
+    """Return True if this jti is in the blocklist.
+
+    Raises :class:`BlocklistUnavailable` if the Redis URL is configured but the
+    backend is unreachable. Returns ``False`` when the URL is unset.
+    """
+    if not jti:
+        return False
+    client = _get_client()
+    if client is None:
+        return False
+    import redis as _redis
+
+    try:
+        return bool(client.exists(_KEY_PREFIX + jti))
+    except _redis.RedisError as e:
+        raise BlocklistUnavailable(f"redis exists failed: {e}") from e

--- a/digikey/src/digikey/blocklist.py
+++ b/digikey/src/digikey/blocklist.py
@@ -4,8 +4,8 @@ Thin wrapper over redis-py. Keys are named ``jti:<uuid>`` and written with
 per-entry TTL equal to the token's remaining lifetime so Redis self-cleans.
 
 Configuration: ``DIGIKEY_BLOCKLIST_REDIS_URL``. When unset, ``is_blocked()``
-returns ``False`` (feature-flag fallback) and ``write_blocklist_bulk()`` is a
-no-op. This lets deployments without Redis keep the existing behavior.
+returns ``False`` and ``write_blocklist_bulk()`` is a no-op — deployments
+without Redis keep the pre-revocation behavior.
 
 On a Redis connection/communication failure in ``is_blocked()``, this module
 re-raises ``BlocklistUnavailable``; ``DigiAuthMiddleware`` converts that to an
@@ -17,11 +17,15 @@ from __future__ import annotations
 import logging
 import os
 
+import redis
+
 logger = logging.getLogger(__name__)
 
 _KEY_PREFIX = "jti:"
+# Redis value for a blocklisted key. Never read — only EXISTS is queried.
+_TOMBSTONE = "1"
 
-_client_cache: tuple[str, object] | None = None
+_client_cache: tuple[str, redis.Redis] | None = None
 
 
 class BlocklistUnavailable(RuntimeError):
@@ -36,7 +40,7 @@ def is_configured() -> bool:
     return bool(_redis_url())
 
 
-def _get_client():
+def _get_client() -> redis.Redis | None:
     """Return a cached redis client for the current URL, or None if unset."""
     global _client_cache
     url = _redis_url()
@@ -45,10 +49,6 @@ def _get_client():
         return None
     if _client_cache is not None and _client_cache[0] == url:
         return _client_cache[1]
-    try:
-        import redis  # local import so digikey loads without redis installed
-    except ImportError as e:  # pragma: no cover - redis is a declared dep
-        raise BlocklistUnavailable(f"redis package not installed: {e}") from e
     client = redis.Redis.from_url(url, decode_responses=True)
     _client_cache = (url, client)
     return client
@@ -71,20 +71,18 @@ def write_blocklist_bulk(entries: list[tuple[str, int]]) -> int:
     client = _get_client()
     if client is None:
         return 0
-    import redis as _redis
-
     pipe = client.pipeline(transaction=False)
     written = 0
     for jti, ttl in entries:
         if ttl <= 0:
             continue
-        pipe.setex(_KEY_PREFIX + jti, ttl, "1")
+        pipe.setex(_KEY_PREFIX + jti, ttl, _TOMBSTONE)
         written += 1
     if written == 0:
         return 0
     try:
         pipe.execute()
-    except _redis.RedisError as e:
+    except redis.RedisError as e:
         raise BlocklistUnavailable(f"redis pipeline failed: {e}") from e
     return written
 
@@ -100,9 +98,7 @@ def is_blocked(jti: str) -> bool:
     client = _get_client()
     if client is None:
         return False
-    import redis as _redis
-
     try:
         return bool(client.exists(_KEY_PREFIX + jti))
-    except _redis.RedisError as e:
+    except redis.RedisError as e:
         raise BlocklistUnavailable(f"redis exists failed: {e}") from e

--- a/digikey/src/digikey/db_schema.py
+++ b/digikey/src/digikey/db_schema.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.sqlite import JSON as SQLITE_JSON
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
@@ -38,6 +38,37 @@ class ApiKeyRow(Base):
         nullable=False,
     )
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class JtiIssuedRow(Base):
+    """
+    Durable record of every jti issued via token exchange.
+
+    Source of truth for "which JTIs were ever issued for this key", used by the
+    revoke endpoint to enumerate live tokens and push them to the Redis blocklist.
+    See ADR-0007.
+    """
+
+    __tablename__ = "digikey_jti_issued"
+
+    jti: Mapped[str] = mapped_column(String(36), primary_key=True)
+    api_key_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("digikey_api_keys.id"),
+        nullable=False,
+    )
+    exp: Mapped[int] = mapped_column(Integer, nullable=False)
+    issued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # Revocation query filters on (api_key_id, exp > now()) — composite index
+        # keeps that lookup from full-scanning as the table grows.
+        Index("ix_digikey_jti_issued_key_exp", "api_key_id", "exp"),
+    )
 
 
 def utcnow() -> datetime:

--- a/digikey/src/digikey/integrations/service_middleware.py
+++ b/digikey/src/digikey/integrations/service_middleware.py
@@ -17,17 +17,6 @@ from digikey.models import DigiAuthContext, claims_to_context
 from digikey.scopes import scope_grants_required
 
 logger = logging.getLogger(__name__)
-_blocklist_warned = False
-
-
-def _warn_blocklist_unconfigured_once() -> None:
-    global _blocklist_warned
-    if not _blocklist_warned:
-        _blocklist_warned = True
-        logger.warning(
-            "DIGIKEY_BLOCKLIST_REDIS_URL unset — JWT revocation checks disabled in this service",
-        )
-
 
 PathScopeFn = Callable[[str, str], list[str] | None]
 """(method, path) -> required scopes, or None if route is auth-exempt."""
@@ -69,18 +58,24 @@ def jwt_context(
         return JSONResponse(
             status_code=401, content={"code": "invalid_token", "message": "Invalid token"}
         )
-    # Post-signature revocation check (ADR-0007). Unset URL → passthrough
-    # (feature-flag fallback). Redis unreachable → 503 (fail-closed).
-    if blocklist.is_configured():
-        if claims.jti:
-            try:
-                if blocklist.is_blocked(claims.jti):
-                    return JSONResponse(status_code=401, content={"detail": "token_revoked"})
-            except blocklist.BlocklistUnavailable as e:
-                logger.error("blocklist check failed: %s", e)
-                return JSONResponse(status_code=503, content={"detail": "auth_backend_unavailable"})
-    else:
-        _warn_blocklist_unconfigured_once()
+    # Post-signature revocation check (ADR-0007). When Redis is unreachable we
+    # fail closed — the alternative is silently accepting revoked tokens.
+    if claims.jti and blocklist.is_configured():
+        try:
+            if blocklist.is_blocked(claims.jti):
+                return JSONResponse(
+                    status_code=401,
+                    content={"code": "token_revoked", "message": "Token has been revoked"},
+                )
+        except blocklist.BlocklistUnavailable as e:
+            logger.error("blocklist check failed: %s", e)
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "code": "auth_backend_unavailable",
+                    "message": "Auth backend temporarily unavailable",
+                },
+            )
     if required_scopes and not scope_grants_required(claims.scopes, required_scopes):
         return JSONResponse(
             status_code=403,

--- a/digikey/src/digikey/integrations/service_middleware.py
+++ b/digikey/src/digikey/integrations/service_middleware.py
@@ -11,11 +11,23 @@ from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
+from digikey import blocklist
 from digikey.jwt_verify import decode_token
 from digikey.models import DigiAuthContext, claims_to_context
 from digikey.scopes import scope_grants_required
 
 logger = logging.getLogger(__name__)
+_blocklist_warned = False
+
+
+def _warn_blocklist_unconfigured_once() -> None:
+    global _blocklist_warned
+    if not _blocklist_warned:
+        _blocklist_warned = True
+        logger.warning(
+            "DIGIKEY_BLOCKLIST_REDIS_URL unset — JWT revocation checks disabled in this service",
+        )
+
 
 PathScopeFn = Callable[[str, str], list[str] | None]
 """(method, path) -> required scopes, or None if route is auth-exempt."""
@@ -57,6 +69,18 @@ def jwt_context(
         return JSONResponse(
             status_code=401, content={"code": "invalid_token", "message": "Invalid token"}
         )
+    # Post-signature revocation check (ADR-0007). Unset URL → passthrough
+    # (feature-flag fallback). Redis unreachable → 503 (fail-closed).
+    if blocklist.is_configured():
+        if claims.jti:
+            try:
+                if blocklist.is_blocked(claims.jti):
+                    return JSONResponse(status_code=401, content={"detail": "token_revoked"})
+            except blocklist.BlocklistUnavailable as e:
+                logger.error("blocklist check failed: %s", e)
+                return JSONResponse(status_code=503, content={"detail": "auth_backend_unavailable"})
+    else:
+        _warn_blocklist_unconfigured_once()
     if required_scopes and not scope_grants_required(claims.scopes, required_scopes):
         return JSONResponse(
             status_code=403,

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import time
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -15,9 +16,10 @@ from digibase.cors import install_cors
 from digibase.errors import register_fastapi_error_handlers
 from digibase.metrics import install_metrics
 
+from digikey import blocklist
 from digikey.crypto_keys import load_or_create_signing_key
 from digikey.db import init_db, session_factory
-from digikey.db_schema import ApiKeyRow
+from digikey.db_schema import ApiKeyRow, JtiIssuedRow, utcnow
 from digikey.jwt_issue import issue_access_token, public_jwks
 from digikey.key_crypto import generate_raw_key, hash_secret, verify_secret
 from digikey.ratelimit import rate_limit_dependency, register_rate_limit_handler
@@ -39,6 +41,11 @@ def _startup() -> None:
     init_db()
     if not admin_token():
         logger.warning("DIGIKEY_ADMIN_TOKEN is unset — POST /v1/admin/keys returns 503")
+    if not blocklist.is_configured():
+        logger.warning(
+            "DIGIKEY_BLOCKLIST_REDIS_URL is unset — JWT revocation blocklist disabled "
+            "(tokens issued before revoke_at will remain valid until exp)",
+        )
     if not (os.environ.get("DIGIKEY_PRIVATE_KEY_PEM") or "").strip():
         if os.environ.get("DIGIKEY_ALLOW_EPHEMERAL_KEY", "0").strip().lower() in (
             "1",
@@ -207,39 +214,94 @@ def oauth_token(body: TokenRequest, request: Request) -> TokenResponse:
     sf = session_factory()
     with sf() as session:
         rows = list(session.scalars(select(ApiKeyRow).where(ApiKeyRow.key_prefix == prefix)))
-    row: ApiKeyRow | None = None
-    for r in rows:
-        if verify_secret(raw, r.key_hash):
-            row = r
-            break
-    if row is None:
-        raise HTTPException(status_code=401, detail="invalid api_key")
-    if row.revoked_at is not None:
-        raise HTTPException(status_code=401, detail="key revoked")
-    if row.kind == "dev_global" and not allow_dev_global_keys():
-        raise HTTPException(status_code=403, detail="dev_global exchange disabled")
+        row: ApiKeyRow | None = None
+        for r in rows:
+            if verify_secret(raw, r.key_hash):
+                row = r
+                break
+        if row is None:
+            raise HTTPException(status_code=401, detail="invalid api_key")
+        if row.revoked_at is not None:
+            raise HTTPException(status_code=401, detail="key revoked")
+        if row.kind == "dev_global" and not allow_dev_global_keys():
+            raise HTTPException(status_code=403, detail="dev_global exchange disabled")
 
-    scopes = list(row.scopes) if isinstance(row.scopes, list) else []
-    if body.requested_scopes:
-        if not scope_grants_required(scopes, body.requested_scopes):
-            raise HTTPException(status_code=400, detail="requested_scopes not allowed for this key")
-        scopes = body.requested_scopes
+        scopes = list(row.scopes) if isinstance(row.scopes, list) else []
+        if body.requested_scopes:
+            if not scope_grants_required(scopes, body.requested_scopes):
+                raise HTTPException(
+                    status_code=400, detail="requested_scopes not allowed for this key"
+                )
+            scopes = body.requested_scopes
 
-    token, _jti = issue_access_token(
-        _private_key,
-        kid=_kid,
-        sub=f"key:{row.id}",
-        tenant_slug=row.tenant_slug,
-        scopes=scopes,
-        key_pub=row.key_prefix,
-        project_id=row.project_id,
-        project_config_ref=row.project_config_ref,
-        principal_kind="api_key",
-        audience=body.audience,
-        ttl_sec=ttl,
-    )
+        token, jti = issue_access_token(
+            _private_key,
+            kid=_kid,
+            sub=f"key:{row.id}",
+            tenant_slug=row.tenant_slug,
+            scopes=scopes,
+            key_pub=row.key_prefix,
+            project_id=row.project_id,
+            project_config_ref=row.project_config_ref,
+            principal_kind="api_key",
+            audience=body.audience,
+            ttl_sec=ttl,
+        )
+        # Track the jti in the durable source-of-truth table so the revoke
+        # endpoint can later enumerate live tokens for this key. If this
+        # insert fails, do NOT return the token — an untracked jti cannot
+        # be revoked. See ADR-0007 §Implementation sketch step 2.
+        try:
+            session.add(JtiIssuedRow(jti=jti, api_key_id=row.id, exp=int(time.time()) + ttl))
+            session.commit()
+        except Exception as e:
+            session.rollback()
+            logger.error("jti_issued insert failed; refusing to issue token: %s", e)
+            raise HTTPException(status_code=503, detail="token issuance unavailable") from e
     llm_key = (os.environ.get("DIGIKEY_LITELLM_PROXY_KEY") or "").strip() or None
     return TokenResponse(access_token=token, expires_in=ttl, litellm_proxy_api_key=llm_key)
+
+
+class RevokeResponse(BaseModel):
+    revoked: bool
+    jtis_invalidated: int
+
+
+@app.post(
+    "/v1/admin/keys/{key_id}/revoke",
+    response_model=RevokeResponse,
+    dependencies=[Depends(rate_limit_dependency)],
+)
+def admin_revoke_key(key_id: str, request: Request) -> RevokeResponse:
+    """Revoke a key and blocklist all live JWTs issued from it (ADR-0007)."""
+    _require_admin(request)
+    sf = session_factory()
+    now_ts = int(time.time())
+    with sf() as session:
+        row = session.get(ApiKeyRow, key_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="key not found")
+        if row.revoked_at is None:
+            row.revoked_at = utcnow()
+        live = list(
+            session.scalars(
+                select(JtiIssuedRow).where(
+                    JtiIssuedRow.api_key_id == key_id,
+                    JtiIssuedRow.exp > now_ts,
+                )
+            )
+        )
+        entries = [(r.jti, r.exp - now_ts) for r in live]
+        try:
+            written = blocklist.write_blocklist_bulk(entries)
+        except blocklist.BlocklistUnavailable as e:
+            # Fail closed: do NOT mark revoked if we can't push to the blocklist;
+            # caller will retry. ADR-0007 requires blocked-within-one-round-trip.
+            session.rollback()
+            logger.error("revoke blocklist write failed: %s", e)
+            raise HTTPException(status_code=503, detail="auth_backend_unavailable") from e
+        session.commit()
+    return RevokeResponse(revoked=True, jtis_invalidated=written)
 
 
 register_fastapi_error_handlers(app, service="digikey")

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -247,10 +247,8 @@ def oauth_token(body: TokenRequest, request: Request) -> TokenResponse:
             audience=body.audience,
             ttl_sec=ttl,
         )
-        # Track the jti in the durable source-of-truth table so the revoke
-        # endpoint can later enumerate live tokens for this key. If this
-        # insert fails, do NOT return the token — an untracked jti cannot
-        # be revoked. See ADR-0007 §Implementation sketch step 2.
+        # An untracked jti can never be revoked, so refuse to emit the token
+        # if the durable record can't be written. See ADR-0007.
         try:
             session.add(JtiIssuedRow(jti=jti, api_key_id=row.id, exp=int(time.time()) + ttl))
             session.commit()
@@ -295,8 +293,9 @@ def admin_revoke_key(key_id: str, request: Request) -> RevokeResponse:
         try:
             written = blocklist.write_blocklist_bulk(entries)
         except blocklist.BlocklistUnavailable as e:
-            # Fail closed: do NOT mark revoked if we can't push to the blocklist;
-            # caller will retry. ADR-0007 requires blocked-within-one-round-trip.
+            # If we can't guarantee every live JWT is blocked, don't mark the
+            # key revoked — otherwise ``revoked_at`` would suggest closure
+            # the blocklist hasn't actually delivered. Caller retries on 503.
             session.rollback()
             logger.error("revoke blocklist write failed: %s", e)
             raise HTTPException(status_code=503, detail="auth_backend_unavailable") from e

--- a/tests/dk/conftest.py
+++ b/tests/dk/conftest.py
@@ -1,0 +1,25 @@
+"""Shared test fixtures for DigiKey tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def fake_blocklist_redis(monkeypatch):
+    """Wire digikey.blocklist onto an in-process fakeredis.
+
+    Yields ``(fake_client, blocklist_module)`` so tests can both drive the
+    backend directly (``fake.setex(...)``) and exercise the wrapper
+    (``blocklist.is_blocked(...)``).
+    """
+    fakeredis = pytest.importorskip("fakeredis")
+    from digikey import blocklist
+
+    blocklist.reset_client_cache()
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(blocklist, "_get_client", lambda: fake)
+    yield fake, blocklist
+    blocklist.reset_client_cache()

--- a/tests/dk/test_blocklist.py
+++ b/tests/dk/test_blocklist.py
@@ -1,0 +1,94 @@
+"""Unit tests for digikey.blocklist (Redis-backed jti blocklist)."""
+
+from __future__ import annotations
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+
+
+@pytest.fixture()
+def fake_redis(monkeypatch):
+    """Patch digikey.blocklist to use fakeredis and set URL."""
+    from digikey import blocklist
+
+    # Reset any memoized real client
+    blocklist.reset_client_cache()
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+
+    server = fakeredis.FakeServer()
+    fake = fakeredis.FakeRedis(server=server, decode_responses=True)
+
+    def _client():
+        return fake
+
+    # Swap the internal _get_client used by write/exists paths
+    monkeypatch.setattr(blocklist, "_get_client", _client)
+    yield fake, blocklist
+    blocklist.reset_client_cache()
+
+
+@pytest.mark.unit
+def test_unconfigured_is_blocked_returns_false(monkeypatch):
+    from digikey import blocklist
+
+    monkeypatch.delenv("DIGIKEY_BLOCKLIST_REDIS_URL", raising=False)
+    blocklist.reset_client_cache()
+    assert blocklist.is_blocked("any-jti") is False
+    assert blocklist.write_blocklist_bulk([("x", 60)]) == 0
+
+
+@pytest.mark.unit
+def test_write_and_check(fake_redis):
+    _fake, blocklist = fake_redis
+    written = blocklist.write_blocklist_bulk([("abc", 60), ("def", 120)])
+    assert written == 2
+    assert blocklist.is_blocked("abc") is True
+    assert blocklist.is_blocked("def") is True
+    assert blocklist.is_blocked("never-written") is False
+
+
+@pytest.mark.unit
+def test_write_skips_expired_entries(fake_redis):
+    fake, blocklist = fake_redis
+    written = blocklist.write_blocklist_bulk([("x", 0), ("y", -5), ("z", 30)])
+    assert written == 1
+    assert fake.exists("jti:z")
+    assert not fake.exists("jti:x")
+    assert not fake.exists("jti:y")
+
+
+@pytest.mark.unit
+def test_write_empty_is_noop(fake_redis):
+    _fake, blocklist = fake_redis
+    assert blocklist.write_blocklist_bulk([]) == 0
+
+
+@pytest.mark.unit
+def test_ttl_is_honored(fake_redis):
+    fake, blocklist = fake_redis
+    blocklist.write_blocklist_bulk([("abc", 99)])
+    ttl = fake.ttl("jti:abc")
+    assert 90 <= ttl <= 99
+
+
+@pytest.mark.unit
+def test_redis_error_raises_blocklist_unavailable(monkeypatch):
+    from digikey import blocklist
+
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+    blocklist.reset_client_cache()
+
+    import redis
+
+    class BrokenClient:
+        def exists(self, *_a, **_k):
+            raise redis.RedisError("boom")
+
+        def pipeline(self, *_a, **_k):
+            raise redis.RedisError("boom")
+
+    monkeypatch.setattr(blocklist, "_get_client", lambda: BrokenClient())
+
+    with pytest.raises(blocklist.BlocklistUnavailable):
+        blocklist.is_blocked("x")

--- a/tests/dk/test_blocklist.py
+++ b/tests/dk/test_blocklist.py
@@ -4,29 +4,6 @@ from __future__ import annotations
 
 import pytest
 
-fakeredis = pytest.importorskip("fakeredis")
-
-
-@pytest.fixture()
-def fake_redis(monkeypatch):
-    """Patch digikey.blocklist to use fakeredis and set URL."""
-    from digikey import blocklist
-
-    # Reset any memoized real client
-    blocklist.reset_client_cache()
-    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
-
-    server = fakeredis.FakeServer()
-    fake = fakeredis.FakeRedis(server=server, decode_responses=True)
-
-    def _client():
-        return fake
-
-    # Swap the internal _get_client used by write/exists paths
-    monkeypatch.setattr(blocklist, "_get_client", _client)
-    yield fake, blocklist
-    blocklist.reset_client_cache()
-
 
 @pytest.mark.unit
 def test_unconfigured_is_blocked_returns_false(monkeypatch):
@@ -39,8 +16,8 @@ def test_unconfigured_is_blocked_returns_false(monkeypatch):
 
 
 @pytest.mark.unit
-def test_write_and_check(fake_redis):
-    _fake, blocklist = fake_redis
+def test_write_and_check(fake_blocklist_redis):
+    _fake, blocklist = fake_blocklist_redis
     written = blocklist.write_blocklist_bulk([("abc", 60), ("def", 120)])
     assert written == 2
     assert blocklist.is_blocked("abc") is True
@@ -49,8 +26,8 @@ def test_write_and_check(fake_redis):
 
 
 @pytest.mark.unit
-def test_write_skips_expired_entries(fake_redis):
-    fake, blocklist = fake_redis
+def test_write_skips_expired_entries(fake_blocklist_redis):
+    fake, blocklist = fake_blocklist_redis
     written = blocklist.write_blocklist_bulk([("x", 0), ("y", -5), ("z", 30)])
     assert written == 1
     assert fake.exists("jti:z")
@@ -59,14 +36,14 @@ def test_write_skips_expired_entries(fake_redis):
 
 
 @pytest.mark.unit
-def test_write_empty_is_noop(fake_redis):
-    _fake, blocklist = fake_redis
+def test_write_empty_is_noop(fake_blocklist_redis):
+    _fake, blocklist = fake_blocklist_redis
     assert blocklist.write_blocklist_bulk([]) == 0
 
 
 @pytest.mark.unit
-def test_ttl_is_honored(fake_redis):
-    fake, blocklist = fake_redis
+def test_ttl_is_honored(fake_blocklist_redis):
+    fake, blocklist = fake_blocklist_redis
     blocklist.write_blocklist_bulk([("abc", 99)])
     ttl = fake.ttl("jti:abc")
     assert 90 <= ttl <= 99

--- a/tests/dk/test_middleware_revocation.py
+++ b/tests/dk/test_middleware_revocation.py
@@ -1,0 +1,133 @@
+"""DigiAuthMiddleware revocation check (ADR-0007)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+fakeredis = pytest.importorskip("fakeredis")
+jwt = pytest.importorskip("jwt")
+
+
+def _issue_and_configure(monkeypatch):
+    """Build a JWT signed with a fresh RSA key, wire env for local verify."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    from digikey.crypto_keys import private_key_to_pem, public_key_to_pem
+    from digikey.jwt_issue import issue_access_token
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_pem = private_key_to_pem(key)
+    pub_pem = public_key_to_pem(key.public_key())
+    monkeypatch.setenv("DIGIKEY_ISSUER", "http://test-dk")
+    monkeypatch.setenv("DIGIKEY_AUDIENCE", "digi-ecosystem")
+    monkeypatch.setenv("DIGIKEY_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.delenv("DIGIKEY_JWKS_URL", raising=False)
+
+    from cryptography.hazmat.primitives import serialization
+
+    priv = serialization.load_pem_private_key(priv_pem.encode(), password=None)
+    token, jti_val = issue_access_token(
+        priv,
+        kid="t1",
+        sub="key:x",
+        tenant_slug="acme",
+        scopes=["digigraph:chat"],
+        key_pub="dgk_prefix",
+    )
+    return token, jti_val
+
+
+def _make_app() -> FastAPI:
+    from digikey.integrations.service_middleware import attach_digi_auth_middleware
+
+    app = FastAPI()
+
+    def scopes_fn(method: str, path: str):
+        if path == "/open":
+            return None
+        return ["digigraph:chat"]
+
+    attach_digi_auth_middleware(app, service="test", path_scopes=scopes_fn)
+
+    @app.get("/protected")
+    def _p():
+        return {"ok": True}
+
+    @app.get("/open")
+    def _o():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.unit
+def test_unblocked_token_passes(monkeypatch):
+    token, _jti = _issue_and_configure(monkeypatch)
+    monkeypatch.delenv("DIGIKEY_BLOCKLIST_REDIS_URL", raising=False)
+    from digikey import blocklist
+
+    blocklist.reset_client_cache()
+
+    client = TestClient(_make_app())
+    r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+
+
+@pytest.mark.unit
+def test_blocked_token_returns_401(monkeypatch):
+    token, jti_val = _issue_and_configure(monkeypatch)
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+    from digikey import blocklist
+
+    blocklist.reset_client_cache()
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(blocklist, "_get_client", lambda: fake)
+
+    # Populate the blocklist with this jti
+    fake.setex(f"jti:{jti_val}", 600, "1")
+
+    client = TestClient(_make_app())
+    r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 401
+    assert r.json() == {"detail": "token_revoked"}
+
+
+@pytest.mark.unit
+def test_redis_unreachable_returns_503(monkeypatch):
+    token, _jti = _issue_and_configure(monkeypatch)
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+    from digikey import blocklist
+
+    blocklist.reset_client_cache()
+
+    def _get():
+        # Simulate error inside is_blocked path
+        class C:
+            def exists(self, *_a, **_k):
+                import redis
+
+                raise redis.RedisError("down")
+
+        return C()
+
+    monkeypatch.setattr(blocklist, "_get_client", _get)
+
+    client = TestClient(_make_app())
+    r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 503
+    assert r.json() == {"detail": "auth_backend_unavailable"}
+
+
+@pytest.mark.unit
+def test_unset_url_is_passthrough(monkeypatch):
+    token, _jti = _issue_and_configure(monkeypatch)
+    monkeypatch.delenv("DIGIKEY_BLOCKLIST_REDIS_URL", raising=False)
+    from digikey import blocklist
+
+    blocklist.reset_client_cache()
+
+    client = TestClient(_make_app())
+    r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200

--- a/tests/dk/test_middleware_revocation.py
+++ b/tests/dk/test_middleware_revocation.py
@@ -91,7 +91,7 @@ def test_blocked_token_returns_401(monkeypatch):
     client = TestClient(_make_app())
     r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 401
-    assert r.json() == {"detail": "token_revoked"}
+    assert r.json() == {"code": "token_revoked", "message": "Token has been revoked"}
 
 
 @pytest.mark.unit
@@ -117,7 +117,10 @@ def test_redis_unreachable_returns_503(monkeypatch):
     client = TestClient(_make_app())
     r = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
     assert r.status_code == 503
-    assert r.json() == {"detail": "auth_backend_unavailable"}
+    assert r.json() == {
+        "code": "auth_backend_unavailable",
+        "message": "Auth backend temporarily unavailable",
+    }
 
 
 @pytest.mark.unit

--- a/tests/dk/test_revoke_endpoint.py
+++ b/tests/dk/test_revoke_endpoint.py
@@ -1,0 +1,136 @@
+"""Integration test: POST /v1/admin/keys/{id}/revoke (ADR-0007)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+fakeredis = pytest.importorskip("fakeredis")
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    # Fresh per-test SQLite db so schemas / rows don't leak across tests
+    db_path = tmp_path / "dk.db"
+    monkeypatch.setenv("DIGIKEY_DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("DIGIKEY_ALLOW_EPHEMERAL_KEY", "1")
+    monkeypatch.setenv("DIGIKEY_ADMIN_TOKEN", "admin-secret")
+    monkeypatch.setenv("DIGIKEY_BLOCKLIST_REDIS_URL", "redis://fake")
+    # Reset module-level singletons so env takes effect
+    from digikey import blocklist, db
+
+    db._engine = None
+    db._session_factory = None
+    blocklist.reset_client_cache()
+
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(blocklist, "_get_client", lambda: fake)
+
+    # Build public JWKS/PEM so jwt_verify has a key (for subsequent middleware tests)
+    from digikey.crypto_keys import load_or_create_signing_key, public_key_to_pem
+
+    priv, _kid = load_or_create_signing_key()
+    os.environ["DIGIKEY_PUBLIC_KEY_PEM"] = public_key_to_pem(priv.public_key())
+
+    from digikey.server import app
+
+    # Trigger startup (TestClient context manager runs startup handlers)
+    with TestClient(app) as c:
+        c.fake_redis = fake  # type: ignore[attr-defined]
+        yield c
+
+
+def _create_key(client: TestClient) -> tuple[str, str]:
+    r = client.post(
+        "/v1/admin/keys",
+        json={"tenant_slug": "acme", "label": "test", "scopes": ["digigraph:chat"]},
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    return data["id"], data["api_key"]
+
+
+def _exchange(client: TestClient, api_key: str) -> str:
+    r = client.post(
+        "/v1/oauth/token",
+        json={"grant_type": "api_key", "api_key": api_key},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+@pytest.mark.unit
+def test_revoke_requires_admin(client: TestClient):
+    r = client.post("/v1/admin/keys/some-id/revoke")
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_revoke_missing_key_404(client: TestClient):
+    r = client.post(
+        "/v1/admin/keys/no-such/revoke",
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.unit
+def test_revoke_writes_jtis_to_blocklist(client: TestClient):
+    key_id, raw = _create_key(client)
+    # Issue two tokens from this key
+    tok1 = _exchange(client, raw)
+    tok2 = _exchange(client, raw)
+    assert tok1 and tok2
+
+    r = client.post(
+        f"/v1/admin/keys/{key_id}/revoke",
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["revoked"] is True
+    assert body["jtis_invalidated"] == 2
+
+    # Both tokens' jtis should now be in the fake Redis
+    fake = client.fake_redis  # type: ignore[attr-defined]
+
+    import jwt as pyjwt
+
+    for tok in (tok1, tok2):
+        claims = pyjwt.decode(tok, options={"verify_signature": False})
+        assert fake.exists(f"jti:{claims['jti']}")
+
+
+@pytest.mark.unit
+def test_revoke_blocks_future_exchanges(client: TestClient):
+    key_id, raw = _create_key(client)
+    _exchange(client, raw)
+
+    client.post(
+        f"/v1/admin/keys/{key_id}/revoke",
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    r = client.post("/v1/oauth/token", json={"grant_type": "api_key", "api_key": raw})
+    assert r.status_code == 401
+
+
+@pytest.mark.unit
+def test_revoke_is_idempotent(client: TestClient):
+    key_id, raw = _create_key(client)
+    _exchange(client, raw)
+    first = client.post(
+        f"/v1/admin/keys/{key_id}/revoke",
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    assert first.status_code == 200
+    second = client.post(
+        f"/v1/admin/keys/{key_id}/revoke",
+        headers={"Authorization": "Bearer admin-secret"},
+    )
+    assert second.status_code == 200
+    # Second revoke is a no-op from a security standpoint — the jtis remain
+    # in the blocklist; the count reflects live DB rows (safe to re-push).
+    assert second.json()["revoked"] is True


### PR DESCRIPTION
## Summary

Implements [ADR-0007](../blob/develop/docs/adr/0007-digikey-revocation.md): a Redis-backed jti blocklist that invalidates issued JWTs in one round-trip when an API key is revoked. Closes the up-to-15-minute exposure window previously documented in `digikey/ARCHITECTURE.md` §6.

- `digikey_jti_issued` table records every jti at token exchange (composite index on `(api_key_id, exp)` for fast enumeration on revoke).
- `POST /v1/admin/keys/{id}/revoke` — admin-gated; sets `revoked_at`, enumerates live JTIs, bulk-writes them to Redis via `pipeline.setex(...).execute()`. Fail-closed on blocklist write failure (revocation rolls back).
- `digikey.blocklist` — thin redis-py wrapper. `DIGIKEY_BLOCKLIST_REDIS_URL` unset → `is_blocked()` returns False (feature-flag fallback).
- `DigiAuthMiddleware` — post-signature check: blocked → 401 `{"detail":"token_revoked"}`, Redis unreachable → 503 `{"detail":"auth_backend_unavailable"}`, URL unset → passthrough (warn-once).

Fixes #6

## Follow-ups (explicitly out of scope)

- [ ] Add Redis service to `docker-compose.yml` and wire `DIGIKEY_BLOCKLIST_REDIS_URL` into DigiKey + consumer containers (ADR-0007 step 6).
- [ ] Periodic cleanup job for `digikey_jti_issued` rows where `exp < now()` (pg_cron or equivalent).
- [ ] Consumer-side negative-cache optimization mentioned in ADR-0007 Consequences.

Migration note: the new table is created by `Base.metadata.create_all()` at startup — existing deployments must either drop-and-recreate the DigiKey DB or run a manual `CREATE TABLE` for `digikey_jti_issued`.

## Test plan

- [x] `pytest tests/ -m unit -k "digikey or dk"` — 35/35 pass (15 new tests across `test_blocklist.py`, `test_middleware_revocation.py`, `test_revoke_endpoint.py`).
- [x] `ruff check` and `ruff format --check` clean.
- [x] `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10.