### PR TITLE
feat(digisearch): Azure semantic search + facets + speller (#144)

### DIFF
--- a/digisearch/src/digisearch/core/models.py
+++ b/digisearch/src/digisearch/core/models.py
@@ -40,6 +40,7 @@ class Query:
     mode: str = "hybrid"
     columns: list[str] | None = None  # optional metadata columns to return (intersected with index config)
     facets: list[str] | None = None  # Azure: facet expressions e.g. ["sourceType", "itemType,count:20"]
+    include_facets: bool = False  # When True, response carries facet counts (from request.facets or index config facets).
     # Azure: hit highlighting (fields must be searchable)
     highlight_fields: list[str] | None = None
     highlight_pre_tag: str | None = None

--- a/digisearch/src/digisearch/indexes/backends/azure_search.py
+++ b/digisearch/src/digisearch/indexes/backends/azure_search.py
@@ -47,6 +47,9 @@ def _get_index_config() -> dict[str, Any]:
                 "result_metadata_fields": cfg.get("result_metadata_fields") or [],
                 "filterable_fields": cfg.get("filterable_fields") or [],
                 "allow_raw_filter": bool(cfg.get("allow_raw_filter", False)),
+                "semantic_configuration": cfg.get("semantic_configuration") or None,
+                "facets": cfg.get("facets") or [],
+                "speller": bool(cfg.get("speller", False)),
             }
     return {
         "index_name": os.environ.get("AZURE_SEARCH_INDEX_NAME", ""),
@@ -57,6 +60,9 @@ def _get_index_config() -> dict[str, Any]:
         "result_metadata_fields": [],
         "filterable_fields": [],
         "allow_raw_filter": False,
+        "semantic_configuration": None,
+        "facets": [],
+        "speller": False,
     }
 
 
@@ -156,6 +162,9 @@ def query_azure(query: Query, index_name: str | None = None) -> SearchResponse:
     extra_fields = cfg.get("result_metadata_fields") or []
     filterable_fields = cfg.get("filterable_fields") or []
     allow_raw_filter = cfg.get("allow_raw_filter", False)
+    semantic_configuration = cfg.get("semantic_configuration")
+    config_facets = cfg.get("facets") or []
+    speller_enabled = bool(cfg.get("speller", False))
 
     # Build select: key, content, doc_id, then requested columns or all result_metadata_fields
     select = [key_f, content_f, doc_id_f]
@@ -182,6 +191,15 @@ def query_azure(query: Query, index_name: str | None = None) -> SearchResponse:
         if isinstance(structured, list):
             odata_filter = _build_odata_filter(structured, filterable_fields)
 
+    # Resolve facets for this request: only populated when caller opts in via include_facets.
+    # Request-supplied facets take precedence; otherwise fall back to index-config facets.
+    effective_facets: list[str] | None = None
+    if query.include_facets:
+        if query.facets:
+            effective_facets = list(query.facets)
+        elif config_facets:
+            effective_facets = list(config_facets)
+
     results: list[Result] = []
     try:
         search_kw: dict[str, Any] = {
@@ -191,10 +209,17 @@ def query_azure(query: Query, index_name: str | None = None) -> SearchResponse:
             "query_type": "simple",
             "search_mode": "any",
         }
+        # Semantic search: upgrade query_type and pass configuration name if set on index config.
+        if semantic_configuration:
+            search_kw["query_type"] = "semantic"
+            search_kw["semantic_configuration_name"] = semantic_configuration
+            # Speller (lexicon) is only valid with semantic queries; ignore otherwise.
+            if speller_enabled:
+                search_kw["speller"] = "lexicon"
         if odata_filter:
             search_kw["filter"] = odata_filter
-        if query.facets:
-            search_kw["facets"] = query.facets
+        if effective_facets:
+            search_kw["facets"] = effective_facets
         if query.skip > 0:
             search_kw["skip"] = query.skip
         if query.include_total_count:
@@ -239,8 +264,14 @@ def query_azure(query: Query, index_name: str | None = None) -> SearchResponse:
                 metadata=raw,
             )
             results.append(Result(chunk=chunk, score=score, rank=i + 1))
-        facets_raw = search_results.get_facets() if hasattr(search_results, "get_facets") else None
-        facets = _normalize_facets(facets_raw) if facets_raw else None
+        # Only fetch/return facets when caller opted in — keeps default response lean.
+        facets: dict[str, list[dict[str, Any]]] | None = None
+        if query.include_facets and hasattr(search_results, "get_facets"):
+            try:
+                facets_raw = search_results.get_facets()
+            except Exception:
+                facets_raw = None
+            facets = _normalize_facets(facets_raw) if facets_raw else None
         total_count: int | None = None
         if query.include_total_count and hasattr(search_results, "get_count"):
             try:

--- a/digisearch/src/digisearch/orchestrator_tools.py
+++ b/digisearch/src/digisearch/orchestrator_tools.py
@@ -115,6 +115,10 @@ def build_search_tool(index_config: dict[str, Any] | None = None) -> dict[str, A
                         "items": {"type": "string"},
                         "description": "Optional facet expressions, e.g. ['sourceType', 'itemType,count:20'] to get value counts.",
                     },
+                    "include_facets": {
+                        "type": "boolean",
+                        "description": "When true, response carries facet counts (Azure only). Use for narrowing follow-up queries.",
+                    },
                     "order_by": {
                         "type": "array",
                         "items": {"type": "string"},

--- a/digisearch/src/digisearch/server.py
+++ b/digisearch/src/digisearch/server.py
@@ -158,6 +158,13 @@ class QueryRequest(BaseModel):
         default=None,
         description="Azure: facet expressions e.g. ['sourceType', 'itemType,count:20']",
     )
+    include_facets: bool = Field(
+        default=False,
+        description=(
+            "When true, response.facets is populated (Azure only). "
+            "Fields come from request.facets or the index config's facets list."
+        ),
+    )
     highlight_fields: list[str] | None = Field(
         default=None, description="Azure: fields to highlight matches in (searchable fields)"
     )
@@ -314,6 +321,7 @@ def run_query(req: QueryRequest) -> QueryResponse:
         order_by=req.order_by,
         skip=req.skip,
         include_total_count=req.include_total_count,
+        include_facets=req.include_facets,
         workspace_id=(
             req.workspace_id.strip() if req.workspace_id and req.workspace_id.strip() else None
         ),
@@ -414,6 +422,7 @@ def _query_request_from_digisearch_args(
     filters = args.get("filters") if isinstance(args.get("filters"), list) else None
     columns = args.get("columns") if isinstance(args.get("columns"), list) else None
     facets = args.get("facets") if isinstance(args.get("facets"), list) else None
+    include_facets = bool(args.get("include_facets", False))
     order_by = args.get("order_by") if isinstance(args.get("order_by"), list) else None
     response_mode = str(args.get("response_mode") or "full")
     summarize_raw = args.get("summarize_if_over")
@@ -427,6 +436,7 @@ def _query_request_from_digisearch_args(
         filters=filters,
         columns=columns,
         facets=facets,
+        include_facets=include_facets,
         order_by=order_by,
         response_mode=response_mode,
         summarize_if_over=summarize_if_over,

--- a/tests/ds/test_azure_semantic_facets.py
+++ b/tests/ds/test_azure_semantic_facets.py
@@ -1,0 +1,262 @@
+"""Unit tests for Azure semantic search, facet gating, and speller (issue #144)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from digisearch.core.models import Query, SearchResponse
+from digisearch.server import QueryRequest, QueryResponse, app
+from digisearch.search import add_chunks
+from digisearch.core.models import Chunk
+from tests.digi_test_jwt import auth_headers
+
+
+# --- Index config accepts new fields ---------------------------------------
+
+
+@pytest.mark.unit
+def test_index_config_accepts_new_fields(tmp_path, monkeypatch) -> None:
+    """YAML index config accepts semantic_configuration, facets, speller."""
+    from digisearch.indexes.backends.azure_search import _get_index_config
+
+    cfg_path = tmp_path / "idx.yaml"
+    cfg_path.write_text(
+        "index_name: myindex\n"
+        "field_mapping:\n"
+        "  key_field: id\n"
+        "  content_field: content\n"
+        "  doc_id_field: doc_id\n"
+        "result_metadata_fields: [year]\n"
+        "filterable_fields: [year]\n"
+        "facets: [year, region, doc_type]\n"
+        "semantic_configuration: my-semantic-config\n"
+        "speller: true\n"
+    )
+    monkeypatch.setenv("DIGISEARCH_INDEX_CONFIG", str(cfg_path))
+    cfg = _get_index_config()
+    assert cfg["semantic_configuration"] == "my-semantic-config"
+    assert cfg["facets"] == ["year", "region", "doc_type"]
+    assert cfg["speller"] is True
+
+
+@pytest.mark.unit
+def test_index_config_new_fields_default_absent(tmp_path, monkeypatch) -> None:
+    """Missing fields default to None / [] / False (back-compat)."""
+    from digisearch.indexes.backends.azure_search import _get_index_config
+
+    cfg_path = tmp_path / "idx.yaml"
+    cfg_path.write_text("index_name: myindex\n")
+    monkeypatch.setenv("DIGISEARCH_INDEX_CONFIG", str(cfg_path))
+    cfg = _get_index_config()
+    assert cfg["semantic_configuration"] is None
+    assert cfg["facets"] == []
+    assert cfg["speller"] is False
+
+
+# --- Query request / response wire-up --------------------------------------
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, headers=auth_headers())
+
+
+@pytest.fixture
+def _stub_results(client: TestClient) -> str:
+    idx = "__unit_test_facets__"
+    add_chunks(
+        idx,
+        [Chunk(id="c1", content="Content one", doc_id="d1", embedding=None, metadata={})],
+    )
+    return idx
+
+
+@pytest.mark.unit
+def test_query_request_accepts_include_facets() -> None:
+    """QueryRequest validates include_facets as a boolean."""
+    req = QueryRequest(text="hello", include_facets=True)
+    assert req.include_facets is True
+    req2 = QueryRequest(text="hello")
+    assert req2.include_facets is False
+
+
+@pytest.mark.unit
+def test_query_response_facets_null_by_default(client: TestClient, _stub_results: str) -> None:
+    """Default response (no include_facets) serializes facets as null on keyword backends."""
+    r = client.post("/query", json={"text": "Content", "index_name": _stub_results})
+    assert r.status_code == 200
+    data = r.json()
+    assert "facets" in data
+    assert data["facets"] is None
+
+
+@pytest.mark.unit
+def test_query_response_facets_serialization_shape() -> None:
+    """QueryResponse.facets is dict[str, list[{value, count}]] when populated."""
+    resp = QueryResponse(
+        results=[],
+        query="x",
+        index_name="i",
+        total=0,
+        facets={"year": [{"value": "2024", "count": 7}, {"value": "2023", "count": 3}]},
+    )
+    payload = resp.model_dump(mode="json")
+    assert payload["facets"]["year"][0] == {"value": "2024", "count": 7}
+
+
+# --- Azure backend SDK signature -------------------------------------------
+
+
+def _azure_env(monkeypatch, tmp_path, **cfg_extra) -> None:
+    monkeypatch.setenv("AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setenv("AZURE_SEARCH_API_KEY", "testkey")
+    base = {
+        "index_name": "idx",
+        "field_mapping": {"key_field": "id", "content_field": "content", "doc_id_field": "doc_id"},
+    }
+    base.update(cfg_extra)
+    import yaml
+
+    cfg_path = tmp_path / "idx.yaml"
+    cfg_path.write_text(yaml.safe_dump(base))
+    monkeypatch.setenv("DIGISEARCH_INDEX_CONFIG", str(cfg_path))
+
+
+def _patched_client(return_docs: list[dict] | None = None, facets: dict | None = None) -> MagicMock:
+    docs = return_docs or []
+    page = MagicMock()
+    page.__iter__ = lambda self: iter(docs)
+    page.get_facets = MagicMock(return_value=facets)
+    page.get_count = MagicMock(return_value=len(docs))
+    client = MagicMock()
+    client.search = MagicMock(return_value=page)
+    return client
+
+
+@pytest.mark.unit
+def test_azure_semantic_kwargs_passed_to_sdk(monkeypatch, tmp_path) -> None:
+    """When semantic_configuration is set on the index config, the SDK call uses query_type='semantic'."""
+    # Force azure SDK import guard to True without actually importing the package.
+    import digisearch.indexes.backends.azure_search as az
+
+    _azure_env(monkeypatch, tmp_path, semantic_configuration="my-config")
+    # Refresh module-level env captures.
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client()
+    with patch.object(az, "_get_client", return_value=mock_client):
+        resp = az.query_azure(Query(text="hello", top_k=5), index_name="idx")
+
+    assert isinstance(resp, SearchResponse)
+    mock_client.search.assert_called_once()
+    kwargs = mock_client.search.call_args.kwargs
+    assert kwargs["query_type"] == "semantic"
+    assert kwargs["semantic_configuration_name"] == "my-config"
+
+
+@pytest.mark.unit
+def test_azure_no_semantic_keeps_simple_query_type(monkeypatch, tmp_path) -> None:
+    """Without semantic_configuration, query_type stays 'simple' (back-compat)."""
+    import digisearch.indexes.backends.azure_search as az
+
+    _azure_env(monkeypatch, tmp_path)
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client()
+    with patch.object(az, "_get_client", return_value=mock_client):
+        az.query_azure(Query(text="hello", top_k=5), index_name="idx")
+
+    kwargs = mock_client.search.call_args.kwargs
+    assert kwargs["query_type"] == "simple"
+    assert "semantic_configuration_name" not in kwargs
+    assert "speller" not in kwargs
+
+
+@pytest.mark.unit
+def test_azure_speller_only_with_semantic(monkeypatch, tmp_path) -> None:
+    """speller='lexicon' is passed iff speller=true AND semantic_configuration is set."""
+    import digisearch.indexes.backends.azure_search as az
+
+    # Case 1: speller true + semantic set -> passed.
+    _azure_env(monkeypatch, tmp_path, semantic_configuration="sc", speller=True)
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client()
+    with patch.object(az, "_get_client", return_value=mock_client):
+        az.query_azure(Query(text="hi", top_k=3), index_name="idx")
+    assert mock_client.search.call_args.kwargs.get("speller") == "lexicon"
+
+    # Case 2: speller true but no semantic -> ignored.
+    _azure_env(monkeypatch, tmp_path, speller=True)
+    mock_client2 = _patched_client()
+    with patch.object(az, "_get_client", return_value=mock_client2):
+        az.query_azure(Query(text="hi", top_k=3), index_name="idx")
+    assert "speller" not in mock_client2.search.call_args.kwargs
+
+
+@pytest.mark.unit
+def test_azure_facets_gated_by_include_facets(monkeypatch, tmp_path) -> None:
+    """include_facets=False -> no facets kwarg and response.facets is None, even if config has facets."""
+    import digisearch.indexes.backends.azure_search as az
+
+    _azure_env(monkeypatch, tmp_path, facets=["year", "region"])
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client(facets={"year": [{"value": "2024", "count": 1}]})
+    with patch.object(az, "_get_client", return_value=mock_client):
+        resp = az.query_azure(Query(text="hi", top_k=3, include_facets=False), index_name="idx")
+    assert "facets" not in mock_client.search.call_args.kwargs
+    assert resp.facets is None
+
+
+@pytest.mark.unit
+def test_azure_facets_use_config_when_include_facets_and_no_request_facets(
+    monkeypatch, tmp_path
+) -> None:
+    """include_facets=True with no request facets -> falls back to config facets."""
+    import digisearch.indexes.backends.azure_search as az
+
+    _azure_env(monkeypatch, tmp_path, facets=["year", "region"])
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client(
+        facets={"year": [{"value": "2024", "count": 5}, {"value": "2023", "count": 2}]},
+    )
+    with patch.object(az, "_get_client", return_value=mock_client):
+        resp = az.query_azure(Query(text="hi", top_k=3, include_facets=True), index_name="idx")
+
+    assert mock_client.search.call_args.kwargs["facets"] == ["year", "region"]
+    assert resp.facets is not None
+    assert resp.facets["year"][0] == {"value": "2024", "count": 5}
+
+
+@pytest.mark.unit
+def test_azure_request_facets_override_config(monkeypatch, tmp_path) -> None:
+    """Request-supplied facets list takes precedence over config facets."""
+    import digisearch.indexes.backends.azure_search as az
+
+    _azure_env(monkeypatch, tmp_path, facets=["year"])
+    monkeypatch.setattr(az, "AZURE_SEARCH_ENDPOINT", "https://example.search.windows.net")
+    monkeypatch.setattr(az, "AZURE_SEARCH_API_KEY", "testkey")
+    monkeypatch.setattr(az, "_AZURE_AVAILABLE", True)
+
+    mock_client = _patched_client(facets={})
+    with patch.object(az, "_get_client", return_value=mock_client):
+        az.query_azure(
+            Query(text="hi", top_k=3, include_facets=True, facets=["region,count:10"]),
+            index_name="idx",
+        )
+    assert mock_client.search.call_args.kwargs["facets"] == ["region,count:10"]


### PR DESCRIPTION
## Summary
- Adds `semantic_configuration`, `facets`, and `speller` to the DigiSearch index config (YAML). Azure backend uses `query_type="semantic"` + `semantic_configuration_name` when configured; `speller="lexicon"` is forwarded only with semantic (Azure constraint).
- `POST /query` gains `include_facets: bool = false`. Response `facets` is populated only when opted in, sourced from the request's `facets` list or, as a fallback, the index config's `facets`. Non-Azure backends keep returning null. This lets the research loop issue narrowing follow-up queries without inflating the default response.
- Orchestrator tool schema for `digisearch` advertises `include_facets` so the orchestrator can request facet counts.

Fixes #144

## Test plan
- [x] `pytest tests/ds/test_azure_semantic_facets.py -v` (11 new tests)
- [x] `pytest tests/ds/test_server_query.py tests/ds/test_azure_filter.py -v` (existing suite still green)
- [x] `pytest -m unit -k "digisearch or ds"` — 197 passed, 3 skipped (rank_bm25 optional)
- [x] `ruff check digisearch/` — clean
- [x] `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10

## Notes
- Kept the existing raw-dict index-config style (no new Pydantic `IndexConfig` model). The repo has no Pydantic model for index configs today; matching house style. Happy to upgrade if reviewers prefer stronger typing.
- `speller="lexicon"` is silently ignored without semantic config because Azure rejects it otherwise — avoids surprising 400s.

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>