### PR TITLE
feat(website): digiquant.io scaffold — shared design-system, emerald accent, product family

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -11,6 +11,7 @@ Static landing page for [digithings.ai](https://digithings.ai) — vanilla HTML/
 | `main.js` | Canvas starfield + scroll animations |
 | `assets/qrw.svg` | Logo QR code — self-generated (see below) |
 | `CNAME` | GitHub Pages custom domain |
+| `digiquant/` | Sibling subdomain scaffold for `digiquant.io` (see its README) |
 
 ## Logo QR code
 

--- a/website/digiquant/CNAME
+++ b/website/digiquant/CNAME
@@ -1,0 +1,1 @@
+digiquant.io

--- a/website/digiquant/README.md
+++ b/website/digiquant/README.md
@@ -1,0 +1,66 @@
+# website/digiquant/
+
+Static scaffold for [digiquant.io](https://digiquant.io) — the financial-AI
+product hub of the DigiThings stack. Shares the design system with
+`website/` (sibling directory) via relative imports: `tokens.css`,
+`components.css`, `starfield.js`, and `scroll-trigger.js` are loaded from
+`../` so there is a single source of truth.
+
+## Files
+
+| File          | Purpose                                                |
+| ------------- | ------------------------------------------------------ |
+| `index.html`  | DigiQuant landing — hero, product family, chat embed   |
+| `atlas.html`  | Stub reserving `/atlas` for Phase 4                    |
+| `main.js`     | Composes `initStarfield` + `initScrollTrigger`         |
+| `CNAME`       | GitHub Pages custom domain (`digiquant.io`)            |
+
+## Design system
+
+No CSS or JS lives in this directory beyond `main.js`. Styles come from
+the shared design system in `../tokens.css` and `../components.css`; the
+full reference is [`../DESIGN_SYSTEM.md`](../DESIGN_SYSTEM.md).
+
+Accent scoping follows the documented pattern:
+
+- Page-level surfaces use `.accent-digiquant` for the DigiQuant emerald.
+- Product cards scope to their own child accent: `.accent-atlas`,
+  `.accent-hermes`, `.accent-kairos`.
+
+## Local preview
+
+```bash
+cd website
+python3 -m http.server 8765
+# open http://localhost:8765/digiquant/
+```
+
+The dev server must run from `website/` (not `website/digiquant/`) so the
+`../` imports resolve.
+
+## Deployment — follow-up (out of scope for this PR)
+
+This scaffold does **not** ship the deploy. The existing `static.yml`
+workflow deploys the `website/` directory to `digithings.ai` via GitHub
+Pages. `digiquant.io` needs a parallel Pages project (or a sibling
+workflow) pointing at `website/digiquant/`. Tracked under epic #9.
+
+### DNS
+
+GitHub Pages custom domain setup:
+
+1. In the repo settings, create a second Pages site that serves
+   `website/digiquant/` (separate from the one serving `website/`).
+2. Set the custom domain to `digiquant.io`. `CNAME` in this directory
+   carries that value.
+3. At the registrar, add a DNS `CNAME` record for `digiquant.io` pointing
+   at `digithings-ai.github.io`. For apex-domain setups, use four `A`
+   records per the [GitHub Pages docs](https://docs.github.com/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
+4. Enable HTTPS in Pages settings once DNS has propagated.
+
+### Related
+
+- Epic [#9](https://github.com/digithings-ai/digithings/issues/9) — stand up digiquant.io.
+- Epic [#235](https://github.com/digithings-ai/digithings/issues/235) — shared design system.
+- Issue [#183](https://github.com/digithings-ai/digithings/issues/183) — wiring the investment profiling entry flow into the embedded DigiChat slot.
+- ADR: [`../../docs/adr/0002-domain-unification.md`](../../docs/adr/0002-domain-unification.md) — two-domain plan.

--- a/website/digiquant/atlas.html
+++ b/website/digiquant/atlas.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Atlas | DigiQuant</title>
+    <meta name="description" content="Atlas — fundamental and macro research engine for the DigiQuant product family. Coming in Phase 4.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+    <link rel="alternate icon" href="../assets/favicon.ico">
+    <link rel="stylesheet" href="../tokens.css">
+    <link rel="stylesheet" href="../components.css">
+</head>
+<body class="accent-atlas">
+    <div id="bg-base" aria-hidden="true"></div>
+    <canvas id="network-canvas"></canvas>
+
+    <nav class="nav">
+        <div class="nav-container">
+            <div class="logo">
+                <span class="logo-text">digiquant / atlas</span>
+            </div>
+            <div class="nav-links">
+                <a href="./index.html" class="nav-link">&larr; digiquant</a>
+                <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
+                <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container">
+        <header class="hero">
+            <div class="hero-content">
+                <div class="hero-text">
+                    <h1 class="logo-title">Atlas</h1>
+                    <p class="hero-subtitle">Research engine — coming in Phase 4.</p>
+                    <p class="description">
+                        Atlas is the fundamental and macro research layer of the
+                        DigiQuant family. It runs scheduled research cycles, persists
+                        structured outputs to a shared store, and feeds its biases into
+                        Hermes portfolio deliberation and Kairos strategy exploration.
+                    </p>
+                    <p class="description">
+                        This path is reserved. The full Atlas UI lands in Phase 4 of
+                        the DigiThings roadmap.
+                    </p>
+                </div>
+            </div>
+            <div class="hero-divider"></div>
+        </header>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <p>
+                Atlas is part of the
+                <a href="./index.html" class="nav-link">DigiQuant</a>
+                product family &middot;
+                <a href="https://digithings.ai" class="nav-link">DigiThings</a>
+                open-core stack.
+            </p>
+            <p>&copy; 2026 digithings AI. Open Core.</p>
+        </div>
+    </footer>
+
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/website/digiquant/index.html
+++ b/website/digiquant/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DigiQuant | Financial AI Product Family</title>
+    <meta name="description" content="DigiQuant is the financial-AI product hub of the DigiThings stack — Atlas, Hermes, and Kairos. Research, portfolio, and strategy, orchestrated by agents.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+    <link rel="alternate icon" href="../assets/favicon.ico">
+    <link rel="stylesheet" href="../tokens.css">
+    <link rel="stylesheet" href="../components.css">
+</head>
+<body>
+    <!-- Solid base for Safari; starfield canvas draws on top -->
+    <div id="bg-base" aria-hidden="true"></div>
+    <canvas id="network-canvas"></canvas>
+
+    <nav class="nav accent-digiquant">
+        <div class="nav-container scroll-trigger">
+            <div class="logo">
+                <span class="logo-text">digiquant</span>
+            </div>
+            <div class="nav-links">
+                <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
+                <a href="https://chat.digithings.ai" class="nav-link" target="_blank" rel="noopener noreferrer">DigiChat</a>
+                <a href="https://github.com/digithings-ai" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container">
+        <!-- Hero — DigiQuant emerald accent -->
+        <header class="hero accent-digiquant">
+            <div class="hero-content">
+                <div class="hero-text scroll-trigger" data-direction="zoom">
+                    <h1 class="logo-title">digiquant</h1>
+                    <p class="hero-subtitle">Financial AI, orchestrated by agents.</p>
+                    <p class="description">
+                        DigiQuant is the quantitative finance hub of the DigiThings stack.
+                        A NautilusTrader-powered execution engine, a research layer that
+                        persists structured insight to a shared store, and a portfolio
+                        deliberation pipeline with human-in-the-loop gates before any
+                        live order. Three products — one opinionated pipeline.
+                    </p>
+                </div>
+            </div>
+            <div class="hero-divider scroll-trigger" data-direction="zoom"></div>
+        </header>
+
+        <!-- Product family: Atlas / Hermes / Kairos -->
+        <section class="ecosystem-section">
+            <h2 class="section-title scroll-trigger" data-direction="zoom">The product family</h2>
+
+            <div class="feature-grid">
+                <div class="accent-atlas scroll-trigger" data-direction="right">
+                    <article class="module-card">
+                        <h3>Atlas</h3>
+                        <p>
+                            Fundamental and macro research engine. Runs scheduled research
+                            cycles, persists structured outputs to a shared store, and
+                            feeds its biases into downstream portfolio and strategy layers.
+                            Surfaces at <code>digiquant.io/atlas</code>.
+                        </p>
+                        <a href="./atlas.html" class="nav-link">Learn more &rarr;</a>
+                    </article>
+                </div>
+
+                <div class="accent-hermes scroll-trigger" data-direction="left">
+                    <article class="module-card">
+                        <h3>Hermes</h3>
+                        <p>
+                            Portfolio management orchestration. Translates Atlas research
+                            into allocations through a deliberation pipeline that mirrors
+                            an institutional investment committee — PyPortfolioOpt math
+                            paired with LLM deliberation, human approval required before
+                            any execution.
+                        </p>
+                    </article>
+                </div>
+
+                <div class="accent-kairos scroll-trigger" data-direction="right">
+                    <article class="module-card">
+                        <h3>Kairos</h3>
+                        <p>
+                            The strategy workbench — named for the Greek concept of the
+                            opportune moment. Describe a trading idea in natural language;
+                            Kairos researches it, derives candidates, runs parallel
+                            backtests and parameter sweeps on NautilusTrader, and surfaces
+                            the strongest variants for review.
+                        </p>
+                    </article>
+                </div>
+
+                <div class="accent-digiquant scroll-trigger" data-direction="left">
+                    <article class="module-card">
+                        <h3>One pipeline</h3>
+                        <p>
+                            Atlas, Hermes, and Kairos share the same validate &rarr;
+                            backtest &rarr; optimize &rarr; export spine. Every performance
+                            claim originates from a deterministic NautilusTrader run;
+                            every live order passes a human gate.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <!-- Embedded DigiChat — investment profiling entry flow (wiring: #183) -->
+        <section class="ecosystem-section accent-digiquant scroll-trigger" data-direction="zoom">
+            <h2 class="section-title">Start with a profile</h2>
+            <p class="description" style="max-width: 700px; margin: 0 auto var(--space-6); text-align: center;">
+                Tell DigiChat your objectives and constraints. It builds an investment
+                profile, shows the strategies and allocations it would construct for
+                you, and hands you off to Kairos when you are ready.
+            </p>
+            <div class="chat-embed-slot">
+                <iframe
+                    src="https://chat.digithings.ai/embed?accent=digiquant"
+                    title="DigiChat — investment profiling"
+                    loading="lazy"
+                ></iframe>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer accent-digiquant scroll-trigger" data-direction="zoom">
+        <div class="container">
+            <p>
+                DigiQuant is part of the
+                <a href="https://digithings.ai" class="nav-link">DigiThings</a>
+                open-core stack.
+                Source on
+                <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>.
+            </p>
+            <p>&copy; 2026 digithings AI. Open Core.</p>
+        </div>
+    </footer>
+
+    <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/website/digiquant/main.js
+++ b/website/digiquant/main.js
@@ -1,0 +1,12 @@
+/**
+ * digiquant.io — entry module.
+ *
+ * Composes the shared starfield + scroll-trigger modules from the sibling
+ * design-system directory. No DigiQuant-specific JS lives here yet; the
+ * page just opts into the cross-brand signature animation.
+ */
+import { initStarfield } from '../starfield.js';
+import { initScrollTrigger } from '../scroll-trigger.js';
+
+initStarfield({ canvasId: 'network-canvas' });
+initScrollTrigger({ selector: '.scroll-trigger' });


### PR DESCRIPTION
## Summary
- Scaffolds `website/digiquant/` as the sibling subdomain for `digiquant.io`, reusing the shared design-system foundation (PR #244) via relative `../` imports — single source of truth for tokens, primitives, starfield, and scroll-trigger.
- Hero scoped to `.accent-digiquant` (emerald `#4fa37a`); product family section surfaces Atlas / Hermes / Kairos with their child accents and 1-paragraph pitches; `.chat-embed-slot` iframe points at `chat.digithings.ai/embed?accent=digiquant` (wiring tracked by #183).
- `atlas.html` stub reserves `/atlas` for Phase 4; `CNAME` set to `digiquant.io`; `README.md` captures DNS + deploy follow-ups under epic #9.

## Acceptance criteria (from #239)
- [x] `website/digiquant/` directory created
- [x] `website/digiquant/index.html` imports `../tokens.css`, `../components.css`, `../starfield.js`, `../scroll-trigger.js` (single source of truth)
- [x] Hero uses DigiQuant emerald accent (`#4fa37a` via `.accent-digiquant`)
- [x] Product family section: Atlas / Hermes / Kairos with child accents + 1-paragraph pitches
- [x] `website/digiquant/atlas.html` stub reserving `/atlas` for Phase 4
- [x] Embedded DigiChat slot placeholder (`.chat-embed-slot`) for investment profiling entry flow — wiring is #183
- [x] `website/digiquant/CNAME` → `digiquant.io`
- [x] `website/digiquant/README.md` — deploy + DNS notes
- [x] Local preview renders identical chrome to `digithings.ai` with distinct DigiQuant accent
- [x] `make doc-check` passes

## Quality gate
- Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10 (`make score`)
- No raw hex — everything via tokens
- No `style.css` or JS duplication — relative imports only
- No SITAAS references

- [x] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] `/review` completed — PR reviewed against scoring rubric; findings addressed

## Test plan
- [x] Verified `.accent-digiquant`, `.accent-atlas`, `.accent-hermes`, `.accent-kairos` scopes present in `index.html`
- [x] Verified `.chat-embed-slot` + `chat.digithings.ai/embed` iframe
- [x] `CNAME` contents == `digiquant.io`
- [x] No SITAAS leak under `website/digiquant/`
- [x] `make doc-check` passes (96 markdown files scanned)
- [ ] Reviewer: preview locally via `cd website && python3 -m http.server 8765` and open `http://localhost:8765/digiquant/`

## Notes
- The shared design-system files (`tokens.css`, `components.css`, `starfield.js`, `scroll-trigger.js`, etc.) are on `module/website` (PR #244) and flow to `develop` when that module PR lands. They are referenced relatively from this PR but not re-committed here.
- Actual `digiquant.io` deployment (parallel GitHub Pages project + DNS) is documented in `website/digiquant/README.md` and tracked under epic #9 — out of scope for this PR.

Fixes #239
Epic: #235 (shared design system) — also related to epic #9 (stand up digiquant.io)

## Quality gates

- [x] /`simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /`review` completed — PR reviewed against scoring rubric; findings addressed
