### PR TITLE
feat(atlas): preflight + Phase 1/2 wiring (Atlas migration 4/9)

### DIFF
--- a/apps/digiquant-atlas/pyproject.toml
+++ b/apps/digiquant-atlas/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "supabase>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.27",
+    # In-repo monorepo dependency; installed via editable install in dev.
+    # digibase provides the audit-redaction contract that every Atlas write must go through.
+    "digibase",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +46,10 @@ digiquant_atlas = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+# Monorepo layout: digibase lives two levels up. Added to sys.path so tests
+# resolve it without requiring an editable install (PEP 668 blocks that
+# by default on Homebrew Python).
+pythonpath = ["src", "../../digibase/src"]
 markers = [
     "unit: offline unit tests",
     "e2e: requires stack / Supabase",

--- a/apps/digiquant-atlas/pyproject.toml
+++ b/apps/digiquant-atlas/pyproject.toml
@@ -16,9 +16,11 @@ dependencies = [
     "jsonschema>=4.21",
     "python-dotenv>=1.0.0",
     "httpx>=0.27",
-    # In-repo monorepo dependency; installed via editable install in dev.
-    # digibase provides the audit-redaction contract that every Atlas write must go through.
+    # In-repo monorepo dependencies; installed via editable installs in dev.
+    # digibase provides audit redaction; digigraph provides research_agent +
+    # pipeline_builder (the generic primitives Atlas composes into its 9-phase graph).
     "digibase",
+    "digigraph",
 ]
 
 [project.optional-dependencies]
@@ -54,7 +56,12 @@ testpaths = ["tests"]
 # Monorepo layout: digibase lives two levels up. Added to sys.path so tests
 # resolve it without requiring an editable install (PEP 668 blocks that
 # by default on Homebrew Python).
-pythonpath = ["src", "../../digibase/src"]
+pythonpath = [
+    "src",
+    "../../digibase/src",
+    "../../digigraph/src",
+    "../../digismith/src",
+]
 markers = [
     "unit: offline unit tests",
     "e2e: requires stack / Supabase",

--- a/apps/digiquant-atlas/pyproject.toml
+++ b/apps/digiquant-atlas/pyproject.toml
@@ -14,16 +14,21 @@ dependencies = [
     "langgraph>=0.2",
     "PyYAML>=6",
     "jsonschema>=4.21",
-    "supabase>=2.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
+# Supabase client is only needed when writing to the production DB;
+# unit tests use an in-memory fake. Keep the base install slim.
+supabase = [
+    "supabase>=2.0.0",
+]
 dev = [
     "pytest>=8",
     "pytest-cov>=5",
     "ruff>=0.5",
+    "supabase>=2.0.0",
 ]
 # Legacy scripts (apps/digiquant-atlas/scripts/) retain pandas + yfinance.
 # New digiquant_atlas package code is Polars-only per repo policy.

--- a/apps/digiquant-atlas/pyproject.toml
+++ b/apps/digiquant-atlas/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "digiquant-atlas"
+version = "0.1.0"
+description = "DigiQuant Atlas — research pipeline sub-graph wiring for DigiGraph"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+dependencies = [
+    "pydantic>=2",
+    "langgraph>=0.2",
+    "PyYAML>=6",
+    "jsonschema>=4.21",
+    "supabase>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=5",
+    "ruff>=0.5",
+]
+# Legacy scripts (apps/digiquant-atlas/scripts/) retain pandas + yfinance.
+# New digiquant_atlas package code is Polars-only per repo policy.
+legacy-scripts = [
+    "yfinance>=0.2.40",
+    "pandas>=2.0.0",
+    "pandas-ta>=0.3.14b",
+    "numpy>=1.24.0",
+    "requests>=2.28.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+digiquant_atlas = ["py.typed"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+markers = [
+    "unit: offline unit tests",
+    "e2e: requires stack / Supabase",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/__init__.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/__init__.py
@@ -1,0 +1,18 @@
+"""DigiQuant Atlas — phase-structured research pipeline over DigiGraph.
+
+Public surface (added across commits 2–9):
+
+- :class:`digiquant_atlas.state.AtlasResearchState` — the sub-graph state model.
+- :func:`digiquant_atlas.skills.load_skill` — SKILL.md loader.
+- :func:`digiquant_atlas.schemas.load_schema` — JSON-Schema loader (authoritative shape source).
+- :func:`digiquant_atlas.graph.build_atlas_graph` — compiled LangGraph entry point (commit 9).
+- :class:`digiquant_atlas.graph.AtlasInput` — DigiClaw-facing invocation contract (commit 9).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/__init__.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/__init__.py
@@ -1,0 +1,15 @@
+"""Atlas sub-graph phase modules.
+
+Each phase maps to a section of ``apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md``:
+
+- ``preflight`` — config load, prior context, data-layer probe.
+- ``phase1_altdata`` — 4 alt-data nodes (sentiment, CTA, options, politician).
+- ``phase2_institutional`` — 2 institutional nodes (flows, hedge funds).
+- ``phase3_macro`` — single macro-regime node (commit 5).
+- ``phase4_assetclass`` — 5 asset-class nodes (commit 5).
+- ``phase5_equities`` — US equity + 11-sector swarm (commit 6).
+- ``phase6_consolidate`` / ``phase7_*`` / ``phase9_evolution`` — commits 7–8.
+
+Each phase module exposes ``build_nodes()`` — a sequence of ``NodeSpec`` the
+pipeline builder wires into the StateGraph.
+"""

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py
@@ -2,17 +2,23 @@
 
 Most phase nodes follow the same pattern:
 1. Build shared_context from state (config, prior_context, data_layer).
-2. Load the segment's skill text.
-3. Call the generic research agent with the segment's output model.
-4. Wrap the result in a ``SegmentSlot`` → stash under the phase's output dict.
+2. Assemble phase_inputs (volatile per-phase context — may include upstream
+   phase outputs).
+3. Load the segment's skill text.
+4. Call the generic research agent with the segment's output model.
+5. Wrap the result in a ``SegmentSlot`` → stash under the phase's output dict
+   (or a scalar state field for single-slot phases like macro).
 
-Instead of repeating that skeleton 20+ times, this factory produces a
-node callable from a small spec. Keeps phase modules short and makes the
-pattern reviewable in one place.
+The factory exposes two seams so every Atlas phase can use it:
+- ``inputs_builder`` — customizes step 2. Lets Phase 3+ nodes pull upstream
+  phase outputs into phase_inputs; Phases 1/2 use the default.
+- ``write_adapter`` — customizes step 5. Lets macro (single slot) and the
+  dict-valued phases share one implementation.
 
-Triage (delta-mode carry-forward) is wired in commit 8 — the factory takes
-an optional ``triage_gate`` callable that, when supplied, decides whether
-to regenerate or emit ``Carried`` for a given (state, segment_slug).
+Triage is consulted in three orders of precedence:
+1. Explicit ``triage_gate`` kwarg (used by tests that want to bypass state).
+2. ``state.triage`` decisions (how the compiled graph wires delta carry-forward).
+3. Otherwise: run the LLM.
 """
 
 from __future__ import annotations
@@ -50,6 +56,11 @@ class SegmentNodeSpec:
     """AtlasResearchState attribute this node updates (e.g. 'phase1_outputs')."""
 
 
+# Type aliases for the two factory seams.
+InputsBuilder = Callable[[AtlasResearchState, SegmentNodeSpec], dict[str, Any]]
+WriteAdapter = Callable[[SegmentNodeSpec, SegmentSlot], dict[str, Any]]
+
+
 def _shared_context(state: AtlasResearchState) -> dict[str, Any]:
     """Assemble the stable, run-wide context block passed to every phase node.
 
@@ -66,44 +77,71 @@ def _shared_context(state: AtlasResearchState) -> dict[str, Any]:
     }
 
 
-def _phase_inputs(state: AtlasResearchState, spec: SegmentNodeSpec) -> dict[str, Any]:
-    """Volatile per-segment inputs. Kept small so the cache wins on stable parts.
+def default_inputs_builder(_state: AtlasResearchState, spec: SegmentNodeSpec) -> dict[str, Any]:
+    """Volatile per-segment inputs — minimal default.
 
-    For Phase 1–2 segments there is little per-segment volatile context
-    today — each alt-data / institutional sub-agent reads the macro regime
-    in their prompt only at Phase 3+. When a segment needs upstream phase
-    outputs, extend ``_phase_inputs`` to look up the relevant keys from state.
+    Phase 1 and Phase 2 nodes use this as-is; later phases supply their own
+    builder that pulls upstream phase outputs into phase_inputs (see
+    ``phase4_assetclass.py``'s macro-regime injection).
     """
-    inputs: dict[str, Any] = {"segment": spec.segment_slug}
-    # If this is a Phase 3+ node, it can read earlier-phase outputs. Phases
-    # 1 and 2 don't consume prior-phase work beyond shared_context, so the
-    # baseline lookup is empty for them.
-    return inputs
+    return {"segment": spec.segment_slug}
+
+
+def dict_slot_write_adapter(spec: SegmentNodeSpec, slot: SegmentSlot) -> dict[str, Any]:
+    """Default write: update ``state.<phase_outputs_field>[segment_slug] = slot``."""
+    return {spec.phase_outputs_field: {spec.segment_slug: slot}}
+
+
+def scalar_slot_write_adapter(spec: SegmentNodeSpec, slot: SegmentSlot) -> dict[str, Any]:
+    """Scalar write: ``state.<phase_outputs_field> = slot`` (used by single-slot
+    phases like macro where ``phase_outputs_field`` names a scalar field, not a
+    dict)."""
+    return {spec.phase_outputs_field: slot}
 
 
 def build_segment_node(
     spec: SegmentNodeSpec,
     *,
+    inputs_builder: InputsBuilder = default_inputs_builder,
+    write_adapter: WriteAdapter = dict_slot_write_adapter,
     triage_gate: Callable[[AtlasResearchState, str], Carried | None] | None = None,
     model: str | None = None,
 ) -> Callable[[AtlasResearchState], dict[str, Any]]:
     """Return a LangGraph-shaped node function for one segment.
 
-    ``triage_gate`` (optional, wired in commit 8): if given and returns a
-    ``Carried`` for this (state, segment), the node short-circuits without
-    calling the LLM. Otherwise it regenerates.
+    Parameters:
+        spec: segment slug, skill slug, output model, output field name.
+        inputs_builder: customizes the volatile per-call phase_inputs block.
+            Default returns ``{"segment": spec.segment_slug}``. Phases 3+
+            supply builders that pull upstream phase outputs.
+        write_adapter: maps (spec, slot) → state-update dict. Default writes
+            into the phase's output dict; ``scalar_slot_write_adapter``
+            handles single-slot fields like ``phase3_output``.
+        triage_gate: explicit gate callable (test-only). When None, the node
+            reads ``state.triage`` in-node to pick carry vs. regen.
+        model: LiteLLM model override; defaults to DIGI_LLM_MODE routing.
     """
 
     def _node(state: AtlasResearchState) -> dict[str, Any]:
+        carried: Carried | None = None
         if triage_gate is not None:
             carried = triage_gate(state, spec.segment_slug)
-            if carried is not None:
-                slot = SegmentSlot(payload=carried)
-                return {spec.phase_outputs_field: {spec.segment_slug: slot}}
+        elif state.triage is not None:
+            decision = next(
+                (d for d in state.triage.decisions if d.segment == spec.segment_slug),
+                None,
+            )
+            if decision is not None and decision.decision == "carry":
+                carried = Carried(
+                    baseline_date=state.baseline_date or state.run_date,
+                    reason=decision.reason,
+                )
+        if carried is not None:
+            return write_adapter(spec, SegmentSlot(payload=carried))
 
         skill_text = load_skill(spec.skill_slug)
         shared = _shared_context(state)
-        inputs = _phase_inputs(state, spec)
+        inputs = inputs_builder(state, spec)
         result = run_research_agent(
             skill_text=skill_text,
             phase_inputs=inputs,
@@ -116,7 +154,17 @@ def build_segment_node(
             body=result.model_dump(mode="json"),
             as_of=state.run_date,
         )
-        slot = SegmentSlot(payload=payload)
-        return {spec.phase_outputs_field: {spec.segment_slug: slot}}
+        return write_adapter(spec, SegmentSlot(payload=payload))
 
     return _node
+
+
+__all__ = [
+    "InputsBuilder",
+    "SegmentNodeSpec",
+    "WriteAdapter",
+    "build_segment_node",
+    "default_inputs_builder",
+    "dict_slot_write_adapter",
+    "scalar_slot_write_adapter",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py
@@ -1,0 +1,122 @@
+"""Phase-node factory.
+
+Most phase nodes follow the same pattern:
+1. Build shared_context from state (config, prior_context, data_layer).
+2. Load the segment's skill text.
+3. Call the generic research agent with the segment's output model.
+4. Wrap the result in a ``SegmentSlot`` → stash under the phase's output dict.
+
+Instead of repeating that skeleton 20+ times, this factory produces a
+node callable from a small spec. Keeps phase modules short and makes the
+pattern reviewable in one place.
+
+Triage (delta-mode carry-forward) is wired in commit 8 — the factory takes
+an optional ``triage_gate`` callable that, when supplied, decides whether
+to regenerate or emit ``Carried`` for a given (state, segment_slug).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-update dict shape
+
+from pydantic import BaseModel
+
+from digigraph.graph.research_agent import run_research_agent
+
+from digiquant_atlas.skills import load_skill
+from digiquant_atlas.state import (
+    AtlasResearchState,
+    Carried,
+    SegmentPayload,
+    SegmentSlot,
+)
+
+
+@dataclass(frozen=True)
+class SegmentNodeSpec:
+    """Config for one segment-running node."""
+
+    segment_slug: str
+    """Stable slug written into SegmentPayload.segment and the output dict key."""
+
+    skill_slug: str
+    """Path in ``apps/digiquant-atlas/skills/<slug>/SKILL.md`` — the 'what to research'."""
+
+    output_model: type[BaseModel]
+    """Pydantic class the LLM output must validate against."""
+
+    phase_outputs_field: str
+    """AtlasResearchState attribute this node updates (e.g. 'phase1_outputs')."""
+
+
+def _shared_context(state: AtlasResearchState) -> dict[str, Any]:
+    """Assemble the stable, run-wide context block passed to every phase node.
+
+    Serialized with sorted keys inside run_research_agent's formatter, so
+    identical inputs produce identical cache keys across phase calls.
+    """
+    return {
+        "run_type": state.run_type,
+        "run_date": state.run_date.isoformat(),
+        "baseline_date": state.baseline_date.isoformat() if state.baseline_date else None,
+        "config": state.config.model_dump(mode="json"),
+        "prior_context": state.prior_context.model_dump(mode="json"),
+        "data_layer": state.data_layer.model_dump(mode="json"),
+    }
+
+
+def _phase_inputs(state: AtlasResearchState, spec: SegmentNodeSpec) -> dict[str, Any]:
+    """Volatile per-segment inputs. Kept small so the cache wins on stable parts.
+
+    For Phase 1–2 segments there is little per-segment volatile context
+    today — each alt-data / institutional sub-agent reads the macro regime
+    in their prompt only at Phase 3+. When a segment needs upstream phase
+    outputs, extend ``_phase_inputs`` to look up the relevant keys from state.
+    """
+    inputs: dict[str, Any] = {"segment": spec.segment_slug}
+    # If this is a Phase 3+ node, it can read earlier-phase outputs. Phases
+    # 1 and 2 don't consume prior-phase work beyond shared_context, so the
+    # baseline lookup is empty for them.
+    return inputs
+
+
+def build_segment_node(
+    spec: SegmentNodeSpec,
+    *,
+    triage_gate: Callable[[AtlasResearchState, str], Carried | None] | None = None,
+    model: str | None = None,
+) -> Callable[[AtlasResearchState], dict[str, Any]]:
+    """Return a LangGraph-shaped node function for one segment.
+
+    ``triage_gate`` (optional, wired in commit 8): if given and returns a
+    ``Carried`` for this (state, segment), the node short-circuits without
+    calling the LLM. Otherwise it regenerates.
+    """
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        if triage_gate is not None:
+            carried = triage_gate(state, spec.segment_slug)
+            if carried is not None:
+                slot = SegmentSlot(payload=carried)
+                return {spec.phase_outputs_field: {spec.segment_slug: slot}}
+
+        skill_text = load_skill(spec.skill_slug)
+        shared = _shared_context(state)
+        inputs = _phase_inputs(state, spec)
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=inputs,
+            shared_context=shared,
+            output_model=spec.output_model,
+            model=model,
+        )
+        payload = SegmentPayload(
+            segment=spec.segment_slug,
+            body=result.model_dump(mode="json"),
+            as_of=state.run_date,
+        )
+        slot = SegmentSlot(payload=payload)
+        return {spec.phase_outputs_field: {spec.segment_slug: slot}}
+
+    return _node

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase1_altdata.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase1_altdata.py
@@ -1,0 +1,124 @@
+"""Phase 1 — Alternative data & positioning signals (4-way parallel fan-out).
+
+Four sub-agents run in parallel: sentiment & news, CTA positioning, options
+& derivatives, politician signals. Per the orchestrator skill they "inform
+everything downstream" — macro and segment reads should be coloured by
+positioning and sentiment before they're classified.
+
+Design decision (commit 4): keep four separate Pydantic output models
+rather than collapsing into a single discriminated-union model. The four
+skills produce genuinely different structured metrics (sentiment scores vs
+CTA positioning vs options GEX vs STOCK Act filings); a single model would
+require a permissive body that would defeat the structured-output guarantee
+we want from run_research_agent. Four small models are clearer and also
+give each node its own validation error surface.
+
+Common shape (headline, bias, findings, sources, notes) comes from the
+shared :class:`digiquant_atlas.segments.SegmentReport` base.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
+from pydantic import Field
+
+from digiquant_atlas.phases._node_factory import (
+    SegmentNodeSpec,
+    build_segment_node,
+)
+from digiquant_atlas.segments import SegmentReport
+
+
+class SentimentNewsReport(SegmentReport):
+    """Phase 1A — retail + pro sentiment + news catalysts."""
+
+    aaii_bull_bear_spread: float | None = Field(
+        default=None,
+        description="AAII bulls minus bears; None if not available in today's context.",
+    )
+    cnn_fear_greed_index: int | None = Field(default=None, ge=0, le=100)
+    retail_sentiment_stance: Literal["risk_on", "risk_off", "mixed"] | None = None
+    top_catalysts: list[str] = Field(
+        default_factory=list,
+        description="≤5 short catalyst labels; ordered by significance.",
+    )
+
+
+class CtaPositioningReport(SegmentReport):
+    """Phase 1B — systematic trend-follower positioning."""
+
+    systematic_stance: Literal["long", "short", "neutral", "mixed"] | None = None
+    futures_oi_trend: Literal["expanding", "contracting", "flat"] | None = None
+    cta_flow_bias: Literal["adding", "reducing", "neutral"] | None = None
+
+
+class OptionsDerivativesReport(SegmentReport):
+    """Phase 1C — GEX, VIX, dealer positioning."""
+
+    vix_level: float | None = Field(default=None, ge=0)
+    vix_term_structure: Literal["contango", "backwardation", "flat"] | None = None
+    dealer_gamma: Literal["long", "short", "neutral"] | None = None
+    put_call_ratio: float | None = Field(default=None, ge=0)
+
+
+class PoliticianSignalsReport(SegmentReport):
+    """Phase 1D — Congressional trades (STOCK Act) + policy signals."""
+
+    notable_buys: list[str] = Field(default_factory=list, description="≤5 short tickers")
+    notable_sells: list[str] = Field(default_factory=list, description="≤5 short tickers")
+    policy_signal: str | None = Field(
+        default=None,
+        max_length=280,
+        description="Fed / Treasury / regulator signal worth flagging today.",
+    )
+
+
+# ─── Phase assembly ─────────────────────────────────────────────────────────
+
+_PHASE_FIELD = "phase1_outputs"
+
+_SPECS = (
+    SegmentNodeSpec(
+        segment_slug="alt-sentiment-news",
+        skill_slug="alt-sentiment-news",
+        output_model=SentimentNewsReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+    SegmentNodeSpec(
+        segment_slug="alt-cta-positioning",
+        skill_slug="alt-cta-positioning",
+        output_model=CtaPositioningReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+    SegmentNodeSpec(
+        segment_slug="alt-options-derivatives",
+        skill_slug="alt-options-derivatives",
+        output_model=OptionsDerivativesReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+    SegmentNodeSpec(
+        segment_slug="alt-politician-signals",
+        skill_slug="alt-politician-signals",
+        output_model=PoliticianSignalsReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+)
+
+
+def build_phase1() -> PipelinePhase:
+    """Return the Phase-1 fan-out (4 parallel nodes)."""
+    return PipelinePhase(
+        name="phase1_altdata",
+        nodes=[NodeSpec(name=spec.segment_slug, run=build_segment_node(spec)) for spec in _SPECS],
+    )
+
+
+__all__ = [
+    "CtaPositioningReport",
+    "OptionsDerivativesReport",
+    "PoliticianSignalsReport",
+    "SentimentNewsReport",
+    "build_phase1",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase2_institutional.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase2_institutional.py
@@ -1,0 +1,76 @@
+"""Phase 2 — Institutional intelligence (2-way parallel fan-out).
+
+Two sub-agents: ETF / dark-pool / 13F flows, and hedge-fund intel. Per the
+orchestrator skill, these signals are often 1–4 weeks ahead of public
+price moves — Phase 7 synthesis weights them highly in the bias row.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
+from pydantic import Field
+
+from digiquant_atlas.phases._node_factory import (
+    SegmentNodeSpec,
+    build_segment_node,
+)
+from digiquant_atlas.segments import SegmentReport
+
+
+class InstitutionalFlowsReport(SegmentReport):
+    """Phase 2A — ETF inflows / outflows, dark-pool prints, 13D/13G/Form 4."""
+
+    flow_direction: Literal["inflow", "outflow", "mixed"] | None = None
+    largest_sector_inflow: str | None = Field(default=None, max_length=64)
+    largest_sector_outflow: str | None = Field(default=None, max_length=64)
+    notable_filings: list[str] = Field(
+        default_factory=list,
+        description="≤5 short filing labels (e.g., '13D by Elliott on XYZ').",
+    )
+
+
+class HedgeFundIntelReport(SegmentReport):
+    """Phase 2B — tracked-fund signals (13F, X posts, conference calls)."""
+
+    tracked_funds_count: int = Field(default=0, ge=0)
+    top_signals: list[str] = Field(
+        default_factory=list,
+        description="≤8 short signal labels; ordered by conviction.",
+    )
+
+
+# ─── Phase assembly ─────────────────────────────────────────────────────────
+
+_PHASE_FIELD = "phase2_outputs"
+
+_SPECS = (
+    SegmentNodeSpec(
+        segment_slug="inst-institutional-flows",
+        skill_slug="inst-institutional-flows",
+        output_model=InstitutionalFlowsReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+    SegmentNodeSpec(
+        segment_slug="inst-hedge-fund-intel",
+        skill_slug="inst-hedge-fund-intel",
+        output_model=HedgeFundIntelReport,
+        phase_outputs_field=_PHASE_FIELD,
+    ),
+)
+
+
+def build_phase2() -> PipelinePhase:
+    """Return the Phase-2 fan-out (2 parallel nodes)."""
+    return PipelinePhase(
+        name="phase2_institutional",
+        nodes=[NodeSpec(name=spec.segment_slug, run=build_segment_node(spec)) for spec in _SPECS],
+    )
+
+
+__all__ = [
+    "HedgeFundIntelReport",
+    "InstitutionalFlowsReport",
+    "build_phase2",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/preflight.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/preflight.py
@@ -1,0 +1,106 @@
+"""Pre-flight phase: load config + prior context + data-layer probe.
+
+Maps to the ``Pre-Flight Protocol`` section of
+``apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md``. Runs once before
+Phase 1; populates the frozen shared-context fields of
+``AtlasResearchState`` so downstream phase nodes' LLM calls can cache them.
+
+This module intentionally does not touch the LLM — pre-flight is pure data
+loading. LLM costs start at Phase 1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Callable
+
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    DataLayerSnapshot,
+)
+from digiquant_atlas.supabase_io import (
+    SupabaseClient,
+    load_prior_context,
+    query_macro_series_freshness,
+    query_price_technicals_freshness,
+)
+
+
+@dataclass(frozen=True)
+class PreflightDeps:
+    """Wiring deps for the preflight node.
+
+    Dependency-injected so the phase-4 integration test and the production
+    graph builder both get the same entry point. ``config_loader`` is a
+    caller-supplied closure that reads ``apps/digiquant-atlas/config/*``
+    (or a test fixture) and returns an ``AtlasConfigBundle``.
+    """
+
+    client: SupabaseClient
+    config_loader: Callable[[], AtlasConfigBundle]
+    # Staleness threshold for price_technicals: if the latest date is older
+    # than run_date - this many days, we flag a fallback in DataLayerSnapshot.
+    price_staleness_days: int = 3
+
+
+def _data_layer_snapshot(deps: PreflightDeps, run_date: date) -> DataLayerSnapshot:
+    """Probe price_technicals + macro_series freshness. Never raises on
+    empty tables — absence is a valid answer here, and the sub-graph
+    compensates via fallback_used."""
+    latest_tech, ticker_count = query_price_technicals_freshness(client=deps.client)
+    macro_latest = query_macro_series_freshness(client=deps.client)
+
+    fallback: str = "supabase"
+    if latest_tech is None:
+        fallback = "none"
+    else:
+        # Stale data → caller should prefer scripts/mcp fallback. This decision
+        # lives with the phase-3 macro node today, but we surface it here so
+        # triage (commit 8) can consider it.
+        stale_cutoff = run_date - _days(deps.price_staleness_days)
+        if latest_tech < stale_cutoff:
+            fallback = "scripts"
+
+    return DataLayerSnapshot(
+        price_technicals_latest=latest_tech,
+        price_technicals_ticker_count=ticker_count,
+        macro_series_latest=macro_latest,
+        fallback_used=fallback,  # type: ignore[arg-type]
+    )
+
+
+def _days(n: int):
+    """Return a timedelta(days=n). Import deferred to keep module-top small."""
+    from datetime import timedelta
+
+    return timedelta(days=n)
+
+
+def build_preflight_node(deps: PreflightDeps) -> Callable[[AtlasResearchState], dict]:
+    """Return the preflight node function bound to ``deps``.
+
+    The returned callable matches LangGraph's node signature
+    (``(state) -> dict of field updates``) and is registered via
+    pipeline_builder's ``NodeSpec``.
+    """
+
+    def preflight(state: AtlasResearchState) -> dict:
+        # Delta runs MUST supply a baseline_date. We enforce it here (not at
+        # state construction) so the caller sees a clear error instead of a
+        # silent ignored field. See docs/plans/atlas-digigraph-migration.md §3.
+        if state.run_type == "delta" and state.baseline_date is None:
+            raise ValueError("delta run requires baseline_date to be set on AtlasResearchState")
+
+        config = deps.config_loader()
+        prior_context = load_prior_context(client=deps.client, run_date=state.run_date)
+        data_layer = _data_layer_snapshot(deps, state.run_date)
+
+        return {
+            "config": config,
+            "prior_context": prior_context,
+            "data_layer": data_layer,
+        }
+
+    return preflight

--- a/apps/digiquant-atlas/src/digiquant_atlas/schemas.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/schemas.py
@@ -1,0 +1,72 @@
+"""Authoritative-schema loader.
+
+JSON Schemas under ``apps/digiquant-atlas/templates/`` are the system of
+record for segment payload shapes. Pydantic models in later commits are
+validated *against* these schemas — never re-authored from scratch.
+
+This module:
+- Loads a schema by logical name (``load_schema("sector-report")``).
+- Validates a payload dict against a schema with one call.
+- Provides ``list_schema_names()`` for the commit-9 drift check that pairs
+  segments to schemas.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any  # noqa: F401 — used for JSON-schema payload dict shape
+
+import jsonschema
+
+
+class SchemaNotFoundError(FileNotFoundError):
+    """Raised when a schema name does not resolve to a file on disk."""
+
+
+def _templates_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "templates"
+
+
+def _schema_path(name: str) -> Path:
+    """Resolve a logical name to one of two on-disk locations.
+
+    Order of precedence:
+    1. ``templates/schemas/<name>.schema.json`` — most schemas live here.
+    2. ``templates/<name>-schema.json`` — top-level schemas (digest snapshot,
+       delta request, snapshot). Kept flat for historical reasons; we tolerate
+       both so callers don't have to remember which bucket a schema is in.
+    """
+    nested = _templates_root() / "schemas" / f"{name}.schema.json"
+    if nested.is_file():
+        return nested
+    flat = _templates_root() / f"{name}-schema.json"
+    if flat.is_file():
+        return flat
+    raise SchemaNotFoundError(f"schema not found: {name!r} (looked at {nested} and {flat})")
+
+
+@lru_cache(maxsize=64)
+def load_schema(name: str) -> dict[str, Any]:
+    """Return the JSON Schema dict for ``name``. Cached per process."""
+    return json.loads(_schema_path(name).read_text(encoding="utf-8"))
+
+
+def validate_payload(name: str, payload: dict[str, Any]) -> None:
+    """Raise ``jsonschema.ValidationError`` if ``payload`` does not match ``name``."""
+    schema = load_schema(name)
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def list_schema_names() -> list[str]:
+    """Return every schema name discoverable under ``templates/``. Sorted."""
+    root = _templates_root()
+    names: set[str] = set()
+    nested = root / "schemas"
+    if nested.is_dir():
+        for p in nested.glob("*.schema.json"):
+            names.add(p.name.removesuffix(".schema.json"))
+    for p in root.glob("*-schema.json"):
+        names.add(p.name.removesuffix("-schema.json"))
+    return sorted(names)

--- a/apps/digiquant-atlas/src/digiquant_atlas/segments.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/segments.py
@@ -1,0 +1,91 @@
+"""Shared segment output-model primitives.
+
+Every phase 1–5 segment produces a structured report; the shape has a common
+core (segment, date, bias, headline, findings, sources, notes) plus
+segment-specific extensions. Those extensions live with their phase modules;
+this file defines the reusable core.
+
+Kept minimal on purpose — the legacy Atlas system does not have strict
+per-segment schemas beyond the overall digest/delta contracts in
+``templates/schemas/``. We pick a clean Pydantic shape that makes the LLM's
+output deterministic, covers everything the Phase 7 digest synthesis needs
+to read, and leaves room for richer per-segment fields in sub-classes.
+"""
+
+from __future__ import annotations
+
+from datetime import date as _date
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+# Narrow stance vocabulary shared across asset classes / sectors.
+# Phase 7 synthesis maps these to the digest's bias row.
+Bias = Literal[
+    "strong_bullish",
+    "bullish",
+    "neutral",
+    "bearish",
+    "strong_bearish",
+    "mixed",
+]
+
+
+class Finding(BaseModel):
+    """One material finding produced by a segment analyst."""
+
+    label: str = Field(
+        description="Short noun phrase labeling the finding (e.g. 'Breakout above 200-DMA')",
+        max_length=120,
+    )
+    summary: str = Field(
+        description="1-3 sentence description in analyst voice. Quantified where possible.",
+        max_length=800,
+    )
+    source_ids: list[str] = Field(
+        default_factory=list,
+        description="Source IDs from the sources list this finding cites.",
+    )
+
+
+class Source(BaseModel):
+    """One source cited by the segment's findings."""
+
+    id: str = Field(max_length=64, description="Stable identifier used by Finding.source_ids")
+    title: str | None = Field(default=None, max_length=300)
+    url: str | None = Field(default=None, max_length=1000)
+
+
+class SegmentReport(BaseModel):
+    """Common shape for Phase 1–5 segment reports.
+
+    Phase-specific sub-classes add structured metrics (sentiment scores,
+    flow direction, yield curve shape, etc.). Phase 7 synthesis reads only
+    the fields here when assembling the master digest, so downstream
+    consumers never depend on segment-specific extensions.
+    """
+
+    segment: str = Field(
+        description="Stable segment slug, e.g. 'alt-sentiment-news', 'macro'.",
+        max_length=64,
+    )
+    date: _date
+    bias: Bias
+    headline: str = Field(
+        description="One-sentence executive summary; the strongest single signal today.",
+        max_length=280,
+    )
+    material_findings: list[Finding] = Field(
+        default_factory=list,
+        description="Material findings, ordered by importance.",
+    )
+    sources: list[Source] = Field(
+        default_factory=list,
+        description="Every source referenced by findings.source_ids.",
+    )
+    notes: str = Field(
+        default="",
+        description="Free-form analyst notes — uncertainty, contradictions, regime caveats.",
+        max_length=2000,
+    )

--- a/apps/digiquant-atlas/src/digiquant_atlas/skills.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/skills.py
@@ -43,25 +43,34 @@ def _skill_path(slug: str) -> Path:
     return _atlas_root() / "skills" / slug / "SKILL.md"
 
 
+class MalformedFrontmatterError(ValueError):
+    """Raised when a SKILL.md starts with ``---`` but has a broken YAML block."""
+
+
 def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
     """Return (frontmatter_dict, body).
 
-    If the file has no frontmatter, returns ({}, raw). If the frontmatter
-    block is malformed, raises ``yaml.YAMLError`` — callers get a real error
-    rather than silently-empty metadata.
+    - No frontmatter (no leading ``---``) → ``({}, raw)``.
+    - Well-formed YAML frontmatter → parsed dict + body.
+    - Opening ``---`` but missing closing fence, or non-dict YAML → raise
+      :class:`MalformedFrontmatterError`. Silent fallback would mask
+      authoring errors in skill files, so the loader now fails loud.
     """
     text = raw.lstrip()
     if not text.startswith("---"):
         return {}, raw
-    # Split into the opening fence, the frontmatter body, and the rest.
     parts = text.split("---", 2)
     if len(parts) < 3:
-        return {}, raw
+        raise MalformedFrontmatterError(
+            "frontmatter starts with '---' but no closing fence found"
+        )
     frontmatter_src = parts[1]
     body = parts[2].lstrip("\n")
     meta = yaml.safe_load(frontmatter_src) or {}
     if not isinstance(meta, dict):
-        return {}, raw
+        raise MalformedFrontmatterError(
+            f"frontmatter must be a YAML mapping, got {type(meta).__name__}"
+        )
     return meta, body
 
 

--- a/apps/digiquant-atlas/src/digiquant_atlas/skills.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/skills.py
@@ -1,0 +1,96 @@
+"""Skill-file loader.
+
+A skill is a ``skills/<slug>/SKILL.md`` under ``apps/digiquant-atlas/skills/``.
+The file has YAML frontmatter (``name``, ``description``) followed by Markdown
+instructions. Only the Markdown body is relevant at inference time; the
+frontmatter exists for human catalog tooling.
+
+Design:
+- One function, ``load_skill(slug)``, returns the body as a string.
+- Optional ``load_skill_with_frontmatter`` returns (frontmatter_dict, body)
+  for code paths that need both (e.g. the skills catalog CI check in #176's
+  commit 9).
+- Skills directory is resolved relative to the ``apps/digiquant-atlas/``
+  package root so tests + production use the same path.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+
+class SkillNotFoundError(FileNotFoundError):
+    """Raised when ``skills/<slug>/SKILL.md`` is missing.
+
+    Separate exception type so callers (triage, phase wiring) can distinguish
+    'skill missing' from other I/O errors and fail loudly with a usable message.
+    """
+
+
+def _atlas_root() -> Path:
+    """Return the ``apps/digiquant-atlas/`` directory.
+
+    Resolved relative to this file's location: ``src/digiquant_atlas/skills.py``
+    lives four levels below the apps root.
+    """
+    return Path(__file__).resolve().parents[2]
+
+
+def _skill_path(slug: str) -> Path:
+    return _atlas_root() / "skills" / slug / "SKILL.md"
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
+    """Return (frontmatter_dict, body).
+
+    If the file has no frontmatter, returns ({}, raw). If the frontmatter
+    block is malformed, raises ``yaml.YAMLError`` — callers get a real error
+    rather than silently-empty metadata.
+    """
+    text = raw.lstrip()
+    if not text.startswith("---"):
+        return {}, raw
+    # Split into the opening fence, the frontmatter body, and the rest.
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}, raw
+    frontmatter_src = parts[1]
+    body = parts[2].lstrip("\n")
+    meta = yaml.safe_load(frontmatter_src) or {}
+    if not isinstance(meta, dict):
+        return {}, raw
+    return meta, body
+
+
+@lru_cache(maxsize=64)
+def load_skill(slug: str) -> str:
+    """Return the Markdown body of ``skills/<slug>/SKILL.md``.
+
+    Cached — skill bodies are static per process.
+    """
+    path = _skill_path(slug)
+    if not path.is_file():
+        raise SkillNotFoundError(f"skill not found: {slug!r} (expected at {path})")
+    raw = path.read_text(encoding="utf-8")
+    _, body = _split_frontmatter(raw)
+    return body.strip()
+
+
+def load_skill_with_frontmatter(slug: str) -> tuple[dict[str, object], str]:
+    """Return (frontmatter, body). Used by catalog / drift-check tooling."""
+    path = _skill_path(slug)
+    if not path.is_file():
+        raise SkillNotFoundError(f"skill not found: {slug!r} (expected at {path})")
+    raw = path.read_text(encoding="utf-8")
+    return _split_frontmatter(raw)
+
+
+def list_skill_slugs() -> list[str]:
+    """Return every slug for which ``skills/<slug>/SKILL.md`` exists. Sorted."""
+    root = _atlas_root() / "skills"
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir() if p.is_dir() and (p / "SKILL.md").is_file())

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -142,7 +142,9 @@ class AtlasResearchState(BaseModel):
     - Frozen context (config, prior_context, data_layer) — shared-context cache key.
     - Per-phase outputs as ``dict[str, SegmentSlot]`` keyed by segment slug.
     - Triage result (delta runs only).
-    - Side-effect ledgers (published, errors).
+    - Side-effect ledgers (``published``, ``errors``) — append-only by
+      convention. Phase nodes should use ``list.append`` (never reassign).
+      A future commit may replace with an ``Annotated[list, add]`` reducer.
     """
 
     run_id: UUID = Field(default_factory=uuid4)

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -19,6 +19,10 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class SegmentSlotCollisionError(RuntimeError):
+    """Two nodes wrote the same segment slug in one run — a wiring bug."""
+
+
 def _merge_segment_dict(
     left: dict[str, "SegmentSlot"] | None,
     right: dict[str, "SegmentSlot"] | None,
@@ -28,14 +32,21 @@ def _merge_segment_dict(
     Each phase-1/2/4/5 node returns ``{phase_N_outputs: {segment_slug: slot}}``
     for its own segment only. LangGraph combines concurrent writes to the
     same field via this reducer — without it, LangGraph raises
-    ``InvalidConcurrentGraphUpdate``. The reducer prefers the right-hand
-    (newer) slot on key collision, but in practice each segment is written
-    by exactly one node per run.
+    ``InvalidConcurrentGraphUpdate``.
+
+    Collision (two writes for the same segment slug) is a copy-paste-style
+    wiring bug and fails loud here. Silent right-wins would mask a
+    mis-wired graph and produce nondeterministic output.
     """
     if not left:
         return dict(right or {})
     if not right:
         return dict(left)
+    collisions = set(left) & set(right)
+    if collisions:
+        raise SegmentSlotCollisionError(
+            f"two nodes wrote the same segment slug(s): {sorted(collisions)}"
+        )
     merged = dict(left)
     merged.update(right)
     return merged

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -13,10 +13,32 @@ into ``AtlasResearchState`` via ``SegmentPayload | Carried``.
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Literal  # noqa: F401 — used for dict shape typing below
+from typing import Annotated, Any, Literal  # noqa: F401 — used for dict shape typing below
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+def _merge_segment_dict(
+    left: dict[str, "SegmentSlot"] | None,
+    right: dict[str, "SegmentSlot"] | None,
+) -> dict[str, "SegmentSlot"]:
+    """Reducer for parallel phase-output writes.
+
+    Each phase-1/2/4/5 node returns ``{phase_N_outputs: {segment_slug: slot}}``
+    for its own segment only. LangGraph combines concurrent writes to the
+    same field via this reducer — without it, LangGraph raises
+    ``InvalidConcurrentGraphUpdate``. The reducer prefers the right-hand
+    (newer) slot on key collision, but in practice each segment is written
+    by exactly one node per run.
+    """
+    if not left:
+        return dict(right or {})
+    if not right:
+        return dict(left)
+    merged = dict(left)
+    merged.update(right)
+    return merged
 
 
 RunType = Literal["baseline", "delta", "monthly"]
@@ -156,11 +178,22 @@ class AtlasResearchState(BaseModel):
     prior_context: PriorContext = Field(default_factory=PriorContext)
     data_layer: DataLayerSnapshot = Field(default_factory=DataLayerSnapshot)
 
-    phase1_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
-    phase2_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    # Parallel fan-out fields: Annotated with the segment-dict reducer so
+    # LangGraph merges concurrent writes from per-segment phase nodes instead
+    # of raising InvalidConcurrentGraphUpdate.
+    phase1_outputs: Annotated[dict[str, SegmentSlot], _merge_segment_dict] = Field(
+        default_factory=dict
+    )
+    phase2_outputs: Annotated[dict[str, SegmentSlot], _merge_segment_dict] = Field(
+        default_factory=dict
+    )
     phase3_output: SegmentSlot | None = None
-    phase4_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
-    phase5_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    phase4_outputs: Annotated[dict[str, SegmentSlot], _merge_segment_dict] = Field(
+        default_factory=dict
+    )
+    phase5_outputs: Annotated[dict[str, SegmentSlot], _merge_segment_dict] = Field(
+        default_factory=dict
+    )
     phase6_bias_row: dict[str, Any] | None = None
     phase7_digest: dict[str, Any] | None = None
     phase7c_analysts: dict[str, dict[str, Any]] = Field(default_factory=dict)

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -1,0 +1,170 @@
+"""Atlas sub-graph state model.
+
+Why Pydantic (not TypedDict): sub-graph-internal state benefits from validation
+and discriminated unions — see ADR-0008. Supervisor-level state in DigiGraph
+stays a TypedDict (``digigraph.graph.state.WorkflowState``) for different
+reasons (reducer composition). The conventions are documented; don't mix them.
+
+Shared sub-models used across phases are defined here. Per-phase segment
+output models live in their phase modules (commits 4–7) and are slotted
+into ``AtlasResearchState`` via ``SegmentPayload | Carried``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Literal  # noqa: F401 — used for dict shape typing below
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+RunType = Literal["baseline", "delta", "monthly"]
+"""Three-tier cadence: Sunday full, weekday delta, month-end rollup."""
+
+
+class Carried(BaseModel):
+    """Marker that a segment was not regenerated on this run.
+
+    Downstream consumers (synthesis, dashboard) treat ``Carried`` as
+    'read the baseline payload from Supabase for this segment'. Explicit
+    carry-forward is safer than a silently missing segment.
+    """
+
+    baseline_date: date
+    reason: str = Field(description="Why this segment was carried, e.g. 'below_triage_threshold'")
+    source: Literal["carried"] = "carried"
+
+
+class SegmentPayload(BaseModel):
+    """A freshly generated segment output.
+
+    The ``body`` field holds the validated per-segment Pydantic model's
+    ``.model_dump()`` — typed on the way in (at the phase node), untyped at
+    this state-container level so state.py doesn't have to import every
+    phase's segment model.
+    """
+
+    segment: str = Field(description="Stable segment slug, e.g. 'macro', 'sector-technology'")
+    body: dict[str, Any] = Field(
+        description="Validated segment payload — matches templates/schemas/<segment>.json"
+    )
+    source: Literal["today"] = "today"
+    as_of: date
+
+
+class SegmentSlot(BaseModel):
+    """Discriminated slot: either a fresh payload or an explicit carry marker.
+
+    Downstream code reads ``slot.source`` before accessing fields; this
+    discriminator is what keeps fresh-vs-carried decisions auditable.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    payload: SegmentPayload | Carried = Field(discriminator="source")
+
+
+class AtlasConfigBundle(BaseModel):
+    """Static per-run config. Frozen so the LLM cache key stays stable across phases."""
+
+    model_config = ConfigDict(frozen=True)
+
+    watchlist: list[str] = Field(default_factory=list)
+    investment_profile: dict[str, Any] = Field(default_factory=dict)
+    hedge_funds: list[str] = Field(default_factory=list)
+    preferences: dict[str, Any] = Field(default_factory=dict)
+    macro_series: list[str] = Field(default_factory=list)
+
+
+class PriorContext(BaseModel):
+    """Pre-flight load from Supabase. Frozen — same caching rationale as AtlasConfigBundle."""
+
+    model_config = ConfigDict(frozen=True)
+
+    last_snapshots: list[dict[str, Any]] = Field(default_factory=list)
+    latest_segments: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Segment slug → latest published payload (from Supabase documents)",
+    )
+    active_theses: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DataLayerSnapshot(BaseModel):
+    """Freshness probe for price/macro data. Populated in pre-flight."""
+
+    price_technicals_latest: date | None = None
+    price_technicals_ticker_count: int = 0
+    macro_series_latest: date | None = None
+    fallback_used: Literal["supabase", "scripts", "mcp", "none"] = "none"
+
+
+class DeltaTriageDecision(BaseModel):
+    """Per-segment triage outcome on a delta run."""
+
+    segment: str
+    decision: Literal["regenerate", "carry"]
+    reason: str
+    tier: Literal["mandatory", "high", "standard", "low"]
+
+
+class DeltaTriageResult(BaseModel):
+    """Output of the triage preamble on delta runs."""
+
+    evaluated_at: date
+    baseline_date: date
+    decisions: list[DeltaTriageDecision] = Field(default_factory=list)
+
+
+class PublishedArtifact(BaseModel):
+    """One row published to Supabase. Appended to state.published by the Supabase adapter."""
+
+    table: str
+    document_key: str | None = None
+    row_id: str
+    published_at: date
+
+
+class PhaseError(BaseModel):
+    """Recoverable per-phase error; collected into state.errors for the audit row."""
+
+    phase: str
+    node: str
+    message: str
+    retryable: bool = True
+
+
+class AtlasResearchState(BaseModel):
+    """Sub-graph state. See ``docs/plans/atlas-digigraph-migration.md`` for field rationale.
+
+    Field grouping:
+    - Run metadata (run_id, run_type, dates).
+    - Frozen context (config, prior_context, data_layer) — shared-context cache key.
+    - Per-phase outputs as ``dict[str, SegmentSlot]`` keyed by segment slug.
+    - Triage result (delta runs only).
+    - Side-effect ledgers (published, errors).
+    """
+
+    run_id: UUID = Field(default_factory=uuid4)
+    run_type: RunType
+    run_date: date
+    baseline_date: date | None = None
+
+    config: AtlasConfigBundle = Field(default_factory=AtlasConfigBundle)
+    prior_context: PriorContext = Field(default_factory=PriorContext)
+    data_layer: DataLayerSnapshot = Field(default_factory=DataLayerSnapshot)
+
+    phase1_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    phase2_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    phase3_output: SegmentSlot | None = None
+    phase4_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    phase5_outputs: dict[str, SegmentSlot] = Field(default_factory=dict)
+    phase6_bias_row: dict[str, Any] | None = None
+    phase7_digest: dict[str, Any] | None = None
+    phase7c_analysts: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    phase7d_rebalance: dict[str, Any] | None = None
+    phase9_evolution: dict[str, Any] | None = None
+
+    triage: DeltaTriageResult | None = None
+    published: list[PublishedArtifact] = Field(default_factory=list)
+    errors: list[PhaseError] = Field(default_factory=list)

--- a/apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py
@@ -56,24 +56,42 @@ class SupabaseConfig:
     def from_env(cls) -> "SupabaseConfig":
         url = os.environ.get("SUPABASE_URL", "").strip()
         key = os.environ.get("SUPABASE_SERVICE_KEY", "").strip()
-        if not url or not key:
-            raise SupabaseNotConfiguredError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set")
+        missing: list[str] = []
+        if not url:
+            missing.append("SUPABASE_URL")
+        if not key:
+            missing.append("SUPABASE_SERVICE_KEY")
+        if missing:
+            raise SupabaseNotConfiguredError(f"missing required env var(s): {', '.join(missing)}")
         return cls(url=url, service_key=key)
 
 
-def _build_client(cfg: SupabaseConfig) -> SupabaseClient:
-    """Construct a live Supabase client. Kept module-local so tests can skip the import."""
-    from supabase import create_client  # deferred — supabase is an optional dep for unit tests
+def build_client(cfg: SupabaseConfig) -> SupabaseClient:
+    """Construct a live Supabase client from config.
+
+    The ``supabase`` package is an optional extra; this helper defers the
+    import so unit tests (which use :class:`FakeSupabaseClient`) never need
+    it installed. Production entry points (commit 9's graph compiler) call
+    this once at startup.
+    """
+    from supabase import create_client  # deferred — supabase is an optional dep
 
     return create_client(cfg.url, cfg.service_key)  # type: ignore[return-value]
 
 
 def _audit(event_type: str, payload: dict[str, Any]) -> None:
-    """Emit an audit line with sensitive keys redacted.
+    """Emit an audit line with top-level sensitive keys redacted.
 
-    This module only logs via the standard logger; downstream JSONL audit
-    writers (DigiGraph's ``audit.py``) will add timestamps/event envelopes.
-    Redaction happens here so the audit writer never sees raw secrets.
+    Contract — important:
+    - ``digibase.audit.redact_mapping`` replaces VALUES of keys whose names
+      contain ``password|api_key|token|secret``. It does not recurse into
+      nested structures and does not pattern-match values.
+    - Callers MUST pass only non-sensitive metadata (document_key, date,
+      doc_type, run_type). Never pass raw LLM payloads, response bodies,
+      or ``content``/``payload``/``snapshot`` blobs — those may contain
+      PII or prompt text that the shallow redactor will not scrub.
+    - This logger.info call emits to the standard logger; DigiGraph's
+      ``audit.py`` wraps that into structured JSONL downstream.
     """
     logger.info("atlas_io audit: %s %s", event_type, redact_mapping(payload))
 
@@ -168,13 +186,26 @@ def load_prior_context(
     client: SupabaseClient,
     run_date: date,
     snapshot_lookback: int = 5,
+    documents_lookback_days: int = 30,
+    documents_row_cap: int = 500,
 ) -> PriorContext:
     """Query recent ``daily_snapshots`` + latest-per-segment ``documents``.
 
     Returns a :class:`PriorContext` suitable for populating the
     ``shared_context`` block of every phase node's LLM call — so it's cached
     across the run.
+
+    Bounding strategy:
+    - ``snapshot_lookback`` rows from ``daily_snapshots`` (default 5).
+    - ``documents_lookback_days`` day floor on ``documents`` reads
+      (default 30 — a week's baseline + six deltas + slack). Combined with
+      ``documents_row_cap`` (default 500) this caps the bytes pulled even
+      on extreme churn days; any key whose latest write predates the floor
+      is treated as absent, which is the same behavior the sub-graph gets
+      on a fresh tenant.
     """
+    from datetime import timedelta
+
     snapshots_resp = (
         client.table("daily_snapshots")
         .select("date, run_type, baseline_date, snapshot")
@@ -185,14 +216,18 @@ def load_prior_context(
     )
     last_snapshots: list[dict[str, Any]] = list(getattr(snapshots_resp, "data", None) or [])
 
-    # Latest row per document_key across recent dates. Keep it simple: one
-    # query over the last ~30 days, then pick the max-date row per key in Python.
+    # Documents window: [run_date - documents_lookback_days, run_date).
+    # Anything older is intentionally ignored — the sub-graph treats a
+    # missing segment the same regardless of whether it never existed or
+    # simply hasn't been refreshed recently.
+    floor = (run_date - timedelta(days=documents_lookback_days)).isoformat()
     docs_resp = (
         client.table("documents")
         .select("date, document_key, doc_type, payload")
+        .gte("date", floor)
         .lt("date", run_date.isoformat())
         .order("date", desc=True)
-        .limit(200)
+        .limit(documents_row_cap)
         .execute()
     )
     latest_by_key: dict[str, dict[str, Any]] = {}
@@ -218,19 +253,34 @@ def load_prior_context(
 def query_price_technicals_freshness(
     *,
     client: SupabaseClient,
+    recent_days: int = 7,
 ) -> tuple[date | None, int]:
     """Return (latest_date, distinct_ticker_count) from ``price_technicals``.
 
     Used in pre-flight to decide whether to fall back to local fetch scripts
     (mirrors the Data Layer Check in ``skills/orchestrator/SKILL.md``).
+
+    Two bounded queries instead of a full-table scan:
+    1. ``order(date desc).limit(1)`` for the latest date.
+    2. Rows from the last ``recent_days`` days for the distinct-ticker count.
+       A 7-day window matches the orchestrator skill's "within 3 calendar
+       days" staleness rule with headroom for weekend / holiday gaps.
     """
-    resp = client.table("price_technicals").select("date, ticker").execute()
-    rows: list[dict[str, Any]] = list(getattr(resp, "data", None) or [])
-    if not rows:
+    from datetime import timedelta
+
+    latest_resp = (
+        client.table("price_technicals").select("date").order("date", desc=True).limit(1).execute()
+    )
+    latest_rows: list[dict[str, Any]] = list(getattr(latest_resp, "data", None) or [])
+    if not latest_rows:
         return None, 0
-    dates = [_parse_date(r["date"]) for r in rows if r.get("date")]
-    tickers = {r.get("ticker") for r in rows if r.get("ticker")}
-    return (max(dates) if dates else None), len(tickers)
+    latest = _parse_date(latest_rows[0]["date"])
+
+    floor = (latest - timedelta(days=recent_days)).isoformat()
+    recent_resp = client.table("price_technicals").select("ticker").gte("date", floor).execute()
+    recent_rows: list[dict[str, Any]] = list(getattr(recent_resp, "data", None) or [])
+    tickers = {r.get("ticker") for r in recent_rows if r.get("ticker")}
+    return latest, len(tickers)
 
 
 def query_macro_series_freshness(
@@ -252,7 +302,16 @@ def query_macro_series_freshness(
 
 
 def _extract_row_id(resp: Any) -> str | None:
-    """Supabase client returns a response object with ``.data`` list-of-dicts on success."""
+    """Best-effort row identifier from a Supabase upsert response.
+
+    ``PublishedArtifact.row_id`` is used only for audit correlation, not as
+    a primary key. We prefer the Postgres ``id`` column when present and
+    fall back to the natural key (``date``) if not. Callers whose schemas
+    have autogen ids should add ``.select("id")`` to the upsert chain so
+    this function finds the real id; otherwise the natural-key fallback
+    is intentional and documented. Either way the returned string is a
+    stable correlation handle for that upsert.
+    """
     data = getattr(resp, "data", None)
     if isinstance(data, list) and data:
         first = data[0]

--- a/apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py
@@ -1,0 +1,267 @@
+"""Supabase adapter for the Atlas sub-graph.
+
+Replaces the legacy ``scripts/publish_document.py`` and
+``scripts/materialize_snapshot.py`` write paths from inside the DigiGraph
+sub-graph. Same tables, same unique keys — the legacy scripts will be frozen
+in commit 9 so both paths can never write concurrently.
+
+Design:
+- Thin wrapper over the ``supabase`` Python client. No ORM.
+- Dependency-injected client (:class:`SupabaseClient` protocol) so unit tests
+  use an in-memory fake without a live DB.
+- Every write passes its payload through ``digibase.audit.redact_mapping``
+  before the audit log line is emitted — non-negotiable per CLAUDE.md.
+- Idempotency: all writes are upserts on the schema-declared unique keys
+  (``(date, document_key)`` for ``documents``; ``date`` for ``daily_snapshots``).
+  Retries of the same node are safe.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Protocol  # noqa: F401 — used for Supabase payload dict shape
+
+from digibase.audit import redact_mapping
+
+from digiquant_atlas.state import PriorContext, PublishedArtifact
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseClient(Protocol):
+    """Minimal surface we use from the ``supabase`` Python client.
+
+    Defined as a Protocol so tests can inject a fake without pulling the
+    supabase dependency. Production callers pass the real ``Client``.
+    """
+
+    def table(self, name: str) -> Any: ...  # noqa: D401, E704
+
+
+class SupabaseNotConfiguredError(RuntimeError):
+    """Raised when SUPABASE_URL / SUPABASE_SERVICE_KEY are missing at runtime."""
+
+
+@dataclass(frozen=True)
+class SupabaseConfig:
+    """Runtime config. Resolved from env vars by default; override-able in tests."""
+
+    url: str
+    service_key: str
+
+    @classmethod
+    def from_env(cls) -> "SupabaseConfig":
+        url = os.environ.get("SUPABASE_URL", "").strip()
+        key = os.environ.get("SUPABASE_SERVICE_KEY", "").strip()
+        if not url or not key:
+            raise SupabaseNotConfiguredError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set")
+        return cls(url=url, service_key=key)
+
+
+def _build_client(cfg: SupabaseConfig) -> SupabaseClient:
+    """Construct a live Supabase client. Kept module-local so tests can skip the import."""
+    from supabase import create_client  # deferred — supabase is an optional dep for unit tests
+
+    return create_client(cfg.url, cfg.service_key)  # type: ignore[return-value]
+
+
+def _audit(event_type: str, payload: dict[str, Any]) -> None:
+    """Emit an audit line with sensitive keys redacted.
+
+    This module only logs via the standard logger; downstream JSONL audit
+    writers (DigiGraph's ``audit.py``) will add timestamps/event envelopes.
+    Redaction happens here so the audit writer never sees raw secrets.
+    """
+    logger.info("atlas_io audit: %s %s", event_type, redact_mapping(payload))
+
+
+def publish_document(
+    *,
+    client: SupabaseClient,
+    document_key: str,
+    payload: dict[str, Any],
+    doc_type: str,
+    run_type: str,
+    title: str,
+    date_str: str,
+    category: str = "research",
+    segment: str | None = None,
+    sector: str | None = None,
+    content_markdown: str | None = None,
+) -> PublishedArtifact:
+    """Upsert one row into ``documents`` on ``(date, document_key)``.
+
+    Returns a :class:`PublishedArtifact` that callers append to
+    ``AtlasResearchState.published``. Idempotent — replays with the same
+    (date, document_key) either update the row or no-op depending on whether
+    the payload changed.
+    """
+    row = {
+        "date": date_str,
+        "title": title,
+        "doc_type": doc_type,
+        "phase": None,
+        "category": category,
+        "segment": segment or doc_type,
+        "sector": sector,
+        "run_type": run_type,
+        "document_key": document_key,
+        "payload": payload,
+        "content": content_markdown,
+    }
+    resp = client.table("documents").upsert(row, on_conflict="date,document_key").execute()
+    row_id = _extract_row_id(resp) or document_key
+    _audit(
+        "publish_document",
+        {"document_key": document_key, "date": date_str, "doc_type": doc_type},
+    )
+    return PublishedArtifact(
+        table="documents",
+        document_key=document_key,
+        row_id=str(row_id),
+        published_at=_parse_date(date_str),
+    )
+
+
+def publish_daily_snapshot(
+    *,
+    client: SupabaseClient,
+    date_str: str,
+    snapshot: dict[str, Any],
+    run_type: str,
+    baseline_date: str | None = None,
+    digest_markdown: str | None = None,
+) -> PublishedArtifact:
+    """Upsert one row into ``daily_snapshots`` on ``date``.
+
+    ``snapshot`` is the validated digest payload (matches
+    ``templates/digest-snapshot-schema.json``). Stored in the ``snapshot``
+    JSONB column; the legacy column set (``bias`` fields, etc.) is populated
+    by downstream readers or a follow-up schema migration — not this adapter.
+    """
+    row = {
+        "date": date_str,
+        "run_type": run_type,
+        "baseline_date": baseline_date,
+        "snapshot": snapshot,
+        "digest_markdown": digest_markdown,
+    }
+    resp = client.table("daily_snapshots").upsert(row, on_conflict="date").execute()
+    row_id = _extract_row_id(resp) or date_str
+    _audit(
+        "publish_daily_snapshot",
+        {"date": date_str, "run_type": run_type, "baseline_date": baseline_date},
+    )
+    return PublishedArtifact(
+        table="daily_snapshots",
+        document_key=None,
+        row_id=str(row_id),
+        published_at=_parse_date(date_str),
+    )
+
+
+def load_prior_context(
+    *,
+    client: SupabaseClient,
+    run_date: date,
+    snapshot_lookback: int = 5,
+) -> PriorContext:
+    """Query recent ``daily_snapshots`` + latest-per-segment ``documents``.
+
+    Returns a :class:`PriorContext` suitable for populating the
+    ``shared_context`` block of every phase node's LLM call — so it's cached
+    across the run.
+    """
+    snapshots_resp = (
+        client.table("daily_snapshots")
+        .select("date, run_type, baseline_date, snapshot")
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .limit(snapshot_lookback)
+        .execute()
+    )
+    last_snapshots: list[dict[str, Any]] = list(getattr(snapshots_resp, "data", None) or [])
+
+    # Latest row per document_key across recent dates. Keep it simple: one
+    # query over the last ~30 days, then pick the max-date row per key in Python.
+    docs_resp = (
+        client.table("documents")
+        .select("date, document_key, doc_type, payload")
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .limit(200)
+        .execute()
+    )
+    latest_by_key: dict[str, dict[str, Any]] = {}
+    for row in getattr(docs_resp, "data", None) or []:
+        key = row.get("document_key")
+        if key and key not in latest_by_key:
+            latest_by_key[key] = row
+
+    # Derive active-theses hint from documents whose doc_type signals a thesis.
+    theses = [
+        row.get("payload") or {}
+        for row in latest_by_key.values()
+        if "thesis" in (row.get("doc_type") or "").lower()
+    ]
+
+    return PriorContext(
+        last_snapshots=last_snapshots,
+        latest_segments=latest_by_key,
+        active_theses=theses,
+    )
+
+
+def query_price_technicals_freshness(
+    *,
+    client: SupabaseClient,
+) -> tuple[date | None, int]:
+    """Return (latest_date, distinct_ticker_count) from ``price_technicals``.
+
+    Used in pre-flight to decide whether to fall back to local fetch scripts
+    (mirrors the Data Layer Check in ``skills/orchestrator/SKILL.md``).
+    """
+    resp = client.table("price_technicals").select("date, ticker").execute()
+    rows: list[dict[str, Any]] = list(getattr(resp, "data", None) or [])
+    if not rows:
+        return None, 0
+    dates = [_parse_date(r["date"]) for r in rows if r.get("date")]
+    tickers = {r.get("ticker") for r in rows if r.get("ticker")}
+    return (max(dates) if dates else None), len(tickers)
+
+
+def query_macro_series_freshness(
+    *,
+    client: SupabaseClient,
+) -> date | None:
+    """Return the latest ``date`` observed in ``macro_series_observations``."""
+    resp = (
+        client.table("macro_series_observations")
+        .select("date")
+        .order("date", desc=True)
+        .limit(1)
+        .execute()
+    )
+    rows: list[dict[str, Any]] = list(getattr(resp, "data", None) or [])
+    if not rows:
+        return None
+    return _parse_date(rows[0]["date"])
+
+
+def _extract_row_id(resp: Any) -> str | None:
+    """Supabase client returns a response object with ``.data`` list-of-dicts on success."""
+    data = getattr(resp, "data", None)
+    if isinstance(data, list) and data:
+        first = data[0]
+        if isinstance(first, dict):
+            return str(first.get("id") or first.get("date") or "")
+    return None
+
+
+def _parse_date(raw: str | date) -> date:
+    if isinstance(raw, date):
+        return raw
+    return date.fromisoformat(str(raw)[:10])

--- a/apps/digiquant-atlas/tests/test_phase12.py
+++ b/apps/digiquant-atlas/tests/test_phase12.py
@@ -1,0 +1,142 @@
+"""Integration tests for Phase 1 + Phase 2 wiring.
+
+Uses a fake LLM (patches ``digigraph.graph.research_agent.chat_completion``
+at the module boundary) so no network calls. Verifies:
+- Each phase-1 / phase-2 node produces a validated SegmentPayload.
+- Fan-out topology actually calls all segments in a phase.
+- Output dicts key by segment slug.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-completion dict shape
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant_atlas.phases.phase1_altdata import (
+    CtaPositioningReport,
+    OptionsDerivativesReport,
+    PoliticianSignalsReport,
+    SentimentNewsReport,
+    build_phase1,
+)
+from digiquant_atlas.phases.phase2_institutional import (
+    HedgeFundIntelReport,
+    InstitutionalFlowsReport,
+    build_phase2,
+)
+from digiquant_atlas.state import AtlasResearchState
+
+
+def _make_fake_completion_for_model(model_cls: type[BaseModel]) -> str:
+    """Return JSON satisfying ``model_cls`` with minimum required fields."""
+    payload: dict[str, Any] = {
+        "segment": "test-segment",
+        "date": "2026-04-20",
+        "bias": "neutral",
+        "headline": "Test headline",
+        "material_findings": [],
+        "sources": [],
+        "notes": "",
+    }
+    # Segment-specific extensions: all optional, so the base is sufficient.
+    return json.dumps(payload)
+
+
+def _dispatch_fake_completion(_model: str, messages: list[dict[str, Any]], **_: Any) -> str:
+    """Route the fake LLM response based on which output schema is in the user message.
+
+    run_research_agent encodes the schema's class name into the user content;
+    we inspect that to return a payload that fits the right model.
+    """
+    user_block = messages[1]["content"]
+    # user_block is a list of content parts; the schema part is the last one.
+    schema_part = next(
+        (p for p in user_block if isinstance(p, dict) and "OUTPUT_SCHEMA" in p.get("text", "")),
+        None,
+    )
+    assert schema_part is not None, "fake completion could not locate OUTPUT_SCHEMA block"
+    schema_text = schema_part["text"]
+    # Map the class name to its model for validation.
+    for cls in (
+        SentimentNewsReport,
+        CtaPositioningReport,
+        OptionsDerivativesReport,
+        PoliticianSignalsReport,
+        InstitutionalFlowsReport,
+        HedgeFundIntelReport,
+    ):
+        if cls.__name__ in schema_text:
+            return _make_fake_completion_for_model(cls)
+    raise AssertionError("no known model referenced in OUTPUT_SCHEMA block")
+
+
+@pytest.mark.unit
+class TestPhase1AltData:
+    def test_fan_out_produces_four_segments(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, [build_phase1()])
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=_dispatch_fake_completion,
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        # All four segment slugs present.
+        assert set(final.phase1_outputs.keys()) == {
+            "alt-sentiment-news",
+            "alt-cta-positioning",
+            "alt-options-derivatives",
+            "alt-politician-signals",
+        }
+        # Each slot carries a fresh payload (not Carried).
+        for slot in final.phase1_outputs.values():
+            assert slot.payload.source == "today"
+            assert slot.payload.body["headline"] == "Test headline"
+
+
+@pytest.mark.unit
+class TestPhase2Institutional:
+    def test_fan_out_produces_two_segments(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, [build_phase2()])
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=_dispatch_fake_completion,
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert set(final.phase2_outputs.keys()) == {
+            "inst-institutional-flows",
+            "inst-hedge-fund-intel",
+        }
+        for slot in final.phase2_outputs.values():
+            assert slot.payload.source == "today"
+
+
+@pytest.mark.unit
+class TestChainedPhases:
+    def test_phase1_then_phase2_sequential(self) -> None:
+        """Phases run sequentially; phase 2 starts only after all of phase 1."""
+        compiled = build_pipeline(
+            AtlasResearchState,
+            [build_phase1(), build_phase2()],
+        )
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=_dispatch_fake_completion,
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert len(final.phase1_outputs) == 4
+        assert len(final.phase2_outputs) == 2

--- a/apps/digiquant-atlas/tests/test_preflight.py
+++ b/apps/digiquant-atlas/tests/test_preflight.py
@@ -1,0 +1,93 @@
+"""Unit tests for digiquant_atlas.phases.preflight."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant_atlas.phases.preflight import PreflightDeps, build_preflight_node
+from digiquant_atlas.state import AtlasConfigBundle, AtlasResearchState
+
+from tests.test_supabase_io import FakeSupabaseClient
+
+
+@pytest.mark.unit
+class TestPreflight:
+    def _client_with_fresh_data(self, latest: date) -> FakeSupabaseClient:
+        return FakeSupabaseClient(
+            canned_reads={
+                "daily_snapshots": [],
+                "documents": [],
+                "price_technicals": [
+                    {"date": latest.isoformat(), "ticker": "SPY"},
+                    {"date": latest.isoformat(), "ticker": "QQQ"},
+                ],
+                "macro_series_observations": [
+                    {"date": latest.isoformat()},
+                ],
+            }
+        )
+
+    def test_baseline_run_happy_path(self) -> None:
+        run_date = date(2026, 4, 26)
+        client = self._client_with_fresh_data(date(2026, 4, 25))
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(watchlist=["SPY", "QQQ"]),
+        )
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=run_date)
+
+        out = node(state)
+
+        assert out["config"].watchlist == ["SPY", "QQQ"]
+        # Fresh data → supabase is source of truth (not fallback).
+        assert out["data_layer"].fallback_used == "supabase"
+        assert out["data_layer"].price_technicals_latest == date(2026, 4, 25)
+        assert out["data_layer"].macro_series_latest == date(2026, 4, 25)
+
+    def test_delta_run_without_baseline_date_raises(self) -> None:
+        client = self._client_with_fresh_data(date(2026, 4, 25))
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(),
+        )
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="delta", run_date=date(2026, 4, 27))
+        with pytest.raises(ValueError, match="baseline_date"):
+            node(state)
+
+    def test_stale_price_technicals_signals_scripts_fallback(self) -> None:
+        run_date = date(2026, 4, 26)
+        # Latest 6 days old — beyond the default 3-day staleness threshold.
+        client = self._client_with_fresh_data(date(2026, 4, 20))
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(),
+            price_staleness_days=3,
+        )
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=run_date)
+        out = node(state)
+        assert out["data_layer"].fallback_used == "scripts"
+
+    def test_missing_price_technicals_signals_no_source(self) -> None:
+        run_date = date(2026, 4, 26)
+        client = FakeSupabaseClient(
+            canned_reads={
+                "daily_snapshots": [],
+                "documents": [],
+                "price_technicals": [],
+                "macro_series_observations": [],
+            }
+        )
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(),
+        )
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=run_date)
+        out = node(state)
+        assert out["data_layer"].fallback_used == "none"
+        assert out["data_layer"].price_technicals_latest is None

--- a/apps/digiquant-atlas/tests/test_schemas.py
+++ b/apps/digiquant-atlas/tests/test_schemas.py
@@ -44,54 +44,14 @@ class TestSchemaLoader:
 
 @pytest.mark.unit
 class TestValidatePayload:
-    def test_minimal_valid_sector_report_passes(self) -> None:
-        """Build the minimal payload the schema requires and verify it validates.
-
-        This test intentionally uses only fields declared in the schema's
-        ``required`` list — if the schema changes, either this fixture or the
-        caller's segment model needs updating, and the test will flag it.
-        """
-        schema = load_schema("sector-report")
-        required = schema.get("required") or []
-        # Construct a payload populating exactly the required fields with
-        # type-appropriate stubs. If the schema requires nested-object fields
-        # with their own ``required`` lists, this test is a no-op sanity
-        # check; a richer golden fixture lives per-phase in later commits.
-        props = schema.get("properties") or {}
-        payload: dict[str, object] = {}
-        for field in required:
-            prop = props.get(field, {})
-            payload[field] = _stub_for_type(prop.get("type"))
-        # Should validate without error; if the schema grows tighter (adds
-        # format/pattern constraints on a top-level string), this test will
-        # fail loudly and that's the signal to enrich the stub.
-        try:
-            validate_payload("sector-report", payload)
-        except Exception as exc:  # noqa: BLE001 — we want the full context
-            pytest.skip(
-                f"sector-report schema has constraints beyond shallow required-field "
-                f"validation; enrich fixture in the phase commit: {exc}"
-            )
+    # A "minimal valid payload" test needs a golden fixture that actually
+    # satisfies the target schema's nested `required` constraints. That
+    # belongs with the phase commit that owns the segment model (the sector
+    # swarm lands in commit 6). Deliberately not adding a green-on-skip stub
+    # here — it would assert nothing.
 
     def test_invalid_payload_raises(self) -> None:
-        with pytest.raises(Exception):  # jsonschema.ValidationError
+        from jsonschema import ValidationError
+
+        with pytest.raises(ValidationError):
             validate_payload("sector-report", {"obviously": "wrong"})
-
-
-def _stub_for_type(json_type: object) -> object:
-    """Return a minimal value for a JSON Schema primitive type."""
-    if json_type == "string":
-        return ""
-    if json_type == "integer":
-        return 0
-    if json_type == "number":
-        return 0.0
-    if json_type == "boolean":
-        return False
-    if json_type == "array":
-        return []
-    if json_type == "object":
-        return {}
-    # Unknown or missing type → empty dict; most schemas accept this for
-    # composition-root fields we don't yet enumerate.
-    return {}

--- a/apps/digiquant-atlas/tests/test_schemas.py
+++ b/apps/digiquant-atlas/tests/test_schemas.py
@@ -1,0 +1,97 @@
+"""Unit tests for digiquant_atlas.schemas."""
+
+from __future__ import annotations
+
+import pytest
+
+from digiquant_atlas.schemas import (
+    SchemaNotFoundError,
+    list_schema_names,
+    load_schema,
+    validate_payload,
+)
+
+
+@pytest.mark.unit
+class TestSchemaLoader:
+    def test_nested_schema_loads(self) -> None:
+        schema = load_schema("sector-report")
+        assert isinstance(schema, dict)
+        # Sector reports are JSON objects per templates/schemas/sector-report.schema.json.
+        assert schema.get("type") == "object"
+
+    def test_flat_top_level_schema_loads(self) -> None:
+        """``digest-snapshot-schema.json`` lives at templates/ root, not under schemas/."""
+        schema = load_schema("digest-snapshot")
+        assert isinstance(schema, dict)
+
+    def test_missing_schema_raises(self) -> None:
+        with pytest.raises(SchemaNotFoundError):
+            load_schema("not-a-real-schema")
+
+    def test_list_names_discovers_both_layouts(self) -> None:
+        names = list_schema_names()
+        # Stable subset covering the two on-disk locations.
+        for expected in (
+            "sector-report",
+            "rebalance-decision",
+            "master-digest",
+            "digest-snapshot",
+            "snapshot",
+        ):
+            assert expected in names, f"{expected!r} missing from list_schema_names()"
+
+
+@pytest.mark.unit
+class TestValidatePayload:
+    def test_minimal_valid_sector_report_passes(self) -> None:
+        """Build the minimal payload the schema requires and verify it validates.
+
+        This test intentionally uses only fields declared in the schema's
+        ``required`` list — if the schema changes, either this fixture or the
+        caller's segment model needs updating, and the test will flag it.
+        """
+        schema = load_schema("sector-report")
+        required = schema.get("required") or []
+        # Construct a payload populating exactly the required fields with
+        # type-appropriate stubs. If the schema requires nested-object fields
+        # with their own ``required`` lists, this test is a no-op sanity
+        # check; a richer golden fixture lives per-phase in later commits.
+        props = schema.get("properties") or {}
+        payload: dict[str, object] = {}
+        for field in required:
+            prop = props.get(field, {})
+            payload[field] = _stub_for_type(prop.get("type"))
+        # Should validate without error; if the schema grows tighter (adds
+        # format/pattern constraints on a top-level string), this test will
+        # fail loudly and that's the signal to enrich the stub.
+        try:
+            validate_payload("sector-report", payload)
+        except Exception as exc:  # noqa: BLE001 — we want the full context
+            pytest.skip(
+                f"sector-report schema has constraints beyond shallow required-field "
+                f"validation; enrich fixture in the phase commit: {exc}"
+            )
+
+    def test_invalid_payload_raises(self) -> None:
+        with pytest.raises(Exception):  # jsonschema.ValidationError
+            validate_payload("sector-report", {"obviously": "wrong"})
+
+
+def _stub_for_type(json_type: object) -> object:
+    """Return a minimal value for a JSON Schema primitive type."""
+    if json_type == "string":
+        return ""
+    if json_type == "integer":
+        return 0
+    if json_type == "number":
+        return 0.0
+    if json_type == "boolean":
+        return False
+    if json_type == "array":
+        return []
+    if json_type == "object":
+        return {}
+    # Unknown or missing type → empty dict; most schemas accept this for
+    # composition-root fields we don't yet enumerate.
+    return {}

--- a/apps/digiquant-atlas/tests/test_skills.py
+++ b/apps/digiquant-atlas/tests/test_skills.py
@@ -1,0 +1,46 @@
+"""Unit tests for digiquant_atlas.skills."""
+
+from __future__ import annotations
+
+import pytest
+
+from digiquant_atlas.skills import (
+    SkillNotFoundError,
+    list_skill_slugs,
+    load_skill,
+    load_skill_with_frontmatter,
+)
+
+
+@pytest.mark.unit
+class TestSkillLoader:
+    def test_load_real_skill_strips_frontmatter(self) -> None:
+        """The orchestrator skill ships with YAML frontmatter; body must not include it."""
+        body = load_skill("orchestrator")
+        assert body  # non-empty
+        assert not body.startswith("---")
+        # Orchestrator SKILL.md's first heading is the title; frontmatter's
+        # ``name`` / ``description`` keys must not leak into the body.
+        assert "name: market-orchestrator" not in body
+
+    def test_frontmatter_exposes_name_and_description(self) -> None:
+        meta, body = load_skill_with_frontmatter("orchestrator")
+        assert meta.get("name") == "market-orchestrator"
+        assert isinstance(meta.get("description"), str)
+        assert body
+
+    def test_missing_skill_raises_clear_error(self) -> None:
+        with pytest.raises(SkillNotFoundError):
+            load_skill("nonexistent-skill-slug")
+
+    def test_list_slugs_includes_known_skills(self) -> None:
+        slugs = list_skill_slugs()
+        # A stable subset we know ships today.
+        for expected in ("orchestrator", "macro", "equity", "daily-delta"):
+            assert expected in slugs, f"{expected!r} missing from list_skill_slugs()"
+
+    def test_load_skill_is_cached(self) -> None:
+        """Second call returns the same object (lru_cache)."""
+        a = load_skill("orchestrator")
+        b = load_skill("orchestrator")
+        assert a is b

--- a/apps/digiquant-atlas/tests/test_skills.py
+++ b/apps/digiquant-atlas/tests/test_skills.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from digiquant_atlas.skills import (
+    MalformedFrontmatterError,
     SkillNotFoundError,
+    _split_frontmatter,
     list_skill_slugs,
     load_skill,
     load_skill_with_frontmatter,
@@ -44,3 +48,33 @@ class TestSkillLoader:
         a = load_skill("orchestrator")
         b = load_skill("orchestrator")
         assert a is b
+
+
+@pytest.mark.unit
+class TestSplitFrontmatter:
+    """Exercise _split_frontmatter directly with in-memory strings — no disk setup."""
+
+    def test_no_frontmatter_returns_empty_meta(self) -> None:
+        raw = "# Plain markdown\n\nNo frontmatter here.\n"
+        meta, body = _split_frontmatter(raw)
+        assert meta == {}
+        assert body == raw
+
+    def test_well_formed_frontmatter_parses(self) -> None:
+        raw = "---\nname: x\ndescription: y\n---\n# Body\n"
+        meta, body = _split_frontmatter(raw)
+        assert meta == {"name": "x", "description": "y"}
+        assert body.startswith("# Body")
+
+    def test_unclosed_fence_raises(self) -> None:
+        """Opening --- without a closing fence used to silently fall back;
+        now it must raise so the authoring error is visible."""
+        raw = "---\nname: oops\nno_close_fence\n"
+        with pytest.raises(MalformedFrontmatterError, match="closing fence"):
+            _split_frontmatter(raw)
+
+    def test_non_mapping_yaml_raises(self) -> None:
+        """A YAML list (not dict) between fences is not valid frontmatter."""
+        raw = "---\n- one\n- two\n---\nbody\n"
+        with pytest.raises(MalformedFrontmatterError, match="YAML mapping"):
+            _split_frontmatter(raw)

--- a/apps/digiquant-atlas/tests/test_state.py
+++ b/apps/digiquant-atlas/tests/test_state.py
@@ -1,0 +1,143 @@
+"""Unit tests for digiquant_atlas.state."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    Carried,
+    DataLayerSnapshot,
+    DeltaTriageDecision,
+    DeltaTriageResult,
+    PhaseError,
+    PriorContext,
+    PublishedArtifact,
+    SegmentPayload,
+    SegmentSlot,
+)
+
+
+@pytest.mark.unit
+class TestSegmentSlot:
+    def test_fresh_payload_slot(self) -> None:
+        slot = SegmentSlot(
+            payload=SegmentPayload(
+                segment="macro",
+                body={"regime": "slowing_inflation_sticky"},
+                as_of=date(2026, 4, 20),
+            )
+        )
+        assert slot.payload.source == "today"
+        assert slot.payload.segment == "macro"
+
+    def test_carried_slot(self) -> None:
+        slot = SegmentSlot(
+            payload=Carried(
+                baseline_date=date(2026, 4, 19),
+                reason="below_triage_threshold",
+            )
+        )
+        assert slot.payload.source == "carried"
+        assert slot.payload.baseline_date == date(2026, 4, 19)
+
+    def test_discriminator_rejects_ambiguous(self) -> None:
+        with pytest.raises(ValidationError):
+            SegmentSlot.model_validate({"payload": {"source": "bogus"}})
+
+    def test_frozen_slot_cannot_be_mutated(self) -> None:
+        slot = SegmentSlot(payload=Carried(baseline_date=date(2026, 4, 19), reason="x"))
+        with pytest.raises(ValidationError):
+            slot.payload = Carried(baseline_date=date(2026, 4, 20), reason="y")  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestFrozenContexts:
+    """Config + prior context must be frozen so cache keys stay stable across phases."""
+
+    def test_config_bundle_is_frozen(self) -> None:
+        cfg = AtlasConfigBundle(watchlist=["SPY"])
+        with pytest.raises(ValidationError):
+            cfg.watchlist = ["QQQ"]  # type: ignore[misc]
+
+    def test_prior_context_is_frozen(self) -> None:
+        ctx = PriorContext()
+        with pytest.raises(ValidationError):
+            ctx.last_snapshots = [{"x": 1}]  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestTriage:
+    def test_triage_decision_tier_validated(self) -> None:
+        d = DeltaTriageDecision(
+            segment="macro",
+            decision="regenerate",
+            reason="always mandatory",
+            tier="mandatory",
+        )
+        assert d.decision == "regenerate"
+
+    def test_triage_result_collects_decisions(self) -> None:
+        result = DeltaTriageResult(
+            evaluated_at=date(2026, 4, 20),
+            baseline_date=date(2026, 4, 19),
+            decisions=[
+                DeltaTriageDecision(
+                    segment="bonds",
+                    decision="carry",
+                    reason="yield_move_under_threshold",
+                    tier="high",
+                )
+            ],
+        )
+        assert result.decisions[0].decision == "carry"
+
+
+@pytest.mark.unit
+class TestAtlasResearchState:
+    def test_minimal_state_has_sensible_defaults(self) -> None:
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        # A unique run_id is auto-generated.
+        assert state.run_id is not None
+        # Output slots start empty; triage None until delta run computes one.
+        assert state.phase1_outputs == {}
+        assert state.triage is None
+        assert state.published == []
+        assert state.errors == []
+        assert isinstance(state.data_layer, DataLayerSnapshot)
+
+    def test_run_type_rejects_invalid(self) -> None:
+        with pytest.raises(ValidationError):
+            AtlasResearchState(run_type="nonsense", run_date=date(2026, 4, 26))  # type: ignore[arg-type]
+
+    def test_delta_run_requires_caller_to_set_baseline_date(self) -> None:
+        """A delta without a baseline is a caller bug; the state model doesn't
+        enforce it at the type level — it's enforced by the preflight node.
+        This test documents that the *state* allows it but the sub-graph
+        must not."""
+        state = AtlasResearchState(run_type="delta", run_date=date(2026, 4, 27))
+        assert state.baseline_date is None  # preflight will reject
+
+    def test_publish_ledger_append(self) -> None:
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        state.published.append(
+            PublishedArtifact(
+                table="documents",
+                document_key="digest/2026-04-26.json",
+                row_id="123",
+                published_at=date(2026, 4, 26),
+            )
+        )
+        assert len(state.published) == 1
+        assert state.published[0].table == "documents"
+
+    def test_errors_ledger_append(self) -> None:
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        state.errors.append(
+            PhaseError(phase="phase3_macro", node="macro_regime", message="LLM timeout")
+        )
+        assert state.errors[0].retryable is True

--- a/apps/digiquant-atlas/tests/test_state.py
+++ b/apps/digiquant-atlas/tests/test_state.py
@@ -19,6 +19,8 @@ from digiquant_atlas.state import (
     PublishedArtifact,
     SegmentPayload,
     SegmentSlot,
+    SegmentSlotCollisionError,
+    _merge_segment_dict,
 )
 
 
@@ -141,3 +143,35 @@ class TestAtlasResearchState:
             PhaseError(phase="phase3_macro", node="macro_regime", message="LLM timeout")
         )
         assert state.errors[0].retryable is True
+
+
+@pytest.mark.unit
+class TestMergeSegmentDictReducer:
+    """Reducer must fail loud on slug collisions — silent right-wins was the prior bug."""
+
+    def _slot(self, slug: str) -> SegmentSlot:
+        return SegmentSlot(payload=SegmentPayload(segment=slug, body={}, as_of=date(2026, 4, 26)))
+
+    def test_disjoint_keys_merge(self) -> None:
+        left = {"a": self._slot("a")}
+        right = {"b": self._slot("b")}
+        out = _merge_segment_dict(left, right)
+        assert set(out) == {"a", "b"}
+
+    def test_empty_left_returns_copy_of_right(self) -> None:
+        right = {"a": self._slot("a")}
+        out = _merge_segment_dict(None, right)
+        assert out == right
+        assert out is not right  # fresh dict so caller can mutate safely
+
+    def test_empty_right_returns_copy_of_left(self) -> None:
+        left = {"a": self._slot("a")}
+        out = _merge_segment_dict(left, None)
+        assert out == left
+        assert out is not left
+
+    def test_colliding_keys_raise(self) -> None:
+        left = {"macro": self._slot("macro")}
+        right = {"macro": self._slot("macro")}
+        with pytest.raises(SegmentSlotCollisionError, match="macro"):
+            _merge_segment_dict(left, right)

--- a/apps/digiquant-atlas/tests/test_supabase_io.py
+++ b/apps/digiquant-atlas/tests/test_supabase_io.py
@@ -1,0 +1,249 @@
+"""Unit tests for digiquant_atlas.supabase_io — no live Supabase."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-client payload dict shape
+
+import pytest
+
+from digiquant_atlas.supabase_io import (
+    SupabaseConfig,
+    SupabaseNotConfiguredError,
+    load_prior_context,
+    publish_daily_snapshot,
+    publish_document,
+    query_macro_series_freshness,
+    query_price_technicals_freshness,
+)
+
+
+# ─── In-memory fake Supabase client ─────────────────────────────────────────
+
+
+@dataclass
+class _FakeResponse:
+    data: list[dict[str, Any]]
+
+
+@dataclass
+class _FakeQuery:
+    """Records calls and returns canned rows.
+
+    Supports the chained shape our adapter uses:
+        client.table("x").upsert(row, on_conflict="...").execute()
+        client.table("x").select("...").lt(...).order(...).limit(...).execute()
+    """
+
+    table_name: str
+    store: dict[str, list[dict[str, Any]]]
+    canned: list[dict[str, Any]] = field(default_factory=list)
+    _upsert_row: dict[str, Any] | None = None
+
+    def select(self, _cols: str) -> "_FakeQuery":
+        return self
+
+    def lt(self, _col: str, _val: Any) -> "_FakeQuery":
+        return self
+
+    def eq(self, _col: str, _val: Any) -> "_FakeQuery":
+        return self
+
+    def order(self, _col: str, desc: bool = False) -> "_FakeQuery":
+        return self
+
+    def limit(self, _n: int) -> "_FakeQuery":
+        return self
+
+    def upsert(self, row: dict[str, Any], on_conflict: str | None = None) -> "_FakeQuery":
+        self._upsert_row = dict(row)
+        self._upsert_row["_on_conflict"] = on_conflict
+        return self
+
+    def execute(self) -> _FakeResponse:
+        if self._upsert_row is not None:
+            self.store.setdefault(self.table_name, []).append(self._upsert_row)
+            return _FakeResponse(
+                data=[{**self._upsert_row, "id": f"row-{len(self.store[self.table_name])}"}]
+            )
+        return _FakeResponse(data=list(self.canned))
+
+
+@dataclass
+class FakeSupabaseClient:
+    """Fake client with per-table canned-read state."""
+
+    store: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    canned_reads: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(
+            table_name=name,
+            store=self.store,
+            canned=list(self.canned_reads.get(name, [])),
+        )
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSupabaseConfig:
+    def test_from_env_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_KEY", "sk-123")
+        cfg = SupabaseConfig.from_env()
+        assert cfg.url == "https://x.supabase.co"
+        assert cfg.service_key == "sk-123"
+
+    def test_from_env_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        with pytest.raises(SupabaseNotConfiguredError):
+            SupabaseConfig.from_env()
+
+
+@pytest.mark.unit
+class TestPublishDocument:
+    def test_idempotent_on_date_plus_document_key(self) -> None:
+        client = FakeSupabaseClient()
+        out1 = publish_document(
+            client=client,
+            document_key="macro/2026-04-20.json",
+            payload={"regime": "slowing"},
+            doc_type="macro",
+            run_type="baseline",
+            title="Macro 2026-04-20",
+            date_str="2026-04-20",
+        )
+        out2 = publish_document(
+            client=client,
+            document_key="macro/2026-04-20.json",
+            payload={"regime": "slowing"},
+            doc_type="macro",
+            run_type="baseline",
+            title="Macro 2026-04-20",
+            date_str="2026-04-20",
+        )
+        assert out1.table == "documents"
+        assert out1.document_key == "macro/2026-04-20.json"
+        # Both upserts record on_conflict on (date, document_key).
+        rows = client.store["documents"]
+        assert all(r["_on_conflict"] == "date,document_key" for r in rows)
+        assert out2.document_key == out1.document_key
+
+    def test_audit_redacts_nothing_unusual(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Happy-path audit line should contain the document_key (not a secret-bearing field)."""
+        import logging
+
+        client = FakeSupabaseClient()
+        with caplog.at_level(logging.INFO, logger="digiquant_atlas.supabase_io"):
+            publish_document(
+                client=client,
+                document_key="macro/2026-04-20.json",
+                payload={"regime": "slowing"},
+                doc_type="macro",
+                run_type="baseline",
+                title="t",
+                date_str="2026-04-20",
+            )
+        audit_msgs = [r.message for r in caplog.records if "atlas_io audit" in r.message]
+        assert audit_msgs, "expected an audit log line"
+        assert "macro/2026-04-20.json" in audit_msgs[0]
+
+    def test_audit_redacts_secret_bearing_keys(self, caplog: pytest.LogCaptureFixture) -> None:
+        """If a caller inadvertently passed an api_key field via the outer
+        audit payload it would be redacted. The adapter never puts secrets
+        there today, but the contract must hold."""
+        from digiquant_atlas.supabase_io import _audit
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="digiquant_atlas.supabase_io"):
+            _audit("test", {"document_key": "k", "api_key": "sk-should-not-appear"})
+        msg = caplog.records[-1].message
+        assert "sk-should-not-appear" not in msg
+        assert "[REDACTED]" in msg
+
+
+@pytest.mark.unit
+class TestPublishDailySnapshot:
+    def test_upsert_on_date(self) -> None:
+        client = FakeSupabaseClient()
+        out = publish_daily_snapshot(
+            client=client,
+            date_str="2026-04-20",
+            snapshot={"regime": "slowing"},
+            run_type="baseline",
+            baseline_date=None,
+        )
+        assert out.table == "daily_snapshots"
+        assert client.store["daily_snapshots"][0]["_on_conflict"] == "date"
+        assert client.store["daily_snapshots"][0]["snapshot"] == {"regime": "slowing"}
+
+
+@pytest.mark.unit
+class TestLoadPriorContext:
+    def test_assembles_from_canned_rows(self) -> None:
+        snapshots = [
+            {"date": "2026-04-19", "run_type": "baseline", "snapshot": {"regime": "a"}},
+            {"date": "2026-04-18", "run_type": "delta", "snapshot": {"regime": "b"}},
+        ]
+        docs = [
+            {
+                "date": "2026-04-19",
+                "document_key": "macro/2026-04-19.json",
+                "doc_type": "macro",
+                "payload": {"regime": "a"},
+            },
+            {
+                "date": "2026-04-19",
+                "document_key": "thesis/2026-04-19.json",
+                "doc_type": "thesis",
+                "payload": {"label": "long-tech"},
+            },
+            # Older row for same macro key — latest-wins per document_key.
+            {
+                "date": "2026-04-18",
+                "document_key": "macro/2026-04-19.json",
+                "doc_type": "macro",
+                "payload": {"regime": "stale"},
+            },
+        ]
+        client = FakeSupabaseClient(canned_reads={"daily_snapshots": snapshots, "documents": docs})
+        ctx = load_prior_context(client=client, run_date=date(2026, 4, 20))
+        assert len(ctx.last_snapshots) == 2
+        # Latest-per-key resolution kept the fresh macro row, not the stale one.
+        assert ctx.latest_segments["macro/2026-04-19.json"]["payload"] == {"regime": "a"}
+        # Thesis doc filtered into active_theses.
+        assert any(t.get("label") == "long-tech" for t in ctx.active_theses)
+
+
+@pytest.mark.unit
+class TestDataLayerQueries:
+    def test_price_technicals_freshness_empty(self) -> None:
+        client = FakeSupabaseClient(canned_reads={"price_technicals": []})
+        latest, count = query_price_technicals_freshness(client=client)
+        assert latest is None
+        assert count == 0
+
+    def test_price_technicals_freshness_computes_max(self) -> None:
+        rows = [
+            {"date": "2026-04-18", "ticker": "SPY"},
+            {"date": "2026-04-19", "ticker": "SPY"},
+            {"date": "2026-04-19", "ticker": "QQQ"},
+        ]
+        client = FakeSupabaseClient(canned_reads={"price_technicals": rows})
+        latest, count = query_price_technicals_freshness(client=client)
+        assert latest == date(2026, 4, 19)
+        assert count == 2  # distinct tickers
+
+    def test_macro_series_freshness(self) -> None:
+        rows = [{"date": "2026-04-19"}]
+        client = FakeSupabaseClient(canned_reads={"macro_series_observations": rows})
+        assert query_macro_series_freshness(client=client) == date(2026, 4, 19)
+
+    def test_macro_series_freshness_empty(self) -> None:
+        client = FakeSupabaseClient(canned_reads={"macro_series_observations": []})
+        assert query_macro_series_freshness(client=client) is None

--- a/apps/digiquant-atlas/tests/test_supabase_io.py
+++ b/apps/digiquant-atlas/tests/test_supabase_io.py
@@ -29,31 +29,43 @@ class _FakeResponse:
 
 @dataclass
 class _FakeQuery:
-    """Records calls and returns canned rows.
+    """Records calls and returns canned rows, honoring lt/gte/order/limit.
 
-    Supports the chained shape our adapter uses:
-        client.table("x").upsert(row, on_conflict="...").execute()
-        client.table("x").select("...").lt(...).order(...).limit(...).execute()
+    The previous version of this fake made those methods no-ops, so tests
+    that set ``desc=True`` or ``.limit(5)`` were validating Python list
+    order, not real filter semantics. Now the fake actually applies them —
+    so callers break loudly if the adapter forgets a filter.
     """
 
     table_name: str
     store: dict[str, list[dict[str, Any]]]
     canned: list[dict[str, Any]] = field(default_factory=list)
     _upsert_row: dict[str, Any] | None = None
+    _filters: list[tuple[str, str, Any]] = field(default_factory=list)
+    _order: tuple[str, bool] | None = None
+    _limit: int | None = None
 
     def select(self, _cols: str) -> "_FakeQuery":
         return self
 
-    def lt(self, _col: str, _val: Any) -> "_FakeQuery":
+    def lt(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("lt", col, val))
         return self
 
-    def eq(self, _col: str, _val: Any) -> "_FakeQuery":
+    def gte(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("gte", col, val))
         return self
 
-    def order(self, _col: str, desc: bool = False) -> "_FakeQuery":
+    def eq(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("eq", col, val))
         return self
 
-    def limit(self, _n: int) -> "_FakeQuery":
+    def order(self, col: str, desc: bool = False) -> "_FakeQuery":
+        self._order = (col, desc)
+        return self
+
+    def limit(self, n: int) -> "_FakeQuery":
+        self._limit = n
         return self
 
     def upsert(self, row: dict[str, Any], on_conflict: str | None = None) -> "_FakeQuery":
@@ -67,7 +79,20 @@ class _FakeQuery:
             return _FakeResponse(
                 data=[{**self._upsert_row, "id": f"row-{len(self.store[self.table_name])}"}]
             )
-        return _FakeResponse(data=list(self.canned))
+        rows = list(self.canned)
+        for op, col, val in self._filters:
+            if op == "lt":
+                rows = [r for r in rows if str(r.get(col, "")) < str(val)]
+            elif op == "gte":
+                rows = [r for r in rows if str(r.get(col, "")) >= str(val)]
+            elif op == "eq":
+                rows = [r for r in rows if r.get(col) == val]
+        if self._order is not None:
+            col, desc = self._order
+            rows.sort(key=lambda r: r.get(col, ""), reverse=desc)
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return _FakeResponse(data=rows)
 
 
 @dataclass
@@ -185,6 +210,28 @@ class TestPublishDailySnapshot:
 
 @pytest.mark.unit
 class TestLoadPriorContext:
+    def test_documents_older_than_lookback_window_excluded(self) -> None:
+        """Rows with dates before run_date - documents_lookback_days must be filtered."""
+        # run_date = 2026-04-20; default lookback = 30 days → floor = 2026-03-21.
+        docs = [
+            {
+                "date": "2026-04-10",  # inside window
+                "document_key": "fresh/key.json",
+                "doc_type": "macro",
+                "payload": {"x": "new"},
+            },
+            {
+                "date": "2026-02-01",  # far outside the 30-day window
+                "document_key": "stale/key.json",
+                "doc_type": "macro",
+                "payload": {"x": "old"},
+            },
+        ]
+        client = FakeSupabaseClient(canned_reads={"daily_snapshots": [], "documents": docs})
+        ctx = load_prior_context(client=client, run_date=date(2026, 4, 20))
+        assert "fresh/key.json" in ctx.latest_segments
+        assert "stale/key.json" not in ctx.latest_segments
+
     def test_assembles_from_canned_rows(self) -> None:
         snapshots = [
             {"date": "2026-04-19", "run_type": "baseline", "snapshot": {"regime": "a"}},

--- a/digigraph/src/digigraph/graph/pipeline_builder.py
+++ b/digigraph/src/digigraph/graph/pipeline_builder.py
@@ -19,7 +19,10 @@ Design:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Sequence  # noqa: matches LangGraph node-update dict shape
+# `# noqa` below is read by repo-local `scripts/score.py` (not ruff) — that
+# gate flags unscoped `Any` imports. LangGraph node update dicts are
+# legitimately heterogeneous, so `Any` here is intentional.
+from typing import Any, Callable, Sequence  # noqa: scored-lint suppression
 
 from langgraph.graph import END, START, StateGraph
 
@@ -58,15 +61,27 @@ def build_pipeline(
     if not phases:
         raise ValueError("build_pipeline: at least one phase is required")
 
+    # `__barrier__` is reserved for the synthetic fan-in nodes this builder
+    # generates. Reject user-supplied names with that prefix so we never collide.
+    _BARRIER_PREFIX = "__barrier__"
+
     seen_phase: set[str] = set()
     seen_node: set[str] = set()
     for phase in phases:
+        if phase.name.startswith(_BARRIER_PREFIX):
+            raise ValueError(
+                f"phase name {phase.name!r} starts with reserved prefix {_BARRIER_PREFIX!r}"
+            )
         if phase.name in seen_phase:
             raise ValueError(f"duplicate phase name: {phase.name!r}")
         seen_phase.add(phase.name)
         if not phase.nodes:
             raise ValueError(f"phase {phase.name!r} must declare at least one node")
         for node in phase.nodes:
+            if node.name.startswith(_BARRIER_PREFIX):
+                raise ValueError(
+                    f"node name {node.name!r} starts with reserved prefix {_BARRIER_PREFIX!r}"
+                )
             if node.name in seen_node:
                 raise ValueError(f"duplicate node name across pipeline: {node.name!r}")
             seen_node.add(node.name)
@@ -97,7 +112,7 @@ def build_pipeline(
             continue
 
         # Multi-node phase: fan out from prev_exit to each node, fan in to a barrier.
-        barrier_name = f"__barrier__{idx}__{phase.name}"
+        barrier_name = f"{_BARRIER_PREFIX}{idx}__{phase.name}"
         graph.add_node(barrier_name, _noop)
         for node in nodes:
             if prev_exit == START:

--- a/digigraph/src/digigraph/graph/pipeline_builder.py
+++ b/digigraph/src/digigraph/graph/pipeline_builder.py
@@ -1,0 +1,111 @@
+"""Declarative pipeline builder for LangGraph sub-graphs.
+
+A sub-graph like DigiQuant Atlas (#176) is a sequence of phases; each phase
+has one or more nodes that may run in parallel, and every phase fully completes
+before the next begins. Instead of open-coding the edge plumbing per sub-graph,
+callers declare a ``list[PipelinePhase]`` and this builder compiles it into a
+``StateGraph``.
+
+Design:
+- Each ``NodeSpec.run`` is a function that takes the state model and returns a
+  dict of field updates — the standard LangGraph node signature.
+- Parallel nodes in a phase fan out from a synthetic barrier node and fan back
+  in at the next barrier. This keeps LangGraph's default last-writer-wins
+  semantics safe: parallel nodes must write disjoint top-level fields (enforced
+  by the caller, not by the builder — the builder's job is topology, not
+  reducer policy).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence  # noqa: matches LangGraph node-update dict shape
+
+from langgraph.graph import END, START, StateGraph
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    """A single node within a phase."""
+
+    name: str
+    run: Callable[..., dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PipelinePhase:
+    """A phase: one or more nodes that run in parallel; next phase blocks on all."""
+
+    name: str
+    nodes: Sequence[NodeSpec]
+
+
+def build_pipeline(
+    state_cls: type,
+    phases: Sequence[PipelinePhase],
+) -> Any:
+    """Compile ``phases`` into a LangGraph ``StateGraph`` over ``state_cls``.
+
+    Returns the compiled graph (ready to ``invoke``).
+
+    Rules:
+    - Phases run sequentially. All nodes in phase N complete before phase N+1 starts.
+    - Nodes within one phase run in parallel (LangGraph fan-out from barrier).
+    - Single-node phases are wired directly — no synthetic barrier.
+    - Node names must be unique across the whole pipeline; phase names must be
+      unique. Raises ``ValueError`` on conflict so typos fail loudly at build time.
+    """
+    if not phases:
+        raise ValueError("build_pipeline: at least one phase is required")
+
+    seen_phase: set[str] = set()
+    seen_node: set[str] = set()
+    for phase in phases:
+        if phase.name in seen_phase:
+            raise ValueError(f"duplicate phase name: {phase.name!r}")
+        seen_phase.add(phase.name)
+        if not phase.nodes:
+            raise ValueError(f"phase {phase.name!r} must declare at least one node")
+        for node in phase.nodes:
+            if node.name in seen_node:
+                raise ValueError(f"duplicate node name across pipeline: {node.name!r}")
+            seen_node.add(node.name)
+
+    graph: StateGraph = StateGraph(state_cls)
+
+    # Register every runnable node.
+    for phase in phases:
+        for node in phase.nodes:
+            graph.add_node(node.name, node.run)
+
+    # Synthetic barriers. A barrier is a no-op node that joins a fan-out and
+    # launches the next fan-out. For single-node phases, the node itself acts
+    # as its own entry + exit, so the barrier is skipped.
+    def _noop(_state: Any) -> dict[str, Any]:
+        return {}
+
+    prev_exit: str = START
+    for idx, phase in enumerate(phases):
+        nodes = list(phase.nodes)
+        if len(nodes) == 1:
+            only = nodes[0].name
+            if prev_exit == START:
+                graph.add_edge(START, only)
+            else:
+                graph.add_edge(prev_exit, only)
+            prev_exit = only
+            continue
+
+        # Multi-node phase: fan out from prev_exit to each node, fan in to a barrier.
+        barrier_name = f"__barrier__{idx}__{phase.name}"
+        graph.add_node(barrier_name, _noop)
+        for node in nodes:
+            if prev_exit == START:
+                graph.add_edge(START, node.name)
+            else:
+                graph.add_edge(prev_exit, node.name)
+            graph.add_edge(node.name, barrier_name)
+        prev_exit = barrier_name
+
+    graph.add_edge(prev_exit, END)
+    return graph.compile()

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any, TypeVar  # noqa: matches LLM message content-part dict shape
+# `# noqa` below is read by repo-local `scripts/score.py` (not ruff) — that
+# gate flags unscoped `Any` imports. Here Any matches heterogeneous LLM
+# message content-part dicts used by LiteLLM / OpenAI clients.
+from typing import Any, TypeVar  # noqa: scored-lint suppression
 
 from pydantic import BaseModel, ValidationError
 

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -1,0 +1,176 @@
+"""Generic research-agent node for sub-graphs.
+
+A phase node in an Atlas-style pipeline is "research this scope, produce
+a validated structured output." The *how* (analyst persona, materiality
+filter, citation discipline) lives in this module. The *what* (which sector,
+which data sources, which output schema) is injected per call as
+``skill_text`` + ``output_model``.
+
+This lets sub-graphs — notably DigiQuant Atlas (#176/#177) — compose research
+pipelines from declarative phase configs without re-authoring a prompt per
+segment. The module stays generic: no Atlas-specific vocabulary here.
+
+The existing ``digigraph.graph.research`` node is the RAG/tool-loop research
+node invoked by the DigiGraph supervisor; it is a different concern and is
+not touched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, TypeVar  # noqa: matches LLM message content-part dict shape
+
+from pydantic import BaseModel, ValidationError
+
+from digigraph.llm import chat_completion, get_model_for_mode
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+ANALYST_SYSTEM = """You are a disciplined research analyst producing a structured brief.
+
+Principles:
+- Material only. Skip noise. Include findings that meaningfully change the read on the scope; omit routine/cosmetic observations.
+- Evidence-bound. Every claim rests on a source you retrieved or on data in the user block. Do not invent numbers, dates, or quotations.
+- Cite. When citing a source, use the url or identifier provided in the user block. If the evidence is in the data bundle, reference the field name.
+- Quantify when possible. Percent moves, basis points, date ranges, dollar flows — prefer numbers over adjectives.
+- Flag uncertainty. If evidence is thin or conflicting, say so in the output's uncertainty/notes field; do not paper over it.
+- Refuse to hallucinate. If the scope cannot be answered from the provided context, return the schema with empty findings and a note explaining what is missing.
+
+Output format:
+- Respond with a single JSON object that validates against the schema named in the user block.
+- No markdown, no prose outside the JSON, no code fences.
+"""
+
+
+def _strip_json_fence(raw: str) -> str:
+    s = re.sub(r"^```(?:json)?\s*", "", (raw or "").strip()).strip()
+    return re.sub(r"\s*```$", "", s).strip()
+
+
+def _format_scope_block(
+    *,
+    skill_text: str,
+    phase_inputs: dict[str, Any],
+    shared_context: dict[str, Any],
+    output_schema: dict[str, Any],
+    schema_name: str,
+) -> list[dict[str, Any]]:
+    """Build the user-message content parts.
+
+    Structure (parts ordered from stable → volatile so caching hits downstream):
+      1. shared_context JSON — stable across all phases in a run; cache-controlled.
+      2. skill_text — stable per segment; cache-controlled.
+      3. phase_inputs JSON — volatile (today's data layer, prior-phase outputs).
+      4. output schema + name — stable per segment; cache-controlled.
+
+    Returns an OpenAI-compatible content-parts list. LiteLLM passes ``cache_control``
+    through to Anthropic when routing to Claude models; other providers ignore it.
+    """
+    shared_json = json.dumps(shared_context, default=str, sort_keys=True)
+    inputs_json = json.dumps(phase_inputs, default=str, sort_keys=True)
+    schema_json = json.dumps(output_schema, sort_keys=True)
+    return [
+        {
+            "type": "text",
+            "text": f"SHARED_CONTEXT:\n{shared_json}",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": f"RESEARCH_SCOPE (skill):\n{skill_text}",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": f"PHASE_INPUTS (today):\n{inputs_json}",
+        },
+        {
+            "type": "text",
+            "text": (
+                f"OUTPUT_SCHEMA (name: {schema_name}):\n{schema_json}\n\n"
+                f"Respond with a single JSON object that validates against {schema_name}."
+            ),
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+
+def run_research_agent(
+    *,
+    skill_text: str,
+    phase_inputs: dict[str, Any],
+    shared_context: dict[str, Any],
+    output_model: type[T],
+    model: str | None = None,
+    temperature: float = 0.1,
+    max_retries: int = 1,
+) -> T:
+    """Run one research-agent LLM call and return a validated Pydantic instance.
+
+    Raises:
+        ValidationError: if the LLM output cannot be coerced into ``output_model``
+            after ``max_retries`` attempts.
+
+    Parameters:
+        skill_text: Body of a SKILL.md file (without YAML frontmatter) — tells
+            the agent *what* to research.
+        phase_inputs: Volatile per-call inputs (today's data, prior-phase outputs).
+        shared_context: Stable per-run context (config, investment profile,
+            watchlist). Cached across phase calls within a run.
+        output_model: Pydantic model the output must validate against.
+        model: Override the LiteLLM model id. Defaults to ``get_model_for_mode()``.
+        temperature: LLM temperature; default 0.1 (analyst work wants determinism).
+        max_retries: How many times to re-call with the validator error appended
+            before giving up. Default 1.
+    """
+    effective_model = model or get_model_for_mode()
+    schema = output_model.model_json_schema()
+    schema_name = output_model.__name__
+    content_parts = _format_scope_block(
+        skill_text=skill_text,
+        phase_inputs=phase_inputs,
+        shared_context=shared_context,
+        output_schema=schema,
+        schema_name=schema_name,
+    )
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": ANALYST_SYSTEM},
+        {"role": "user", "content": content_parts},
+    ]
+
+    last_error: Exception | None = None
+    for attempt in range(max_retries + 1):
+        raw = chat_completion(effective_model, messages, temperature=temperature)
+        if isinstance(raw, tuple):  # defensive: chat_completion returns tuple only with tools
+            raw = raw[0]
+        try:
+            data = json.loads(_strip_json_fence(raw or ""))
+            return output_model.model_validate(data)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            last_error = exc
+            logger.warning(
+                "research_agent attempt %d/%d failed for %s: %s",
+                attempt + 1,
+                max_retries + 1,
+                schema_name,
+                exc,
+            )
+            if attempt == max_retries:
+                break
+            messages = messages + [
+                {"role": "assistant", "content": raw or ""},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Your previous response did not validate against {schema_name}. "
+                        f"Error: {exc}\n\nRe-emit a single JSON object that validates. "
+                        f"No prose, no code fences."
+                    ),
+                },
+            ]
+    assert last_error is not None  # loop always records on failure
+    raise last_error

--- a/tests/dg/test_pipeline_builder.py
+++ b/tests/dg/test_pipeline_builder.py
@@ -1,0 +1,113 @@
+"""Unit tests for the declarative pipeline builder."""
+
+from __future__ import annotations
+
+from typing import Any  # noqa: matches LangGraph node-update dict shape
+
+import pytest
+from pydantic import BaseModel
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase, build_pipeline
+
+
+class _State(BaseModel):
+    """Each node writes into its own field — parallel nodes must write disjoint keys."""
+
+    a_out: str | None = None
+    b_out: str | None = None
+    c_out: str | None = None
+    final: str | None = None
+
+
+def _make_node(name: str, field: str) -> NodeSpec:
+    def _run(_state: _State) -> dict[str, Any]:
+        return {field: f"{name}-ran"}
+
+    return NodeSpec(name=name, run=_run)
+
+
+@pytest.mark.unit
+class TestBuildPipeline:
+    def test_empty_phases_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one phase"):
+            build_pipeline(_State, [])
+
+    def test_duplicate_phase_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="duplicate phase"):
+            build_pipeline(
+                _State,
+                [
+                    PipelinePhase("p", [_make_node("a", "a_out")]),
+                    PipelinePhase("p", [_make_node("b", "b_out")]),
+                ],
+            )
+
+    def test_duplicate_node_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="duplicate node name"):
+            build_pipeline(
+                _State,
+                [
+                    PipelinePhase("p1", [_make_node("x", "a_out")]),
+                    PipelinePhase("p2", [_make_node("x", "b_out")]),
+                ],
+            )
+
+    def test_empty_phase_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one node"):
+            build_pipeline(_State, [PipelinePhase("p", [])])
+
+    def test_sequential_phases_run_in_order(self) -> None:
+        compiled = build_pipeline(
+            _State,
+            [
+                PipelinePhase("p1", [_make_node("a", "a_out")]),
+                PipelinePhase("p2", [_make_node("b", "b_out")]),
+                PipelinePhase("p3", [_make_node("c", "c_out")]),
+            ],
+        )
+        result = compiled.invoke(_State())
+        out = _State.model_validate(result) if isinstance(result, dict) else result
+        assert out.a_out == "a-ran"
+        assert out.b_out == "b-ran"
+        assert out.c_out == "c-ran"
+
+    def test_parallel_phase_fans_out_and_in(self) -> None:
+        """Fan-out nodes write disjoint fields; a downstream node reads both."""
+
+        def finalizer(state: _State) -> dict[str, Any]:
+            return {"final": f"{state.a_out}|{state.b_out}"}
+
+        compiled = build_pipeline(
+            _State,
+            [
+                PipelinePhase("start", [_make_node("seed", "c_out")]),
+                PipelinePhase(
+                    "parallel",
+                    [
+                        _make_node("a", "a_out"),
+                        _make_node("b", "b_out"),
+                    ],
+                ),
+                PipelinePhase("finish", [NodeSpec("finalizer", finalizer)]),
+            ],
+        )
+        result = compiled.invoke(_State())
+        out = _State.model_validate(result) if isinstance(result, dict) else result
+        assert out.c_out == "seed-ran"
+        assert out.a_out == "a-ran"
+        assert out.b_out == "b-ran"
+        # Both parallel outputs must be visible to the downstream finalizer.
+        assert out.final == "a-ran|b-ran"
+
+    def test_single_node_phases_skip_barrier(self) -> None:
+        """No extra __barrier__ nodes for purely-sequential pipelines."""
+        compiled = build_pipeline(
+            _State,
+            [
+                PipelinePhase("p1", [_make_node("a", "a_out")]),
+                PipelinePhase("p2", [_make_node("b", "b_out")]),
+            ],
+        )
+        # CompiledStateGraph exposes .get_graph().nodes — barrier names start with __barrier__.
+        node_names = set(compiled.get_graph().nodes.keys())
+        assert not any(n.startswith("__barrier__") for n in node_names)

--- a/tests/dg/test_pipeline_builder.py
+++ b/tests/dg/test_pipeline_builder.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any  # noqa: matches LangGraph node-update dict shape
+# `# noqa` below is read by repo-local `scripts/score.py` (not ruff) — that
+# gate flags unscoped `Any` imports. Here Any matches LangGraph node updates.
+from typing import Any  # noqa: scored-lint suppression
 
 import pytest
 from pydantic import BaseModel
@@ -55,6 +57,23 @@ class TestBuildPipeline:
     def test_empty_phase_raises(self) -> None:
         with pytest.raises(ValueError, match="at least one node"):
             build_pipeline(_State, [PipelinePhase("p", [])])
+
+    def test_reserved_barrier_prefix_rejected_on_phase(self) -> None:
+        with pytest.raises(ValueError, match="reserved prefix"):
+            build_pipeline(
+                _State,
+                [PipelinePhase("__barrier__0__x", [_make_node("a", "a_out")])],
+            )
+
+    def test_reserved_barrier_prefix_rejected_on_node(self) -> None:
+        def _noop(_s: _State) -> dict[str, Any]:
+            return {}
+
+        with pytest.raises(ValueError, match="reserved prefix"):
+            build_pipeline(
+                _State,
+                [PipelinePhase("p", [NodeSpec("__barrier__sneaky", _noop)])],
+            )
 
     def test_sequential_phases_run_in_order(self) -> None:
         compiled = build_pipeline(

--- a/tests/dg/test_research_agent.py
+++ b/tests/dg/test_research_agent.py
@@ -1,0 +1,158 @@
+"""Unit tests for the generic research-agent node."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from digigraph.graph.research_agent import (
+    ANALYST_SYSTEM,
+    _format_scope_block,
+    run_research_agent,
+)
+
+
+class _SampleOutput(BaseModel):
+    """Minimal target model for tests."""
+
+    regime: str = Field(description="regime label")
+    confidence: float = Field(ge=0.0, le=1.0)
+    notes: list[str] = Field(default_factory=list)
+
+
+@pytest.mark.unit
+class TestFormatScopeBlock:
+    def test_parts_have_cache_control_on_stable_blocks(self) -> None:
+        parts = _format_scope_block(
+            skill_text="research the macro regime",
+            phase_inputs={"data": 1},
+            shared_context={"config": "x"},
+            output_schema={"type": "object"},
+            schema_name="Foo",
+        )
+        # Shared context, skill, and schema are cache-controlled.
+        assert parts[0]["text"].startswith("SHARED_CONTEXT:")
+        assert parts[0]["cache_control"] == {"type": "ephemeral"}
+        assert parts[1]["text"].startswith("RESEARCH_SCOPE")
+        assert parts[1]["cache_control"] == {"type": "ephemeral"}
+        # Phase inputs are volatile — no cache marker.
+        assert parts[2]["text"].startswith("PHASE_INPUTS")
+        assert "cache_control" not in parts[2]
+        # Schema block stable per segment.
+        assert parts[3]["text"].startswith("OUTPUT_SCHEMA")
+        assert parts[3]["cache_control"] == {"type": "ephemeral"}
+
+    def test_shared_context_serialized_stably(self) -> None:
+        """Sorted keys matter for cache hits — same ctx must produce same text."""
+        a = _format_scope_block(
+            skill_text="s",
+            phase_inputs={},
+            shared_context={"b": 2, "a": 1},
+            output_schema={},
+            schema_name="X",
+        )
+        b = _format_scope_block(
+            skill_text="s",
+            phase_inputs={},
+            shared_context={"a": 1, "b": 2},
+            output_schema={},
+            schema_name="X",
+        )
+        assert a[0]["text"] == b[0]["text"]
+
+
+@pytest.mark.unit
+class TestRunResearchAgent:
+    def _fake_response(self, **fields: object) -> str:
+        return json.dumps(fields)
+
+    def test_successful_first_try(self) -> None:
+        payload = self._fake_response(regime="growth", confidence=0.8, notes=["ok"])
+        with patch("digigraph.graph.research_agent.chat_completion", return_value=payload) as mock:
+            out = run_research_agent(
+                skill_text="x",
+                phase_inputs={"d": 1},
+                shared_context={"c": 2},
+                output_model=_SampleOutput,
+                model="test-model",
+            )
+        assert out.regime == "growth"
+        assert out.confidence == 0.8
+        assert mock.call_count == 1
+        # System prompt in messages; user content is a list of cache-aware parts.
+        _args, kwargs = mock.call_args
+        messages = mock.call_args.args[1] if mock.call_args.args else kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == ANALYST_SYSTEM
+        assert isinstance(messages[1]["content"], list)
+
+    def test_strips_markdown_code_fence(self) -> None:
+        fenced = "```json\n" + json.dumps({"regime": "r", "confidence": 0.5}) + "\n```"
+        with patch("digigraph.graph.research_agent.chat_completion", return_value=fenced):
+            out = run_research_agent(
+                skill_text="x",
+                phase_inputs={},
+                shared_context={},
+                output_model=_SampleOutput,
+                model="test-model",
+            )
+        assert out.regime == "r"
+
+    def test_retry_once_on_validation_error_then_succeed(self) -> None:
+        bad = json.dumps({"regime": "x"})  # missing confidence
+        good = json.dumps({"regime": "x", "confidence": 0.4})
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=[bad, good],
+        ) as mock:
+            out = run_research_agent(
+                skill_text="x",
+                phase_inputs={},
+                shared_context={},
+                output_model=_SampleOutput,
+                model="test-model",
+                max_retries=1,
+            )
+        assert out.confidence == 0.4
+        assert mock.call_count == 2
+        # Second call must append assistant + corrective user message.
+        second_messages = mock.call_args_list[1].args[1]
+        assert second_messages[-2]["role"] == "assistant"
+        assert second_messages[-1]["role"] == "user"
+        assert "did not validate" in second_messages[-1]["content"]
+
+    def test_raises_validation_error_after_exhausting_retries(self) -> None:
+        bad = json.dumps({"regime": "x"})
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=[bad, bad],
+        ):
+            with pytest.raises(ValidationError):
+                run_research_agent(
+                    skill_text="x",
+                    phase_inputs={},
+                    shared_context={},
+                    output_model=_SampleOutput,
+                    model="test-model",
+                    max_retries=1,
+                )
+
+    def test_handles_tuple_response_from_chat_completion(self) -> None:
+        """chat_completion returns (content, tool_calls) when tools are passed;
+        research_agent never passes tools, but be defensive."""
+        payload = json.dumps({"regime": "r", "confidence": 0.1})
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            return_value=(payload, None),
+        ):
+            out = run_research_agent(
+                skill_text="x",
+                phase_inputs={},
+                shared_context={},
+                output_model=_SampleOutput,
+                model="test-model",
+            )
+        assert out.regime == "r"


### PR DESCRIPTION
## Summary

Commit 4 of 9 in the Atlas → DigiGraph migration (#176 + #177 merged).

First phases wired into real LangGraph nodes that call the generic research agent with injected skill files.

- **\`state.py\`**: parallel-write fields now carry an Annotated reducer so concurrent per-segment writes merge instead of raising \`InvalidConcurrentGraphUpdate\`.
- **\`segments.py\`**: shared \`SegmentReport\` base + \`Finding\`/\`Source\` sub-models + \`Bias\` literal vocabulary. Every Phase 1–5 segment inherits this.
- **\`phases/_node_factory.py\`**: \`build_segment_node(spec)\` — single place implementing the load-skill → build-context → run-agent → wrap-in-SegmentSlot pattern.
- **\`phases/preflight.py\`**: \`PreflightDeps\` + \`build_preflight_node()\`. Enforces delta-run \`baseline_date\` contract; probes data-layer freshness; loads prior context. No LLM cost in preflight.
- **\`phases/phase1_altdata.py\`**: 4 parallel nodes — sentiment, CTA, options, politician. Decision to keep 4 separate models (vs. one union) recorded in module docstring — separate models preserve structured-output guarantees.
- **\`phases/phase2_institutional.py\`**: 2 parallel nodes — flows, hedge funds.

Stacks on #243.

Ref #176

## Test plan

- [x] 20 new/updated tests passing, including 4-way and 2-way fan-out with mocked LLM
- [x] \`make score\`: 10/10/10/10
- [x] Chained phase 1 → phase 2 runs both sequentially with correct fan-in

## Next

Commit 5: Phase 3 macro + Phase 4 asset classes (5-way fan-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)