### PR TITLE
feat(digigraph): NL → filter hint extraction for SITAAS (#143)

### DIFF
--- a/digigraph/src/digigraph/filter_hints.py
+++ b/digigraph/src/digigraph/filter_hints.py
@@ -1,0 +1,132 @@
+"""NL → filter hints for SITAAS search.
+
+Extract lightweight, structured filter hints (year, region, topic) from a natural-language
+query so downstream search can pre-narrow without the user specifying formal filters.
+
+The extraction is a tiny LLM call on the hot path. It is fail-open: any error returns
+an empty :class:`FilterHints` so search still runs. Results ride the shared
+``chat_completion`` cache (``DIGI_LLM_CACHE_TTL_SECONDS``) so repeated queries are free.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from digigraph.llm import chat_completion, get_model_for_mode
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """You extract search filter hints from a user's natural-language query.
+Return exactly one JSON object (no markdown, no prose) with these optional keys:
+- "year": 4-digit integer (e.g. 2024) if the query mentions a specific year; otherwise null
+- "region": geographic region/country/continent if mentioned (e.g. "Europe", "Asia", "US"); otherwise null
+- "topic": a short subject phrase (2-6 words) capturing what the query is about; otherwise null
+
+Rules:
+- Only fill fields the query clearly implies. Omit or use null when uncertain.
+- Do NOT infer a year from vague phrases like "this week", "recently", "last quarter".
+- Keep "topic" concise — no more than 6 words, lowercase, no trailing punctuation.
+- Output JSON only. No explanation."""
+
+
+class FilterHints(BaseModel):
+    """Structured hints extracted from an NL query for pre-narrowing search."""
+
+    year: int | None = Field(default=None, ge=1900, le=2100)
+    region: str | None = None
+    topic: str | None = None
+
+    @field_validator("region", "topic", mode="before")
+    @classmethod
+    def _blank_to_none(cls, v: Any) -> Any:
+        if v is None:
+            return None
+        if isinstance(v, str) and not v.strip():
+            return None
+        return v
+
+    def is_empty(self) -> bool:
+        return self.year is None and not self.region and not self.topic
+
+    def as_context_block(self) -> str:
+        """Return a compact bracketed block to prepend to the user message, or "" if empty."""
+        if self.is_empty():
+            return ""
+        parts: list[str] = []
+        if self.year is not None:
+            parts.append(f"year={self.year}")
+        if self.region:
+            parts.append(f"region={self.region}")
+        if self.topic:
+            parts.append(f"topic={self.topic}")
+        return "[Detected filter hints: " + ", ".join(parts) + "]"
+
+
+_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.DOTALL)
+
+
+def _strip_fence(s: str) -> str:
+    return _FENCE_RE.sub("", (s or "").strip()).strip()
+
+
+def _parse_hints_json(content: str) -> dict[str, Any]:
+    s = _strip_fence(content)
+    if not s:
+        return {}
+    decoder = json.JSONDecoder()
+    try:
+        obj, _ = decoder.raw_decode(s)
+        return obj if isinstance(obj, dict) else {}
+    except json.JSONDecodeError:
+        pass
+    start = s.find("{")
+    if start == -1:
+        return {}
+    try:
+        obj, _ = decoder.raw_decode(s, start)
+        return obj if isinstance(obj, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _is_disabled() -> bool:
+    return os.environ.get("DIGI_FILTER_HINTS", "1").strip().lower() in ("0", "false", "no", "off")
+
+
+def extract_filter_hints(query: str) -> FilterHints:
+    """Extract :class:`FilterHints` from an NL query. Fail-open on any error.
+
+    Disabled when ``DIGI_FILTER_HINTS=0``. Results ride the shared LLM cache so
+    repeated queries are effectively free on the hot path.
+    """
+    if _is_disabled():
+        return FilterHints()
+    q = (query or "").strip()
+    if not q:
+        return FilterHints()
+    try:
+        content = chat_completion(
+            model=get_model_for_mode(),
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": q},
+            ],
+            temperature=0.0,
+        )
+        if not isinstance(content, str) or not content.strip():
+            return FilterHints()
+        data = _parse_hints_json(content)
+        if not data:
+            return FilterHints()
+        # Only keep known keys to avoid pydantic strict-mode surprises on future fields.
+        allowed = {k: data.get(k) for k in ("year", "region", "topic") if k in data}
+        return FilterHints.model_validate(allowed)
+    except Exception as exc:
+        logger.debug("extract_filter_hints failed (fail-open): %s", exc)
+        return FilterHints()

--- a/digigraph/src/digigraph/graph/research.py
+++ b/digigraph/src/digigraph/graph/research.py
@@ -9,6 +9,7 @@ import re
 from contextvars import ContextVar
 from typing import Any
 
+from digigraph.filter_hints import extract_filter_hints
 from digigraph.graph.state import WorkflowState
 from digigraph.llm import chat_completion, chat_completion_with_tools, get_model_for_mode
 from digigraph.project_config import DigiProjectConfig
@@ -151,7 +152,11 @@ def _vertical_url_host_hints() -> str:
     parts: list[str] = []
     ds = (os.environ.get("DIGISEARCH_URL") or "").strip().lower()
     dq = (os.environ.get("DIGIQUANT_URL") or "").strip().lower()
-    if "://digisearch" in ds or ds.startswith("http://digisearch") or ds.startswith("https://digisearch"):
+    if (
+        "://digisearch" in ds
+        or ds.startswith("http://digisearch")
+        or ds.startswith("https://digisearch")
+    ):
         parts.append(
             "DIGISEARCH_URL uses the Docker hostname `digisearch`, which does not resolve on the host. "
             "For `make stack-local` set DIGISEARCH_URL=http://127.0.0.1:8002 in repo-root `.env` (run_stack_local.sh exports this for its children; IDE/manual uvicorn may still load the Docker value)."
@@ -200,7 +205,10 @@ def _is_likely_network_failure(exc: Exception) -> bool:
     try:
         import httpx
 
-        if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.TimeoutException)):
+        if isinstance(
+            exc,
+            (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.TimeoutException),
+        ):
             return True
     except ImportError:
         pass
@@ -315,11 +323,23 @@ def _run_document_rag_path(
     def stream_callback(event_type: str, data: Any) -> None:
         if raw_callback is None:
             return
-        if event_type == "tool_call" and data and data.get("name") in ("digisearch", "digisearch_fetch_all"):
+        if (
+            event_type == "tool_call"
+            and data
+            and data.get("name") in ("digisearch", "digisearch_fetch_all")
+        ):
             data = {**data, "index_name": index_display_name}
         raw_callback(event_type, data)
 
     user_content = str(prompt)
+
+    # SITAAS-only (project mode): prepend NL filter hints so the LLM folds them into
+    # digisearch tool args. Opt out via DIGI_FILTER_HINTS=0. extract_filter_hints is fail-open.
+    if run_data_dir:
+        hint_block = extract_filter_hints(user_content).as_context_block()
+        if hint_block:
+            user_content = hint_block + "\n\n" + user_content
+
     stored = state.get("stored_datasets") or {}
     if stored and isinstance(stored, dict):
         parts: list[str] = []
@@ -366,7 +386,9 @@ def _run_document_rag_path(
         from digigraph.planning.executor import run_plan
 
         plan_results = run_plan(plan, execute_search)
-        synthesis_parts = [f"Step {sid}: {_plan_result_preview(r)}" for sid, r in plan_results.items()]
+        synthesis_parts = [
+            f"Step {sid}: {_plan_result_preview(r)}" for sid, r in plan_results.items()
+        ]
         synthesis_user = (
             "The following plan was executed. Summarize the results for the user.\n\n"
             "Plan results:\n" + "\n".join(synthesis_parts) + "\n\nOriginal request: " + user_content
@@ -425,7 +447,9 @@ def _run_quant_or_augmented_path(
     )
     user_content = str(prompt)
     if doc_context:
-        user_content = f"[Document context from DigiSearch]\n{doc_context}\n\n[User prompt]\n{prompt}"
+        user_content = (
+            f"[Document context from DigiSearch]\n{doc_context}\n\n[User prompt]\n{prompt}"
+        )
 
     try:
         content = chat_completion(

--- a/tests/dg/test_filter_hints.py
+++ b/tests/dg/test_filter_hints.py
@@ -1,0 +1,118 @@
+"""Unit tests for NL → FilterHints extraction (digigraph.filter_hints)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from digigraph.filter_hints import FilterHints, extract_filter_hints
+
+
+def _canned(content: str):
+    """Return a patch context that makes chat_completion return ``content``."""
+    return patch("digigraph.filter_hints.chat_completion", return_value=content)
+
+
+@pytest.mark.unit
+def test_extracts_year_and_region() -> None:
+    payload = json.dumps({"year": 2024, "region": "Europe", "topic": "AI funding"})
+    with _canned(payload):
+        hints = extract_filter_hints("AI funding in Europe 2024")
+    assert hints.year == 2024
+    assert hints.region == "Europe"
+    assert hints.topic and "ai funding" in hints.topic.lower()
+    assert not hints.is_empty()
+
+
+@pytest.mark.unit
+def test_no_year_or_region_for_vague_time_reference() -> None:
+    payload = json.dumps({"year": None, "region": None, "topic": "best stocks"})
+    with _canned(payload):
+        hints = extract_filter_hints("best stocks this week")
+    assert hints.year is None
+    assert hints.region is None
+    # topic may still be populated; that's fine
+
+
+@pytest.mark.unit
+def test_extracts_region_and_topic_without_year() -> None:
+    payload = json.dumps({"region": "Asia", "topic": "climate policy changes"})
+    with _canned(payload):
+        hints = extract_filter_hints("climate policy changes in Asia")
+    assert hints.year is None
+    assert hints.region == "Asia"
+    assert hints.topic and "climate" in hints.topic.lower()
+
+
+@pytest.mark.unit
+def test_fail_open_on_llm_exception() -> None:
+    with patch("digigraph.filter_hints.chat_completion", side_effect=RuntimeError("boom")):
+        hints = extract_filter_hints("any query here")
+    assert hints == FilterHints()
+    assert hints.is_empty()
+
+
+@pytest.mark.unit
+def test_fail_open_on_garbage_output() -> None:
+    with _canned("this is not json at all"):
+        hints = extract_filter_hints("AI funding in Europe 2024")
+    assert hints.is_empty()
+
+
+@pytest.mark.unit
+def test_handles_fenced_json() -> None:
+    fenced = "```json\n" + json.dumps({"year": 2023, "region": "US"}) + "\n```"
+    with _canned(fenced):
+        hints = extract_filter_hints("US market 2023")
+    assert hints.year == 2023
+    assert hints.region == "US"
+
+
+@pytest.mark.unit
+def test_context_block_formatting() -> None:
+    h = FilterHints(year=2024, region="Europe", topic="ai funding")
+    block = h.as_context_block()
+    assert block.startswith("[Detected filter hints:")
+    assert "year=2024" in block
+    assert "region=Europe" in block
+    assert "topic=ai funding" in block
+
+
+@pytest.mark.unit
+def test_empty_hints_produce_empty_block() -> None:
+    assert FilterHints().as_context_block() == ""
+
+
+@pytest.mark.unit
+def test_empty_query_short_circuits() -> None:
+    with patch("digigraph.filter_hints.chat_completion") as m:
+        hints = extract_filter_hints("   ")
+    assert hints.is_empty()
+    m.assert_not_called()
+
+
+@pytest.mark.unit
+def test_env_disable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_FILTER_HINTS", "0")
+    with patch("digigraph.filter_hints.chat_completion") as m:
+        hints = extract_filter_hints("AI funding in Europe 2024")
+    assert hints.is_empty()
+    m.assert_not_called()
+
+
+@pytest.mark.unit
+def test_invalid_year_rejected_fail_open() -> None:
+    # year=42 fails the 1900..2100 validator → fail-open to empty hints.
+    with _canned(json.dumps({"year": 42, "region": "Europe"})):
+        hints = extract_filter_hints("something weird")
+    assert hints.is_empty()
+
+
+@pytest.mark.unit
+def test_blank_strings_become_none() -> None:
+    with _canned(json.dumps({"year": None, "region": "  ", "topic": ""})):
+        hints = extract_filter_hints("whatever")
+    assert hints.region is None
+    assert hints.topic is None


### PR DESCRIPTION
## Summary
- Adds `digigraph/src/digigraph/filter_hints.py` with a Pydantic-v2 `FilterHints` model (year/region/topic) and `extract_filter_hints(query)` — a tiny LLM call that structures-outputs hints for a natural-language search query.
- Wires extraction into the research node's SITAAS path (`_run_document_rag_path`): when `run_data_dir` is set, hints are prepended to the user message as `[Detected filter hints: ...]`, so the tool-calling LLM folds them into its DigiSearch args. Default (non-project) research flows are unchanged.
- Fail-open on any error (garbage JSON, LLM exception, validation failure) → empty hints, search continues. Opt-out via `DIGI_FILTER_HINTS=0`. Results ride the shared `chat_completion` cache.

## Test plan
- [x] `pytest tests/dg/test_filter_hints.py -v` — 12 unit tests cover the 3 required NL variants plus fence handling, fail-open, env disable, blank-string normalization, and invalid-year validation.
- [x] `pytest tests/dg/ -m unit` — 238 passed (1 pre-existing failure unrelated: missing optional `langgraph-checkpoint-sqlite`).
- [x] `ruff check` + `ruff format --check` — clean.
- [x] `make score` — Security 10, Quality 9, Optimization 10, Accuracy 10 (all thresholds met).

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)