### PR TITLE
feat(root): three-tier execution label framework (#229)

### DIFF
--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -12,16 +12,22 @@ You write GitHub Issue bodies for the DigiThings agent backlog. The issue templa
 
 1. `.github/ISSUE_TEMPLATE/agent_task.yml` — confirms current required fields (may change over time).
 2. `docs/agent-backlog/SPEC_TEMPLATE.md` — preferred body prose structure.
-3. `agents.yml` — component list + `human_gates` regex.
+3. `agents.yml` — component list, `human_gates`, and `execution_tiers` / `tier_routing`.
+   Also: `docs/agents/EXECUTION_TIERS.md` — the canonical decision tree.
 4. If a component is identified: `{component}/AGENTS.md` for acceptance-criteria vocabulary.
 
 ## Procedure
 
 1. Identify the component. If unclear, invoke the `component-router` subagent first.
 2. Assess human-gate risk by checking the goal against `agents.yml` `orchestration.human_gates.patterns`. Set risk accordingly.
-3. Draft the acceptance criteria using the `write-acceptance-criteria` skill conventions (Given/When/Then + test command).
-4. Identify docs that must be updated: the component's `ARCHITECTURE.md` almost always; `AGENTS.md` if the contract changes; `SECURITY.md` if security surface changes.
-5. Fill in Context with any ADR references or links the user supplied.
+3. **Classify the execution tier** using the decision tree in `docs/agents/EXECUTION_TIERS.md`:
+   - `exec:claude` — risk:high, human-gated, auth/crypto, live-trading, cross-module, architectural, or iterative.
+   - `exec:cursor` — scoped to one paragraph + clear acceptance, single component, no mid-task dialogue.
+   - `exec:copilot` — triggered housekeeping only (dep bumps, lint, stale sweep, CVE auto-PRs).
+   When in doubt, escalate to the higher tier — a lower-tier agent must never pick up higher-tier work.
+4. Draft the acceptance criteria using the `write-acceptance-criteria` skill conventions (Given/When/Then + test command).
+5. Identify docs that must be updated: the component's `ARCHITECTURE.md` almost always; `AGENTS.md` if the contract changes; `SECURITY.md` if security surface changes.
+6. Fill in Context with any ADR references or links the user supplied.
 
 ## Output structure
 
@@ -36,6 +42,9 @@ Emit a single markdown block ready for `gh issue create --body-file`:
 
 ## Risk level
 low | med | high
+
+## Execution tier
+copilot | cursor | claude — <one-line justification tied to the decision tree>
 
 ## Acceptance criteria
 1. **Given** … **when** … **then** …
@@ -54,10 +63,11 @@ low | med | high
 yes | no — <reason if yes>
 ```
 
-After emitting, output a separator `---` and a single line: the proposed `gh issue create` command with `--title`, `--label agent-task --label component:<name> --label risk:<level>`, and `--body-file` pointing to a temp path. Do not execute it — let the user confirm.
+After emitting, output a separator `---` and a single line: the proposed `gh issue create` command with `--title`, `--label agent-task --label component:<name> --label risk:<level> --label exec:<tier>`, and `--body-file` pointing to a temp path. Do not execute it — let the user confirm.
 
 ## Never
 
 - Never open the issue yourself. Draft only.
 - Never invent links, ADR numbers, or acceptance criteria the user didn't express. If more info is needed, ask one question before drafting.
 - Never skip the risk / human-gate classification — the orchestration pipeline depends on it.
+- Never skip the execution-tier classification. When unsure between two tiers, pick the higher one — lower tiers must never pick up higher-tier work.

--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -36,6 +36,17 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: exec
+    attributes:
+      label: Execution tier
+      description: "Minimum-capability ceiling. See docs/agents/EXECUTION_TIERS.md. copilot = triggered housekeeping; cursor = one-paragraph spec, clear acceptance; claude = judgment, cross-module, or human-gated."
+      options:
+        - copilot
+        - cursor
+        - claude
+    validations:
+      required: true
+  - type: dropdown
     id: model
     attributes:
       label: Model

--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -105,7 +105,7 @@ jobs:
           URL=$(gh issue create \
             --repo "$REPO" \
             --title "$TITLE" \
-            --label "copilot,ci:failure,maintenance,component:root,risk:low" \
+            --label "copilot,ci:failure,maintenance,component:root,risk:low,exec:cursor" \
             --body "$BODY")
 
           echo "Created: $URL"

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -62,7 +62,7 @@ jobs:
 
           URL=$(gh issue create --repo "$REPO" \
             --title "$TITLE" \
-            --label "copilot,security:finding,maintenance,component:root,risk:high" \
+            --label "copilot,security:finding,maintenance,component:root,risk:high,exec:claude" \
             --body "## Security Finding
 
 pip-audit found **${COUNT}** CVE(s) in Python dependencies.
@@ -140,7 +140,7 @@ ${AUDIT_OUTPUT:0:2000}
 
           URL=$(gh issue create --repo "$REPO" \
             --title "$TITLE" \
-            --label "copilot,cleanup,housekeeping,maintenance,component:root,risk:low" \
+            --label "copilot,cleanup,housekeeping,maintenance,component:root,risk:low,exec:copilot" \
             --body "## Stale Branch Cleanup
 
 Found **${COUNT}** branches that are merged into \`develop\` and have not been updated in 14+ days.
@@ -196,7 +196,7 @@ done
 
           URL=$(gh issue create --repo "$REPO" \
             --title "$TITLE" \
-            --label "copilot,housekeeping,maintenance,component:root,risk:low" \
+            --label "copilot,housekeeping,maintenance,component:root,risk:low,exec:cursor" \
             --body "## Broken Internal Doc Links
 
 \`python3 scripts/check_doc_links.py\` found broken markdown links in the repository.
@@ -255,7 +255,7 @@ ${OUTPUT:0:2000}
 
           URL=$(gh issue create --repo "$REPO" \
             --title "$TITLE" \
-            --label "copilot,housekeeping,maintenance,component:root,risk:low" \
+            --label "copilot,housekeeping,maintenance,component:root,risk:low,exec:copilot" \
             --body "## agents-init Drift
 
 Generated files in \`.claude/\` are out of sync with \`agents.yml\` + \`agents/sources/\`.

--- a/agents.yml
+++ b/agents.yml
@@ -31,6 +31,59 @@ scoring_thresholds:
   optimization: 7
   accuracy: 9
 
+execution_tiers:
+  # Minimum-capability ceiling: a lower tier must NEVER pick up a higher-tier task.
+  # A human on Claude Code can take anything. See docs/agents/EXECUTION_TIERS.md.
+  - label: "exec:copilot"
+    name: "Tier 1 — GitHub Copilot"
+    scope: "Triggered automation — fixed rule, no judgment. Housekeeping only."
+    examples:
+      - "Dependabot bumps, pip-audit, gitleaks, type-check reports"
+      - "Stale issue/PR cleanup, formatting autofix, coverage PR comments"
+      - "Structured CI-failure triage comments (no code fixes)"
+    never:
+      - "Judgment calls about correctness"
+      - "Changes spanning more than a few files"
+      - "Anything touching live-trading or auth code"
+  - label: "exec:cursor"
+    name: "Tier 2 — Cursor Cloud Agent"
+    scope: "One-paragraph spec, clear acceptance criteria, no mid-task dialogue."
+    examples:
+      - "Bug fixes with a concrete repro"
+      - "Unit tests for a specified module"
+      - "Docstrings / typed models / small MCP tools"
+      - "Scoped refactors inside a single component"
+    never:
+      - "Cross-module integration"
+      - "Ambiguous success criteria"
+      - "Architectural or novel design"
+  - label: "exec:claude"
+    name: "Tier 3 — Claude Code Max (human-supervised)"
+    scope: "Interactive, cross-module, architectural, or human-gated work."
+    examples:
+      - "Architecture and new-module scaffolding"
+      - "Complex debugging, optimization, security review"
+      - "Strategy / iterative design work"
+      - "Decomposing milestones into Tier 1/2 tasks; reviewing agent PRs"
+
+# Heuristics for default tier when a creator hasn't classified explicitly.
+# risk:high OR matches a human_gate → exec:claude.
+# risk:low + housekeeping (deps, lint, stale) → exec:copilot.
+# Everything else → exec:cursor.
+tier_routing:
+  claude_triggers:
+    - "risk:high"
+    - "human_gate:yes"
+    - "component:digikey (auth/JWT changes)"
+    - "live-trading paths"
+    - "cross-component integration"
+  copilot_triggers:
+    - "label:security:finding (pip-audit/gitleaks CVE bumps)"
+    - "label:housekeeping:deps"
+    - "label:housekeeping:format"
+    - "label:stale"
+  cursor_default: true
+
 human_gates:
   - "Any change to auth, JWT, or cryptography code (digikey/)"
   - "Any change that touches live-trading paths"

--- a/agents/sources/subagents/spec-writer.md
+++ b/agents/sources/subagents/spec-writer.md
@@ -11,16 +11,22 @@ You write GitHub Issue bodies for the DigiThings agent backlog. The issue templa
 
 1. `.github/ISSUE_TEMPLATE/agent_task.yml` — confirms current required fields (may change over time).
 2. `docs/agent-backlog/SPEC_TEMPLATE.md` — preferred body prose structure.
-3. `agents.yml` — component list + `human_gates` regex.
+3. `agents.yml` — component list, `human_gates`, and `execution_tiers` / `tier_routing`.
+   Also: `docs/agents/EXECUTION_TIERS.md` — the canonical decision tree.
 4. If a component is identified: `{component}/AGENTS.md` for acceptance-criteria vocabulary.
 
 ## Procedure
 
 1. Identify the component. If unclear, invoke the `component-router` subagent first.
 2. Assess human-gate risk by checking the goal against `agents.yml` `orchestration.human_gates.patterns`. Set risk accordingly.
-3. Draft the acceptance criteria using the `write-acceptance-criteria` skill conventions (Given/When/Then + test command).
-4. Identify docs that must be updated: the component's `ARCHITECTURE.md` almost always; `AGENTS.md` if the contract changes; `SECURITY.md` if security surface changes.
-5. Fill in Context with any ADR references or links the user supplied.
+3. **Classify the execution tier** using the decision tree in `docs/agents/EXECUTION_TIERS.md`:
+   - `exec:claude` — risk:high, human-gated, auth/crypto, live-trading, cross-module, architectural, or iterative.
+   - `exec:cursor` — scoped to one paragraph + clear acceptance, single component, no mid-task dialogue.
+   - `exec:copilot` — triggered housekeeping only (dep bumps, lint, stale sweep, CVE auto-PRs).
+   When in doubt, escalate to the higher tier — a lower-tier agent must never pick up higher-tier work.
+4. Draft the acceptance criteria using the `write-acceptance-criteria` skill conventions (Given/When/Then + test command).
+5. Identify docs that must be updated: the component's `ARCHITECTURE.md` almost always; `AGENTS.md` if the contract changes; `SECURITY.md` if security surface changes.
+6. Fill in Context with any ADR references or links the user supplied.
 
 ## Output structure
 
@@ -35,6 +41,9 @@ Emit a single markdown block ready for `gh issue create --body-file`:
 
 ## Risk level
 low | med | high
+
+## Execution tier
+copilot | cursor | claude — <one-line justification tied to the decision tree>
 
 ## Acceptance criteria
 1. **Given** … **when** … **then** …
@@ -53,10 +62,11 @@ low | med | high
 yes | no — <reason if yes>
 ```
 
-After emitting, output a separator `---` and a single line: the proposed `gh issue create` command with `--title`, `--label agent-task --label component:<name> --label risk:<level>`, and `--body-file` pointing to a temp path. Do not execute it — let the user confirm.
+After emitting, output a separator `---` and a single line: the proposed `gh issue create` command with `--title`, `--label agent-task --label component:<name> --label risk:<level> --label exec:<tier>`, and `--body-file` pointing to a temp path. Do not execute it — let the user confirm.
 
 ## Never
 
 - Never open the issue yourself. Draft only.
 - Never invent links, ADR numbers, or acceptance criteria the user didn't express. If more info is needed, ask one question before drafting.
 - Never skip the risk / human-gate classification — the orchestration pipeline depends on it.
+- Never skip the execution-tier classification. When unsure between two tiers, pick the higher one — lower tiers must never pick up higher-tier work.

--- a/docs/agents/EXECUTION_TIERS.md
+++ b/docs/agents/EXECUTION_TIERS.md
@@ -1,0 +1,69 @@
+# Execution Tiers — Agent Delegation Framework
+
+Every DigiThings backlog task carries exactly one `exec:*` label identifying the **minimum-capability tier** allowed to execute it. A lower tier must never pick up a higher-tier task. A human on Claude Code can always take anything.
+
+Source of truth: `agents.yml` → `execution_tiers` and `tier_routing`. Regenerate platform adapters (`CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/digithings.mdc`) with `make agents-init` after edits.
+
+## The three tiers
+
+### `exec:copilot` — Tier 1 — GitHub Copilot
+
+Triggered automation. Fixed rule, no judgment. Runs on a schedule or event inside GitHub Actions.
+
+**Fits:** Dependabot bumps, `pip-audit`, `gitleaks`, `ruff format`, `mypy` reports, stale issue/PR cleanup, coverage PR comments, structured CI-failure triage comments.
+
+**Never:** judgment calls, multi-file code changes, live-trading, auth, cryptography.
+
+### `exec:cursor` — Tier 2 — Cursor Cloud Agent
+
+Autonomous, asynchronous. Describable in one paragraph with clear acceptance criteria. Opens a PR for human review.
+
+**Fits:** bug fixes with a concrete repro; unit tests for a specified module; docstrings; typed-model migrations; scoped refactors inside a single component; small MCP tools with defined signatures.
+
+**Never:** cross-module integration, ambiguous success criteria, novel design, anything requiring mid-task dialogue.
+
+### `exec:claude` — Tier 3 — Claude Code Max (human-supervised)
+
+Interactive, local, human-in-the-loop. The top tier; takes everything above and adds judgment-heavy work.
+
+**Fits:** architecture and new-module scaffolding; complex debugging; cross-module integration; security review; strategy/iterative design; milestone decomposition; reviewing agent PRs.
+
+## Decision tree
+
+```
+Fully automatable with a trigger + fixed rule?
+├── YES → exec:copilot
+└── NO
+    └── Spec fits one paragraph, no mid-task dialogue, clear acceptance?
+        ├── YES → exec:cursor
+        └── NO  → exec:claude
+```
+
+## Default routing when the creator doesn't classify
+
+Applied by `scripts/create_issue.sh` and the `spec-writer` subagent:
+
+| Condition | Default tier |
+|---|---|
+| `risk:high`, matches a human gate, or touches `digikey/` auth / live-trading paths | `exec:claude` |
+| Labelled `security:finding`, `housekeeping:deps`, `housekeeping:format`, `stale` | `exec:copilot` |
+| Everything else | `exec:cursor` |
+
+## Responsibilities by tier
+
+- **Copilot workflows** (`scheduled-maintenance.yml`, `ci-failure-triage.yml`) must tag every issue they open with an `exec:*` label. CVE bumps and lint drift → `exec:copilot`. CI failures needing code fixes → `exec:cursor`. Architectural findings → `exec:claude` plus `needs-human`.
+- **Cursor Cloud Agents** must only pick up issues labelled `exec:cursor` or `exec:copilot`. If a task feels larger than the one-paragraph spec implied, relabel it `exec:claude` and comment why — do not proceed.
+- **Claude Code (you)** decomposes milestones, writes issue bodies via `/spec`, assigns tiers, and reviews PRs from the lower tiers.
+
+## Workflow
+
+1. **Claude Code** — read milestone, decompose, write issues via `/spec`, tier each one.
+2. **Cursor Cloud Agents** — execute `exec:cursor` issues in parallel; open PRs.
+3. **Claude Code** — review PRs; merge clean ones; re-issue broken ones with corrected spec.
+4. **Copilot** — runs continuously, catches regressions, opens tiered follow-up issues.
+
+## Cost note
+
+- Copilot: flat subscription — use freely.
+- Cursor: burns compute credits — keep tasks scoped; 15 min good, 2 h bad.
+- Claude Code Max: reserve for the hard work.

--- a/scripts/create_issue.sh
+++ b/scripts/create_issue.sh
@@ -19,6 +19,9 @@
 #   --kind KIND        Kind: Epic, Feature, Task, Bug, Chore, Research
 #   --priority PRI     Priority: P0, P1, P2, P3
 #   --model MODEL      Model: sonnet (default) | opus (for high-risk tasks)
+#   --exec TIER        Execution tier: copilot | cursor | claude
+#                      If omitted, derived from --risk and --type (see routing below).
+#                      See docs/agents/EXECUTION_TIERS.md.
 #
 # When --phase/--area/--kind/--priority are provided:
 #   - A row is appended to scripts/project_fields.tsv automatically.
@@ -46,6 +49,7 @@ AREA=""
 KIND=""
 PRIORITY=""
 MODEL="sonnet"
+EXEC_TIER=""
 
 VALID_COMPONENTS="digigraph digiquant digisearch digismith digiclaw digibase digikey digichat website root"
 VALID_TYPES="feat fix refactor docs test chore style perf"
@@ -55,6 +59,7 @@ VALID_AREAS="Cross-cutting|DigiGraph|DigiQuant|DigiSearch|DigiSmith|DigiKey|Digi
 VALID_KINDS="Epic Feature Task Bug Chore Research"
 VALID_PRIORITIES="P0 P1 P2 P3"
 VALID_MODELS="sonnet opus"
+VALID_EXEC="copilot cursor claude"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 die() { echo "ERROR: $*" >&2; exit 1; }
@@ -84,6 +89,7 @@ while [[ $# -gt 0 ]]; do
     --kind)      KIND="$2";      shift 2 ;;
     --priority)  PRIORITY="$2";  shift 2 ;;
     --model)     MODEL="$2";     shift 2 ;;
+    --exec)      EXEC_TIER="$2"; shift 2 ;;
     -h|--help)
       sed -n '2,29p' "$0" | sed 's/^# \?//'
       exit 0
@@ -138,6 +144,32 @@ if [[ -z "$COMPONENT" && -z "$TITLE" ]]; then
   echo "Model (sonnet/opus) [sonnet]:"
   read -r _MODEL
   MODEL="${_MODEL:-sonnet}"
+
+  echo "Execution tier (copilot/cursor/claude) [auto — derived from risk/type]:"
+  read -r EXEC_TIER
+fi
+
+# ── Default exec tier derivation ───────────────────────────────────────────────
+# Heuristic matches agents.yml:tier_routing. See docs/agents/EXECUTION_TIERS.md.
+derive_exec_tier() {
+  local risk="$1" comp="$2" type="$3"
+  # Claude triggers: high risk, auth/crypto component, live-trading work
+  if [[ "$risk" == "high" ]] || [[ "$comp" == "digikey" ]]; then
+    echo "claude"; return
+  fi
+  # Copilot triggers: pure housekeeping (deps, format, stale, chore-only lint)
+  if [[ "$type" == "chore" || "$type" == "style" ]] && [[ "$risk" == "low" ]]; then
+    echo "copilot"; return
+  fi
+  # Default: cursor
+  echo "cursor"
+}
+
+if [[ -z "$EXEC_TIER" ]]; then
+  EXEC_TIER=$(derive_exec_tier "$RISK" "$COMPONENT" "$TYPE")
+  _EXEC_AUTO=true
+else
+  _EXEC_AUTO=false
 fi
 
 # ── Validation ────────────────────────────────────────────────────────────────
@@ -176,6 +208,9 @@ fi
 # shellcheck disable=SC2086
 contains "$MODEL" $VALID_MODELS || \
   die "Invalid model '${MODEL}'. Valid: ${VALID_MODELS}"
+# shellcheck disable=SC2086
+contains "$EXEC_TIER" $VALID_EXEC || \
+  die "Invalid exec tier '${EXEC_TIER}'. Valid: ${VALID_EXEC}"
 
 # ── Normalize title ───────────────────────────────────────────────────────────
 # Strip leading [agent] if user added it; we'll add our own prefix
@@ -191,7 +226,7 @@ if [[ -z "$BODY" ]] && ! $DRAFT; then
 fi
 
 # ── Build labels ──────────────────────────────────────────────────────────────
-LABELS="agent-task,component:${COMPONENT},risk:${RISK}"
+LABELS="agent-task,component:${COMPONENT},risk:${RISK},exec:${EXEC_TIER}"
 
 # ── Confirmation ──────────────────────────────────────────────────────────────
 if ! $DRAFT; then
@@ -206,6 +241,11 @@ if ! $DRAFT; then
   [[ -n "$KIND" ]]     && echo "  Kind:      ${KIND}"
   [[ -n "$PRIORITY" ]] && echo "  Priority:  ${PRIORITY}"
   echo "  Model:     ${MODEL}"
+  if $_EXEC_AUTO; then
+    echo "  Exec tier: ${EXEC_TIER}  (auto — override with --exec)"
+  else
+    echo "  Exec tier: ${EXEC_TIER}"
+  fi
   [[ -n "$BODY" ]]     && echo "  Body:      (${#BODY} chars)"
   echo ""
   read -rp "Proceed? [Y/n] " confirm

--- a/scripts/create_issue.sh
+++ b/scripts/create_issue.sh
@@ -146,30 +146,27 @@ if [[ -z "$COMPONENT" && -z "$TITLE" ]]; then
   MODEL="${_MODEL:-sonnet}"
 
   echo "Execution tier (copilot/cursor/claude) [auto — derived from risk/type]:"
-  read -r EXEC_TIER
+  read -r _EXEC_TIER
+  EXEC_TIER="${_EXEC_TIER}"
 fi
 
 # ── Default exec tier derivation ───────────────────────────────────────────────
 # Heuristic matches agents.yml:tier_routing. See docs/agents/EXECUTION_TIERS.md.
 derive_exec_tier() {
   local risk="$1" comp="$2" type="$3"
-  # Claude triggers: high risk, auth/crypto component, live-trading work
   if [[ "$risk" == "high" ]] || [[ "$comp" == "digikey" ]]; then
     echo "claude"; return
   fi
-  # Copilot triggers: pure housekeeping (deps, format, stale, chore-only lint)
   if [[ "$type" == "chore" || "$type" == "style" ]] && [[ "$risk" == "low" ]]; then
     echo "copilot"; return
   fi
-  # Default: cursor
   echo "cursor"
 }
 
+EXEC_TIER_EXPLICIT=true
 if [[ -z "$EXEC_TIER" ]]; then
   EXEC_TIER=$(derive_exec_tier "$RISK" "$COMPONENT" "$TYPE")
-  _EXEC_AUTO=true
-else
-  _EXEC_AUTO=false
+  EXEC_TIER_EXPLICIT=false
 fi
 
 # ── Validation ────────────────────────────────────────────────────────────────
@@ -241,10 +238,10 @@ if ! $DRAFT; then
   [[ -n "$KIND" ]]     && echo "  Kind:      ${KIND}"
   [[ -n "$PRIORITY" ]] && echo "  Priority:  ${PRIORITY}"
   echo "  Model:     ${MODEL}"
-  if $_EXEC_AUTO; then
-    echo "  Exec tier: ${EXEC_TIER}  (auto — override with --exec)"
-  else
+  if $EXEC_TIER_EXPLICIT; then
     echo "  Exec tier: ${EXEC_TIER}"
+  else
+    echo "  Exec tier: ${EXEC_TIER}  (auto — override with --exec)"
   fi
   [[ -n "$BODY" ]]     && echo "  Body:      (${#BODY} chars)"
   echo ""


### PR DESCRIPTION
## Summary
- Introduce `exec:copilot` / `exec:cursor` / `exec:claude` as a minimum-capability ceiling on every backlog task. A lower tier must never pick up a higher-tier task; a human on Claude Code can always take anything.
- Canonical framework in `docs/agents/EXECUTION_TIERS.md`, driven by new `execution_tiers` + `tier_routing` blocks in `agents.yml`.
- Task-creation pipeline wired end-to-end: issue template (required dropdown), `scripts/create_issue.sh` (new `--exec` flag with auto-derive default), and `spec-writer` subagent (classifies tier, emits `## Execution tier` + `--label exec:<tier>`).
- Copilot-maintained workflows now self-route: CVE findings → `exec:claude`, stale-branch/agents-init drift → `exec:copilot`, broken doc links → `exec:cursor`, CI-failure triage → `exec:cursor`.

## Quality gates
- [x] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] `/review` completed — PR reviewed against scoring rubric; findings addressed

## Test plan
- [ ] `scripts/create_issue.sh --help` lists `--exec`
- [ ] Dry-run interactive mode prompts for exec tier with auto default
- [ ] `make agents-init` reports no drift (`git diff --exit-code` clean)
- [ ] Filing a new issue via the UI requires selecting Execution tier
- [ ] Verify `exec:*` labels exist in repo settings (seeded in this PR via `gh label create`)

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)