### PR TITLE
feat(digigraph): Atlas research subgraph scaffolding spike (#146)

### DIFF
--- a/digigraph/src/digigraph/graph/__init__.py
+++ b/digigraph/src/digigraph/graph/__init__.py
@@ -1,5 +1,15 @@
 """LangGraph orchestration: supervisor + sub-graph pattern (Phase 1+)."""
 
+from digigraph.graph.atlas_subgraph import (
+    AtlasResearchState,
+    atlas_subgraph,
+    build_atlas_subgraph,
+)
 from digigraph.graph.graph import build_workflow_graph
 
-__all__ = ["build_workflow_graph"]
+__all__ = [
+    "AtlasResearchState",
+    "atlas_subgraph",
+    "build_atlas_subgraph",
+    "build_workflow_graph",
+]

--- a/digigraph/src/digigraph/graph/atlas_subgraph.py
+++ b/digigraph/src/digigraph/graph/atlas_subgraph.py
@@ -1,0 +1,72 @@
+"""Atlas research subgraph — scaffolding spike (issue #146).
+
+Minimal LangGraph StateGraph with three stub nodes (research → synthesize → persist)
+and a Pydantic v2 state model. Real LLM calls and DB persistence are intentionally
+out of scope for this spike; follow-up tasks under epic #10 will replace the stubs.
+
+This subgraph is *not* wired into the default supervisor — it is exposed only so
+parent graphs can invoke it once the rest of the Atlas epic lands.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from langgraph.graph import END, START, StateGraph
+from pydantic import BaseModel, Field
+
+
+class AtlasResearchState(BaseModel):
+    """State for the Atlas research subgraph.
+
+    Populated progressively by the three nodes:
+    - ``research_node`` fills ``sources`` and ``findings``.
+    - ``synthesize_node`` fills ``synthesis``.
+    - ``persist_node`` fills ``persisted_id``.
+    """
+
+    query: str
+    domain: str | None = None
+    sources: list[dict] = Field(default_factory=list)
+    findings: list[str] = Field(default_factory=list)
+    synthesis: str | None = None
+    persisted_id: str | None = None
+
+
+def research_node(state: AtlasResearchState) -> AtlasResearchState:
+    """STUB: emit one synthetic source + finding. No real LLM call in this spike."""
+    return state.model_copy(
+        update={
+            "sources": [{"id": "stub-source-1", "title": "Synthetic source", "url": None}],
+            "findings": ["Synthetic finding for query: " + state.query],
+        }
+    )
+
+
+def synthesize_node(state: AtlasResearchState) -> AtlasResearchState:
+    """STUB: trivial synthesis summarizing finding count."""
+    return state.model_copy(
+        update={"synthesis": f"Synthesized from {len(state.findings)} findings"}
+    )
+
+
+def persist_node(state: AtlasResearchState) -> AtlasResearchState:
+    """STUB: generate a UUID. No DB write in this spike."""
+    return state.model_copy(update={"persisted_id": str(uuid.uuid4())})
+
+
+def build_atlas_subgraph():
+    """Compile the Atlas research subgraph: research → synthesize → persist."""
+    g: StateGraph[AtlasResearchState] = StateGraph(AtlasResearchState)
+    g.add_node("research", research_node)
+    g.add_node("synthesize", synthesize_node)
+    g.add_node("persist", persist_node)
+    g.add_edge(START, "research")
+    g.add_edge("research", "synthesize")
+    g.add_edge("synthesize", "persist")
+    g.add_edge("persist", END)
+    return g.compile()
+
+
+# Compiled subgraph, importable by parent graphs once Atlas wiring lands.
+atlas_subgraph = build_atlas_subgraph()

--- a/tests/dg/test_atlas_subgraph.py
+++ b/tests/dg/test_atlas_subgraph.py
@@ -1,0 +1,36 @@
+"""Scaffolding-spike tests for the Atlas research subgraph (issue #146)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from digigraph.graph import AtlasResearchState, atlas_subgraph, build_atlas_subgraph
+
+
+@pytest.mark.unit
+def test_atlas_subgraph_populates_all_state_fields():
+    """Invoking the compiled subgraph walks research → synthesize → persist."""
+    result = atlas_subgraph.invoke(AtlasResearchState(query="test"))
+
+    # LangGraph returns either a dict or a state model depending on version; normalize.
+    state = result if isinstance(result, dict) else result.model_dump()
+
+    assert state["query"] == "test"
+    assert isinstance(state["sources"], list) and len(state["sources"]) == 1
+    assert isinstance(state["findings"], list) and len(state["findings"]) == 1
+    assert isinstance(state["synthesis"], str) and state["synthesis"]
+    # persisted_id should be a valid UUID string.
+    uuid.UUID(state["persisted_id"])
+
+
+@pytest.mark.unit
+def test_build_atlas_subgraph_returns_fresh_compiled_graph():
+    """Factory returns a compiled graph distinct from the module-level singleton."""
+    sg = build_atlas_subgraph()
+    assert sg is not atlas_subgraph
+    result = sg.invoke(AtlasResearchState(query="x", domain="macro"))
+    state = result if isinstance(result, dict) else result.model_dump()
+    assert state["domain"] == "macro"
+    assert state["persisted_id"] is not None


### PR DESCRIPTION
## Summary

- Adds `AtlasResearchState` (Pydantic v2) + a compiled LangGraph StateGraph with three stub nodes: `research -> synthesize -> persist`.
- Exposes `atlas_subgraph`, `build_atlas_subgraph`, and `AtlasResearchState` from `digigraph.graph` but does **not** wire the subgraph into the default supervisor — activation is deferred to the rest of epic #10.
- Scope is intentionally minimal: no real LLM in `research_node`, no DB write in `persist_node` (UUID stub only). Follow-up issues will replace the stubs.

Refs #146 #10

## Test plan

- [x] `pytest tests/dg/test_atlas_subgraph.py -v` — 2 passed
- [x] `pytest tests/ -m unit -k "digigraph or atlas" -v` — 15 passed, 1 skipped (unrelated nautilus import)
- [x] `ruff check digigraph/ tests/dg/test_atlas_subgraph.py` — clean
- [x] `ruff format --check` — clean
- [x] `make score` — 10/10 across Security, Quality, Optimization, Accuracy