### PR TITLE
feat(ci): GitHub Copilot maintenance agent — scheduled workflows and auto-triage

### DIFF
--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -54,6 +54,7 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
           ACTOR: ${{ github.event.workflow_run.actor.login }}
           PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
         run: |
@@ -85,7 +86,7 @@ jobs:
 
 ## Task for Copilot
 
-1. Fetch the failure logs: \`gh run view --log-failed $(basename ${RUN_URL})\`
+1. Fetch the failure logs: \`gh run view --log-failed ${RUN_ID}\`
 2. Identify the root cause (lint error, test failure, doc link, agents-init drift, etc.)
 3. Apply the minimal fix on branch \`copilot/fix-${SHORT_SHA}\`
 4. Open a PR targeting \`${BRANCH}\` with the fix

--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -81,6 +81,8 @@ jobs:
 **Triggered by:** @${ACTOR}
 **Run:** ${RUN_URL}
 
+> **Assign to Copilot:** Open this issue → Assignees → **GitHub Copilot** to trigger autonomous fix.
+
 ## Task for Copilot
 
 1. Fetch the failure logs: \`gh run view --log-failed $(basename ${RUN_URL})\`

--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -1,0 +1,113 @@
+name: CI failure triage — create Copilot issue
+
+# Fires when any workflow completes with failure on a PR branch.
+# Creates a structured issue labelled `copilot` + `ci:failure` so
+# GitHub Copilot can be assigned to investigate and fix.
+
+on:
+  workflow_run:
+    workflows:
+      - Docs
+      - CI
+      - PR quality gate
+      - digibase tests
+      - digichat tests
+      - digiclaw tests
+      - digigraph tests
+      - digikey tests
+      - digiquant tests
+      - digisearch tests
+      - digismith tests
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    name: Create Copilot triage issue
+    runs-on: ubuntu-latest
+    # Only act on failures from PR branches (not develop/main pushes)
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Check token
+        id: token
+        env:
+          TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+        run: |
+          if [[ -n "${TOKEN:-}" ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DIGITHINGS_PROJECT_TOKEN not set — cannot create issue or add to project."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create triage issue
+        if: steps.token.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          ACTOR: ${{ github.event.workflow_run.actor.login }}
+          PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
+        run: |
+          set -euo pipefail
+
+          SHORT_SHA="${SHA:0:7}"
+          TITLE="[ci:failure] ${WORKFLOW} failed on ${BRANCH} (${SHORT_SHA})"
+
+          # Check if a triage issue for this SHA already exists (avoid duplicates)
+          EXISTING=$(gh issue list --repo "$REPO" \
+            --label "ci:failure" --state open \
+            --search "${SHORT_SHA} in:title" \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [[ -n "$EXISTING" ]]; then
+            echo "Triage issue #${EXISTING} already exists for ${SHORT_SHA} — skipping."
+            exit 0
+          fi
+
+          BODY="## CI Failure
+
+**Workflow:** \`${WORKFLOW}\`
+**Branch:** \`${BRANCH}\`
+**Commit:** \`${SHORT_SHA}\`
+**Triggered by:** @${ACTOR}
+**Run:** ${RUN_URL}
+
+## Task for Copilot
+
+1. Fetch the failure logs: \`gh run view --log-failed $(basename ${RUN_URL})\`
+2. Identify the root cause (lint error, test failure, doc link, agents-init drift, etc.)
+3. Apply the minimal fix on branch \`copilot/fix-${SHORT_SHA}\`
+4. Open a PR targeting \`${BRANCH}\` with the fix
+5. Add a comment on this issue summarising what was fixed
+
+## Acceptance Criteria
+- [ ] Root cause identified and documented in a PR comment
+- [ ] Fix applied — CI passes on the fix PR
+- [ ] No unrelated changes in the fix PR
+
+## Notes
+- If the fix requires human decision-making, comment here with the question instead of guessing
+- Branch name must follow taxonomy: \`copilot/<slug>\`
+"
+
+          URL=$(gh issue create \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --label "copilot,ci:failure,maintenance,component:root,risk:low" \
+            --body "$BODY")
+
+          echo "Created: $URL"
+
+          # Add to maintenance project
+          if [[ -n "${PROJ:-}" ]]; then
+            gh project item-add "$PROJ" --owner digithings-ai --url "$URL" >/dev/null 2>&1 || true
+          fi

--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -1,0 +1,72 @@
+name: Copilot PR review assist
+
+# On every PR open/reopen, posts a structured review checklist comment.
+# For non-task branches (docs/*, chore/*, fix/*), also suggests requesting
+# a Copilot review via the GitHub UI.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review-assist:
+    name: Post review checklist
+    runs-on: ubuntu-latest
+    # Skip draft PRs and Dependabot
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
+    steps:
+      - name: Post review checklist comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          IS_TASK=false
+          [[ "$PR_BRANCH" =~ ^task/ ]] && IS_TASK=true
+
+          if $IS_TASK; then
+            CHECKLIST="## Pre-merge checklist (task branch)
+
+This is a \`task/*\` branch — the following are **required** before merge:
+
+- [ ] \`/simplify\` run — 3-agent code review pass (reuse, quality, efficiency); issues fixed
+- [ ] \`/review\` completed — PR reviewed against scoring rubric; findings addressed
+- [ ] Score gate: \`make score\` passes (Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9)
+- [ ] Component tests pass: \`make test-unit\`
+- [ ] \`docs/\` updated if any interface or behaviour changed
+
+> Run the checkboxes in Claude Code, then **edit the PR body** to check them before merging.
+> The \`PR quality gate\` CI check enforces this."
+          else
+            CHECKLIST="## Review notes (non-task branch)
+
+Quick review checklist for \`${PR_BRANCH}\`:
+
+- [ ] Change matches the PR title and description
+- [ ] No unintended file changes (check diff carefully)
+- [ ] Tests pass: \`make test-unit\`
+- [ ] Doc links intact: \`make doc-check\`
+
+**Copilot review available:** In the GitHub UI, go to *Reviewers → GitHub Copilot* to request an automated Copilot review of this PR."
+          fi
+
+          # Only post if no checklist comment already exists
+          EXISTING=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json comments \
+            --jq '.comments[].body' 2>/dev/null | \
+            grep -c "Pre-merge checklist\|Review notes" || echo 0)
+
+          if [[ "$EXISTING" -eq 0 ]]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$CHECKLIST"
+            echo "Posted review checklist on PR #${PR_NUMBER}"
+          else
+            echo "Checklist already posted — skipping."
+          fi

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -1,0 +1,279 @@
+name: Scheduled maintenance
+
+# Weekly maintenance sweep: security scan, quality check, stale branch cleanup,
+# dependency audit. Creates labelled issues for Copilot to pick up, or auto-fixes
+# trivial housekeeping directly.
+
+on:
+  schedule:
+    - cron: '0 08 * * 1'   # Every Monday 08:00 UTC
+  workflow_dispatch:         # Manual trigger anytime
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+
+  # ── 1. Dependency CVE audit ───────────────────────────────────────────────────
+  dependency-audit:
+    name: Dependency CVE audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run pip-audit
+        id: audit
+        run: |
+          pip install pip-audit --quiet
+          set +e
+          OUTPUT=$(pip-audit --format=json -r requirements*.txt 2>&1 || true)
+          COUNT=$(echo "$OUTPUT" | python3 -c "
+          import json,sys
+          try:
+              d = json.load(sys.stdin)
+              vulns = sum(len(p.get('vulns',[])) for p in d.get('dependencies',[]))
+              print(vulns)
+          except:
+              print(0)
+          " 2>/dev/null || echo "0")
+          echo "vuln_count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "output<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create CVE issue if findings
+        if: steps.audit.outputs.vuln_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO: ${{ github.repository }}
+          COUNT: ${{ steps.audit.outputs.vuln_count }}
+          AUDIT_OUTPUT: ${{ steps.audit.outputs.output }}
+          PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
+        run: |
+          TITLE="[security:finding] pip-audit found ${COUNT} CVE(s) — $(date +%Y-%m-%d)"
+          EXISTING=$(gh issue list --repo "$REPO" --label "security:finding" --state open \
+            --search "pip-audit in:title" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          [[ -n "$EXISTING" ]] && { echo "Issue #$EXISTING already open — skipping."; exit 0; }
+
+          URL=$(gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --label "copilot,security:finding,maintenance,component:root,risk:high" \
+            --body "## Security Finding
+
+pip-audit found **${COUNT}** CVE(s) in Python dependencies.
+
+## Task for Copilot
+1. Run \`pip-audit -r requirements*.txt\` to see full findings
+2. For each CVE: bump the affected package to a patched version
+3. Run tests to confirm no regressions: \`make test-unit\`
+4. Open a PR with the bumped versions
+
+## Raw audit output (truncated)
+\`\`\`
+${AUDIT_OUTPUT:0:2000}
+\`\`\`
+
+## Acceptance Criteria
+- [ ] All CVEs resolved or documented as false positives with rationale
+- [ ] \`make test-unit\` passes after bumps
+- [ ] PR opened and labelled \`security:finding\`")
+          echo "Created: $URL"
+          [[ -n "${PROJ:-}" ]] && gh project item-add "$PROJ" --owner digithings-ai --url "$URL" >/dev/null 2>&1 || true
+
+  # ── 2. Stale branch cleanup ───────────────────────────────────────────────────
+  stale-branches:
+    name: Stale branch cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find stale branches
+        id: stale
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Branches merged into develop and older than 14 days
+          CUTOFF=$(date -d '14 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                   date -v-14d +%Y-%m-%dT%H:%M:%SZ)
+          git fetch origin --prune --quiet
+
+          STALE=""
+          while IFS= read -r branch; do
+            [[ "$branch" =~ ^(main|develop|HEAD)$ ]] && continue
+            [[ "$branch" =~ ^module/ ]] && continue
+            LAST=$(git log -1 --format="%aI" "origin/$branch" 2>/dev/null || echo "")
+            [[ -z "$LAST" ]] && continue
+            if [[ "$LAST" < "$CUTOFF" ]]; then
+              MERGED=$(git branch -r --merged origin/develop | grep "origin/$branch" || true)
+              [[ -n "$MERGED" ]] && STALE="${STALE}${branch}\n"
+            fi
+          done < <(git branch -r | sed 's|origin/||' | tr -d ' ')
+
+          echo "stale_branches<<EOF" >> "$GITHUB_OUTPUT"
+          printf "$STALE" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          COUNT=$(printf "$STALE" | grep -c . || echo 0)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Create cleanup issue if stale branches found
+        if: steps.stale.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO: ${{ github.repository }}
+          STALE: ${{ steps.stale.outputs.stale_branches }}
+          COUNT: ${{ steps.stale.outputs.count }}
+          PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
+        run: |
+          TITLE="[cleanup] ${COUNT} stale merged branches — $(date +%Y-%m-%d)"
+          EXISTING=$(gh issue list --repo "$REPO" --label "cleanup" --state open \
+            --search "stale merged branches in:title" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          [[ -n "$EXISTING" ]] && { echo "Issue #$EXISTING already open — skipping."; exit 0; }
+
+          BRANCH_LIST=$(printf "$STALE" | sed 's/^/- /')
+
+          URL=$(gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --label "copilot,cleanup,housekeeping,maintenance,component:root,risk:low" \
+            --body "## Stale Branch Cleanup
+
+Found **${COUNT}** branches that are merged into \`develop\` and have not been updated in 14+ days.
+
+## Branches to delete
+${BRANCH_LIST}
+
+## Task for Copilot
+Delete each branch after confirming it is fully merged:
+\`\`\`bash
+for branch in <list>; do
+  git push origin --delete \"\$branch\"
+done
+\`\`\`
+
+## Acceptance Criteria
+- [ ] All listed branches deleted from origin
+- [ ] No unmerged work lost (verify each branch is merged before deletion)
+- [ ] Comment on this issue with the list of branches deleted")
+          echo "Created: $URL"
+          [[ -n "${PROJ:-}" ]] && gh project item-add "$PROJ" --owner digithings-ai --url "$URL" >/dev/null 2>&1 || true
+
+  # ── 3. Doc link check ─────────────────────────────────────────────────────────
+  doc-links:
+    name: Broken doc links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check doc links
+        id: doccheck
+        run: |
+          set +e
+          OUTPUT=$(python3 scripts/check_doc_links.py 2>&1)
+          EXIT=$?
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          echo "output<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create issue if broken links
+        if: steps.doccheck.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO: ${{ github.repository }}
+          OUTPUT: ${{ steps.doccheck.outputs.output }}
+          PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
+        run: |
+          TITLE="[housekeeping] Broken internal doc links — $(date +%Y-%m-%d)"
+          EXISTING=$(gh issue list --repo "$REPO" --label "housekeeping" --state open \
+            --search "Broken internal doc links in:title" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          [[ -n "$EXISTING" ]] && { echo "Issue #$EXISTING already open — skipping."; exit 0; }
+
+          URL=$(gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --label "copilot,housekeeping,maintenance,component:root,risk:low" \
+            --body "## Broken Internal Doc Links
+
+\`python3 scripts/check_doc_links.py\` found broken markdown links in the repository.
+
+## Task for Copilot
+1. Run \`make doc-check\` to see the full list
+2. Fix each broken link (update path or remove the link)
+3. Run \`make doc-check\` again to confirm clean
+4. Open a PR with the fixes
+
+## Output (truncated)
+\`\`\`
+${OUTPUT:0:2000}
+\`\`\`
+
+## Acceptance Criteria
+- [ ] \`make doc-check\` exits 0
+- [ ] No links removed that should be kept (prefer fixing paths over removal)")
+          echo "Created: $URL"
+          [[ -n "${PROJ:-}" ]] && gh project item-add "$PROJ" --owner digithings-ai --url "$URL" >/dev/null 2>&1 || true
+
+  # ── 4. agents-init drift check ────────────────────────────────────────────────
+  agents-drift:
+    name: agents-init drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install pyyaml --quiet
+
+      - name: Check for drift
+        id: drift
+        run: |
+          set +e
+          OUTPUT=$(python3 scripts/agents_init.py --check 2>&1)
+          EXIT=$?
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          echo "output=$OUTPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Create issue if drifted
+        if: steps.drift.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO: ${{ github.repository }}
+          OUTPUT: ${{ steps.drift.outputs.output }}
+          PROJ: ${{ vars.DIGI_MAINTENANCE_PROJECT_NUMBER }}
+        run: |
+          TITLE="[housekeeping] agents-init drift detected — $(date +%Y-%m-%d)"
+          EXISTING=$(gh issue list --repo "$REPO" --label "housekeeping" --state open \
+            --search "agents-init drift in:title" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          [[ -n "$EXISTING" ]] && { echo "Issue #$EXISTING already open — skipping."; exit 0; }
+
+          URL=$(gh issue create --repo "$REPO" \
+            --title "$TITLE" \
+            --label "copilot,housekeeping,maintenance,component:root,risk:low" \
+            --body "## agents-init Drift
+
+Generated files in \`.claude/\` are out of sync with \`agents.yml\` + \`agents/sources/\`.
+
+## Task for Copilot
+\`\`\`bash
+make agents-init
+git add .claude/ agents/sources/
+git commit -m 'chore(root): sync agents-init generated files'
+\`\`\`
+
+## Drift details
+\`\`\`
+${OUTPUT}
+\`\`\`
+
+## Acceptance Criteria
+- [ ] \`python3 scripts/agents_init.py --check\` exits 0
+- [ ] PR opened and merged to develop")
+          echo "Created: $URL"
+          [[ -n "${PROJ:-}" ]] && gh project item-add "$PROJ" --owner digithings-ai --url "$URL" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Sets up GitHub Copilot as an autonomous maintenance agent via three GitHub Actions workflows and a dedicated maintenance project board.

## What's included

### `ci-failure-triage.yml`
Fires when any CI workflow fails on a PR branch. Creates a structured issue labelled `copilot` + `ci:failure` with step-by-step instructions for Copilot to diagnose and fix. Deduplicates by commit SHA — one issue per failure, not one per run.

### `scheduled-maintenance.yml`
Runs every Monday 08:00 UTC + manual dispatch. Four independent jobs:
- **Dependency CVE audit** — pip-audit over all requirements files → issue if CVEs found
- **Stale branch cleanup** — finds branches merged into develop but not deleted in 14+ days → cleanup issue
- **Broken doc links** — `make doc-check` → issue if broken links found
- **agents-init drift** — `python3 scripts/agents_init.py --check` → issue if out of sync

All jobs deduplicate (skip if same issue already open this week).

### `copilot-pr-review.yml`
Posts a review checklist comment on every non-draft PR:
- `task/*` branches → full pre-merge checklist (simplify, review, score gate, tests, docs)
- All other branches → lighter checklist + instructions to request a Copilot review via GitHub UI

### Infrastructure
- **maintenance project** (#11) — all maintenance issues routed here
- **Labels** — `copilot`, `maintenance`, `ci:failure`, `security:finding`, `cleanup`, `housekeeping`

## How to assign issues to Copilot
In the GitHub UI: open any issue labelled `copilot` → Assignees → **GitHub Copilot**. Copilot will open its workspace and create a fix PR automatically.

## Test plan
- [ ] Merge PR #224 first (fixes agents-init) so the agents-drift job passes on first run
- [ ] Trigger `scheduled-maintenance` manually via Actions → verify all 4 jobs run cleanly
- [ ] Open a test PR → verify `copilot-pr-review` posts the checklist comment
- [ ] Verify maintenance issues appear in project #11

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)