### PR TITLE
docs(vision): per-module vision and architecture documents

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,7 +1,9 @@
 # DigiThings Vision
 
-**Last reviewed:** 2026-04-18
+**Last reviewed:** 2026-04-19
 **Status:** living document — source of truth for product direction. Implementation detail belongs in `ARCHITECTURE.md`, component `DIGIxxx.md` files, and ADRs under `docs/adr/`.
+
+> **Per-module vision & roadmap:** see [`docs/vision/`](vision/README.md) for one document per module (positioning, current state, 12-month roadmap, open vs. proprietary split).
 
 ## One-liner
 

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -1,0 +1,93 @@
+# DigiThings — Ecosystem Overview
+> A modular AI production platform that assembles the best open-source infrastructure into a pre-wired stack, with proprietary domain expertise layered on top.
+
+## What it is
+
+DigiThings is a modular AI production platform sitting at the intersection of AI engineering, quantitative finance, and developer infrastructure. It assembles best-of-breed open-source tools — LiteLLM, LangGraph, NautilusTrader, Supabase, OpenBB — into a pre-wired, production-ready stack, then layers proprietary domain expertise on top through a library of specialised agent sub-graphs (composable, independently deployable workflow units).
+
+The core value proposition: a declarative project spec — config file plus index definitions plus API key — collapses weeks of engineering setup into hours. A consultant can deploy a client-facing intelligent application over their data without rebuilding auth, RAG (retrieval-augmented generation), orchestration, or LLM routing from scratch. The stack is pre-integrated; the configuration is the work.
+
+**Three customer shapes:**
+
+1. **Independent researcher or quant** — personal toolkit for strategy development, research synthesis, and portfolio management. Low barrier; deploy locally or via managed hosting.
+2. **Consultancy client (SITAAS pattern)** — config plus index plus API key produces a deployed, client-facing product in hours. The first pilot is SITAAS, deployed with Microsoft SSO and domain-specific RAG over internal documents.
+3. **Developer** — open-core modules to build and extend. Proprietary agents and skills available as paid add-ons.
+
+## The problem it solves
+
+Most AI deployments fall into one of two failure modes: thin wrappers that provide no domain expertise and break under real-world complexity, or fully bespoke builds where every engagement rebuilds auth, retrieval, routing, and streaming from scratch. Neither scales.
+
+DigiThings is the composable middle ground. It provides the infrastructure layer pre-built and pre-integrated, so the work that remains is configuration and domain logic — not plumbing.
+
+**Why not just use LiteLLM, LangChain, or existing SDKs?** LiteLLM routes models. LangChain provides primitives. DigiThings routes entire workflows — research, analysis, retrieval, execution, auth, audit — and the proprietary value is in domain-specific agent sub-graphs and the integration pattern. The difference between plumbing materials and a working kitchen. Using LiteLLM is a component choice within DigiThings, not an alternative to it.
+
+## How it fits in the ecosystem
+
+DigiThings occupies the layer between raw AI infrastructure (model providers, vector databases, execution engines) and client-facing applications. It does not compete with model providers or cloud platforms. It competes with the engineering time and cost of building production AI systems from scratch.
+
+**No lock-in philosophy:** Use the entire DigiThings platform, or integrate individual modules into an existing stack. Every capability is exposed as a REST endpoint, MCP tool (for Claude Desktop, Cursor, and other AI apps), CLI command, and Docker container via DigiLink. Switching costs nothing because no module assumes you are using any other DigiThings module exclusively.
+
+The platform integrates with and extends the open-source tools clients may already have in place — it is additive, not replacement.
+
+## Capabilities — Current
+
+Shipped and in active use:
+
+### DigiGraph — agent orchestration hub
+LangGraph-based workflow engine with a supervisor node, research and analysis sub-graphs, dynamic tool registry, OpenAI-compatible API, server-sent event (SSE) streaming, JWT auth, per-IP rate limiting, LiteLLM routing, DigiSmith tracing, and an MCP server. Parallel tool execution and tool allowlist/policy enforcement included.
+
+### DigiQuant — quantitative finance platform
+NautilusTrader-backed strategy engine with backtest and optimisation nodes wired into DigiGraph. Connects to OpenBB for market data. Atlas (research), Hermes (portfolio), and Kairos (strategy execution) are in active development as sub-graph modules.
+
+### DigiSearch — RAG and retrieval pipeline
+Document ingestion, chunking, embedding, and hybrid vector/keyword search. Pluggable backends. Powers the SITAAS internal document search deployment.
+
+### DigiChat — chat interface and BFF
+Next.js production chat UI deployed at chat.digithings.ai. BYOK (bring-your-own-key) flow, model selector, Auth.js authentication, Drizzle ORM, adaptive UI scoped by access level.
+
+### DigiKey — auth control plane
+JWT-based authentication with scoped API keys (RS256, JWKS endpoint), SSO federation groundwork, org and project membership model.
+
+### DigiSmith — observability
+LangSmith tracing, Prometheus metrics, correlation IDs (workflow, request, session). `/v1/status` public endpoint.
+
+### DigiClaw — always-on agent orchestration
+Scheduled and continuous agent execution via OpenClaw. Heartbeat and audit capabilities. MCP skill interface.
+
+### DigiBase — shared library
+HTTP utilities, error envelopes, immutable audit logging (JSONL with redaction). Shared across all service boundaries.
+
+**Note — not yet shipped:** DigiStore (unified storage abstraction over Supabase, SQLite, S3/MinIO) and DigiLink (the protocol translation and connector layer) are designed and specced but not yet implemented as standalone modules. Their functions exist today within individual services.
+
+## Capabilities — 12-month roadmap
+
+- **Atlas** running daily research cycles autonomously — parallel, batched, prompt-cached, fully integrated as a DigiGraph sub-graph
+- **Hermes** maintaining live portfolio allocations with deliberation sub-graph and human approval gate before any execution
+- **Kairos** enabling chat-based strategy development through DigiChat — a quant researcher's interactive strategy workbench
+- **SITAAS** fully deployed with Microsoft SSO, proper domain RAG, and a client-facing chat interface
+- **DigiLink** formalised as a module — MCP adapter generation from OpenAPI specs, CLI wrapper auto-generation, desktop AI app connector library (Claude Desktop, Cursor, Windsurf)
+- **DigiStore** shipping as a unified storage abstraction with Supabase, SQLite, and S3/MinIO backends behind a single interface
+- **Graphiti graph memory** integrated into DigiGraph for persistent, structured knowledge across sessions
+- **digithings.ai and digiquant.io** live with embedded chat demos
+- **Expanded proprietary sub-graph library** — investor document builder, scholarly article synthesis, exploration agent, strategy development pipeline
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):**
+- DigiGraph engine, tool registry, LangGraph integration, OpenAI-compatible API, MCP server
+- DigiSearch ingestion and retrieval pipeline
+- DigiKey auth primitives
+- DigiSmith tracing helpers
+- DigiClaw heartbeat and audit core
+- DigiBase shared library
+- DigiLink connector framework (when shipped)
+- DigiStore storage abstraction (when shipped)
+
+**Proprietary (commercial):**
+- Domain-specific sub-graph implementations: Atlas research cycles, Hermes portfolio deliberation, Kairos strategy execution
+- Strategy library and backtest configuration templates
+- Investor document builder and scholarly synthesis sub-graphs
+- Managed hosting and deployment
+- Enterprise SSO federation and org management extensions
+
+The open core is the infrastructure. The proprietary layer is the domain expertise that makes it immediately useful for finance, research, and consulting deployments.

--- a/docs/vision/digibase.md
+++ b/docs/vision/digibase.md
@@ -1,0 +1,15 @@
+# DigiBase
+
+> Shared infrastructure library — the utilities every DigiThings service uses, kept minimal and dependency-free.
+
+**What it is:** DigiBase is a shared Python library that provides the common infrastructure patterns every DigiThings service needs: standardized error envelopes, outbound HTTP correlation headers, audit log redaction, optional OpenTelemetry wiring. It is imported as a library — not deployed as a service.
+
+**Design principle:** Side-effect-free on import. Zero runtime dependencies beyond the optional extras. If DigiBase grows into a service, something has gone wrong in the architecture.
+
+**Scope clarification:** DigiBase is intentionally minimal. The "data-plane broker" role (managing Postgres/Redis credentials per tenant) that was discussed in earlier roadmap versions is now owned by DigiStore. DigiBase stays a library.
+
+**Current state:** v0.1 shipped. 7 source files: error envelopes, outbound HTTP headers, audit redaction, Prometheus metrics instrumentation, optional OTel wiring. Fully tested.
+
+**12-month roadmap:** Extend OTel wiring as other modules adopt it. Add shared HTTP patterns as they emerge from other module development. Resist scope expansion — keep it a library.
+
+**Open source vs. proprietary:** Entirely open.

--- a/docs/vision/digichat.md
+++ b/docs/vision/digichat.md
@@ -7,7 +7,7 @@
 **The problem:** Most AI chat interfaces are locked to one model provider and one use case. Switching providers means switching platforms. Adding new data sources or tools means custom integration work. DigiChat inverts this — the orchestration and tooling are DigiThings, the compute and data are the user's own.
 
 **BYOK model selector — core feature:**
-A settings panel where users configure their LLM backend: API key input, provider selection (OpenAI, Anthropic, Gemini, Ollama, and others), optional OAuth login for providers that require it. Stored in DigiStore per user. LiteLLM translates any provider into one standardized API language — translation only, not routing intelligence. The user pays their provider directly. DigiThings provides the orchestration, tooling, and graph layer.
+A settings panel where users configure their LLM backend: API key input, provider selection (OpenAI, Anthropic, Gemini, Ollama, and others), optional OAuth login for providers that require it. Keys persist in the DigiChat Drizzle/Postgres store today, and migrate to DigiStore once that module ships. LiteLLM translates any provider into one standardized API language — translation only, not routing intelligence. The user pays their provider directly. DigiThings provides the orchestration, tooling, and graph layer.
 
 **Adaptive UI driven by DigiKey JWT scopes:**
 DigiChat reads the user's JWT on login and shows only what they're authorized to use. If a scope is absent, the feature doesn't appear — not locked, not visible.

--- a/docs/vision/digichat.md
+++ b/docs/vision/digichat.md
@@ -1,0 +1,44 @@
+# DigiChat
+
+> The conversational interface for every DigiThings deployment — your models, your keys, your data.
+
+**What it is:** DigiChat is the client-facing chat interface that powers every DigiThings deployment. It is a Next.js application with a backend-for-frontend layer that connects to DigiGraph for agent orchestration. Two core principles define it: (1) bring your own keys — users supply their own LLM provider API keys and pay their own compute costs; (2) adaptive UI — the interface surfaces only what the user has access to based on their DigiKey permission scope.
+
+**The problem:** Most AI chat interfaces are locked to one model provider and one use case. Switching providers means switching platforms. Adding new data sources or tools means custom integration work. DigiChat inverts this — the orchestration and tooling are DigiThings, the compute and data are the user's own.
+
+**BYOK model selector — core feature:**
+A settings panel where users configure their LLM backend: API key input, provider selection (OpenAI, Anthropic, Gemini, Ollama, and others), optional OAuth login for providers that require it. Stored in DigiStore per user. LiteLLM translates any provider into one standardized API language — translation only, not routing intelligence. The user pays their provider directly. DigiThings provides the orchestration, tooling, and graph layer.
+
+**Adaptive UI driven by DigiKey JWT scopes:**
+DigiChat reads the user's JWT on login and shows only what they're authorized to use. If a scope is absent, the feature doesn't appear — not locked, not visible.
+
+Examples:
+- digiquant:read → DigiQuant tools available as chat connections
+- index:research → Research library DigiSearch index available
+- subgraph:atlas → Atlas research sub-graph accessible
+- tier:free → 3 questions, public index only, no proprietary sub-graphs
+
+**Two live deployments:**
+
+digithings.ai — platform demo:
+DigiThings own documentation indexed. Free tier: 3 questions with a cheap fast model. BYOK to continue beyond free. Model selector spans OpenAI, Anthropic, Gemini, Ollama. Sample questions displayed to guide exploration ("What does DigiQuant do?"). Goal: let any visitor experience the DigiThings stack directly.
+
+digiquant.io — investment profiling:
+Entry flow powered by a proprietary investment profiling sub-graph. User inputs investment preferences → DigiChat builds and saves an investment profile to DigiStore (user acquisition + personalization). Shows what strategies and allocations could be constructed for their profile. Paywall trigger: "Ready to build your first strategy? Start with Kairos." Free taste → paid conversion.
+
+**Enterprise deployments (client pattern):**
+A client organization deploys DigiChat pointed at their own DigiSearch index. Users log in via their corporate SSO (Microsoft, Google) — DigiKey identifies them, maps them to their organization's project, and issues a JWT with the appropriate index and tool scopes. The UI adapts: only their organization's indexes and approved tools appear. Index results are filtered by user access level.
+
+**Current state (shipped):**
+Next.js BFF + React UI, Auth.js sessions, Drizzle ORM, AI SDK, Postgres for conversation history, BYOK UI flow live, deployed to chat.digithings.ai.
+
+**12-month roadmap:**
+- Model selector settings panel (full provider list, BYOK per provider)
+- Investment profiling sub-graph (digiquant.io entry flow)
+- Microsoft SSO and Google OIDC login via DigiKey
+- Adaptive UI: scope-driven connection visibility
+- digithings.ai demo instance (docs indexed, 3-question free tier)
+- User conversation history and session management
+- Kairos strategy exploration interface
+
+**Open source vs. proprietary:** DigiChat application — open. Proprietary sub-graphs that power specific chat flows (investment profiling, Atlas research interface) — commercial.

--- a/docs/vision/digiclaw.md
+++ b/docs/vision/digiclaw.md
@@ -1,0 +1,36 @@
+# DigiClaw
+
+> The always-on agent layer — scheduled and continuous AI agents that run the ecosystem autonomously.
+
+**What it is:** DigiClaw is the persistent agent orchestration layer. Where DigiGraph handles on-demand requests triggered by users, DigiClaw handles scheduled, continuous, and autonomously running agents. It is a deployment and scheduling wrapper around OpenClaw that simplifies defining, launching, and monitoring long-running agents — giving them access to DigiGraph sub-graphs, DigiSearch indexes, and DigiQuant tools on a schedule or continuously.
+
+**The problem:** Most agent systems are reactive — they respond to user requests and then stop. But some of the most valuable AI workflows are proactive: monitoring a live strategy around the clock, continuously exploring new research directions, running daily analysis cycles autonomously. DigiClaw is the infrastructure that makes these workflows reliable and auditable.
+
+**Architecture:**
+- Agent definitions: what the agent does, which tools and sub-graphs it has access to, what outputs it produces
+- Schedule config: cron schedule, continuous (24/7), or event-triggered
+- Tool provisioning: controlled access grants to DigiGraph sub-graphs, DigiSearch indexes, DigiQuant tools
+- Audit trail: immutable JSONL log of every action taken autonomously — critical accountability layer for agents operating without human supervision
+- OpenClaw runtime: the agent execution layer underneath DigiClaw
+
+**Confirmed use cases:**
+- Atlas runner: the daily delta research cycle, weekly full generation, and monthly rollup are DigiClaw-scheduled jobs — this is what makes Atlas run reliably without manual execution
+- Strategy monitor: watches a deployed live strategy's P&L, flags drift, takes defined actions on threshold breach
+- Strategy explorer: runs Kairos autonomously in the background, continuously iterating on strategy ideas and populating the research library
+- Code reviewer: scheduled agent that reviews recent commits against quality criteria and files issues on failures
+
+**Why the audit trail matters:** When autonomous agents make decisions — modifying research files, flagging strategy drift, triggering rebalancing recommendations — there must be an immutable record. DigiClaw's audit log is the accountability layer for everything that runs without a human in the loop.
+
+**ADDM (Adaptive Drift Detection Monitor):** Detects when autonomous agent outputs or running strategy behavior deviates from expected patterns — both strategy performance drift (vs. backtest baseline) and agent output quality drift (outputs changing character over time). Flags for human review before automated action.
+
+**Current state:** Heartbeat polling (DigiGraph, DigiQuant health) and JSONL audit logging implemented. OpenClaw integration, agent definition framework, and scheduling system not yet built. Atlas daily cycle still runs manually — migrating to DigiClaw is a near-term priority.
+
+**12-month roadmap:**
+- OpenClaw integration
+- Agent definition schema and registry
+- Cron and continuous scheduling
+- Atlas daily cycle running automatically via DigiClaw
+- Strategy performance monitor agent
+- DigiClaw dashboard (agent status, audit log viewer)
+
+**Open source vs. proprietary:** DigiClaw framework — open. The specific agent definitions (what Atlas does, how the strategy monitor reasons) — proprietary.

--- a/docs/vision/digigraph.md
+++ b/docs/vision/digigraph.md
@@ -41,7 +41,7 @@ Shipped and in production:
 - Server-sent event (SSE) streaming for real-time response delivery
 - JWT authentication via DigiKey
 - Per-IP rate limiting
-- DigiStore session storage for checkpoint persistence
+- Checkpoint persistence via `DIGI_CHECKPOINTER` (memory / SQLite / Postgres today; migrates to DigiStore once that module ships)
 - LiteLLM routing — model selection, caching, cost controls
 - DigiSmith tracing — every workflow tagged with `workflow_id`, `request_id`, `session_id`
 - MCP server — DigiGraph capabilities available as MCP tools for Claude Desktop and similar clients

--- a/docs/vision/digigraph.md
+++ b/docs/vision/digigraph.md
@@ -1,0 +1,85 @@
+# DigiGraph
+> The orchestration hub — every agent workflow, tool call, and sub-graph in the DigiThings ecosystem flows through here.
+
+## What it is
+
+DigiGraph is the central orchestration brain of the DigiThings stack. It maintains a LangGraph StateGraph (a directed graph of stateful processing nodes) that routes user requests through research, analysis, retrieval, and execution nodes depending on what the request requires. It exposes an OpenAI-compatible API so any client that speaks the standard OpenAI protocol — including third-party tools and existing integrations — can use it without modification.
+
+The dynamic tool registry is DigiGraph's core architectural feature: vertical services like DigiQuant and DigiSearch register their capabilities at runtime via `POST /v1/orchestrator_tools`. DigiGraph discovers and calls them without hardcoded configuration. Adding a new capability to the ecosystem means registering it; DigiGraph routes to it automatically.
+
+## The problem it solves
+
+Agent orchestration is consistently the hardest part of building AI systems in production. Every team rebuilds routing logic, tool management, session state, authentication, and streaming from scratch. The patterns are not obvious, the failure modes are subtle, and the work does not compound — each new project starts over.
+
+DigiGraph provides this as a pre-built, extensible foundation. The plumbing is done. The work that remains is adding domain-specific nodes and sub-graphs, not rebuilding the infrastructure they run on.
+
+## How it fits in the ecosystem
+
+DigiGraph sits at the centre of the DigiThings stack. All inbound requests — from DigiChat, from MCP clients, from REST callers — enter through DigiGraph. It dispatches to DigiQuant for quantitative tasks, DigiSearch for retrieval, and DigiKey for auth decisions. DigiSmith records spans for every workflow.
+
+### Sub-graph registry pattern
+
+Sub-graphs are composable, independently deployable workflow units that register alongside tools in the same registry. A workflow can invoke one sub-graph or chain several; there is no forced coupling. Sub-graphs can be used in isolation or composed into larger pipelines. This pattern is how DigiThings separates infrastructure (open) from domain expertise (proprietary): the engine that runs sub-graphs is open; the sub-graphs that encode domain logic are the commercial product.
+
+### Architecture decision guide — when to use what
+
+Choosing the right abstraction level matters for maintainability and cost:
+
+- **Skill or instruction file** — stateless, single-turn, no tool calls. Lightest option. Use for prompt templates, formatting rules, constrained generation.
+- **Agent** — multi-turn reasoning, tool use, memory, or iteration required. Use when the output depends on intermediate results.
+- **Sub-graph** — ordered pipeline with defined stages, branching, or parallel execution. Use when the *structure* of the work matters, not just the output. Atlas research cycles and Hermes portfolio deliberation are sub-graphs because their stage ordering and branching logic are as important as their outputs.
+
+Start with the lightest abstraction that works. Promote up only when the task demands it.
+
+## Capabilities — Current
+
+Shipped and in production:
+
+- LangGraph StateGraph with supervisor node, research node, backtest node, and optimisation node
+- Dynamic tool registry — verticals register at runtime, no hardcoded routing
+- OpenAI-compatible REST API (`/workflow`, `/v1/chat/completions`)
+- Server-sent event (SSE) streaming for real-time response delivery
+- JWT authentication via DigiKey
+- Per-IP rate limiting
+- DigiStore session storage for checkpoint persistence
+- LiteLLM routing — model selection, caching, cost controls
+- DigiSmith tracing — every workflow tagged with `workflow_id`, `request_id`, `session_id`
+- MCP server — DigiGraph capabilities available as MCP tools for Claude Desktop and similar clients
+- Parallel tool execution
+- Planning executor (multi-step plan before execution)
+- Tool allowlist and policy flags
+
+## Capabilities — 12-month roadmap
+
+**Engine improvements:**
+- Graphiti graph memory integration — persistent, structured knowledge that survives session boundaries
+- Remote MCP enumeration — discover and call external MCP servers registered at runtime
+- Auth-bound checkpoints — per-API-key RBAC on graph state, so different principals see different checkpoints
+- OpenAI Responses API support (in addition to existing Chat Completions compatibility)
+
+**Sub-graph migrations:**
+- Atlas research cycles fully migrated from standalone scripts to DigiGraph sub-graphs — parallel batching, prompt caching, scheduled daily runs
+- Hermes portfolio deliberation as a DigiGraph sub-graph with human approval gate before any allocation change
+
+**Proprietary sub-graph library expansion:**
+- Strategy development pipeline (Kairos) — chat-based, connected to DigiQuant
+- Investor document builder — structured output from research inputs
+- Scholarly article synthesis — multi-source ingestion into a persistent research library
+- Exploration agent — cheap model, exhaustive index search, surfaces candidates for deeper analysis
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):**
+- DigiGraph engine: StateGraph management, supervisor routing, streaming, checkpointing
+- Tool registry: registration protocol, discovery, parallel dispatch
+- LangGraph integration layer
+- OpenAI-compatible API surface
+- MCP server implementation
+- DigiSmith integration and tracing decorators
+
+**Proprietary (commercial):**
+- Specific sub-graph implementations with domain logic: Atlas research cycles, Hermes portfolio deliberation, Kairos strategy execution
+- Investor document builder, scholarly synthesis, and exploration agent sub-graphs
+- The strategy library and research prompt templates that drive the proprietary sub-graphs
+
+The engine is the open infrastructure. The sub-graphs that encode years of domain expertise in quantitative research and portfolio management are the commercial product.

--- a/docs/vision/digikey.md
+++ b/docs/vision/digikey.md
@@ -28,7 +28,7 @@ Client employees authenticate via Microsoft SSO → DigiKey identifies them → 
 - Google OIDC integration
 - Organization + project membership API
 - Resource-level JWT claims
-- JWT revocation (jti blocklist in Redis — closes current security gap)
-- Ephemeral JWKS rotation hardening (currently rotates on restart)
+- JWT revocation via a `jti` blocklist in Redis
+- Scheduled JWKS rotation with overlap windows for zero-downtime key rollover
 
 **Open source vs. proprietary:** Entirely open. Auth infrastructure is commodity — the value is in how it's integrated with the rest of the ecosystem.

--- a/docs/vision/digikey.md
+++ b/docs/vision/digikey.md
@@ -1,0 +1,34 @@
+# DigiKey
+
+> The auth control plane — API keys, JWT issuance, SSO federation, and access scope enforcement for the entire ecosystem.
+
+**What it is:** DigiKey is the single authentication and authorization control plane for all DigiThings services. Every user, every API call, every sub-graph invocation is gated by a DigiKey-issued JWT. It manages the full identity lifecycle: issuing credentials, federating corporate SSO identities, assigning organization and project membership, and encoding fine-grained access scopes that downstream services enforce.
+
+**The problem:** In multi-service architectures, auth is typically bolted on per-service and inconsistently enforced. DigiKey makes auth a first-class concern: one control plane, all services validate the same tokens via JWKS, and access decisions are encoded in the token itself — not scattered across service-specific configurations.
+
+**Current state (shipped):**
+RS256 JWT issuance with JWKS endpoint, API key management (dgk_live_ prefix, bcrypt hash), token exchange (api_key and bff_session grant types), scope enforcement with wildcard matching, admin key issuance. Downstream services verify JWTs locally via cached JWKS — DigiKey is off the hot path after initial exchange.
+
+**Three major additions in roadmap:**
+
+1. SSO identity federation:
+Microsoft OIDC/SAML, Google OIDC, AWS SSO, and other enterprise identity providers. Pattern: user authenticates via corporate SSO → DigiKey maps identity to DigiThings project/organization → issues JWT with appropriate scopes. This is how a client company's employee logs in with their existing corporate credentials and gets exactly the DigiThings access their organization has provisioned for them.
+
+2. Organization and project membership model:
+DigiKey maintains a user → organization → project → access tier mapping. One DigiThings deployment can serve multiple client organizations without cross-contamination. A user's JWT contains their org ID and project ID — downstream services use this to filter data and tool access to only what belongs to their organization.
+
+3. Resource-level access in JWTs:
+Beyond service-level scopes (e.g. digisearch:read), JWTs will carry resource-level permissions — which specific DigiSearch indexes, which sub-graphs, what data filter rules apply. DigiSearch reads these to return only authorized results from a shared index. This enables one index to serve multiple users at different access levels without separate deployments.
+
+**Enterprise client pattern:**
+Client employees authenticate via Microsoft SSO → DigiKey identifies them → maps to their client project → issues JWT with index:client-project and appropriate tool scopes → DigiChat surfaces only their organization's indexes and tools → DigiSearch filters results by their access level. Zero code changes per client — configuration only.
+
+**12-month roadmap:**
+- Microsoft OIDC/SAML integration
+- Google OIDC integration
+- Organization + project membership API
+- Resource-level JWT claims
+- JWT revocation (jti blocklist in Redis — closes current security gap)
+- Ephemeral JWKS rotation hardening (currently rotates on restart)
+
+**Open source vs. proprietary:** Entirely open. Auth infrastructure is commodity — the value is in how it's integrated with the rest of the ecosystem.

--- a/docs/vision/digilink.md
+++ b/docs/vision/digilink.md
@@ -1,0 +1,61 @@
+# DigiLink
+> Every DigiThings capability, any protocol — the connection layer that eliminates lock-in.
+
+## What it is
+
+DigiLink is the connection and translation layer for the entire DigiThings ecosystem. It serves two roles: standardising how modules communicate with each other internally, and translating capabilities to external protocols so clients can access them via whatever interface fits their workflow — HTTP REST, MCP tool (the protocol used by Claude Desktop, Cursor, Windsurf, and other AI apps), CLI command, or Docker container.
+
+DigiLink is not yet implemented as a standalone module. It is designed and its specification is settled. The problem it solves is real and growing — today, each DigiThings module exposes its own REST API independently without a shared translation layer. DigiLink consolidates and standardises this. The schedule and current state are described plainly below.
+
+## The problem it solves
+
+Most AI platforms force a specific integration pattern: use the SDK, or use the HTTP API, or call the CLI. Switching requires rebuilding the integration. When a client wants to call a DigiQuant backtest via Claude Desktop instead of a curl command, they currently cannot — or they build the MCP adapter themselves.
+
+DigiLink makes this a non-issue. A capability is defined once and is available through every supported protocol automatically. The integration is not rebuilt per client; it is generated from a single source of truth.
+
+## How it fits in the ecosystem
+
+### The core principle
+
+No DigiThings capability is protocol-native. Every capability is defined once. DigiLink translates it to:
+
+- **REST endpoint** — default, always present, source of truth for all capabilities
+- **MCP tool definition** — enables Claude Desktop, Cursor, Windsurf, and other desktop AI apps to call DigiThings capabilities natively
+- **CLI command** — scripting, automation, direct terminal use
+- **Docker entrypoint** — portable deployment without additional tooling
+- **Webhook / event connector** — async integrations (planned)
+
+### Internal face
+
+DigiThings modules communicate with each other using the same standard protocol they expose externally: HTTP REST today, gRPC for performance-critical paths in the future. No proprietary internal messaging. No custom IPC. If a module's internal interface differs from its external interface, that is a design defect, not a feature.
+
+### External face
+
+The protocol translation layer. A capability is added to the registry; DigiLink generates the adapters. Adding a new module does not require writing integration code for each protocol — the translation is handled centrally.
+
+### What this means for clients
+
+A client running Claude Desktop calls DigiQuant backtest tools via MCP. Another client running automated scripts uses the generated CLI. An enterprise integration uses the REST API. A third-party webhook triggers a DigiSearch ingestion run. Same underlying capability, zero rebuilding, no vendor lock-in.
+
+DigiLink replaces the deferred "OpenClaw gateway" concept from the early DigiClaw roadmap. DigiClaw now focuses purely on agent orchestration and scheduled execution. DigiLink owns the connector layer.
+
+## Capabilities — Current
+
+**Not yet implemented as a standalone module.** This is the honest current state.
+
+Today, individual DigiThings services expose their own REST APIs independently. DigiGraph has an MCP server. DigiClaw has an MCP skill interface. These exist and work. What does not yet exist is the unified capability registry and the automated adapter generation that DigiLink will provide — the layer that makes "add a capability once, expose it everywhere" true across the entire ecosystem rather than per-module.
+
+The protocol translation problem is solved piecemeal today. DigiLink makes it systematic.
+
+## Capabilities — 12-month roadmap
+
+- **Formal DigiLink module** — capability registry, adapter framework, routing from a single source of truth
+- **MCP adapter generation from OpenAPI specs** — any service with an OpenAPI schema gets an MCP tool definition automatically
+- **CLI wrapper auto-generation** — REST endpoints become CLI commands without manual implementation
+- **Desktop AI app connector library** — tested, documented connectors for Claude Desktop, Cursor, and Windsurf; available as a standalone installable package
+- **Webhook and event connector** — async trigger support for ingestion pipelines, scheduled workflows, and third-party system integrations
+- **gRPC for internal service communication** — performance-critical inter-service paths migrate from REST to gRPC while the external REST surface remains unchanged
+
+## Open source vs. proprietary
+
+DigiLink is entirely open (MIT/Apache). The connector framework, adapter generation tooling, and all protocol translation code are infrastructure — no proprietary components. The goal is broad adoption: the more DigiThings capabilities are accessible via the widest range of protocols, the more valuable the ecosystem is for everyone building on it.

--- a/docs/vision/digiquant.md
+++ b/docs/vision/digiquant.md
@@ -1,0 +1,160 @@
+# DigiQuant
+> The quantitative finance platform — from macro research to deployed trading strategies, powered by AI agents.
+
+## What it is
+
+DigiQuant is the quantitative finance vertical within DigiThings. It is not a trading platform in the traditional sense — it is an AI-powered toolkit for the complete investment workflow: researching markets, constructing theses, building and testing strategies, and deploying them.
+
+Three distinct products cover each stage of that workflow. DigiQuant is accessed via DigiGraph agent tools, a dedicated DigiChat interface, and a CLI — never requiring the user to write infrastructure code.
+
+## The problem it solves
+
+Systematic quantitative trading and AI-driven investment research have historically required either expensive institutional infrastructure (Bloomberg, FactSet, proprietary execution systems) or a research engineering team to stitch together disparate tools. The result is that rigorous, systematic investment research has been the exclusive domain of well-funded institutions and large funds.
+
+DigiQuant makes this accessible to independent researchers, small funds, and individual investors by automating the infrastructure and exposing it through natural language interfaces. The full pipeline — from daily macro research through thesis construction, strategy development, backtesting, optimization, and live deployment — is available without writing infrastructure code.
+
+## Products
+
+### Atlas
+
+Atlas is the macro research engine and the knowledge foundation everything else builds on.
+
+It runs daily research cycles across parallel layers — data ingestion, sector analysis, macro synthesis — producing a persistent, structured research library and a daily market digest. Three temporal cycles govern how that library is maintained:
+
+- **Daily delta updates** — line-level edits to existing documents, minimizing token cost. Rather than regenerating full documents every day, Atlas patches only what changed. This is the core cost optimization of the system.
+- **Weekly full document regeneration** — complete rewrites to ensure coherence and catch accumulated drift.
+- **Monthly lookback rollup** — synthesizes the month's deltas and weeklies into a durable archival summary.
+
+Atlas is built as DigiGraph sub-graphs with parallel execution, batched API calls, structured Pydantic outputs at every node, and prompt caching. The delta system keeps daily operating costs predictable at scale — a key design constraint for a platform intended to run autonomously and continuously.
+
+### Hermes
+
+Hermes is the portfolio management orchestration layer. It takes Atlas research and translates it into portfolio action through a structured deliberation pipeline:
+
+1. **Research ingestion** — pulls the current Atlas research library as context.
+2. **Investment thesis construction** — generates theses with explicit validity requirements and exit triggers.
+3. **Asset mapping** — filters candidate assets by the user's investment profile (risk tolerance, sector preferences, geographic constraints, account type).
+4. **Parallel analyst deliberation** — spawns parallel agent instances per asset, each producing a bull case, bear case, headwinds/tailwinds analysis, and a formal recommendation.
+5. **Portfolio manager synthesis** — a top-level agent deliberates across all analyst outputs, aware of the full current portfolio state and user preferences, and produces a final portfolio with weights and rationale.
+
+Hermes uses PyPortfolioOpt for the quantitative portfolio math — mean-variance optimization, Black-Litterman, and Hierarchical Risk Parity — alongside LLM deliberation. Structured outputs at every node keep token costs predictable and outputs auditable. The separation between analyst agents and the portfolio manager agent mirrors institutional investment committee structures.
+
+### Kairos
+
+Kairos is the hands-on strategy building toolkit, named after the Greek concept of the opportune moment — the recognition that algorithmic trading is fundamentally about identifying and seizing the exact right entry and exit window.
+
+Kairos operates in two modes:
+
+**Developer mode** — a well-documented toolkit for researchers and engineers who want direct control. Operated via CLI or coding agent (Claude Code, Cursor), with the full strategy development pipeline exposed as composable components.
+
+**Product mode** — a DigiChat interface where a user describes a trading idea in natural language. Kairos researches the idea, derives candidate strategies, runs parallel backtests across multiple variations, optimizes parameters, and presents results with performance metrics, risk analysis, and deployment options. No code required.
+
+The strategy development pipeline enforces a progression:
+
+1. **VectorBT** — fast vectorized backtesting for rapid ideation. 100 strategy variations in seconds. Used for research and screening, not production validation.
+2. **NautilusTrader** — final strategy validation in a Rust-core, event-driven backtesting environment that matches the live execution environment exactly.
+3. **Alpaca paper trading** — realistic fills in a live market environment without capital at risk.
+4. **Live deployment** — to Alpaca or QuantConnect. No skipping steps in the progression.
+
+Multi-strategy parallel research rounds accelerate ideation at scale — Kairos can explore a broad strategy space autonomously before surfacing the most promising candidates for human review.
+
+## How it fits in the ecosystem
+
+DigiQuant is a vertical service that DigiGraph orchestrates. DigiGraph agents call DigiQuant tools — `run_backtest`, `optimize_strategy`, `get_price_history`, `compute_indicator` — through the standard MCP tool registry. From DigiGraph's perspective, DigiQuant is one of several vertical capabilities, alongside DigiSearch and others.
+
+Data and state flow across the broader stack:
+
+- **DigiStore** holds the research library, strategy definitions, backtest results, and portfolio state.
+- **DigiSearch** indexes finalized research documents for semantic retrieval, so agents can pull relevant research context on demand.
+- **DigiClaw** runs Atlas and Hermes on their daily and weekly schedules autonomously — DigiQuant's scheduled execution layer.
+- **DigiChat** is the user-facing interface for Kairos product mode and for querying Atlas research interactively.
+
+## Data philosophy
+
+Free data first, always. The internet is free and DigiQuant capitalizes on it. Paid API connectors exist but require user-supplied keys — DigiThings never pays for data on behalf of users.
+
+Production data stack:
+
+- **OpenBB** — aggregation layer covering approximately 100 data sources. DigiStore's primary data retrieval interface.
+- **Twelve Data** — price history and technicals. 800 API calls per day on the free tier.
+- **EdgarTools** — SEC filings and XBRL data. No rate limits. Includes an MCP server, so agents can query SEC filings directly without custom tooling.
+- **FRED** — macroeconomic data from the Federal Reserve. Free, authoritative, and comprehensive.
+- **CoinGecko** — cryptocurrency market data.
+- **Finnhub** — news feeds and sentiment signals.
+- **S3 / MinIO** — object storage for large datasets, backtest results, and research archives.
+
+This stack provides broad coverage across equities, macro, crypto, and alternative data without a mandatory paid subscription. Users who need higher rate limits or premium data sources supply their own keys.
+
+## Technology decisions
+
+**NautilusTrader** — Rust-core event-driven backtesting and live execution. Used for final strategy validation and all live deployments. The Rust core eliminates Python GIL constraints and delivers execution fidelity that matches production at nanosecond resolution. Chosen because the backtesting environment and the live execution environment are the same system — there is no translation layer that introduces behavioral drift.
+
+**VectorBT** — vectorized backtesting for rapid strategy ideation. 10–100x faster than event-driven backtesting for parameter sweeps and strategy screening. Used exclusively for research; never for production validation. The performance gap between VectorBT and NautilusTrader is the reason for the two-stage validation pipeline — use the fast tool to explore the space, use the faithful tool to validate candidates.
+
+**PyPortfolioOpt** — portfolio optimization math. Mean-variance, Black-Litterman, and Hierarchical Risk Parity are implemented here and called by Hermes during portfolio construction.
+
+**Polars only** — no pandas anywhere in the pipeline. Polars' lazy evaluation and columnar execution model handle financial time series data efficiently. The constraint is non-negotiable: pandas is a dependency target, not a data processing tool.
+
+**Schema-first outputs** — every node in every DigiGraph sub-graph that DigiQuant uses produces a structured Pydantic v2 output. Claude's structured outputs API enforces schema compliance at generation time. The Instructor library handles retry logic on schema violations. YAML config files define guardrails for strategy parameters, risk limits, and deployment gates. This makes every intermediate state auditable and every output predictable.
+
+**Paper trading gate** — the progression is internal simulator → Alpaca paper → live. No step is skippable. Alpaca paper trading uses a free account with realistic fill simulation in a live market environment. This gate exists because backtesting, even on NautilusTrader, cannot fully replicate live market microstructure.
+
+## Current state
+
+The DigiQuant engine is operational with six registered strategies:
+
+- EMA cross variants (multiple parameter configurations)
+- RSI momentum
+- Bollinger Band mean-reversion
+- MACD trend-following
+
+Three optimization engines are available: grid search, random search, and Bayesian optimization.
+
+Five export targets are supported: NautilusTrader, TradingView PineScript, Alpaca, QuantConnect, and JSON.
+
+Atlas exists as instruction files and manual scripts. The research methodology is defined and has been run manually, but it is not yet a deterministic DigiGraph execution graph with scheduled autonomous execution.
+
+Hermes and Kairos product interfaces are not yet built. The portfolio optimization math (PyPortfolioOpt) is integrated; the deliberation pipeline and the DigiChat interface are roadmap items.
+
+## 12-month roadmap
+
+**Months 1–3 — Atlas to DigiGraph**
+Migrate the Atlas research methodology from instruction files to deterministic, parallel DigiGraph sub-graph execution. Wire in DigiClaw for scheduled daily, weekly, and monthly cycle triggers. Deliver the first autonomous daily digest.
+
+**Months 3–6 — Hermes deliberation pipeline**
+Build the full Hermes pipeline as DigiGraph sub-graphs: thesis construction, parallel analyst agents, portfolio manager synthesis, PyPortfolioOpt integration. Deliver portfolio output with weights and rationale driven by Atlas research.
+
+**Months 4–7 — Kairos DigiChat interface**
+Build the Kairos product-mode DigiChat interface for strategy exploration. Users describe a trading idea; Kairos returns backtest results, optimization curves, and deployment options. Integrate VectorBT → NautilusTrader progression into the interface.
+
+**Months 5–8 — OpenBB integration**
+Integrate OpenBB as DigiStore's primary data retrieval layer. Replace ad-hoc data fetching across Atlas, Hermes, and Kairos with a single OpenBB-backed interface. Expand data source coverage.
+
+**Months 7–10 — Strategy library expansion**
+Run Kairos parallel research rounds autonomously to expand the strategy library beyond the current six strategies. Systematic coverage across asset classes, time frames, and market regimes.
+
+**Months 8–11 — Live deployment**
+Live strategy deployment to Alpaca and QuantConnect. Full paper-to-live progression enforced by the deployment gate. Human approval required before any live capital commitment.
+
+**Months 10–12 — digiquant.io entry flow**
+Build the digiquant.io investment profiling entry flow. Free tier gives access to Atlas research and basic backtesting. Paywall gates access to Hermes portfolio management and Kairos strategy building. This is the consumer-facing monetization surface for DigiQuant.
+
+## Open source vs. proprietary
+
+DigiQuant follows the DigiThings open-core model. The infrastructure layer is open; the intelligence layer is proprietary.
+
+**Open source:**
+- DigiQuant engine and CLI
+- NautilusTrader integration and adapter layer
+- Backtesting framework and VectorBT integration
+- Data connectors (OpenBB, Twelve Data, EdgarTools, FRED, CoinGecko, Finnhub)
+- Strategy definition schema and export targets
+- Optimization engine implementations (grid, random, Bayesian)
+
+**Proprietary:**
+- Atlas research sub-graphs and the delta patching system
+- Hermes deliberation pipeline and the analyst agent prompting system
+- Kairos strategy library (the accumulated output of research rounds)
+- Specific strategy implementations with tuned parameters
+- Execution layer and deployment gate logic
+- digiquant.io investment profiling and paywall infrastructure

--- a/docs/vision/digisearch.md
+++ b/docs/vision/digisearch.md
@@ -1,0 +1,47 @@
+# DigiSearch
+
+> RAG and retrieval for the DigiThings ecosystem — semantic search, hybrid retrieval, and pluggable vector backends.
+
+**What it is:** DigiSearch is the centralized RAG (Retrieval-Augmented Generation) and document search layer. It handles the complete retrieval pipeline: ingestion, parsing, chunking, embedding, vector indexing, hybrid search, reranking, and result normalization. It is backend-agnostic — the same API works whether the vector store is pgvector, Chroma, Azure AI Search, Qdrant, or any other supported backend.
+
+**The problem:** Every AI application that needs to search over documents reinvents the parsing, chunking, embedding, and retrieval stack. DigiSearch provides this as a service that any DigiThings module or client application can call, with a consistent interface regardless of the underlying vector technology.
+
+**Key architectural insight — retrieval mode matches query type:**
+Not every query needs vector search. DigiSearch selects the retrieval strategy based on what's being asked:
+- "All macro research for 2026-04-19" → direct document selection (SQL query to DigiStore)
+- "Macro + sector research, last 2 weeks" → metadata filter → fetch documents directly
+- "Find research mentioning oil supply disruption" → filter by document type → vector search on filtered set
+- "What themes appear across Q1?" → pure semantic vector search
+
+This distinction matters: vector search is expensive and noisy when metadata filtering is sufficient. DigiSearch applies the cheapest effective strategy for each query type.
+
+**Selective indexing (what gets indexed and what doesn't):**
+Not everything in DigiStore gets indexed by DigiSearch. Specifically:
+- Index: finalized research documents, strategy summaries, thesis documents, monthly rollups, Digest archives
+- Do not index: raw delta patches, in-progress drafts, intermediate agent outputs
+- Re-index trigger: document transitions from draft → final state in DigiStore
+- Rationale: delta documents (daily patches to existing files) are not semantically distinct documents — indexing them pollutes the search space and degrades quality
+
+**Current state (shipped):**
+Parser registry (PDF, DOCX, HTML, Markdown, CSV, text with OCR fallback). 5+ chunking strategies (fixed, recursive, sentence, sliding, semantic). Azure AI Search backend (primary) + Chroma (fallback) + stub for tests. Multi-backend strategy — same code serves Azure enterprise deployments and local Chroma instances via environment config. Hybrid search with RRF (Reciprocal Rank Fusion) fusion for keyword + vector. Optional HybridSearcher for reranking.
+
+**Pluggable backend registry:**
+- pgvector: Supabase/Postgres — no extra service, good default for Supabase users
+- Chroma: local, existing client deployments
+- Azure AI Search: enterprise clients on Microsoft infrastructure
+- Qdrant: high-performance, self-hostable, production-grade
+- Weaviate: strong built-in hybrid search
+- LanceDB: columnar + vector, excellent for local and embedded deployments
+- Pinecone: managed serverless
+- Extensible: new backends added via registry pattern — no core changes required
+
+**Backend selection:** Config-driven. A client on Azure uses Azure AI Search. A local dev instance uses Chroma or pgvector. Same DigiSearch API regardless.
+
+**12-month roadmap:**
+- Expand backend registry to include Qdrant, Weaviate, LanceDB
+- Selective indexing rules enforcement (draft/final state tracking via DigiStore)
+- Index access control: read DigiKey JWT scopes and filter results by user permissions
+- DigiQuant research library indexing (finalized Atlas documents)
+- digithings-guide index live on digithings.ai (powers the site's chat demo)
+
+**Open source vs. proprietary:** Entirely open. The retrieval infrastructure is commodity. Client-specific index configurations and the documents within them are private.

--- a/docs/vision/digismith.md
+++ b/docs/vision/digismith.md
@@ -2,14 +2,14 @@
 
 > Observability for the DigiThings ecosystem — tracing, metrics, and status, without the overhead.
 
-**What it is:** DigiSmith is the observability layer for DigiThings. It provides a thin, side-effect-free wrapper around LangSmith for agent tracing, a Prometheus-compatible metrics endpoint for infrastructure monitoring, and a public `/v1/status` endpoint that reports ecosystem health without leaking secrets.
+**What it is:** DigiSmith is the observability layer for DigiThings. It provides a thin, side-effect-free wrapper around LangSmith for agent tracing and a public `/v1/status` endpoint that reports ecosystem health without leaking secrets. The Prometheus metrics helper itself lives in DigiBase (`install_metrics`); DigiSmith's role is to drive consistent adoption of that helper across services alongside tracing.
 
 **Design principle:** DigiSmith should be invisible when working and loud when something breaks. Zero dependencies beyond FastAPI and Pydantic. LangSmith integration is optional — if not configured, tracing calls are no-ops.
 
 **Current state:** LangSmith wrapper (optional), `/v1/status` endpoint returning public metadata, `/health` and `/healthz` liveness endpoints. No database, no background workers.
 
 **12-month roadmap:**
-- Prometheus metrics endpoint per-service
+- Roll the DigiBase `install_metrics` helper out to every service so each exposes a `/metrics` endpoint with consistent labels
 - X-Request-ID correlation ID propagation across all services (DigiGraph, DigiSearch, DigiQuant, DigiKey, DigiClaw) — enables tracing a request through the full stack
 - PII redaction middleware before any data reaches LangSmith
 - Structured logging throughout (DigiSearch currently has zero structured logging)

--- a/docs/vision/digismith.md
+++ b/docs/vision/digismith.md
@@ -1,0 +1,18 @@
+# DigiSmith
+
+> Observability for the DigiThings ecosystem — tracing, metrics, and status, without the overhead.
+
+**What it is:** DigiSmith is the observability layer for DigiThings. It provides a thin, side-effect-free wrapper around LangSmith for agent tracing, a Prometheus-compatible metrics endpoint for infrastructure monitoring, and a public `/v1/status` endpoint that reports ecosystem health without leaking secrets.
+
+**Design principle:** DigiSmith should be invisible when working and loud when something breaks. Zero dependencies beyond FastAPI and Pydantic. LangSmith integration is optional — if not configured, tracing calls are no-ops.
+
+**Current state:** LangSmith wrapper (optional), `/v1/status` endpoint returning public metadata, `/health` and `/healthz` liveness endpoints. No database, no background workers.
+
+**12-month roadmap:**
+- Prometheus metrics endpoint per-service
+- X-Request-ID correlation ID propagation across all services (DigiGraph, DigiSearch, DigiQuant, DigiKey, DigiClaw) — enables tracing a request through the full stack
+- PII redaction middleware before any data reaches LangSmith
+- Structured logging throughout (DigiSearch currently has zero structured logging)
+- Grafana dashboard for operational visibility
+
+**Open source vs. proprietary:** Entirely open. Observability infrastructure is commodity.

--- a/docs/vision/digistore.md
+++ b/docs/vision/digistore.md
@@ -1,0 +1,35 @@
+# DigiStore
+
+> The storage abstraction layer — one interface for every backend, from SQLite to Supabase to S3.
+
+**What it is:** DigiStore is the unified storage abstraction layer for the DigiThings ecosystem. Every module that needs to persist data does so through DigiStore — which means the underlying storage backend can change without touching application code. DigiStore sits beneath DigiSearch (which indexes its contents) and above every specific storage technology.
+
+**The problem:** AI applications typically couple directly to specific storage solutions — Postgres queries hardcoded, S3 calls scattered through services, vector store SDK calls mixed into business logic. When requirements change (different client, different scale, different region), the coupling makes migration expensive. DigiStore decouples storage intent from storage implementation.
+
+**Architecture — one interface, multiple backends:**
+- SQLite: local development, zero setup, no services required
+- Postgres (Supabase, Neon with auto-scaling): production relational storage
+- S3 / MinIO: file and blob storage (research documents, exports, strategy files). MinIO runs in Docker locally and is S3-API-compatible for cloud deployment.
+- pgvector: vector storage embedded in Postgres/Supabase — no separate vector DB required for simpler use cases
+- Extensible: new backends added via config, not code changes
+
+**Local dev docker stack:** SQLite + MinIO + local Postgres — full suite, zero cloud dependency.
+**Production:** Supabase (primary) + S3-compatible cloud storage.
+
+**What gets stored where:**
+- Research documents, strategy exports, large artifacts → S3/MinIO
+- Structured data (thesis, portfolio weights, backtest results, user profiles, investment preferences) → Postgres/Supabase
+- Conversations, session artifacts, caches → SQLite (local) or Postgres (production)
+
+**Relationship to OpenBB:** OpenBB is the data retrieval layer (fetches live data from ~100 sources). DigiStore persists, caches, and serves what OpenBB retrieves. DigiStore does not replace OpenBB — it wraps it.
+
+**Current state:** Exists as a thin session/dataset cache inside DigiGraph (Digistore). Expanded scope defined but not yet implemented as a standalone module.
+
+**12-month roadmap:**
+- Standalone DigiStore module with clean backend registry
+- Full Supabase integration (strategies, research library, user profiles, Atlas data)
+- MinIO/S3 integration for file storage
+- OpenBB integration as the data retrieval layer
+- Dockerized local dev stack (SQLite + MinIO + Postgres)
+
+**Open source vs. proprietary:** Entirely open. Storage infrastructure is a commodity — no proprietary components.


### PR DESCRIPTION
## Summary

Adds `docs/vision/` — 11 documents covering the full DigiThings ecosystem, written to be readable by clients, investors, and contributors alike. Produced from a deep brainstorming session defining the vision, roadmap, and architecture for every module.

Each document follows a consistent structure: positioning, the problem solved, ecosystem fit, current shipped state, 12-month roadmap, and open vs. proprietary split.

## Documents

| File | Module |
|------|--------|
| `README.md` | Ecosystem overview — product family, open-core model, customer shapes |
| `digigraph.md` | Orchestration hub — sub-graph registry, skill/agent/sub-graph decision guide |
| `digilink.md` | Connection layer — protocol translation (REST/MCP/CLI/Docker), no lock-in |
| `digiquant.md` | Atlas + Hermes + Kairos — full data stack, strategy pipeline, paper trading |
| `digistore.md` | Storage abstraction — multi-backend (SQLite/Postgres/S3), OpenBB integration |
| `digisearch.md` | RAG pipeline — selective indexing, pluggable vector backends, retrieval modes |
| `digichat.md` | BYOK interface — adaptive UI via JWT scopes, two live deployments |
| `digikey.md` | Auth control plane — SSO federation, org/project membership, resource-level JWTs |
| `digiclaw.md` | Always-on agent orchestration — Atlas runner, strategy monitor, ADDM |
| `digismith.md` | Observability — LangSmith, Prometheus, correlation IDs |
| `digibase.md` | Shared library — minimal, purposeful, never a service |

## New modules introduced

Two modules formalised in this session that don't exist in the codebase yet:
- **DigiLink** — connector/translation layer (supersedes deferred OpenClaw gateway)
- **DigiStore** — standalone storage abstraction (currently embedded in DigiGraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)