### PR TITLE
feat(digibase): X-Request-ID correlation middleware + ContextVar + log filter (#213)

### DIFF
--- a/digibase/ARCHITECTURE.md
+++ b/digibase/ARCHITECTURE.md
@@ -23,9 +23,9 @@ The library ships seven source files under `digibase/src/digibase/`:
 
 | File | Purpose | Shipped |
 |------|---------|---------|
-| `__init__.py` | Package entry point; re-exports `outbound_request_id_headers`, `install_metrics`, `async_client`, `sync_client`, `DEFAULT_TIMEOUT` | Yes |
+| `__init__.py` | Package entry point; re-exports `outbound_request_id_headers`, `outbound_service_headers`, `install_request_id_middleware`, `install_request_id_logging`, `current_request_id`, `install_metrics`, `async_client`, `sync_client`, `DEFAULT_TIMEOUT` | Yes |
 | `errors.py` | Pydantic error envelope models; FastAPI error handler registration | Yes |
-| `http.py` | Outbound header helpers for service-to-service calls | Yes |
+| `http.py` | Outbound header helpers plus inbound X-Request-ID correlation middleware, ContextVar, and logging filter (task #213) | Yes |
 | `http_client.py` | Bounded-timeout ``httpx`` client factories (epic #2 hardening) | Yes |
 | `audit.py` | Key-pattern-based redaction for audit payloads | Yes |
 | `metrics.py` | Prometheus `/metrics` endpoint + HTTP instrumentation middleware (ADR-0003) | Yes |
@@ -55,6 +55,14 @@ outbound_service_headers(
 ) -> dict[str, str]
 ```
 Merges correlation id header, optional `Authorization: Bearer <token>` header (raw secret or JWT — no prefix expected in the argument), and arbitrary extras. Returns a plain dict safe to pass directly to httpx or similar clients. Filters out falsy values in `extra`.
+
+```python
+install_request_id_middleware(app: FastAPI) -> None
+current_request_id() -> str | None
+install_request_id_logging(logger: logging.Logger | None = None) -> RequestIdLogFilter
+```
+
+Inbound correlation primitives (task #213). `install_request_id_middleware` registers an HTTP middleware that reads `X-Request-ID` from the incoming request (generating a uuid4 hex when absent or blank), stores it on `request.state.request_id`, binds it to a `ContextVar` for the duration of the request, and echoes it on the response. Must be registered **after** any rate-limit middleware so the id wraps rate-limit rejections and error handlers (Starlette applies `@middleware` in LIFO outer-to-inner order). `current_request_id()` reads the ContextVar — use it from outbound call sites instead of threading the `Request` through every layer. `install_request_id_logging()` attaches a `RequestIdLogFilter` to the target logger (root by default) so every `LogRecord` carries `record.request_id`; records emitted outside any request get `"-"` so formatters with `%(request_id)s` never raise.
 
 ### `digibase.http_client`
 

--- a/digibase/src/digibase/__init__.py
+++ b/digibase/src/digibase/__init__.py
@@ -1,16 +1,26 @@
 """DigiThings shared platform utilities (HTTP, errors, audit redaction, metrics, optional OTel)."""
 
 from digibase.cors import install_cors, resolve_cors_origins
-from digibase.http import outbound_request_id_headers
+from digibase.http import (
+    current_request_id,
+    install_request_id_logging,
+    install_request_id_middleware,
+    outbound_request_id_headers,
+    outbound_service_headers,
+)
 from digibase.http_client import DEFAULT_TIMEOUT, async_client, sync_client
 from digibase.metrics import install_metrics
 
 __all__ = [
     "DEFAULT_TIMEOUT",
     "async_client",
+    "current_request_id",
     "install_cors",
     "install_metrics",
+    "install_request_id_logging",
+    "install_request_id_middleware",
     "outbound_request_id_headers",
+    "outbound_service_headers",
     "resolve_cors_origins",
     "sync_client",
 ]

--- a/digibase/src/digibase/http.py
+++ b/digibase/src/digibase/http.py
@@ -91,7 +91,7 @@ def install_request_id_middleware(app: FastAPI) -> None:
     """
 
     @app.middleware("http")
-    async def _correlation_id(request: Request, call_next):  # type: ignore[no-untyped-def]
+    async def _correlation_id(request: Request, call_next):
         req_id = _coerce_inbound_request_id(request.headers.get("X-Request-ID"))
         request.state.request_id = req_id
         token = _REQUEST_ID_CTX.set(req_id)

--- a/digibase/src/digibase/http.py
+++ b/digibase/src/digibase/http.py
@@ -1,6 +1,39 @@
-"""Outbound HTTP helpers for service-to-service calls."""
+"""Outbound HTTP helpers and inbound X-Request-ID correlation middleware.
+
+X-Request-ID propagation pattern (task #213):
+    - Inbound: :func:`install_request_id_middleware` reads ``X-Request-ID`` from
+      the request, generates one if absent, stores it on ``request.state.request_id``
+      and in a ContextVar (:func:`current_request_id`), and echoes it on the
+      response.
+    - Logging: :class:`RequestIdLogFilter` injects ``request_id`` onto every
+      ``LogRecord`` so formatters can reference ``%(request_id)s``. Outside a
+      request (startup, background tasks), the value falls back to ``"-"``.
+    - Outbound: :func:`outbound_service_headers` (or its narrower sibling
+      :func:`outbound_request_id_headers`) attaches the id to service-to-service
+      calls.
+"""
 
 from __future__ import annotations
+
+import logging
+import uuid
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from starlette.requests import Request
+
+_REQUEST_ID_CTX: ContextVar[str | None] = ContextVar("digi_request_id", default=None)
+"""ContextVar holding the current request's id, or ``None`` outside a request."""
+
+_UNSET_REQUEST_ID = "-"
+"""Placeholder used in log records emitted outside of any request."""
+
+
+def current_request_id() -> str | None:
+    """Return the X-Request-ID for the in-flight request, or ``None`` if unset."""
+    return _REQUEST_ID_CTX.get()
 
 
 def outbound_request_id_headers(request_id: str | None) -> dict[str, str] | None:
@@ -31,4 +64,79 @@ def outbound_service_headers(
     return h
 
 
-__all__ = ["outbound_request_id_headers", "outbound_service_headers"]
+def _coerce_inbound_request_id(raw: str | None) -> str:
+    """Trim the inbound header; generate a hex id when missing or blank."""
+    if raw is None:
+        return uuid.uuid4().hex
+    cleaned = raw.strip()
+    return cleaned or uuid.uuid4().hex
+
+
+def install_request_id_middleware(app: FastAPI) -> None:
+    """Register X-Request-ID correlation middleware on *app*.
+
+    Must be registered **after** any rate-limit middleware so the id wraps
+    rate-limit rejections and error handlers — Starlette applies ``@middleware``
+    in LIFO order (last registered runs outermost).
+
+    Behavior:
+        - Reads ``X-Request-ID`` from the incoming request; generates a uuid4
+          hex when absent or blank.
+        - Stores the id on ``request.state.request_id`` (compat with existing
+          ``digibase.errors`` handlers and per-service resolvers).
+        - Binds the id to :data:`_REQUEST_ID_CTX` for the duration of the
+          request so log records and outbound helpers can read it without
+          threading the ``Request`` through every call site.
+        - Echoes the id on the response's ``X-Request-ID`` header.
+    """
+
+    @app.middleware("http")
+    async def _correlation_id(request: Request, call_next):  # type: ignore[no-untyped-def]
+        req_id = _coerce_inbound_request_id(request.headers.get("X-Request-ID"))
+        request.state.request_id = req_id
+        token = _REQUEST_ID_CTX.set(req_id)
+        try:
+            response = await call_next(request)
+        finally:
+            _REQUEST_ID_CTX.reset(token)
+        response.headers["X-Request-ID"] = req_id
+        return response
+
+
+class RequestIdLogFilter(logging.Filter):
+    """Inject ``request_id`` onto every ``LogRecord``.
+
+    Attach once at process start (see :func:`install_request_id_logging`) so
+    formatters can safely reference ``%(request_id)s`` — records created
+    outside a request get :data:`_UNSET_REQUEST_ID` rather than raising
+    ``KeyError`` in the formatter.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        record.request_id = _REQUEST_ID_CTX.get() or _UNSET_REQUEST_ID
+        return True
+
+
+def install_request_id_logging(logger: logging.Logger | None = None) -> RequestIdLogFilter:
+    """Attach :class:`RequestIdLogFilter` to *logger* (defaults to root).
+
+    Idempotent: re-attaching on hot reload won't stack filters. Returns the
+    filter instance so tests can assert its presence.
+    """
+    target = logger or logging.getLogger()
+    for existing in target.filters:
+        if isinstance(existing, RequestIdLogFilter):
+            return existing
+    flt = RequestIdLogFilter()
+    target.addFilter(flt)
+    return flt
+
+
+__all__ = [
+    "RequestIdLogFilter",
+    "current_request_id",
+    "install_request_id_logging",
+    "install_request_id_middleware",
+    "outbound_request_id_headers",
+    "outbound_service_headers",
+]

--- a/digigraph/src/digigraph/server.py
+++ b/digigraph/src/digigraph/server.py
@@ -21,6 +21,7 @@ from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from digibase.cors import install_cors, resolve_cors_origins
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digigraph_path_scopes
@@ -138,14 +139,8 @@ async def rate_limit(request: Request, call_next):
     return await call_next(request)
 
 
-@app.middleware("http")
-async def correlation_id(request: Request, call_next):
-    """Propagate X-Request-ID header; generate one if absent; expose on request.state."""
-    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
-    request.state.request_id = req_id
-    response = await call_next(request)
-    response.headers["X-Request-ID"] = req_id
-    return response
+install_request_id_middleware(app)
+install_request_id_logging()
 
 
 # OpenAI-compatible API (expose DigiGraph as a model in Open WebUI)

--- a/digikey/src/digikey/server.py
+++ b/digikey/src/digikey/server.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 
 from digibase.cors import install_cors
 from digibase.errors import register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
 from digibase.metrics import install_metrics
 
 from digikey import blocklist
@@ -32,6 +33,8 @@ app = FastAPI(title="DigiKey", version="0.1.0")
 register_rate_limit_handler(app)
 install_metrics(app, service="digikey")
 install_cors(app, service="digikey")
+install_request_id_middleware(app)
+install_request_id_logging()
 
 _private_key, _kid = load_or_create_signing_key()
 

--- a/digiquant/src/digiquant/server.py
+++ b/digiquant/src/digiquant/server.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from digibase.cors import install_cors
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digiquant_path_scopes
@@ -106,14 +107,8 @@ async def rate_limit(request: Request, call_next):
     return await call_next(request)
 
 
-@app.middleware("http")
-async def correlation_id(request: Request, call_next):
-    """Propagate X-Request-ID header; generate one if absent; set request.state."""
-    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
-    request.state.request_id = req_id
-    response = await call_next(request)
-    response.headers["X-Request-ID"] = req_id
-    return response
+install_request_id_middleware(app)
+install_request_id_logging()
 
 
 class BacktestRequest(BaseModel):

--- a/digisearch/src/digisearch/server.py
+++ b/digisearch/src/digisearch/server.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
-import uuid
 from typing import Any
 
 from digibase.cors import install_cors
 from digibase.errors import json_error_response, register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware, digisearch_path_scopes
@@ -118,14 +118,8 @@ async def rate_limit(request: Request, call_next):
     return await call_next(request)
 
 
-@app.middleware("http")
-async def correlation_id(request: Request, call_next):
-    """Propagate X-Request-ID header; generate one if absent; set request.state."""
-    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
-    request.state.request_id = req_id
-    response = await call_next(request)
-    response.headers["X-Request-ID"] = req_id
-    return response
+install_request_id_middleware(app)
+install_request_id_logging()
 
 
 class QueryRequest(BaseModel):

--- a/digismith/ARCHITECTURE.md
+++ b/digismith/ARCHITECTURE.md
@@ -58,11 +58,12 @@ HTTP 200 OK
   "version": "0.1.0",
   "tracing_configured": true,
   "langsmith_sdk_installed": true,
-  "langsmith_host": "api.smith.langchain.com"
+  "langsmith_host": "api.smith.langchain.com",
+  "request_id": "1f0b9c3e4a7d4f62a9c58d1e3c9b2a10"
 }
 ```
 
-`tracing_configured` is `true` iff `LANGSMITH_API_KEY` is non-empty **and** `langsmith` is importable. `langsmith_host` is the hostname extracted from `LANGSMITH_ENDPOINT` (no path, no credentials, no query string). If `LANGSMITH_ENDPOINT` is not set, the default `api.smith.langchain.com` appears.
+`tracing_configured` is `true` iff `LANGSMITH_API_KEY` is non-empty **and** `langsmith` is importable. `langsmith_host` is the hostname extracted from `LANGSMITH_ENDPOINT` (no path, no credentials, no query string). If `LANGSMITH_ENDPOINT` is not set, the default `api.smith.langchain.com` appears. `request_id` echoes the `X-Request-ID` of the call that produced this response (sourced from `digibase.http.install_request_id_middleware`) so operators can correlate the status response with logs and traces (task #213).
 
 ### Python library: `digismith.trace.traceable`
 
@@ -100,6 +101,7 @@ class SmithStatus(BaseModel):
     tracing_configured: bool
     langsmith_sdk_installed: bool
     langsmith_host: str | None = None
+    request_id: str | None = None
 ```
 
 All fields are non-secret by construction. The model is used directly as the FastAPI `response_model` for `GET /v1/status`.

--- a/digismith/src/digismith/config.py
+++ b/digismith/src/digismith/config.py
@@ -52,3 +52,7 @@ class SmithStatus(BaseModel):
         default=None,
         description="Sanitized API host from LANGSMITH_ENDPOINT (no secrets)",
     )
+    request_id: str | None = Field(
+        default=None,
+        description="X-Request-ID of the call that produced this status (echoed for correlation)",
+    )

--- a/digismith/src/digismith/server.py
+++ b/digismith/src/digismith/server.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import uuid
-
 from digibase.cors import install_cors
 from digibase.errors import register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from fastapi import FastAPI, Request
@@ -25,15 +24,8 @@ app = FastAPI(
 )
 install_metrics(app, service="digismith")
 install_cors(app, service="digismith")
-
-
-@app.middleware("http")
-async def correlation_id(request: Request, call_next):
-    req_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
-    request.state.request_id = req_id
-    response = await call_next(request)
-    response.headers["X-Request-ID"] = req_id
-    return response
+install_request_id_middleware(app)
+install_request_id_logging()
 
 
 @app.get("/health")
@@ -53,12 +45,13 @@ def healthz() -> dict[str, bool]:
 
 
 @app.get("/v1/status", response_model=SmithStatus)
-def status() -> SmithStatus:
+def status(request: Request) -> SmithStatus:
     return SmithStatus(
         version=__version__,
         tracing_configured=tracing_enabled(),
         langsmith_sdk_installed=langsmith_sdk_importable(),
         langsmith_host=langsmith_host_sanitized(),
+        request_id=getattr(request.state, "request_id", None),
     )
 
 

--- a/tests/db/test_request_id.py
+++ b/tests/db/test_request_id.py
@@ -1,0 +1,129 @@
+"""Unit tests for the digibase X-Request-ID correlation primitives (task #213)."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from digibase.http import (
+    RequestIdLogFilter,
+    current_request_id,
+    install_request_id_logging,
+    install_request_id_middleware,
+    outbound_request_id_headers,
+    outbound_service_headers,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+_HEX_32 = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/echo")
+    def echo(request: Request) -> dict[str, str | None]:
+        return {
+            "state": getattr(request.state, "request_id", None),
+            "ctx": current_request_id(),
+        }
+
+    return app
+
+
+def test_middleware_passes_through_inbound_header() -> None:
+    client = TestClient(_build_app())
+    resp = client.get("/echo", headers={"X-Request-ID": "trace-abc"})
+    assert resp.status_code == 200
+    assert resp.headers["X-Request-ID"] == "trace-abc"
+    body = resp.json()
+    assert body == {"state": "trace-abc", "ctx": "trace-abc"}
+
+
+def test_middleware_generates_hex_id_when_header_missing() -> None:
+    client = TestClient(_build_app())
+    resp = client.get("/echo")
+    assert resp.status_code == 200
+    generated = resp.headers["X-Request-ID"]
+    assert _HEX_32.match(generated), generated
+    body = resp.json()
+    assert body["state"] == generated
+    assert body["ctx"] == generated
+
+
+def test_middleware_generates_hex_id_when_header_blank() -> None:
+    client = TestClient(_build_app())
+    resp = client.get("/echo", headers={"X-Request-ID": "   "})
+    assert resp.status_code == 200
+    assert _HEX_32.match(resp.headers["X-Request-ID"])
+
+
+def test_context_var_resets_after_request() -> None:
+    """Leaking the ctxvar between requests would cross-contaminate outbound calls."""
+    client = TestClient(_build_app())
+    client.get("/echo", headers={"X-Request-ID": "rid-1"})
+    assert current_request_id() is None
+
+
+def test_outbound_request_id_headers_trims_and_skips_empty() -> None:
+    assert outbound_request_id_headers(None) is None
+    assert outbound_request_id_headers("") is None
+    assert outbound_request_id_headers("   ") is None
+    assert outbound_request_id_headers("  abc  ") == {"X-Request-ID": "abc"}
+
+
+def test_outbound_service_headers_merges_id_bearer_and_extra() -> None:
+    out = outbound_service_headers("rid-7", "jwt.tok", extra={"X-Tenant": "acme", "empty": ""})
+    assert out == {"X-Request-ID": "rid-7", "Authorization": "Bearer jwt.tok", "X-Tenant": "acme"}
+
+
+def test_log_filter_defaults_request_id_when_no_request_active() -> None:
+    """Records emitted at startup or in background tasks must not raise on %(request_id)s."""
+    flt = RequestIdLogFilter()
+    record = logging.LogRecord("x", logging.INFO, "x", 1, "hi", None, None)
+    assert flt.filter(record) is True
+    assert record.request_id == "-"
+
+
+def test_install_request_id_logging_is_idempotent() -> None:
+    target = logging.getLogger("digibase.test.idempotent_req_id")
+    target.filters.clear()
+    first = install_request_id_logging(target)
+    second = install_request_id_logging(target)
+    assert first is second
+    assert sum(isinstance(f, RequestIdLogFilter) for f in target.filters) == 1
+
+
+def test_log_filter_picks_up_in_flight_request_id() -> None:
+    log = logging.getLogger("digibase.test.req_id_flow")
+    log.setLevel(logging.INFO)
+    install_request_id_logging(log)
+
+    captured: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+            captured.append(getattr(record, "request_id", "MISSING"))
+
+    log.addHandler(_Capture())
+
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/log")
+    def _log() -> dict[str, bool]:
+        log.info("hello")
+        return {"ok": True}
+
+    client = TestClient(app)
+    client.get("/log", headers={"X-Request-ID": "rid-log"})
+
+    assert "rid-log" in captured

--- a/tests/integration/test_request_id_hops.py
+++ b/tests/integration/test_request_id_hops.py
@@ -1,0 +1,124 @@
+"""End-to-end X-Request-ID propagation across three service hops (task #213).
+
+Gives us confidence that the *mechanics* of middleware + outbound helper
+survive chaining, not just each service in isolation. Three bare FastAPI apps
+stand in for DigiChat/DigiGraph/DigiSearch — the real service code already
+exercises the same primitives at unit level; what we're asserting here is
+that the id survives two hops of service-to-service forwarding when each hop
+uses :func:`digibase.http.outbound_service_headers`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+
+from digibase.http import (
+    current_request_id,
+    install_request_id_middleware,
+    outbound_service_headers,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _leaf_app(seen: list[str]) -> FastAPI:
+    """Terminal service — records the id it saw, echoes it back."""
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/leaf")
+    def leaf(request: Request) -> dict[str, str | None]:
+        rid = current_request_id()
+        seen.append(rid or "")
+        return {"request_id": rid, "state": getattr(request.state, "request_id", None)}
+
+    return app
+
+
+def _middle_app(leaf: FastAPI, seen: list[str]) -> FastAPI:
+    """Hop 2 — forwards to leaf using the shared outbound helper."""
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/fanout")
+    async def fanout(request: Request) -> dict[str, object]:
+        rid = current_request_id()
+        seen.append(rid or "")
+        transport = httpx.ASGITransport(app=leaf)
+        async with httpx.AsyncClient(transport=transport, base_url="http://leaf") as client:
+            headers = outbound_service_headers(rid, bearer_token=None)
+            r = await client.get("/leaf", headers=headers)
+        return {
+            "middle": rid,
+            "downstream": r.json(),
+            "downstream_header": r.headers.get("X-Request-ID"),
+        }
+
+    return app
+
+
+def _entry_app(middle: FastAPI, seen: list[str]) -> FastAPI:
+    """Hop 1 — simulates DigiChat BFF originating the request."""
+    app = FastAPI()
+    install_request_id_middleware(app)
+
+    @app.get("/entry")
+    async def entry(request: Request) -> dict[str, object]:
+        rid = current_request_id()
+        seen.append(rid or "")
+        transport = httpx.ASGITransport(app=middle)
+        async with httpx.AsyncClient(transport=transport, base_url="http://middle") as client:
+            headers = outbound_service_headers(rid, bearer_token=None)
+            r = await client.get("/fanout", headers=headers)
+        return {
+            "entry": rid,
+            "next": r.json(),
+            "next_header": r.headers.get("X-Request-ID"),
+        }
+
+    return app
+
+
+async def _call(entry: FastAPI, headers: dict[str, str] | None) -> httpx.Response:
+    transport = httpx.ASGITransport(app=entry)
+    async with httpx.AsyncClient(transport=transport, base_url="http://entry") as client:
+        return await client.get("/entry", headers=headers or {})
+
+
+def test_request_id_survives_three_hops_when_client_supplies_id() -> None:
+    seen: list[str] = []
+    leaf = _leaf_app(seen)
+    middle = _middle_app(leaf, seen)
+    entry = _entry_app(middle, seen)
+
+    r = asyncio.run(_call(entry, {"X-Request-ID": "rid-3hops"}))
+
+    assert r.status_code == 200
+    assert r.headers["X-Request-ID"] == "rid-3hops"
+    assert seen == ["rid-3hops", "rid-3hops", "rid-3hops"]
+    body = r.json()
+    assert body["entry"] == "rid-3hops"
+    assert body["next_header"] == "rid-3hops"
+    assert body["next"]["middle"] == "rid-3hops"
+    assert body["next"]["downstream_header"] == "rid-3hops"
+    assert body["next"]["downstream"]["request_id"] == "rid-3hops"
+
+
+def test_generated_id_at_entry_propagates_to_leaf() -> None:
+    """No inbound header → entry generates an id; same id must reach the leaf."""
+    seen: list[str] = []
+    leaf = _leaf_app(seen)
+    middle = _middle_app(leaf, seen)
+    entry = _entry_app(middle, seen)
+
+    r = asyncio.run(_call(entry, None))
+
+    assert r.status_code == 200
+    generated = r.headers["X-Request-ID"]
+    assert len(generated) == 32
+    assert seen == [generated, generated, generated]


### PR DESCRIPTION
## Summary

- Consolidate per-service X-Request-ID middleware (previously 4× copy-pasted) into `digibase.http.install_request_id_middleware`, and add coverage to **DigiKey** (which previously had none).
- New primitives: `current_request_id()` ContextVar reader for outbound call sites, and `RequestIdLogFilter` / `install_request_id_logging()` so every `LogRecord` carries `record.request_id` (defaults to `"-"` outside a request, never raises).
- DigiSmith `GET /v1/status` now echoes `request_id` in the response body for caller-side correlation (AC #4).
- Middleware registration order preserved: request-id wraps auth, rate-limit, and error handlers in every service (verified by reviewing each `server.py`).

## Acceptance criteria (#213)

- [x] All incoming requests assign or pass through X-Request-ID — now enforced in all 5 services via shared helper
- [x] All outbound HTTP calls include X-Request-ID — `outbound_service_headers` unchanged, already used everywhere
- [x] Request ID appears in all log lines — `RequestIdLogFilter` attached in each `server.py`
- [x] Correlation ID visible in DigiSmith `/v1/status` — new `request_id` field on `SmithStatus`
- [x] Integration test: single request traced through 3 service hops — `tests/integration/test_request_id_hops.py`

## Test plan

- [x] `pytest tests/db/test_request_id.py` — 9 unit tests (middleware, ContextVar, log filter, outbound helpers)
- [x] `pytest tests/integration/test_request_id_hops.py` — 3-hop propagation, supplied + generated id
- [x] `pytest tests/dsm tests/dk tests/ds tests/dg tests/dq -m unit` — no regressions in any service
- [x] `ruff check` / `ruff format` — clean
- [x] `make doc-check` — 95 markdown files, no broken links

## Follow-up (not in this PR)

- `digigraph.server._resolve_request_id` is now redundant with `current_request_id()` and can be deleted.

Resolves #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Quality gate

- [x] /simplify run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /review completed — PR reviewed against scoring rubric; findings addressed