### PR TITLE
feat(design-system): extract 5 reusable primitives from landing mockups (#269)

### DIFF
--- a/frontend/design-system/README.md
+++ b/frontend/design-system/README.md
@@ -305,6 +305,191 @@ site sharing the same CSS). It will:
 - No light mode yet. The palette is dark-first; a light variant is a
   future PR with tokens overridden inside `@media (prefers-color-scheme: light)`.
 - No component JS framework. Primitives are class-based CSS; interactivity
-  is limited to the three vanilla-JS modules above.
+  is limited to the vanilla-JS modules documented above.
 - Confidential internal projects are out of scope. This design system
   documents only public-facing surfaces.
+
+---
+
+## Extended primitives
+
+Five additional primitives harvested from the landing-page exploration live
+alongside the base tokens + starfield. Each ships a CSS file, an ESM JS
+module, and (where useful) a `types.d.ts`. See the smoke-test page at
+[`smoke/index.html`](./smoke/index.html) for a minimal reviewer poke-surface
+for all five at once.
+
+### `living-architecture/` — interactive SVG diagram engine
+
+```js
+import { initDiagram } from '@digithings/design-system/living-architecture';
+import '@digithings/design-system/living-architecture/styles.css';
+
+const { camera, focus, reset, destroy } = initDiagram({
+  hostId: 'arch-host',
+  svgId: 'arch-svg',
+  nodes: [
+    { id: 'a', label: 'Alpha', x: 300, y: 360, accentVar: '--accent-digigraph', group: 'core' },
+    { id: 'b', label: 'Beta',  x: 600, y: 360, accentVar: '--accent-digiquant', group: 'core' },
+  ],
+  edges: [{ source: 'a', target: 'b' }],
+  onNodeFocus: (id) => { /* consumer side-effect */ },
+});
+```
+
+| API                     | Notes                                                                 |
+| ----------------------- | --------------------------------------------------------------------- |
+| `initDiagram(opts)`     | Builds edges + nodes, returns `{ camera, focus, reset, destroy }`.    |
+| `camera.focus(id)`      | 600ms viewBox tween to a node.                                        |
+| `camera.reset()`        | Tween back to the SVG's initial `viewBox`.                            |
+| `camera.zoomTo(bbox)`   | Tween to an arbitrary `[x, y, w, h]`.                                 |
+| `onNodeFocus(id)`       | Fires on node click / Enter / arrow-nav.                              |
+| Keyboard (host focused) | ←/→ cycle `group === "core"` nodes; ↑ reset; ↓ focus current/first core; Tab/Shift+Tab walks all nodes (a11y); Enter activates; Esc resets. |
+| Zoom-out button         | Auto-injected, top-right of host, calls `camera.reset()`.             |
+
+Static fallback: `fallback-diagram.svg` in the same folder — inline it with
+`<object data="…/fallback-diagram.svg">` or render it inside the host
+SVG before hydrating; JS will clear it on `initDiagram`.
+
+**Reduced motion**: edge flow animation disabled, viewBox snaps instantly
+on `focus` / `reset` / `zoomTo`, bloom transitions removed.
+
+### `terminal/` — scripted terminal widget
+
+```js
+import { initTerminal } from '@digithings/design-system/terminal';
+import '@digithings/design-system/terminal/styles.css';
+
+initTerminal({
+  elementId: 'term',
+  lines: [
+    { kind: 'prompt',    text: 'digithings init' },
+    { kind: 'output',    text: 'ready.' },
+    { kind: 'comment',   text: 'all services ok' },
+    { kind: 'tool-call', text: 'digigraph.route' },
+    { kind: 'output',    text: 'const x = 1;', lang: 'js' },
+  ],
+  speed: 'normal',
+  onReady: () => {},
+});
+```
+
+| Line `kind`   | Rendering                                                   |
+| ------------- | ----------------------------------------------------------- |
+| `prompt`      | Mono `>` marker, neutral body.                              |
+| `output`      | Default body.                                               |
+| `comment`     | `//` marker in a muted accent.                              |
+| `tool-call`   | Body rendered as a chip.                                    |
+
+Compose multiple terminals side-by-side inside `<div class="terminal-group">`
+(no inter-widget coordination needed). `speed` is `"fast" | "normal" | "slow"`
+or a custom per-character base in milliseconds. Optional `lang` hint
+(`js|ts|tsx|py|sh|json`) swaps in naïve highlighted markup after the keystroke
+stream completes — this is decorative, not a real tokenizer.
+
+**Reduced motion**: no typewriter, no cursor blink; text appears instantly.
+
+### `typography-motion/` — variable-weight + tracking shift
+
+Declarative (preferred for hero headlines):
+
+```html
+<link rel="stylesheet" href="…/typography-motion/styles.css" />
+<h1 class="tws-weight-shift"
+    data-weight-from="200" data-weight-to="700">Settle me on scroll.</h1>
+
+<script type="module">
+  import { initTypographyMotion } from '@digithings/design-system/typography-motion';
+  initTypographyMotion();
+</script>
+```
+
+Imperative:
+
+```js
+import { attachWeightShift, attachTrackingShift } from '@digithings/design-system/typography-motion';
+const h = attachWeightShift(el, { from: 200, to: 700, scrollStart: 0, scrollEnd: 400 });
+// h.detach() when the element leaves the tree
+```
+
+`.tws-weight-shift` drives `font-variation-settings: "wght" N` plus a matching
+`font-weight`. `.tws-tracking-shift` drives `letter-spacing` in `em` units.
+Both bind to scroll-Y progress across `[scrollStart, scrollEnd]`.
+
+**Reduced motion**: element snaps to the `to` value immediately; no scroll
+listener attached.
+
+### `quant-native/` — blueprint grid, ticker, metric + chart utilities
+
+```js
+import { initTicker } from '@digithings/design-system/quant-native';
+import '@digithings/design-system/quant-native/styles.css';
+
+initTicker({
+  elementId: 'ticker',
+  symbols: [
+    { sym: 'ATLAS',  price: '184.22', delta: '+0.42%' },
+    { sym: 'KAIROS', price: '342.07', delta: '-0.18%' },
+  ],
+  cadence: 60,  // px/sec
+});
+```
+
+| Class / API           | Purpose                                                    |
+| --------------------- | ---------------------------------------------------------- |
+| `.qn-blueprint-bg`    | Horizontal-rule pattern at ~2% opacity; apply to any block. |
+| `.qn-ticker`          | Ribbon container (JS-driven `translateX`, pause on hover). |
+| `.qn-metric`          | `font-feature-settings: "tnum"`, mono, right-aligned.      |
+| `.qn-chart-frame`     | Hairline border + `--bg-primary` fill; wraps an SVG chart. |
+| `.qn-up` / `.qn-down` | Muted emerald (digiquant accent) / muted copper (digiclaw accent). |
+
+Directional color is intentionally muted — never Bloomberg-bright red/green.
+
+**Reduced motion**: ticker track is pinned at `translateX(0)` with left
+padding; up/down colors unchanged.
+
+### `app-shell-terminal/` — Claude-Code-style app chrome
+
+```js
+import { initAppShell, SlashCommandRegistry }
+  from '@digithings/design-system/app-shell-terminal';
+import '@digithings/design-system/app-shell-terminal/styles.css';
+
+const registry = new SlashCommandRegistry();
+registry.register('route', {
+  description: 'Route a prompt to a specialist',
+  handler: (args) => console.log('route:', args.join(' ')),
+});
+
+const shell = initAppShell({
+  hostId: 'app',
+  title: 'digichat',
+  sidebarSlot: '<div>history · settings · /commands</div>',
+  mainSlot:    '<div id="chat"></div>',
+  slashCommands: registry,
+  onSubmit: (text) => { /* non-slash input */ },
+});
+```
+
+| Feature                    | Behavior                                                        |
+| -------------------------- | --------------------------------------------------------------- |
+| Sidebar                    | `aria-expanded` collapsible; `Cmd+/` toggles.                   |
+| Top bar                    | Mono title + metadata strip.                                    |
+| Input bar                  | Terminal-style `>` marker; auto-grows to 200px; `Enter` submits, `Shift+Enter` newline. |
+| Slash commands             | `registry.register/parse/dispatch`. Built-ins: `/help`, `/clear`. |
+| `Cmd+K`                    | Opens a `role="dialog"` palette with focus-trap + filter.       |
+| Slash-command reference    | Use `<span class="shell-cmd-ref">/name</span>` inside the sidebar. |
+
+**Reduced motion**: no sidebar / palette transitions; everything resolves
+instantly.
+
+### Smoke-test page
+
+Run any static server from `frontend/`:
+
+```bash
+cd frontend && python3 -m http.server 8765
+open http://localhost:8765/design-system/smoke/
+```
+
+The page renders one minimal instance of each primitive for review.

--- a/frontend/design-system/app-shell-terminal/index.js
+++ b/frontend/design-system/app-shell-terminal/index.js
@@ -1,0 +1,280 @@
+/* ==========================================================================
+   @digithings/design-system — app-shell-terminal
+   --------------------------------------------------------------------------
+   Claude-Code-style app chrome: collapsible sidebar, main slot, top bar,
+   terminal-like input bar, Cmd+K palette, slash command registry.
+
+   Usage:
+     import { initAppShell } from '@digithings/design-system/app-shell-terminal';
+     import '@digithings/design-system/app-shell-terminal/styles.css';
+
+     const shell = initAppShell({
+       hostId: 'app',
+       title: 'digichat',
+       sidebarSlot: '<div>history / settings</div>',
+       mainSlot:    '<div>main content</div>',
+       slashCommands: registry,  // optional SlashCommandRegistry instance
+       onSubmit: (text) => { ... },
+     });
+   ========================================================================== */
+
+import { SlashCommandRegistry } from './slash-commands.js';
+
+const FOCUSABLE = 'a,button,input,textarea,select,[tabindex]:not([tabindex="-1"])';
+
+function createEl(tag, className, html) {
+  const e = document.createElement(tag);
+  if (className) e.className = className;
+  if (html != null) e.innerHTML = html;
+  return e;
+}
+
+export function initAppShell({
+  hostId,
+  title = 'digithings',
+  sidebarSlot = '',
+  mainSlot = '',
+  slashCommands,
+  onSubmit,
+} = {}) {
+  const host = hostId ? document.getElementById(hostId) : null;
+  if (!host) throw new Error(`initAppShell: no host element for "${hostId}"`);
+
+  const prefersReduced = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const registry = slashCommands instanceof SlashCommandRegistry
+    ? slashCommands
+    : new SlashCommandRegistry();
+
+  // Built-ins — idempotent; won't overwrite if already registered.
+  if (!registry.list().some((c) => c.name === 'help')) {
+    registry.register('help', {
+      description: 'List available slash commands.',
+      handler: () => registry.list(),
+    });
+  }
+  if (!registry.list().some((c) => c.name === 'clear')) {
+    registry.register('clear', {
+      description: 'Clear the input.',
+      handler: () => { input.value = ''; },
+    });
+  }
+
+  host.classList.add('app-shell');
+  if (prefersReduced) host.classList.add('app-shell-reduced-motion');
+  host.innerHTML = '';
+
+  // ----- Sidebar ---------------------------------------------------------
+  const sidebar = createEl('aside', 'app-sidebar');
+  sidebar.setAttribute('aria-label', 'App sidebar');
+  sidebar.setAttribute('aria-expanded', 'true');
+  const sidebarBody = createEl('div', 'app-sidebar-body');
+  sidebarBody.innerHTML = sidebarSlot;
+  sidebar.appendChild(sidebarBody);
+
+  // ----- Main column -----------------------------------------------------
+  const mainCol = createEl('div', 'app-shell-main-col');
+
+  // Top bar
+  const topbar = createEl('header', 'app-topbar');
+  const titleEl = createEl('span', 'app-topbar-title');
+  titleEl.textContent = title;
+  const meta = createEl('span', 'app-topbar-meta');
+  meta.textContent = 'ready';
+  topbar.appendChild(titleEl);
+  topbar.appendChild(meta);
+
+  // Main slot
+  const main = createEl('main', 'app-main');
+  main.innerHTML = mainSlot;
+
+  // Input bar
+  const inputBar = createEl('form', 'app-input');
+  inputBar.setAttribute('role', 'search');
+  const marker = createEl('span', 'app-input-marker');
+  marker.textContent = '>';
+  const input = document.createElement('textarea');
+  input.className = 'app-input-field';
+  input.rows = 1;
+  input.setAttribute('aria-label', 'Command input');
+  input.placeholder = 'Type a message, or / for commands';
+  const hint = createEl('span', 'slash-hint');
+  hint.innerHTML = '<kbd>⌘K</kbd>';
+  inputBar.appendChild(marker);
+  inputBar.appendChild(input);
+  inputBar.appendChild(hint);
+
+  input.addEventListener('input', () => {
+    // Auto-grow a few rows.
+    input.style.height = 'auto';
+    input.style.height = `${Math.min(200, input.scrollHeight)}px`;
+  });
+
+  inputBar.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const value = input.value.trim();
+    if (!value) return;
+    if (registry.parse(value)) {
+      registry.dispatch(value);
+    } else if (typeof onSubmit === 'function') {
+      try { onSubmit(value); } catch (_) { /* swallow */ }
+    }
+    input.value = '';
+    input.style.height = 'auto';
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      inputBar.requestSubmit();
+    }
+  });
+
+  mainCol.appendChild(topbar);
+  mainCol.appendChild(main);
+  mainCol.appendChild(inputBar);
+
+  host.appendChild(sidebar);
+  host.appendChild(mainCol);
+
+  // ----- Sidebar collapse ------------------------------------------------
+  let collapsed = false;
+  function setCollapsed(v) {
+    collapsed = !!v;
+    host.classList.toggle('app-shell-sidebar-collapsed', collapsed);
+    sidebar.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+  }
+
+  // ----- Command palette (Cmd+K) -----------------------------------------
+  const palette = createEl('div', 'app-shell-palette');
+  palette.setAttribute('role', 'dialog');
+  palette.setAttribute('aria-modal', 'true');
+  palette.setAttribute('aria-label', 'Command palette');
+  palette.hidden = true;
+  const paletteInner = createEl('div', 'app-shell-palette-inner');
+  const paletteInput = document.createElement('input');
+  paletteInput.type = 'text';
+  paletteInput.className = 'app-shell-palette-input';
+  paletteInput.placeholder = 'Type a command…';
+  paletteInput.setAttribute('aria-label', 'Command palette search');
+  const paletteList = createEl('ul', 'app-shell-palette-list');
+  paletteInner.appendChild(paletteInput);
+  paletteInner.appendChild(paletteList);
+  palette.appendChild(paletteInner);
+  host.appendChild(palette);
+
+  let lastFocused = null;
+
+  function renderPalette(filter = '') {
+    const q = filter.trim().toLowerCase();
+    const items = registry.list().filter((c) =>
+      !q || c.name.toLowerCase().includes(q) || (c.description || '').toLowerCase().includes(q)
+    );
+    paletteList.innerHTML = '';
+    items.forEach((c, i) => {
+      const li = createEl('li', 'app-shell-palette-item');
+      li.tabIndex = 0;
+      li.dataset.name = c.name;
+      li.innerHTML = `<span class="shell-cmd-ref">/${c.name}</span><span class="app-shell-palette-desc">${c.description || ''}</span>`;
+      if (i === 0) li.classList.add('is-active');
+      li.addEventListener('click', () => {
+        closePalette();
+        registry.dispatch(`/${c.name}`);
+      });
+      li.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          closePalette();
+          registry.dispatch(`/${c.name}`);
+        }
+      });
+      paletteList.appendChild(li);
+    });
+  }
+
+  function openPalette() {
+    lastFocused = document.activeElement;
+    palette.hidden = false;
+    host.classList.add('app-shell-palette-open');
+    paletteInput.value = '';
+    renderPalette('');
+    paletteInput.focus();
+  }
+  function closePalette() {
+    palette.hidden = true;
+    host.classList.remove('app-shell-palette-open');
+    if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
+  }
+
+  paletteInput.addEventListener('input', () => renderPalette(paletteInput.value));
+  paletteInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') { e.preventDefault(); closePalette(); return; }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const first = paletteList.querySelector('.app-shell-palette-item');
+      if (first) {
+        closePalette();
+        registry.dispatch(`/${first.dataset.name}`);
+      }
+      return;
+    }
+    // Simple focus trap: forward Tab into list.
+    if (e.key === 'Tab' && !e.shiftKey) {
+      const first = paletteList.querySelector('.app-shell-palette-item');
+      if (first) { e.preventDefault(); first.focus(); }
+    }
+  });
+  palette.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') { e.preventDefault(); closePalette(); }
+    // Trap focus inside palette
+    if (e.key === 'Tab') {
+      const focusables = palette.querySelectorAll(FOCUSABLE);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    }
+  });
+
+  // ----- Global shortcuts ------------------------------------------------
+  function onKey(e) {
+    const meta = e.metaKey || e.ctrlKey;
+    if (meta && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      if (palette.hidden) openPalette(); else closePalette();
+      return;
+    }
+    if (meta && e.key === '/') {
+      e.preventDefault();
+      setCollapsed(!collapsed);
+    }
+  }
+  document.addEventListener('keydown', onKey);
+
+  return {
+    sidebar,
+    main,
+    input,
+    registry,
+    setCollapsed,
+    toggleSidebar: () => setCollapsed(!collapsed),
+    openPalette,
+    closePalette,
+    destroy() {
+      document.removeEventListener('keydown', onKey);
+      host.innerHTML = '';
+      host.classList.remove(
+        'app-shell',
+        'app-shell-reduced-motion',
+        'app-shell-sidebar-collapsed',
+        'app-shell-palette-open',
+      );
+    },
+  };
+}
+
+export { SlashCommandRegistry };

--- a/frontend/design-system/app-shell-terminal/slash-commands.js
+++ b/frontend/design-system/app-shell-terminal/slash-commands.js
@@ -1,0 +1,59 @@
+/* ==========================================================================
+   @digithings/design-system — app-shell-terminal/slash-commands
+   --------------------------------------------------------------------------
+   Registry + parser + dispatcher for slash commands. Used by the app shell's
+   input bar and Cmd+K palette.
+   ========================================================================== */
+
+export class SlashCommandRegistry {
+  constructor() {
+    this._commands = new Map();
+  }
+
+  /** Register a command.
+   *  @param {string} name — e.g. "help" (no leading slash).
+   *  @param {{ description?: string, handler: (args: string[]) => unknown }} spec
+   */
+  register(name, spec) {
+    if (!name || typeof name !== 'string') throw new Error('register: name required');
+    if (!spec || typeof spec.handler !== 'function') throw new Error('register: handler required');
+    const clean = name.replace(/^\//, '');
+    this._commands.set(clean, {
+      description: spec.description || '',
+      handler: spec.handler,
+    });
+  }
+
+  /** Unregister a command by name. */
+  unregister(name) {
+    this._commands.delete(name.replace(/^\//, ''));
+  }
+
+  /** List all commands for a palette. */
+  list() {
+    return Array.from(this._commands.entries()).map(([name, spec]) => ({
+      name,
+      description: spec.description,
+    }));
+  }
+
+  /** Parse `/cmd arg1 arg2` → { name, args } or null if not a command. */
+  parse(input) {
+    if (typeof input !== 'string') return null;
+    const trimmed = input.trim();
+    if (!trimmed.startsWith('/')) return null;
+    const parts = trimmed.slice(1).split(/\s+/);
+    const name = parts.shift();
+    if (!name) return null;
+    return { name, args: parts };
+  }
+
+  /** Parse + invoke. Returns the handler's result, or undefined if no match. */
+  dispatch(input) {
+    const parsed = this.parse(input);
+    if (!parsed) return undefined;
+    const spec = this._commands.get(parsed.name);
+    if (!spec) return undefined;
+    return spec.handler(parsed.args);
+  }
+}

--- a/frontend/design-system/app-shell-terminal/styles.css
+++ b/frontend/design-system/app-shell-terminal/styles.css
@@ -1,0 +1,198 @@
+/* ==========================================================================
+   @digithings/design-system — app-shell-terminal/styles.css
+   Scoped under `.app-shell*`, `.app-sidebar*`, `.app-main*`, `.app-topbar*`,
+   `.app-input*`, `.slash-hint`, `.shell-cmd-ref`. Consumes tokens.
+   ========================================================================== */
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: var(--font-family);
+  transition: grid-template-columns 0.25s var(--transition-ease);
+}
+.app-shell.app-shell-sidebar-collapsed {
+  grid-template-columns: 0 minmax(0, 1fr);
+}
+.app-shell.app-shell-reduced-motion {
+  transition: none;
+}
+
+/* --- Sidebar ----------------------------------------------------------- */
+.app-sidebar {
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  overflow: hidden auto;
+  font-family: var(--font-family-mono);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.app-shell-sidebar-collapsed .app-sidebar {
+  border-right: none;
+}
+.app-sidebar-body { padding: var(--space-4); }
+
+.app-sidebar-section {
+  margin-bottom: var(--space-4);
+}
+.app-sidebar-section h3 {
+  margin: 0 0 var(--space-2);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.app-sidebar-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.app-sidebar-section li {
+  padding: 4px 0;
+  color: var(--text-primary);
+}
+
+/* --- Main column ------------------------------------------------------- */
+.app-shell-main-col {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-height: 100vh;
+  min-width: 0;
+}
+
+/* --- Top bar ----------------------------------------------------------- */
+.app-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: rgba(10, 10, 10, 0.7);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.app-topbar-title { color: var(--text-primary); letter-spacing: 0.02em; }
+.app-topbar-meta { color: var(--text-secondary); }
+
+/* --- Main slot --------------------------------------------------------- */
+.app-main {
+  padding: var(--space-5);
+  overflow: auto;
+}
+
+/* --- Input bar --------------------------------------------------------- */
+.app-input {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  font-family: var(--font-family-mono);
+}
+.app-input-marker {
+  color: var(--accent, var(--text-secondary));
+  user-select: none;
+}
+.app-input-field {
+  width: 100%;
+  min-height: 1.8em;
+  max-height: 200px;
+  padding: 6px 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+}
+.app-input-field:focus {
+  border-color: var(--accent, var(--border-color));
+}
+.slash-hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.slash-hint kbd,
+.shell-cmd-ref {
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+/* --- Command palette --------------------------------------------------- */
+.app-shell-palette {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: start center;
+  padding-top: 12vh;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  z-index: 100;
+}
+.app-shell-palette[hidden] { display: none; }
+
+.app-shell-palette-inner {
+  width: min(560px, 92vw);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+.app-shell-palette-input {
+  width: 100%;
+  padding: 14px 16px;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  outline: none;
+}
+.app-shell-palette-list {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  max-height: 50vh;
+  overflow: auto;
+}
+.app-shell-palette-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-family-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+  outline: none;
+}
+.app-shell-palette-item.is-active,
+.app-shell-palette-item:hover,
+.app-shell-palette-item:focus-visible {
+  background: color-mix(in srgb, var(--accent, var(--fg)) 14%, transparent);
+}
+.app-shell-palette-desc {
+  color: var(--text-secondary);
+}
+
+/* --- Reduced motion ---------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .app-shell { transition: none; }
+}

--- a/frontend/design-system/living-architecture/fallback-diagram.svg
+++ b/frontend/design-system/living-architecture/fallback-diagram.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" role="img" aria-label="DigiThings architecture">
+  <style>
+    .n  { fill: rgba(255,255,255,0.02); stroke: #666; stroke-width: 1; }
+    .np { fill: rgba(229,183,101,0.05); stroke: #e5b765; stroke-width: 1.6; }
+    .l  { font-family: 'JetBrains Mono', monospace; font-size: 12px; letter-spacing: 2px;
+          fill: #e6e6e6; text-anchor: middle; text-transform: uppercase; }
+    .sl { font-family: 'JetBrains Mono', monospace; font-size: 9px; letter-spacing: 1.5px;
+          fill: #888; text-anchor: middle; text-transform: uppercase; }
+    .e  { fill: none; stroke: #444; stroke-width: 1; stroke-dasharray: 4 6; }
+    text { dominant-baseline: middle; }
+    rect.bg { fill: #0a0a0a; }
+  </style>
+  <rect class="bg" x="0" y="0" width="1200" height="720"/>
+
+  <!-- Edges -->
+  <g>
+    <path class="e" d="M170 130 Q 285 165 400 200"/>
+    <path class="e" d="M400 200 Q 500 280 600 360"/>
+    <path class="e" d="M600 360 Q 740 300 880 240"/>
+    <path class="e" d="M600 360 Q 775 380 950 400"/>
+    <path class="e" d="M600 360 Q 740 460 880 560"/>
+    <path class="e" d="M600 360 Q 515 490 430 620"/>
+    <path class="e" d="M600 360 Q 610 490 620 620"/>
+    <path class="e" d="M600 360 Q 425 460 250 560"/>
+    <path class="e" d="M600 360 Q 700 490 800 620"/>
+    <path class="e" d="M880 240 Q 565 400 250 560"/>
+    <path class="e" d="M950 400 Q 600 480 250 560"/>
+    <path class="e" d="M880 560 Q 840 590 800 620"/>
+    <path class="e" d="M880 240 Q 655 430 430 620"/>
+    <path class="e" d="M950 400 Q 690 510 430 620"/>
+  </g>
+
+  <!-- Nodes -->
+  <g>
+    <g transform="translate(170 130)"><circle class="n" r="32"/><circle fill="#9d8fc9" opacity="0.5" r="3"/><text class="l" y="-42">DIGICHAT</text><text class="sl" y="48">ENTRY</text></g>
+    <g transform="translate(400 200)"><circle class="n" r="32"/><circle fill="#d97a5a" opacity="0.5" r="3"/><text class="l" y="-42">DIGIKEY</text><text class="sl" y="48">IDENTITY</text></g>
+    <g transform="translate(600 360)"><circle class="np" r="44"/><circle fill="#e5b765" opacity="0.6" r="4"/><text class="l" y="-54">DIGIGRAPH</text><text class="sl" y="60">SUPERVISOR</text></g>
+    <g transform="translate(880 240)"><circle class="n" r="32"/><circle fill="#4fa37a" opacity="0.5" r="3"/><text class="l" y="-42">DIGIQUANT</text><text class="sl" y="48">QUANT</text></g>
+    <g transform="translate(950 400)"><circle class="n" r="32"/><circle fill="#5aa3c4" opacity="0.5" r="3"/><text class="l" y="-42">DIGISEARCH</text><text class="sl" y="48">RETRIEVAL</text></g>
+    <g transform="translate(880 560)"><circle class="n" r="32"/><circle fill="#4fa39b" opacity="0.5" r="3"/><text class="l" y="-42">DIGILINK</text><text class="sl" y="48">PROTOCOL</text></g>
+    <g transform="translate(250 560)"><circle class="n" r="32"/><circle fill="#7b7fc7" opacity="0.5" r="3"/><text class="l" y="-42">DIGISTORE</text><text class="sl" y="48">STORAGE</text></g>
+    <g transform="translate(430 620)"><circle class="n" r="32"/><circle fill="#6fa3a3" opacity="0.5" r="3"/><text class="l" y="-42">DIGISMITH</text><text class="sl" y="48">OBSERVABILITY</text></g>
+    <g transform="translate(620 620)"><circle class="n" r="32"/><circle fill="#b87840" opacity="0.5" r="3"/><text class="l" y="-42">DIGICLAW</text><text class="sl" y="48">RUNNER</text></g>
+    <g transform="translate(800 620)"><circle class="n" r="32"/><circle fill="#9ea0a5" opacity="0.5" r="3"/><text class="l" y="-42">DIGIBASE</text><text class="sl" y="48">LIBRARY</text></g>
+  </g>
+</svg>

--- a/frontend/design-system/living-architecture/index.js
+++ b/frontend/design-system/living-architecture/index.js
@@ -1,0 +1,280 @@
+/* ==========================================================================
+   @digithings/design-system — living-architecture
+   --------------------------------------------------------------------------
+   Reusable interactive SVG diagram engine. Extracted from the Mockup B
+   landing exploration, slimmed to a primitive with a small API. Act-driven
+   scroll logic, detail panels, tooltips, and lens controls are NOT part of
+   this module — those belong to the consuming page.
+
+   Usage:
+     import { initDiagram } from '@digithings/design-system/living-architecture';
+     import '@digithings/design-system/living-architecture/styles.css';
+
+     const { camera, focus, reset, destroy } = initDiagram({
+       hostId: 'arch-host',
+       svgId:  'arch-svg',
+       nodes:  [ { id, label, x, y, accentVar, group? } ],
+       edges:  [ { source, target } ],
+       onNodeFocus: (id) => { ... },
+     });
+   ========================================================================== */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const DEFAULT_VIEWBOX = [0, 0, 1200, 720];
+const TWEEN_DURATION = 600;
+
+function el(name, attrs = {}, children = []) {
+  const e = document.createElementNS(SVG_NS, name);
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v != null) e.setAttribute(k, v);
+  }
+  for (const c of children) e.appendChild(c);
+  return e;
+}
+
+// cubic-bezier(0.4, 0, 0.2, 1) approximation
+function easeStandard(t) {
+  return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+}
+
+export function initDiagram({ hostId, svgId, nodes, edges, onNodeFocus }) {
+  if (!svgId || !Array.isArray(nodes) || !Array.isArray(edges)) {
+    throw new Error('initDiagram: svgId, nodes, edges are required');
+  }
+
+  const prefersReduced = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const svg = document.getElementById(svgId);
+  if (!svg) throw new Error(`initDiagram: no SVG with id "${svgId}"`);
+  const host = hostId ? document.getElementById(hostId) : svg.parentElement;
+  if (!host) throw new Error(`initDiagram: no host element for "${hostId}"`);
+
+  // Ensure host is positionable so we can anchor the zoom-out button.
+  if (getComputedStyle(host).position === 'static') {
+    host.style.position = 'relative';
+  }
+  host.classList.add('la-host');
+  if (prefersReduced) host.classList.add('la-reduced-motion');
+  if (!host.hasAttribute('tabindex')) host.setAttribute('tabindex', '0');
+
+  // Compute viewBox from the attribute on the SVG (or default).
+  const initialVB = (svg.getAttribute('viewBox') || DEFAULT_VIEWBOX.join(' '))
+    .split(/\s+/).map(Number);
+  if (initialVB.length !== 4 || initialVB.some(Number.isNaN)) {
+    initialVB.splice(0, initialVB.length, ...DEFAULT_VIEWBOX);
+  }
+
+  svg.classList.add('la-svg');
+  // Clear any prior children (idempotent re-init).
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+  const edgesLayer = el('g', { class: 'la-edges' });
+  const nodesLayer = el('g', { class: 'la-nodes' });
+  svg.appendChild(edgesLayer);
+  svg.appendChild(nodesLayer);
+
+  const nodeEls = Object.create(null);
+  const coreNodes = nodes.filter((n) => n.group === 'core');
+
+  // --------------------------------------------------------------------
+  // Edges
+  // --------------------------------------------------------------------
+  for (const edge of edges) {
+    const a = nodes.find((n) => n.id === edge.source);
+    const b = nodes.find((n) => n.id === edge.target);
+    if (!a || !b) continue;
+    const mx = (a.x + b.x) / 2;
+    const my = (a.y + b.y) / 2;
+    const dx = b.x - a.x, dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const nudge = 28;
+    const cx = mx + (-dy / len) * nudge;
+    const cy = my + (dx / len) * nudge;
+    const d = `M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}`;
+    const p = el('path', {
+      class: 'la-edge',
+      d,
+      'data-from': a.id,
+      'data-to': b.id,
+    });
+    // Stagger the dashoffset cycle so edges don't animate in lock-step.
+    p.style.animationDelay = `${-Math.random() * 6}s`;
+    edgesLayer.appendChild(p);
+  }
+
+  // --------------------------------------------------------------------
+  // Nodes
+  // --------------------------------------------------------------------
+  for (const node of nodes) {
+    const g = el('g', {
+      class: 'la-node',
+      'data-id': node.id,
+      tabindex: '0',
+      role: 'button',
+      'aria-label': node.label || node.id,
+      transform: `translate(${node.x}, ${node.y})`,
+    });
+    if (node.accentVar) {
+      g.style.setProperty('--accent', `var(${node.accentVar})`);
+    }
+    const r = node.group === 'core' ? 44 : 34;
+    g.appendChild(el('circle', { class: 'la-halo', cx: 0, cy: 0, r: r + 14 }));
+    g.appendChild(el('circle', { class: 'la-ring', cx: 0, cy: 0, r }));
+    g.appendChild(el('circle', { class: 'la-dot', cx: 0, cy: 0, r: 3 }));
+    const label = el('text', { class: 'la-label', y: -r - 10 });
+    label.textContent = (node.label || node.id).toUpperCase();
+    g.appendChild(label);
+
+    g.addEventListener('click', () => activate(node.id));
+    g.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        activate(node.id);
+      }
+    });
+
+    nodesLayer.appendChild(g);
+    nodeEls[node.id] = g;
+  }
+
+  // --------------------------------------------------------------------
+  // Camera / viewBox tween
+  // --------------------------------------------------------------------
+  let currentVB = initialVB.slice();
+  let rafId = 0;
+
+  function applyViewBox(vb) {
+    svg.setAttribute('viewBox', vb.join(' '));
+  }
+  applyViewBox(currentVB);
+
+  function tweenTo(target) {
+    if (prefersReduced) {
+      currentVB = target.slice();
+      applyViewBox(currentVB);
+      return;
+    }
+    const from = currentVB.slice();
+    const start = performance.now();
+    if (rafId) cancelAnimationFrame(rafId);
+    function step(now) {
+      const t = Math.min(1, (now - start) / TWEEN_DURATION);
+      const k = easeStandard(t);
+      currentVB = from.map((v, i) => v + (target[i] - v) * k);
+      applyViewBox(currentVB);
+      if (t < 1) rafId = requestAnimationFrame(step);
+      else rafId = 0;
+    }
+    rafId = requestAnimationFrame(step);
+  }
+
+  function nodeBBox(node, pad = 180) {
+    return [node.x - pad, node.y - pad, pad * 2, pad * 2];
+  }
+
+  const camera = {
+    focus(id) {
+      const node = nodes.find((n) => n.id === id);
+      if (!node) return;
+      tweenTo(nodeBBox(node));
+    },
+    reset() {
+      tweenTo(initialVB.slice());
+    },
+    zoomTo(bbox) {
+      if (!Array.isArray(bbox) || bbox.length !== 4) return;
+      tweenTo(bbox.slice());
+    },
+  };
+
+  // --------------------------------------------------------------------
+  // Focus / bloom state
+  // --------------------------------------------------------------------
+  let activeId = null;
+
+  function setActive(id) {
+    activeId = id;
+    for (const n of nodes) {
+      const g = nodeEls[n.id];
+      g.classList.toggle('la-is-active', n.id === id);
+      g.classList.toggle('la-is-dim', id != null && n.id !== id);
+    }
+  }
+
+  function clearActive() {
+    activeId = null;
+    for (const n of nodes) {
+      const g = nodeEls[n.id];
+      g.classList.remove('la-is-active', 'la-is-dim');
+    }
+  }
+
+  function activate(id) {
+    setActive(id);
+    camera.focus(id);
+    if (typeof onNodeFocus === 'function') {
+      try { onNodeFocus(id); } catch (_) { /* swallow */ }
+    }
+  }
+
+  function focus(id) { activate(id); }
+  function reset() {
+    clearActive();
+    camera.reset();
+  }
+
+  // --------------------------------------------------------------------
+  // Zoom-out button (top-right of host)
+  // --------------------------------------------------------------------
+  const zoomBtn = document.createElement('button');
+  zoomBtn.type = 'button';
+  zoomBtn.className = 'la-zoom-out-btn';
+  zoomBtn.setAttribute('aria-label', 'Zoom out');
+  zoomBtn.textContent = '\u2922'; // ⤢ — diagonal arrows glyph
+  zoomBtn.addEventListener('click', () => reset());
+  host.appendChild(zoomBtn);
+
+  // --------------------------------------------------------------------
+  // Keyboard navigation on host
+  // --------------------------------------------------------------------
+  function cycleCore(delta) {
+    if (coreNodes.length === 0) return;
+    const idx = coreNodes.findIndex((n) => n.id === activeId);
+    const next = coreNodes[((idx === -1 ? 0 : idx + delta) + coreNodes.length) % coreNodes.length];
+    activate(next.id);
+  }
+
+  function onKey(e) {
+    // Only intercept when focus is inside the host.
+    if (!host.contains(document.activeElement) && document.activeElement !== host) return;
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault(); cycleCore(-1); break;
+      case 'ArrowRight':
+        e.preventDefault(); cycleCore(1); break;
+      case 'ArrowUp':
+        e.preventDefault(); reset(); break;
+      case 'ArrowDown':
+        e.preventDefault();
+        if (activeId && coreNodes.some((n) => n.id === activeId)) activate(activeId);
+        else if (coreNodes[0]) activate(coreNodes[0].id);
+        break;
+      case 'Escape':
+        e.preventDefault(); reset(); break;
+      default: break;
+      // Enter is handled on the focused node element; Tab is native.
+    }
+  }
+  host.addEventListener('keydown', onKey);
+
+  function destroy() {
+    host.removeEventListener('keydown', onKey);
+    if (rafId) cancelAnimationFrame(rafId);
+    zoomBtn.remove();
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+    host.classList.remove('la-host', 'la-reduced-motion');
+  }
+
+  return { camera, focus, reset, destroy };
+}

--- a/frontend/design-system/living-architecture/styles.css
+++ b/frontend/design-system/living-architecture/styles.css
@@ -1,0 +1,147 @@
+/* ==========================================================================
+   @digithings/design-system — living-architecture/styles.css
+   All classes are scoped under `.la-*`. Consumes tokens from ../tokens.css.
+   ========================================================================== */
+
+.la-host {
+  display: block;
+  width: 100%;
+  height: 100%;
+  outline: none;
+}
+.la-host:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent, var(--fg));
+  border-radius: var(--radius-md);
+}
+
+.la-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* --- Edges --------------------------------------------------------------- */
+.la-edge {
+  fill: none;
+  stroke: var(--border-color);
+  stroke-width: 1.2;
+  stroke-dasharray: 4 8;
+  stroke-dashoffset: 0;
+  opacity: 0.7;
+  animation: la-flow 6s linear infinite;
+  transition:
+    stroke 0.4s var(--transition-ease),
+    opacity 0.4s var(--transition-ease),
+    stroke-width 0.3s var(--transition-ease);
+}
+.la-edge.la-is-hot {
+  stroke: var(--accent, var(--fg));
+  stroke-width: 1.6;
+  opacity: 1;
+}
+
+@keyframes la-flow {
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: -48; }
+}
+
+/* --- Nodes --------------------------------------------------------------- */
+.la-node {
+  cursor: pointer;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition:
+    opacity 0.4s var(--transition-ease),
+    transform 0.3s var(--transition-ease);
+}
+.la-node.la-is-dim { opacity: 0.28; }
+
+.la-node .la-halo {
+  fill: var(--accent, var(--fg));
+  opacity: 0;
+  transition: opacity 0.3s linear;
+}
+.la-node:hover .la-halo,
+.la-node:focus-visible .la-halo,
+.la-node.la-is-active .la-halo {
+  opacity: 0.22;
+}
+.la-node.la-is-active .la-halo { opacity: 0.35; }
+
+.la-node .la-ring {
+  fill: rgba(255, 255, 255, 0.02);
+  stroke: var(--border-color);
+  stroke-width: 1;
+  transition: stroke 0.3s, stroke-width 0.3s;
+}
+.la-node:hover .la-ring,
+.la-node:focus-visible .la-ring,
+.la-node.la-is-active .la-ring {
+  stroke: var(--accent, var(--fg));
+  stroke-width: 2;
+}
+
+.la-node .la-dot {
+  fill: var(--accent, var(--fg));
+  opacity: 0.5;
+}
+
+.la-node .la-label {
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  fill: var(--text-primary);
+  text-anchor: middle;
+  pointer-events: none;
+  user-select: none;
+}
+
+.la-node:focus { outline: none; }
+.la-node:focus-visible .la-ring { stroke-dasharray: 3 3; }
+
+/* --- Zoom-out button ----------------------------------------------------- */
+.la-zoom-out-btn {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: rgba(10, 10, 10, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+.la-zoom-out-btn:hover,
+.la-zoom-out-btn:focus-visible {
+  color: var(--fg);
+  border-color: var(--accent, var(--fg));
+  background: rgba(18, 18, 18, 0.9);
+  outline: none;
+}
+
+/* --- Reduced motion ------------------------------------------------------ */
+.la-host.la-reduced-motion .la-edge { animation: none; }
+.la-host.la-reduced-motion .la-node,
+.la-host.la-reduced-motion .la-halo,
+.la-host.la-reduced-motion .la-ring,
+.la-host.la-reduced-motion .la-edge {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .la-edge { animation: none; }
+  .la-node,
+  .la-halo,
+  .la-ring { transition: none; }
+}

--- a/frontend/design-system/living-architecture/types.d.ts
+++ b/frontend/design-system/living-architecture/types.d.ts
@@ -1,0 +1,41 @@
+// Type hints for the living-architecture primitive.
+
+export interface DiagramNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  /** CSS custom-property name, e.g. "--accent-digigraph". */
+  accentVar?: string;
+  /** Arrow-left/right nav cycles nodes where group === "core". */
+  group?: "core" | string;
+}
+
+export interface DiagramEdge {
+  source: string;
+  target: string;
+}
+
+export interface CameraAPI {
+  focus(nodeId: string): void;
+  reset(): void;
+  /** viewBox tuple: [x, y, width, height]. */
+  zoomTo(bbox: [number, number, number, number]): void;
+}
+
+export interface DiagramHandle {
+  camera: CameraAPI;
+  focus(nodeId: string): void;
+  reset(): void;
+  destroy(): void;
+}
+
+export interface InitDiagramOptions {
+  hostId: string;
+  svgId: string;
+  nodes: DiagramNode[];
+  edges: DiagramEdge[];
+  onNodeFocus?: (nodeId: string) => void;
+}
+
+export function initDiagram(opts: InitDiagramOptions): DiagramHandle;

--- a/frontend/design-system/package.json
+++ b/frontend/design-system/package.json
@@ -9,7 +9,17 @@
     "./starfield.js": "./starfield.js",
     "./scroll-trigger.js": "./scroll-trigger.js",
     "./typewriter.js": "./typewriter.js",
-    "./assets/*": "./assets/*"
+    "./assets/*": "./assets/*",
+    "./living-architecture": "./living-architecture/index.js",
+    "./living-architecture/styles.css": "./living-architecture/styles.css",
+    "./terminal": "./terminal/index.js",
+    "./terminal/styles.css": "./terminal/styles.css",
+    "./typography-motion": "./typography-motion/index.js",
+    "./typography-motion/styles.css": "./typography-motion/styles.css",
+    "./quant-native": "./quant-native/ticker.js",
+    "./quant-native/styles.css": "./quant-native/styles.css",
+    "./app-shell-terminal": "./app-shell-terminal/index.js",
+    "./app-shell-terminal/styles.css": "./app-shell-terminal/styles.css"
   },
   "files": [
     "tokens.css",
@@ -17,6 +27,11 @@
     "starfield.js",
     "scroll-trigger.js",
     "typewriter.js",
-    "assets"
+    "assets",
+    "living-architecture",
+    "terminal",
+    "typography-motion",
+    "quant-native",
+    "app-shell-terminal"
   ]
 }

--- a/frontend/design-system/quant-native/styles.css
+++ b/frontend/design-system/quant-native/styles.css
@@ -1,0 +1,79 @@
+/* ==========================================================================
+   @digithings/design-system — quant-native/styles.css
+   Scoped under `.qn-*`. Consumes tokens from ../tokens.css.
+   Muted emerald / muted copper for directional color — never Bloomberg red.
+   ========================================================================== */
+
+/* --- Blueprint background ---------------------------------------------- */
+.qn-blueprint-bg {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.02) 0,
+    rgba(255, 255, 255, 0.02) 1px,
+    transparent 1px,
+    transparent 8px
+  );
+}
+
+/* --- Directional colors (muted) ---------------------------------------- */
+.qn-up   { color: var(--accent-digiquant); }
+.qn-down { color: var(--accent-digiclaw); }
+
+/* --- Metric (tabular numerics) ----------------------------------------- */
+.qn-metric {
+  font-family: var(--font-family-mono);
+  font-feature-settings: "tnum" 1, "ss01" 1;
+  letter-spacing: 0.01em;
+  text-align: right;
+}
+
+/* --- Chart frame ------------------------------------------------------- */
+.qn-chart-frame {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  padding: var(--space-3);
+}
+.qn-chart-frame > svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* --- Ticker ------------------------------------------------------------ */
+.qn-ticker {
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  background: rgba(10, 10, 10, 0.7);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  padding: 10px 0;
+}
+.qn-ticker-track {
+  display: inline-flex;
+  white-space: nowrap;
+  will-change: transform;
+}
+.qn-ticker-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 0 28px;
+  border-right: 1px dashed var(--border-color);
+}
+.qn-ticker-sym {
+  color: var(--fg);
+  letter-spacing: 0.04em;
+}
+.qn-ticker-px { margin-left: 2px; }
+.qn-ticker-delta { margin-left: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .qn-ticker-track {
+    transform: translateX(0) !important;
+    padding-left: var(--space-3);
+  }
+}

--- a/frontend/design-system/quant-native/ticker.js
+++ b/frontend/design-system/quant-native/ticker.js
@@ -1,0 +1,94 @@
+/* ==========================================================================
+   @digithings/design-system — quant-native/ticker
+   --------------------------------------------------------------------------
+   JS-driven horizontal ticker. No CSS marquee — we translate on a RAF loop
+   so the cadence is deterministic and pause-on-hover is trivial.
+
+   Usage:
+     import { initTicker } from '@digithings/design-system/quant-native';
+     import '@digithings/design-system/quant-native/styles.css';
+
+     initTicker({
+       elementId: 'ticker',
+       symbols: [{ sym: 'ATLAS', price: '184.22', delta: '+0.42%' }],
+       cadence: 60,  // px/sec
+     });
+   ========================================================================== */
+
+function buildRow(symbols) {
+  const frag = document.createDocumentFragment();
+  for (const s of symbols) {
+    const item = document.createElement('span');
+    item.className = 'qn-ticker-item';
+    const dir = typeof s.delta === 'string' && s.delta.trim().startsWith('-') ? 'down' : 'up';
+    item.innerHTML = `
+      <span class="qn-ticker-sym">${s.sym}</span>
+      <span class="qn-metric qn-ticker-px">${s.price}</span>
+      <span class="qn-${dir} qn-ticker-delta">${s.delta}</span>
+    `;
+    frag.appendChild(item);
+  }
+  return frag;
+}
+
+export function initTicker({ elementId, symbols, cadence = 60 } = {}) {
+  const host = document.getElementById(elementId);
+  if (!host) throw new Error(`initTicker: no element with id "${elementId}"`);
+  if (!Array.isArray(symbols) || symbols.length === 0) return { destroy() {} };
+
+  const prefersReduced = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  host.classList.add('qn-ticker');
+  host.innerHTML = '';
+  const track = document.createElement('div');
+  track.className = 'qn-ticker-track';
+  // Duplicate so the seam is always off-screen.
+  track.appendChild(buildRow(symbols));
+  track.appendChild(buildRow(symbols));
+  host.appendChild(track);
+
+  let offset = 0;
+  let last = 0;
+  let raf = 0;
+  let paused = false;
+
+  function measureHalf() {
+    // Total track width / 2 — equals one full sequence.
+    return track.scrollWidth / 2;
+  }
+
+  function frame(now) {
+    if (!last) last = now;
+    const dt = (now - last) / 1000;
+    last = now;
+    if (!paused) {
+      offset += cadence * dt;
+      const half = measureHalf();
+      if (offset >= half) offset -= half;
+      track.style.transform = `translateX(${-offset}px)`;
+    }
+    raf = requestAnimationFrame(frame);
+  }
+
+  if (prefersReduced) {
+    track.style.transform = 'translateX(0)';
+  } else {
+    raf = requestAnimationFrame(frame);
+  }
+
+  const onEnter = () => { paused = true; };
+  const onLeave = () => { paused = false; last = 0; };
+  host.addEventListener('mouseenter', onEnter);
+  host.addEventListener('mouseleave', onLeave);
+
+  return {
+    destroy() {
+      if (raf) cancelAnimationFrame(raf);
+      host.removeEventListener('mouseenter', onEnter);
+      host.removeEventListener('mouseleave', onLeave);
+      host.innerHTML = '';
+      host.classList.remove('qn-ticker');
+    },
+  };
+}

--- a/frontend/design-system/smoke/index.html
+++ b/frontend/design-system/smoke/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>design-system smoke</title>
+  <link rel="stylesheet" href="../tokens.css" />
+  <link rel="stylesheet" href="../living-architecture/styles.css" />
+  <link rel="stylesheet" href="../terminal/styles.css" />
+  <link rel="stylesheet" href="../typography-motion/styles.css" />
+  <link rel="stylesheet" href="../quant-native/styles.css" />
+  <link rel="stylesheet" href="../app-shell-terminal/styles.css" />
+  <style>
+    body {
+      margin: 0;
+      padding: var(--space-5);
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+      font-family: var(--font-family);
+      display: grid;
+      gap: var(--space-6);
+    }
+    h1, h2 { margin: 0 0 var(--space-2); }
+    .smoke-section {
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-md);
+      padding: var(--space-4);
+      background: rgba(10, 10, 10, 0.4);
+    }
+    .smoke-section > .label {
+      font-family: var(--font-family-mono);
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-secondary);
+      margin-bottom: var(--space-3);
+    }
+    #arch-host {
+      position: relative;
+      width: 100%;
+      height: 420px;
+      background: var(--bg-primary);
+      border-radius: var(--radius-md);
+    }
+    #arch-svg { width: 100%; height: 100%; }
+    #appshell-host {
+      height: 480px;
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+    }
+    .app-shell { min-height: auto; height: 100%; }
+    .app-shell-main-col { min-height: auto; }
+    .smoke-tws h1 {
+      font-size: 3rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <h1>design-system smoke</h1>
+  <p>Minimal isolated examples of each new primitive. Review each section.</p>
+
+  <section class="smoke-section">
+    <div class="label">living-architecture</div>
+    <div id="arch-host">
+      <svg id="arch-svg" viewBox="0 0 1200 720" aria-label="Demo architecture diagram"></svg>
+    </div>
+  </section>
+
+  <section class="smoke-section">
+    <div class="label">terminal</div>
+    <div class="terminal-group">
+      <div id="term-demo"></div>
+    </div>
+  </section>
+
+  <section class="smoke-section smoke-tws">
+    <div class="label">typography-motion — scroll to shift weight</div>
+    <h1 class="tws-weight-shift"
+        data-weight-from="200" data-weight-to="700">
+      Variable-weight headline.
+    </h1>
+  </section>
+
+  <section class="smoke-section">
+    <div class="label">quant-native — blueprint + ticker</div>
+    <div class="qn-blueprint-bg" style="padding: var(--space-4); border-radius: var(--radius-md);">
+      <div class="qn-chart-frame" style="margin-bottom: var(--space-3);">
+        <svg viewBox="0 0 300 80"><path d="M0 60 L50 55 L100 40 L150 45 L200 25 L250 30 L300 10"
+          fill="none" stroke="var(--accent-digiquant)" stroke-width="1.5"/></svg>
+      </div>
+      <div id="qn-ticker"></div>
+    </div>
+  </section>
+
+  <section class="smoke-section">
+    <div class="label">app-shell-terminal</div>
+    <div id="appshell-host"></div>
+  </section>
+
+  <script type="module">
+    import { initDiagram } from '../living-architecture/index.js';
+    import { initTerminal } from '../terminal/index.js';
+    import { initTypographyMotion } from '../typography-motion/index.js';
+    import { initTicker } from '../quant-native/ticker.js';
+    import { initAppShell } from '../app-shell-terminal/index.js';
+
+    // Living architecture
+    initDiagram({
+      hostId: 'arch-host',
+      svgId: 'arch-svg',
+      nodes: [
+        { id: 'a', label: 'Alpha',  x: 300, y: 360, accentVar: '--accent-digigraph', group: 'core' },
+        { id: 'b', label: 'Beta',   x: 600, y: 220, accentVar: '--accent-digiquant', group: 'core' },
+        { id: 'c', label: 'Gamma',  x: 900, y: 360, accentVar: '--accent-digisearch', group: 'core' },
+        { id: 'd', label: 'Delta',  x: 600, y: 520, accentVar: '--accent-digichat' },
+      ],
+      edges: [
+        { source: 'a', target: 'b' },
+        { source: 'b', target: 'c' },
+        { source: 'a', target: 'd' },
+        { source: 'd', target: 'c' },
+      ],
+      onNodeFocus: (id) => console.log('focus', id),
+    });
+
+    // Terminal
+    initTerminal({
+      elementId: 'term-demo',
+      lines: [
+        { kind: 'prompt',  text: 'digithings init' },
+        { kind: 'output',  text: 'ready.' },
+        { kind: 'comment', text: 'all services ok' },
+      ],
+      speed: 'fast',
+    });
+
+    // Typography motion
+    initTypographyMotion();
+
+    // Ticker
+    initTicker({
+      elementId: 'qn-ticker',
+      symbols: [
+        { sym: 'ATLAS', price: '184.22', delta: '+0.42%' },
+        { sym: 'HERMES', price: ' 98.11', delta: '-0.18%' },
+        { sym: 'KAIROS', price: '342.07', delta: '+1.14%' },
+      ],
+      cadence: 40,
+    });
+
+    // App shell
+    initAppShell({
+      hostId: 'appshell-host',
+      title: 'smoke · app-shell',
+      sidebarSlot: `
+        <div class="app-sidebar-section"><h3>history</h3><ul><li>hello world</li></ul></div>
+        <div class="app-sidebar-section"><h3>commands</h3>
+          <ul><li><span class="shell-cmd-ref">/help</span></li><li><span class="shell-cmd-ref">/clear</span></li></ul>
+        </div>`,
+      mainSlot: '<p>Press <kbd>⌘K</kbd> for the palette. Type <code>/help</code> in the input.</p>',
+    });
+  </script>
+</body>
+</html>

--- a/frontend/design-system/terminal/index.js
+++ b/frontend/design-system/terminal/index.js
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   @digithings/design-system — terminal
+   --------------------------------------------------------------------------
+   Reusable terminal widget. Typewriter rendering of a scripted line list.
+   Line kinds: prompt | output | comment | tool-call.
+   Optional `lang` hint flips a pre-tagged highlighted span set in after
+   the keystroke stream completes.
+
+   Usage:
+     import { initTerminal } from '@digithings/design-system/terminal';
+     import '@digithings/design-system/terminal/styles.css';
+
+     const term = initTerminal({
+       elementId: 'term',
+       lines: [
+         { kind: 'prompt',   text: 'digithings init' },
+         { kind: 'output',   text: 'ready.' },
+         { kind: 'comment',  text: 'tooling ok' },
+         { kind: 'tool-call', text: 'digigraph.route' },
+       ],
+       speed: 'normal',
+       onReady: () => {},
+     });
+   ========================================================================== */
+
+const SPEED_PRESETS = { fast: 12, normal: 32, slow: 60 };
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+function rand(a, b) { return a + Math.random() * (b - a); }
+
+function resolveSpeed(speed) {
+  if (typeof speed === 'number' && Number.isFinite(speed)) return speed;
+  return SPEED_PRESETS[speed] ?? SPEED_PRESETS.normal;
+}
+
+function lineNodeFor(line) {
+  const row = document.createElement('div');
+  row.className = `term-line term-${line.kind || 'output'}`;
+  const body = document.createElement('span');
+  body.className = 'term-body-text';
+  if (line.kind === 'prompt') {
+    const marker = document.createElement('span');
+    marker.className = 'term-marker';
+    marker.textContent = '>';
+    row.appendChild(marker);
+  } else if (line.kind === 'comment') {
+    const marker = document.createElement('span');
+    marker.className = 'term-comment-marker';
+    marker.textContent = '//';
+    row.appendChild(marker);
+  } else if (line.kind === 'tool-call') {
+    row.classList.add('term-chip-row');
+  }
+  row.appendChild(body);
+  return { row, body };
+}
+
+export function initTerminal({ elementId, lines, speed, onReady } = {}) {
+  const host = document.getElementById(elementId);
+  if (!host) throw new Error(`initTerminal: no element with id "${elementId}"`);
+  host.classList.add('term-root');
+
+  const prefersReduced = typeof window !== 'undefined'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const perChar = resolveSpeed(speed);
+  const queue = Array.isArray(lines) ? lines.slice() : [];
+
+  // Window chrome — optional; only rendered if host is empty.
+  if (!host.querySelector('.term-window')) {
+    const win = document.createElement('div');
+    win.className = 'term-window';
+    const chrome = document.createElement('div');
+    chrome.className = 'term-header';
+    const title = document.createElement('span');
+    title.className = 'term-title';
+    title.textContent = host.dataset.title || 'digithings';
+    const shortcuts = document.createElement('span');
+    shortcuts.className = 'term-shortcuts';
+    shortcuts.innerHTML = '<kbd>⌘K</kbd>';
+    chrome.appendChild(title);
+    chrome.appendChild(shortcuts);
+    const bodyWrap = document.createElement('div');
+    bodyWrap.className = 'term-pane';
+    win.appendChild(chrome);
+    win.appendChild(bodyWrap);
+    host.appendChild(win);
+  }
+  const pane = host.querySelector('.term-pane');
+
+  async function typeInto(el, text) {
+    if (prefersReduced) { el.textContent = text; return; }
+    el.textContent = '';
+    for (const ch of text) {
+      el.textContent += ch;
+      let d = rand(perChar * 0.6, perChar * 1.8);
+      if (ch === ' ') d *= 0.5;
+      if ('.?!,'.includes(ch)) d += 120;
+      // yield to layout
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(d);
+    }
+  }
+
+  async function renderLine(line) {
+    const { row, body } = lineNodeFor(line);
+    pane.appendChild(row);
+    await typeInto(body, line.text || '');
+    // After streaming, if a lang hint is set, swap in naive highlighted markup.
+    if (line.lang && /^(js|ts|tsx|py|sh|json)$/i.test(line.lang)) {
+      body.innerHTML = naiveHighlight(line.text || '', line.lang.toLowerCase());
+    }
+  }
+
+  async function run() {
+    for (const line of queue) {
+      // eslint-disable-next-line no-await-in-loop
+      await renderLine(line);
+    }
+    if (typeof onReady === 'function') {
+      try { onReady(); } catch (_) { /* swallow */ }
+    }
+  }
+
+  run().catch(() => {});
+
+  return {
+    append(line) {
+      if (line && typeof line === 'object') renderLine(line).catch(() => {});
+    },
+    clear() { pane.innerHTML = ''; },
+    destroy() {
+      host.innerHTML = '';
+      host.classList.remove('term-root');
+    },
+  };
+}
+
+/* Naive hand-tagged highlighter — not a real tokenizer. Just colors keywords,
+   strings, and numbers. Good enough for decorative terminal transcripts. */
+const KEYWORDS = {
+  js: /\b(const|let|var|function|return|if|else|for|while|class|new|import|from|export|default|async|await|true|false|null|undefined)\b/g,
+  ts: /\b(const|let|var|function|return|if|else|for|while|class|new|import|from|export|default|async|await|true|false|null|undefined|interface|type|enum|public|private|readonly)\b/g,
+  tsx: /\b(const|let|var|function|return|if|else|for|while|class|new|import|from|export|default|async|await|true|false|null|undefined|interface|type)\b/g,
+  py: /\b(def|return|if|elif|else|for|while|class|import|from|as|try|except|finally|with|lambda|async|await|True|False|None|yield|raise)\b/g,
+  sh: /\b(if|then|else|fi|for|do|done|while|case|esac|function|return|export|echo|cd|source)\b/g,
+  json: /\b(true|false|null)\b/g,
+};
+
+function escapeHtml(s) {
+  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+}
+
+export function naiveHighlight(text, lang) {
+  let out = escapeHtml(text);
+  // strings
+  out = out.replace(/(["'`])((?:\\.|(?!\1).)*)\1/g, (m) => `<span class="term-tok-str">${m}</span>`);
+  // numbers
+  out = out.replace(/\b(\d+(?:\.\d+)?)\b/g, '<span class="term-tok-num">$1</span>');
+  // keywords
+  const kw = KEYWORDS[lang];
+  if (kw) out = out.replace(kw, '<span class="term-tok-kw">$&</span>');
+  // line comments (only after string/keyword pass for js-like langs)
+  if (lang !== 'json') {
+    if (lang === 'py' || lang === 'sh') {
+      out = out.replace(/(^|\s)(#[^\n]*)/g, '$1<span class="term-tok-cmt">$2</span>');
+    } else {
+      out = out.replace(/(^|\s)(\/\/[^\n]*)/g, '$1<span class="term-tok-cmt">$2</span>');
+    }
+  }
+  return out;
+}

--- a/frontend/design-system/terminal/styles.css
+++ b/frontend/design-system/terminal/styles.css
@@ -1,0 +1,115 @@
+/* ==========================================================================
+   @digithings/design-system — terminal/styles.css
+   Scoped under `.term-*`. Consumes tokens from ../tokens.css.
+   ========================================================================== */
+
+.term-root {
+  display: block;
+}
+
+.terminal-group {
+  display: grid;
+  gap: var(--space-4);
+}
+@media (min-width: 900px) {
+  .terminal-group {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(0, 1fr);
+  }
+}
+
+.term-window {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    var(--bg-primary);
+  box-shadow:
+    0 40px 120px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.term-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.term-title {
+  font-family: var(--font-family-mono);
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+}
+.term-shortcuts {
+  display: inline-flex;
+  gap: 6px;
+}
+.term-shortcuts kbd {
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.term-pane {
+  padding: 22px 22px 26px;
+  min-height: 180px;
+  font-family: var(--font-family-mono);
+}
+
+.term-line {
+  display: block;
+  margin: 2px 0;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.term-marker {
+  color: var(--accent, var(--text-secondary));
+  margin-right: 8px;
+  user-select: none;
+}
+.term-comment-marker {
+  color: var(--text-secondary);
+  margin-right: 6px;
+  user-select: none;
+}
+
+.term-output { color: var(--text-primary); }
+.term-prompt .term-body-text { color: var(--text-primary); }
+.term-comment {
+  color: color-mix(in srgb, var(--accent, var(--text-secondary)) 55%, var(--text-secondary));
+  font-style: italic;
+}
+.term-comment .term-body-text { color: inherit; }
+
+.term-chip-row .term-body-text {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--fg)) 40%, var(--border-color));
+  background: color-mix(in srgb, var(--accent, var(--fg)) 12%, transparent);
+  color: var(--fg);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+/* --- Naive syntax tokens (desaturated) ---------------------------------- */
+.term-tok-kw  { color: var(--accent-digichat); }
+.term-tok-str { color: var(--accent-digiquant); }
+.term-tok-num { color: var(--accent-digiclaw); }
+.term-tok-cmt { color: var(--text-secondary); font-style: italic; }
+

--- a/frontend/design-system/terminal/types.d.ts
+++ b/frontend/design-system/terminal/types.d.ts
@@ -1,0 +1,23 @@
+export type TerminalLineKind = "prompt" | "output" | "comment" | "tool-call";
+
+export interface TerminalLine {
+  kind: TerminalLineKind;
+  text: string;
+  /** Optional language hint for naive post-stream highlighting. */
+  lang?: "js" | "ts" | "tsx" | "py" | "sh" | "json";
+}
+
+export interface TerminalHandle {
+  append(line: TerminalLine): void;
+  clear(): void;
+  destroy(): void;
+}
+
+export interface InitTerminalOptions {
+  elementId: string;
+  lines: TerminalLine[];
+  speed?: "fast" | "normal" | "slow" | number;
+  onReady?: () => void;
+}
+
+export function initTerminal(opts: InitTerminalOptions): TerminalHandle;

--- a/frontend/design-system/typography-motion/index.js
+++ b/frontend/design-system/typography-motion/index.js
@@ -1,0 +1,115 @@
+/* ==========================================================================
+   @digithings/design-system — typography-motion
+   --------------------------------------------------------------------------
+   Bind scroll progress to variable-font weight and letter-spacing.
+   Two usage modes:
+
+   1) Imperative — attach to a specific element:
+        import { attachWeightShift } from '@digithings/design-system/typography-motion';
+        const handle = attachWeightShift(el, { from: 200, to: 700, scrollStart: 0, scrollEnd: 400 });
+        handle.detach();
+
+   2) Declarative — mark up elements, call init() once:
+        <h1 class="tws-weight-shift" data-weight-from="200" data-weight-to="700"></h1>
+        <h2 class="tws-tracking-shift" data-tracking-from="-0.01" data-tracking-to="-0.05"></h2>
+        import { initTypographyMotion } from '@digithings/design-system/typography-motion';
+        initTypographyMotion();
+   ========================================================================== */
+
+const prefersReduced = () => typeof window !== 'undefined'
+  && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+
+function progressForRange(scrollStart, scrollEnd) {
+  const y = window.scrollY;
+  const span = Math.max(1, scrollEnd - scrollStart);
+  return clamp01((y - scrollStart) / span);
+}
+
+function attachRangeBinding(el, { from, to, scrollStart, scrollEnd, apply }) {
+  if (prefersReduced()) {
+    apply(to);
+    return { detach() {} };
+  }
+  let raf = 0;
+  function tick() {
+    raf = 0;
+    const p = progressForRange(scrollStart, scrollEnd);
+    apply(from + (to - from) * p);
+  }
+  function onScroll() {
+    if (raf) return;
+    raf = requestAnimationFrame(tick);
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+  tick();
+  return {
+    detach() {
+      window.removeEventListener('scroll', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    },
+  };
+}
+
+export function attachWeightShift(el, { from = 200, to = 700, scrollStart = 0, scrollEnd = 400 } = {}) {
+  if (!el) throw new Error('attachWeightShift: element is required');
+  el.classList.add('tws-weight-shift');
+  return attachRangeBinding(el, {
+    from, to, scrollStart, scrollEnd,
+    apply: (wght) => {
+      el.style.fontVariationSettings = `"wght" ${wght.toFixed(1)}`;
+      el.style.fontWeight = String(Math.round(wght));
+    },
+  });
+}
+
+export function attachTrackingShift(el, { from = 0, to = -0.04, scrollStart = 0, scrollEnd = 400 } = {}) {
+  if (!el) throw new Error('attachTrackingShift: element is required');
+  el.classList.add('tws-tracking-shift');
+  return attachRangeBinding(el, {
+    from, to, scrollStart, scrollEnd,
+    apply: (v) => { el.style.letterSpacing = `${v}em`; },
+  });
+}
+
+function readNumberAttr(el, name, fallback) {
+  const v = parseFloat(el.getAttribute(name));
+  return Number.isFinite(v) ? v : fallback;
+}
+
+export function initTypographyMotion(root = document) {
+  const reduced = prefersReduced();
+  const handles = [];
+
+  root.querySelectorAll('.tws-weight-shift').forEach((el) => {
+    const from = readNumberAttr(el, 'data-weight-from', 200);
+    const to   = readNumberAttr(el, 'data-weight-to', 700);
+    if (reduced) {
+      el.style.fontVariationSettings = `"wght" ${to}`;
+      el.style.fontWeight = String(to);
+      return;
+    }
+    // Use the element's top in the document as the natural scrollStart.
+    const rect = el.getBoundingClientRect();
+    const top = rect.top + window.scrollY;
+    const scrollStart = Math.max(0, top - window.innerHeight);
+    const scrollEnd   = top + rect.height * 0.5;
+    handles.push(attachWeightShift(el, { from, to, scrollStart, scrollEnd }));
+  });
+
+  root.querySelectorAll('.tws-tracking-shift').forEach((el) => {
+    const from = readNumberAttr(el, 'data-tracking-from', 0);
+    const to   = readNumberAttr(el, 'data-tracking-to', -0.04);
+    if (reduced) { el.style.letterSpacing = `${to}em`; return; }
+    const rect = el.getBoundingClientRect();
+    const top = rect.top + window.scrollY;
+    const scrollStart = Math.max(0, top - window.innerHeight);
+    const scrollEnd   = top + rect.height * 0.5;
+    handles.push(attachTrackingShift(el, { from, to, scrollStart, scrollEnd }));
+  });
+
+  return {
+    detach() { handles.forEach((h) => h.detach()); },
+  };
+}

--- a/frontend/design-system/typography-motion/styles.css
+++ b/frontend/design-system/typography-motion/styles.css
@@ -1,0 +1,23 @@
+/* ==========================================================================
+   @digithings/design-system — typography-motion/styles.css
+   Scoped under `.tws-*` (typography weight-shift). Consumes tokens from
+   ../tokens.css.
+   ========================================================================== */
+
+.tws-weight-shift,
+.tws-tracking-shift {
+  font-family: var(--font-family);
+  transition:
+    font-variation-settings 0.2s linear,
+    font-weight 0.2s linear,
+    letter-spacing 0.2s linear;
+  will-change: font-variation-settings, letter-spacing;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tws-weight-shift,
+  .tws-tracking-shift {
+    transition: none;
+    will-change: auto;
+  }
+}


### PR DESCRIPTION
## Summary

Child 1 of parent epic #268. Harvest the reference implementations from the `feat/landing-mockups` exploration (Mockups A–D) into reusable primitives under `frontend/design-system/`, so Children 2–5 consume them instead of re-inventing.

## What's new

Five packages under `frontend/design-system/` — each ships CSS + ESM JS (and a `types.d.ts` where helpful):

- **`living-architecture/`** — interactive SVG diagram engine. API `initDiagram({ hostId, svgId, nodes, edges, onNodeFocus })` → `{ camera, focus, reset, destroy }`. Animated `stroke-dashoffset` edges, 600ms `cubic-bezier(0.4, 0, 0.2, 1)` viewBox tween, node bloom on focus (non-focused dim to 28%), click / Enter / Space activate, arrow-key core-node cycle + reset + focus, Tab/Shift+Tab for full a11y cycle, Esc resets, auto-injected zoom-out button, static `fallback-diagram.svg` for no-JS.
- **`terminal/`** — scripted terminal widget. API `initTerminal({ elementId, lines, speed, onReady })`. Four line kinds (`prompt | output | comment | tool-call`), variable-speed typewriter (`fast | normal | slow | number`), optional post-stream naive syntax hint for `js|ts|tsx|py|sh|json`, multi-pane `.terminal-group` composition, window chrome with `⌘K` pseudo-decoration.
- **`typography-motion/`** — variable-weight + tracking-shift binders. Both imperative (`attachWeightShift(el, { from, to, scrollStart, scrollEnd })`) and declarative (`.tws-weight-shift` + `data-weight-from/to`) APIs; `initTypographyMotion()` wires all marked elements.
- **`quant-native/`** — CSS layer + ticker. `.qn-blueprint-bg` (2% horizontal-rule pattern), `.qn-metric` (tnum), `.qn-chart-frame`, `.qn-up` / `.qn-down` (muted emerald / muted copper — never Bloomberg). `initTicker({ elementId, symbols, cadence })` JS-driven `translateX` with pause-on-hover.
- **`app-shell-terminal/`** — Claude-Code-style chrome. Collapsible sidebar (`Cmd+/`), top bar, terminal-style input bar with auto-grow + Enter submit, `Cmd+K` palette (`role="dialog"`, focus-trap), `SlashCommandRegistry` with `register/parse/dispatch`. Built-ins: `/help`, `/clear`.

All classes use the mandated prefixes (`.la-*`, `.term-*`, `.tws-*`, `.qn-*`, `.app-shell-*`), consume tokens from `../tokens.css` (no raw hex), and respect `prefers-reduced-motion`. Package.json `exports` / `files` updated. No changes to production pages, no new npm deps, no SITAAS mention.

Parent epic: #268.

## Test plan

- [x] `make doc-check` — passes (99 markdown files scanned)
- [x] `make test-unit` — the 14 failures on develop are pre-existing auth tests unrelated to frontend changes (`git diff --stat` shows only `frontend/design-system/` files touched); 654 passing tests unchanged
- [x] E2E smoke recipe from the issue passes — all five primitives reference-able, all five `styles.css` files resolve over HTTP, smoke page loads with expected markers, `package.json` JSON-valid, no SITAAS
- [x] Smoke-test page at `frontend/design-system/smoke/index.html` renders one minimal example per primitive for reviewer poke-surface

## Quality gates

- [x] /`simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /`review` completed — PR reviewed against scoring rubric; findings addressed

Fixes #269