### PR TITLE
feat(digismith): PII redaction before LangSmith submission (#214)

### DIFF
--- a/digismith/ARCHITECTURE.md
+++ b/digismith/ARCHITECTURE.md
@@ -40,7 +40,8 @@ DigiSmith ships exactly four source files under `digismith/src/digismith/`:
 |------|------|------------------|--------------------|
 | `__init__.py` | Package identity, `__version__ = "0.1.0"` | Version string | Everything else |
 | `config.py` | Environment introspection + `SmithStatus` model | All four public symbols | Nothing deferred |
-| `trace.py` | `traceable(name)` decorator | Conditional wrapping, no-op fallback | Span attribute enforcement, sampling |
+| `trace.py` | `traceable(name)` decorator | Conditional wrapping, no-op fallback, PII redaction hookup | Span attribute enforcement, sampling |
+| `redaction.py` | `PiiRedactor` — value-pattern redaction for span payloads | Emails, API-key prefixes, phone numbers, `DIGI_PII_PATTERNS` extras | Key-name allowlists, length-based document summarization |
 | `server.py` | FastAPI application, `/health`, `/v1/status`, `/metrics` | All three endpoints, OTel wiring, correlation ID, Prometheus instrumentation | `/v1/status/detailed` |
 
 There is no database, no background worker, no queue, and no internal LangGraph graph. DigiSmith does not receive traces — it only enables other services to emit them via the LangSmith SDK.
@@ -198,13 +199,28 @@ The endpoint deliberately returns only non-secret metadata. `langsmith_host_sani
 
 **Risk:** Future contributors may be tempted to add richer fields (e.g., project name, tracing tags, endpoint path) without recognizing that these can leak operational details. The constraint must be explicitly maintained via code review and documentation.
 
-### PII risk in LangSmith spans
+### PII redaction before LangSmith submission
 
-LangSmith's `traceable` decorator captures function inputs and outputs and sends them to the LangSmith API. In DigiGraph's `chat_completion`, the `messages` parameter contains the full LLM message history — including system prompts, user queries, and potentially retrieved document content.
+`digismith.trace.traceable` attaches a :class:`~digismith.redaction.PiiRedactor`
+to every active LangSmith span via the SDK's native `process_inputs` and
+`process_outputs` callbacks. Inputs and outputs are walked recursively
+(`dict`, `list`, `tuple`, `str`) and value-pattern redaction replaces:
 
-The span attribute contract says "do not put raw prompts" in spans, but `langsmith.traceable` records function arguments by default. The `@_traceable("chat_completion")` decoration on `chat_completion(model, messages, ...)` likely sends the full `messages` list to LangSmith unless the LangSmith SDK is explicitly configured to exclude or truncate inputs.
+| Pattern | Sentinel |
+|---------|----------|
+| Email (RFC-5321-lite) | `[REDACTED_EMAIL]` |
+| API-key prefixes — `sk-`, `sk_`, `dgk_live_`, `dgk_test_`, `lsv2_` | `[REDACTED_KEY]` |
+| E.164 / common North-American phone | `[REDACTED_PHONE]` |
+| Extra regexes from `DIGI_PII_PATTERNS` (comma-separated) | `[REDACTED]` |
 
-**This is a significant gap.** There is no middleware, no input sanitizer, and no `hide_inputs=True` flag passed to `langsmith.traceable`. Any PII in user messages, any API keys passed as tool results, and any retrieved document text will flow to LangSmith if tracing is active.
+Non-string scalars (`int`, `bool`, `None`) pass through untouched. The redactor
+is keyed by *value pattern*, complementing `digibase.audit.redact_mapping`
+(which redacts by *key name* only). If a pinned `langsmith` SDK lacks
+`process_inputs`/`process_outputs`, the decorator logs a debug message and
+falls back to plain `traceable(name=…)` — tracing still flows, but redaction
+is skipped; operators should upgrade the SDK. When `LANGSMITH_API_KEY` is
+unset (i.e. `tracing_enabled()` is false) the decorator is a pure no-op and
+the redactor is never constructed.
 
 ### Span attribute contract not enforced at ingestion
 
@@ -351,9 +367,13 @@ DigiSmith does not expose an MCP server. There are no MCP tools, no tool registr
 
 ## 11. Phase 2+ Gaps and Roadmap
 
-### PII validation and redaction layer
+### PII validation and redaction layer — IMPLEMENTED (#214)
 
-There is no PII scrubbing before spans are sent to LangSmith. The `traceable` decorator captures full function inputs by default. A redaction middleware — either a custom `langsmith.traceable` wrapper that filters `messages` fields, or a process-level span processor — is needed before enabling LangSmith tracing in a production deployment with real user data.
+Baseline value-pattern redaction now ships in `digismith.redaction.PiiRedactor`
+and is wired into `traceable` via LangSmith's `process_inputs`/`process_outputs`
+callbacks. Remaining follow-ups: length-based document body summarization,
+hash-and-count replacement for large blobs, and key-name deny-lists shared
+with `digibase.audit`.
 
 ### Custom trace samplers
 

--- a/digismith/src/digismith/redaction.py
+++ b/digismith/src/digismith/redaction.py
@@ -1,0 +1,124 @@
+"""PII redaction for DigiSmith trace payloads before LangSmith submission.
+
+``PiiRedactor`` walks arbitrary dict / list / tuple structures and replaces
+PII-looking substrings inside string values with opaque sentinels. Built-in
+patterns cover:
+
+* Emails (RFC-5321-lite) → ``[REDACTED_EMAIL]``
+* API key prefixes (``sk-``, ``sk_``, ``dgk_live_``, ``dgk_test_``, ``lsv2_``)
+  → ``[REDACTED_KEY]``
+* E.164 and common North-American phone formats → ``[REDACTED_PHONE]``
+
+Additional comma-separated regexes from the ``DIGI_PII_PATTERNS`` environment
+variable are appended and render as ``[REDACTED]``. Non-string values pass
+through (nested structures recurse).
+
+The module has no runtime dependency on ``langsmith``; it operates on plain
+Python structures. ``digismith.trace`` wires it into ``langsmith.traceable``
+via the SDK's native ``process_inputs`` / ``process_outputs`` hooks.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "DEFAULT_PATTERNS",
+    "EMAIL_PATTERN",
+    "API_KEY_PATTERN",
+    "PHONE_PATTERN",
+    "PiiRedactor",
+    "default_redactor",
+]
+
+
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+API_KEY_PATTERN = re.compile(r"(?:sk-|sk_|dgk_live_|dgk_test_|lsv2_)[A-Za-z0-9_-]{8,}")
+PHONE_PATTERN = re.compile(r"(?:\+?\d{1,3}[-. ]?)?\(?\d{3}\)?[-. ]?\d{3}[-. ]?\d{4}")
+
+
+@dataclass(frozen=True)
+class _Rule:
+    pattern: re.Pattern[str]
+    replacement: str
+
+
+# Order matters: API keys first (they can contain digits that phone would match).
+DEFAULT_PATTERNS: tuple[_Rule, ...] = (
+    _Rule(API_KEY_PATTERN, "[REDACTED_KEY]"),
+    _Rule(EMAIL_PATTERN, "[REDACTED_EMAIL]"),
+    _Rule(PHONE_PATTERN, "[REDACTED_PHONE]"),
+)
+
+
+def _parse_extra_patterns(raw: str | None) -> tuple[_Rule, ...]:
+    """Parse ``DIGI_PII_PATTERNS`` into a tuple of extra redaction rules.
+
+    Mirrors the split/strip/filter idiom used by ``digigraph.tool_policy`` and
+    ``digibase.cors``. Invalid regexes are silently skipped to avoid crashing
+    tracing on a config typo.
+    """
+    if not raw:
+        return ()
+    parts = [entry.strip() for entry in raw.split(",") if entry.strip()]
+    rules: list[_Rule] = []
+    for entry in parts:
+        try:
+            rules.append(_Rule(re.compile(entry), "[REDACTED]"))
+        except re.error:
+            continue
+    return tuple(rules)
+
+
+@dataclass
+class PiiRedactor:
+    """Redact PII substrings inside nested dict / list / tuple structures.
+
+    Instances are cheap and stateless apart from their rule list; the default
+    factory reads ``DIGI_PII_PATTERNS`` at construction time so tests can
+    rebuild the redactor with a fresh environment via ``monkeypatch``.
+    """
+
+    rules: tuple[_Rule, ...] = field(default_factory=lambda: DEFAULT_PATTERNS)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> PiiRedactor:
+        env = env if env is not None else os.environ
+        extra = _parse_extra_patterns(env.get("DIGI_PII_PATTERNS"))
+        return cls(rules=DEFAULT_PATTERNS + extra)
+
+    def redact_text(self, value: str) -> str:
+        out = value
+        for rule in self.rules:
+            out = rule.pattern.sub(rule.replacement, out)
+        return out
+
+    def redact(self, value: Any) -> Any:
+        """Return ``value`` with every nested string run through the ruleset."""
+        if isinstance(value, str):
+            return self.redact_text(value)
+        if isinstance(value, Mapping):
+            return {k: self.redact(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self.redact(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self.redact(v) for v in value)
+        return value
+
+    # Convenience wrappers matching LangSmith's process_inputs / process_outputs
+    # signature (they receive a dict, must return a dict).
+    def process_inputs(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        redacted = self.redact(inputs)
+        return redacted if isinstance(redacted, dict) else {"inputs": redacted}
+
+    def process_outputs(self, outputs: Any) -> Any:
+        return self.redact(outputs)
+
+
+def default_redactor() -> PiiRedactor:
+    """Return a redactor initialized from the current process environment."""
+    return PiiRedactor.from_env()

--- a/digismith/src/digismith/trace.py
+++ b/digismith/src/digismith/trace.py
@@ -1,4 +1,12 @@
-"""Optional LangSmith trace wrappers (same behavior as legacy digigraph llm helpers)."""
+"""Optional LangSmith trace wrappers with PII redaction.
+
+When the LangSmith SDK is installed and ``LANGSMITH_API_KEY`` is set,
+``traceable(name)`` wraps the target function with ``langsmith.traceable``
+and attaches a :class:`~digismith.redaction.PiiRedactor` via the SDK's native
+``process_inputs`` / ``process_outputs`` hooks so span payloads are scrubbed
+before submission. Otherwise the decorator returns the original function
+unmodified (zero per-call overhead).
+"""
 
 from __future__ import annotations
 
@@ -6,6 +14,8 @@ import logging
 import os
 from collections.abc import Callable
 from typing import Any, TypeVar
+
+from digismith.redaction import PiiRedactor, default_redactor
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +29,40 @@ except ImportError:
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+__all__ = ["LANGSMITH_SDK_AVAILABLE", "traceable"]
 
-def traceable(name: str) -> Callable[[F], F]:
-    """Wrap *fn* with LangSmith ``traceable`` when the SDK is installed and ``LANGSMITH_API_KEY`` is set."""
+
+def traceable(name: str, *, redactor: PiiRedactor | None = None) -> Callable[[F], F]:
+    """Wrap *fn* with LangSmith ``traceable`` + PII redaction when enabled.
+
+    The decorator is a no-op when the SDK is missing or ``LANGSMITH_API_KEY``
+    is unset, preserving the original function object (identity, ``__name__``,
+    etc.). When active, inputs and outputs are passed through ``redactor``
+    before LangSmith serializes them, using the SDK's ``process_inputs`` /
+    ``process_outputs`` callbacks.
+    """
 
     def decorator(fn: F) -> F:
         if LANGSMITH_SDK_AVAILABLE and os.environ.get("LANGSMITH_API_KEY"):
+            active_redactor = redactor or default_redactor()
             try:
-                return _langsmith.traceable(name=name)(fn)  # type: ignore[return-value]
+                return _langsmith.traceable(  # type: ignore[return-value]
+                    name=name,
+                    process_inputs=active_redactor.process_inputs,
+                    process_outputs=active_redactor.process_outputs,
+                )(fn)
+            except TypeError:
+                # Older langsmith versions may not accept process_* kwargs.
+                # Fall back to plain traceable; redaction is skipped but the
+                # trace still flows — operators can pin a newer SDK to opt in.
+                logger.debug(
+                    "langsmith.traceable lacks process_inputs/outputs; redaction disabled for %r",
+                    name,
+                )
+                try:
+                    return _langsmith.traceable(name=name)(fn)  # type: ignore[return-value]
+                except Exception as exc:
+                    logger.debug("LangSmith traceable setup failed for %r: %s", name, exc)
             except Exception as exc:
                 logger.debug("LangSmith traceable setup failed for %r: %s", name, exc)
         return fn

--- a/tests/dsm/test_redaction.py
+++ b/tests/dsm/test_redaction.py
@@ -1,0 +1,114 @@
+"""Unit tests for digismith.redaction."""
+
+from __future__ import annotations
+
+import pytest
+
+from digismith.redaction import PiiRedactor, default_redactor
+
+pytestmark = pytest.mark.unit
+
+
+def test_redacts_email() -> None:
+    r = PiiRedactor()
+    assert r.redact_text("contact user@example.com now") == "contact [REDACTED_EMAIL] now"
+
+
+def test_redacts_api_key_prefixes() -> None:
+    r = PiiRedactor()
+    assert r.redact_text("key=sk-abc123def456789") == "key=[REDACTED_KEY]"
+    assert r.redact_text("key=sk_abc123def456789") == "key=[REDACTED_KEY]"
+    assert r.redact_text("key=dgk_live_deadbeef1234567") == "key=[REDACTED_KEY]"
+    assert r.redact_text("key=dgk_test_cafebabe1234567") == "key=[REDACTED_KEY]"
+    assert r.redact_text("key=lsv2_test_fake_key_value") == "key=[REDACTED_KEY]"
+
+
+def test_redacts_phone_numbers() -> None:
+    r = PiiRedactor()
+    assert r.redact_text("call +1-415-555-0199") == "call [REDACTED_PHONE]"
+    assert r.redact_text("tel (415) 555-0199") == "tel [REDACTED_PHONE]"
+    assert r.redact_text("tel 415.555.0199") == "tel [REDACTED_PHONE]"
+    assert r.redact_text("tel +442071838750") == "tel [REDACTED_PHONE]"
+
+
+def test_clean_text_unchanged() -> None:
+    r = PiiRedactor()
+    assert r.redact_text("hello world") == "hello world"
+    assert r.redact("hello world") == "hello world"
+
+
+def test_non_string_values_passthrough() -> None:
+    r = PiiRedactor()
+    assert r.redact(42) == 42
+    assert r.redact(None) is None
+    assert r.redact(True) is True
+    assert r.redact(3.14) == 3.14
+
+
+def test_nested_dict_redaction() -> None:
+    r = PiiRedactor()
+    out = r.redact({"outer": {"email": "u@e.co"}})
+    assert out == {"outer": {"email": "[REDACTED_EMAIL]"}}
+
+
+def test_nested_list_and_tuple_redaction() -> None:
+    r = PiiRedactor()
+    assert r.redact(["u@e.co", 1, None]) == ["[REDACTED_EMAIL]", 1, None]
+    assert r.redact(("sk-abcdefgh12345", "clean")) == ("[REDACTED_KEY]", "clean")
+
+
+def test_mixed_payload() -> None:
+    r = PiiRedactor()
+    payload = {
+        "messages": [
+            {"role": "user", "content": "email me at jane@doe.com"},
+            {"role": "assistant", "content": "sure, call +1-415-555-0199"},
+        ],
+        "meta": {"key": "sk-abcdefghij1234567", "safe": "hello"},
+        "count": 3,
+    }
+    out = r.redact(payload)
+    assert out["messages"][0]["content"] == "email me at [REDACTED_EMAIL]"
+    assert out["messages"][1]["content"] == "sure, call [REDACTED_PHONE]"
+    assert out["meta"]["key"] == "[REDACTED_KEY]"
+    assert out["meta"]["safe"] == "hello"
+    assert out["count"] == 3
+
+
+def test_digi_pii_patterns_env_appends(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_PII_PATTERNS", r"TOP_SECRET_\w+,BADGE-\d{4}")
+    r = PiiRedactor.from_env()
+    assert r.redact_text("data TOP_SECRET_alpha tag") == "data [REDACTED] tag"
+    assert r.redact_text("BADGE-4242 in lobby") == "[REDACTED] in lobby"
+    # defaults still active
+    assert r.redact_text("u@e.co") == "[REDACTED_EMAIL]"
+
+
+def test_digi_pii_patterns_invalid_regex_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_PII_PATTERNS", "[unclosed,VALID_\\d+")
+    r = PiiRedactor.from_env()
+    assert r.redact_text("VALID_123 here") == "[REDACTED] here"
+
+
+def test_digi_pii_patterns_empty_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGI_PII_PATTERNS", raising=False)
+    r = PiiRedactor.from_env()
+    assert r.rules == PiiRedactor().rules
+
+
+def test_process_inputs_returns_dict() -> None:
+    r = PiiRedactor()
+    out = r.process_inputs({"email": "u@e.co"})
+    assert out == {"email": "[REDACTED_EMAIL]"}
+
+
+def test_process_outputs_handles_any() -> None:
+    r = PiiRedactor()
+    assert r.process_outputs("sk-abcdefghij12345") == "[REDACTED_KEY]"
+    assert r.process_outputs({"x": "u@e.co"}) == {"x": "[REDACTED_EMAIL]"}
+
+
+def test_default_redactor_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DIGI_PII_PATTERNS", r"ZZ_\d+")
+    r = default_redactor()
+    assert r.redact_text("ZZ_9 hidden") == "[REDACTED] hidden"

--- a/tests/dsm/test_trace.py
+++ b/tests/dsm/test_trace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from digismith import trace as trace_mod
@@ -29,3 +31,73 @@ def test_traceable_no_op_without_api_key(monkeypatch: pytest.MonkeyPatch) -> Non
         return "x"
 
     assert fn2() == "x"
+
+
+@pytest.mark.unit
+def test_traceable_passes_redaction_hooks_to_langsmith(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When tracing is active, redactor hooks must reach langsmith.traceable."""
+    captured: dict[str, Any] = {}
+
+    def fake_traceable(**kwargs: Any):
+        captured.update(kwargs)
+
+        def wrap(fn):
+            return fn
+
+        return wrap
+
+    class FakeLs:
+        traceable = staticmethod(fake_traceable)
+
+    monkeypatch.setattr(trace_mod, "LANGSMITH_SDK_AVAILABLE", True)
+    monkeypatch.setattr(trace_mod, "_langsmith", FakeLs)
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test_fake_key")
+
+    @trace_mod.traceable("demo3")
+    def fn3(x: int) -> int:
+        return x + 1
+
+    assert fn3(1) == 2
+    assert captured["name"] == "demo3"
+    assert callable(captured["process_inputs"])
+    assert callable(captured["process_outputs"])
+    # Hooks must actually redact.
+    assert captured["process_inputs"]({"email": "u@e.co"}) == {"email": "[REDACTED_EMAIL]"}
+    assert captured["process_outputs"]("sk-abcdefghij1234567") == "[REDACTED_KEY]"
+
+
+@pytest.mark.unit
+def test_traceable_falls_back_when_process_kwargs_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older langsmith SDKs without process_inputs kwarg still decorate."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_traceable(**kwargs: Any):
+        calls.append(kwargs)
+        if "process_inputs" in kwargs or "process_outputs" in kwargs:
+            raise TypeError("unexpected kwarg")
+
+        def wrap(fn):
+            return fn
+
+        return wrap
+
+    class FakeLs:
+        traceable = staticmethod(fake_traceable)
+
+    monkeypatch.setattr(trace_mod, "LANGSMITH_SDK_AVAILABLE", True)
+    monkeypatch.setattr(trace_mod, "_langsmith", FakeLs)
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test_fake_key")
+
+    @trace_mod.traceable("demo4")
+    def fn4() -> int:
+        return 7
+
+    assert fn4() == 7
+    # Two attempts: first with process_* kwargs, then fallback without.
+    assert len(calls) == 2
+    assert "process_inputs" in calls[0]
+    assert "process_inputs" not in calls[1]


### PR DESCRIPTION
## Summary
- New `digismith.redaction.PiiRedactor` walks nested dict/list/tuple structures and redacts emails, API-key prefixes (`sk-`, `sk_`, `dgk_live_`, `dgk_test_`, `lsv2_`), and E.164 / North-American phone numbers from string values. Additional regexes from `DIGI_PII_PATTERNS` (comma-separated) render as `[REDACTED]`.
- `digismith.trace.traceable` wires the redactor into `langsmith.traceable` via the SDK's native `process_inputs` / `process_outputs` callbacks. No-op preserved when `LANGSMITH_API_KEY` is unset or the SDK is missing; graceful fallback to plain `traceable` on older SDK versions.
- `digismith/ARCHITECTURE.md` updated: Section 6 documents the redaction behaviour, Section 11 marks the gap as closed.

Resolves #214

## Test plan
- [x] `pytest tests/dsm -m unit -q` (21 passed)
- [x] `ruff check digismith/ tests/dsm/`
- [x] `ruff format --check digismith/ tests/dsm/`
- [ ] Verify in a staging deployment with `LANGSMITH_API_KEY` set that span inputs/outputs arrive redacted on the LangSmith dashboard.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

## Quality gate

- [x] /simplify run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /review completed — PR reviewed against scoring rubric; findings addressed