### PR TITLE
feat(website): architecture-editorial refactor of digithings.ai

### DIFF
--- a/frontend/website/index.html
+++ b/frontend/website/index.html
@@ -3,317 +3,270 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>digithings | Modular Agentic Framework</title>
-    <meta name="description" content="DigiThings is an open-core, modular agentic stack. Ten composable components for orchestration, retrieval, quant research, chat, auth, and observability.">
+    <title>digithings | An open-core agentic stack</title>
+    <meta name="description" content="DigiThings is an open-core, modular agentic stack. A living architecture of ten composable modules — orchestration, retrieval, quant, chat, auth, and observability.">
 
-    <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="../design-system/assets/favicon.svg">
     <link rel="alternate icon" href="../design-system/assets/favicon.ico">
 
-    <!-- Open Graph / Twitter -->
-    <meta property="og:title" content="DigiThings — Modular Agentic Framework">
-    <meta property="og:description" content="A composable, open-core architecture for building and deploying autonomous agents. Ten modules, one stack.">
+    <meta property="og:title" content="DigiThings — An open-core agentic stack">
+    <meta property="og:description" content="Ten composable modules. One stack. Architecture-native, open core.">
     <meta property="og:image" content="../design-system/assets/og.png">
     <meta property="og:url" content="https://digithings.ai">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="DigiThings — Modular Agentic Framework">
-    <meta name="twitter:description" content="A composable, open-core architecture for building and deploying autonomous agents. Ten modules, one stack.">
+    <meta name="twitter:title" content="DigiThings — An open-core agentic stack">
+    <meta name="twitter:description" content="Ten composable modules. One stack.">
     <meta name="twitter:image" content="../design-system/assets/og.png">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200..700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" href="../design-system/tokens.css">
     <link rel="stylesheet" href="../design-system/components.css">
+    <link rel="stylesheet" href="../design-system/living-architecture/styles.css">
+    <link rel="stylesheet" href="../design-system/terminal/styles.css">
+    <link rel="stylesheet" href="../design-system/typography-motion/styles.css">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
-    <!-- Solid base for Safari; starfield canvas draws on top -->
-    <div id="bg-base" aria-hidden="true"></div>
-    <canvas id="network-canvas"></canvas>
+<body class="dt-page">
 
-    <nav class="navbar">
-        <div class="nav-container scroll-trigger">
-            <div class="logo">
-                <img src="assets/qrw.svg" class="logo-svg" alt="digithings logo">
-                <span class="logo-text">digithings</span>
-            </div>
-            <div class="nav-links">
-                <a href="#ecosystem" class="nav-link">Modules</a>
-                <a href="#try" class="nav-link">Try it</a>
-                <a href="#open-core" class="nav-link">Open core</a>
-                <a href="https://chat.digithings.ai" class="nav-link" target="_blank" rel="noopener noreferrer">DigiChat</a>
-                <a href="https://github.com/digithings-ai" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
+    <!-- Grain overlay retires the starfield -->
+    <div class="dt-grain" aria-hidden="true"></div>
+
+    <nav class="dt-nav">
+        <div class="dt-nav-inner">
+            <a class="dt-logo" href="#top">
+                <img src="assets/qrw.svg" alt="digithings logo" class="dt-logo-svg">
+                <span>digithings</span>
+            </a>
+            <div class="dt-nav-links">
+                <a href="#digigraph">DigiGraph</a>
+                <a href="#digiquant">DigiQuant</a>
+                <a href="#digisearch">DigiSearch</a>
+                <a href="#digichat">DigiChat</a>
+                <a href="#ecosystem">Ecosystem</a>
+                <a href="https://digiquant.io" target="_blank" rel="noopener noreferrer">digiquant.io</a>
+                <a href="https://chat.digithings.ai" target="_blank" rel="noopener noreferrer">DigiChat</a>
+                <a href="https://github.com/digithings-ai" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
     </nav>
 
-    <main class="container">
-        <!-- Hero -->
-        <header class="hero">
-            <div class="hero-content">
-                <div class="hero-text scroll-trigger" data-direction="zoom">
-                    <h1 class="logo-title">
-                        <img src="assets/qrw.svg" class="hero-logo-svg" alt="digithings logo">
-                        digithings
-                    </h1>
-                    <p class="hero-subtitle">The modular agentic framework</p>
-                    <p class="description">
-                        Ten composable, open-core components that snap together into a working agentic stack &mdash; for developers who want to build, and enterprises who want to deploy, without vendor lock-in.
-                    </p>
-                    <div class="hero-actions">
-                        <a href="#ecosystem" class="hero-cta">
-                            Explore the modules
-                            <span class="hero-cta-arrow" aria-hidden="true">&rarr;</span>
-                        </a>
-                        <a href="https://github.com/digithings-ai" class="hero-cta hero-cta-ghost" target="_blank" rel="noopener noreferrer">
-                            View on GitHub
-                        </a>
-                    </div>
+    <!-- ============================================================
+         Sticky diagram spine — the living architecture travels
+         with the user through every act.
+         ============================================================ -->
+    <div class="dt-spine">
+        <div class="dt-spine-sticky">
+            <div id="arch-host" class="dt-arch-host">
+                <svg id="arch-svg" viewBox="0 0 1200 720" role="img"
+                     aria-label="DigiThings ecosystem living architecture diagram"></svg>
+
+                <!-- Ecosystem-act overlays (hidden until Act V toggles activate) -->
+                <svg id="arch-overlays" viewBox="0 0 1200 720"
+                     class="dt-arch-overlays" aria-hidden="true">
+                    <g class="overlay overlay-plugin">
+                        <circle cx="160" cy="120" r="34" class="overlay-ring"/>
+                        <text x="160" y="180" class="overlay-text">your app</text>
+                        <circle cx="1040" cy="120" r="34" class="overlay-ring"/>
+                        <text x="1040" y="180" class="overlay-text">your DB</text>
+                        <circle cx="1040" cy="600" r="34" class="overlay-ring"/>
+                        <text x="1040" y="660" class="overlay-text">your auth</text>
+                    </g>
+                    <g class="overlay overlay-mcp">
+                        <ellipse cx="600" cy="360" rx="560" ry="320" class="overlay-ring"/>
+                        <text x="600" y="36" class="overlay-text">MCP surface</text>
+                        <text x="600" y="700" class="overlay-text">… each module exposed as tool</text>
+                    </g>
+                    <g class="overlay overlay-docker">
+                        <rect x="40" y="40" width="1120" height="640" class="overlay-container"/>
+                        <text x="80" y="76" class="overlay-text">docker-compose up</text>
+                        <text x="300" y="708" class="overlay-text">laptop</text>
+                        <text x="600" y="708" class="overlay-text">VM</text>
+                        <text x="900" y="708" class="overlay-text">Kubernetes</text>
+                    </g>
+                </svg>
+            </div>
+        </div>
+    </div>
+
+    <main class="dt-main" id="top">
+
+        <!-- ========== Hero ========== -->
+        <section class="act act-hero" data-act="hero" aria-labelledby="hero-title">
+            <div class="act-copy">
+                <h1 id="hero-title"
+                    class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">
+                    An open-core agentic stack.
+                </h1>
+                <p class="sub-hero">Modular by design.</p>
+                <p class="lede">
+                    Ten composable modules that snap together into a working agent system —
+                    orchestration, retrieval, quant research, chat, auth, and observability.
+                    Self-hosted from day one. No vendor lock-in.
+                </p>
+                <div class="hero-actions">
+                    <a class="cta" href="#digigraph">Tour the stack <span aria-hidden="true">&rarr;</span></a>
+                    <a class="cta cta-ghost" href="https://github.com/digithings-ai" target="_blank" rel="noopener noreferrer">View on GitHub</a>
                 </div>
+                <div id="hero-term" class="term-host term-hero" data-title="digithings"></div>
+            </div>
+        </section>
 
-                <div class="hero-visual scroll-trigger" data-direction="right">
-                    <div class="terminal-window">
-                        <div class="terminal-header">
-                            <span class="dot red"></span>
-                            <span class="dot yellow"></span>
-                            <span class="dot green"></span>
-                            <span class="terminal-title">agent_init.py</span>
-                        </div>
-                        <div class="terminal-body">
-                            <pre><code id="typewriter-code"></code><span class="cursor">_</span></pre>
-                        </div>
-                    </div>
+        <!-- ========== Act I — DigiGraph ========== -->
+        <section id="digigraph" class="act act-core accent-digigraph" data-act="digigraph" aria-labelledby="act1-title">
+            <div class="act-copy">
+                <p class="act-kicker">Act I — Orchestration</p>
+                <h2 id="act1-title" class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">DigiGraph</h2>
+                <p class="one-liner">The brain. A LangGraph supervisor routes every request.</p>
+                <p class="body">
+                    A declarative tool registry (OpenAI-compatible function schemas) pairs with a
+                    sub-graph supervisor. Any vertical can expose its capabilities via
+                    <code>POST /v1/orchestrator_tools</code> and drop straight in.
+                </p>
+                <p class="body">
+                    LiteLLM routes calls; LangGraph checkpoints keep state durable across
+                    agent hops. The whole thing speaks the OpenAI API on the front door.
+                </p>
+            </div>
+            <aside class="act-side">
+                <div id="term-digigraph" class="term-host" data-title="digigraph/orchestration/registry.py"></div>
+            </aside>
+        </section>
+
+        <!-- ========== Act II — DigiQuant ========== -->
+        <section id="digiquant" class="act act-core accent-digiquant" data-act="digiquant" aria-labelledby="act2-title">
+            <div class="act-copy">
+                <p class="act-kicker">Act II — Quantitative</p>
+                <h2 id="act2-title" class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">DigiQuant</h2>
+                <p class="one-liner">The flagship vertical. Research, execute, audit.</p>
+                <p class="body">
+                    NautilusTrader core with a strategy registry: name your strategy,
+                    bind a config, pick defaults. Atlas reasons over research, Hermes
+                    publishes signals, Kairos executes — loopback-only, human-gated.
+                </p>
+                <p class="body">
+                    <a class="pass-through" href="https://digiquant.io" target="_blank" rel="noopener noreferrer">
+                        Open digiquant.io <span aria-hidden="true">&rarr;</span>
+                    </a>
+                </p>
+            </div>
+            <aside class="act-side">
+                <div id="term-digiquant" class="term-host" data-title="digiquant/strategies/registry.py"></div>
+            </aside>
+        </section>
+
+        <!-- ========== Act III — DigiSearch ========== -->
+        <section id="digisearch" class="act act-core accent-digisearch" data-act="digisearch" aria-labelledby="act3-title">
+            <div class="act-copy">
+                <p class="act-kicker">Act III — Retrieval</p>
+                <h2 id="act3-title" class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">DigiSearch</h2>
+                <p class="one-liner">Ingest. Chunk. Embed. Search. Polars throughout.</p>
+                <p class="body">
+                    A single <code>DigiSearch</code> client resolves index backends on demand —
+                    Chroma, pgvector, Qdrant, or in-memory. Entity names are backend-neutral:
+                    <code>Document</code>, <code>Chunk</code>, <code>Query</code>, <code>Result</code>.
+                </p>
+                <p class="body">
+                    Selective indexing rules keep relevance high and cost low;
+                    multi-mode retrieval (dense / sparse / hybrid) is chosen per query.
+                </p>
+            </div>
+            <aside class="act-side">
+                <div id="term-digisearch" class="term-host" data-title="digisearch/client.py"></div>
+            </aside>
+        </section>
+
+        <!-- ========== Act IV — DigiChat ========== -->
+        <section id="digichat" class="act act-core accent-digichat" data-act="digichat" aria-labelledby="act4-title">
+            <div class="act-copy">
+                <p class="act-kicker">Act IV — Chat</p>
+                <h2 id="act4-title" class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">DigiChat</h2>
+                <p class="one-liner">Next.js chat UI + BFF. Streams DigiGraph. BYOK.</p>
+                <p class="body">
+                    Machine API keys or a user session — DigiChat brokers DigiGraph traffic
+                    with the right bearer, tenant, and LiteLLM proxy key. The UI adapts
+                    to whatever scopes your JWT grants.
+                </p>
+                <p class="body">
+                    <a class="pass-through" href="https://chat.digithings.ai" target="_blank" rel="noopener noreferrer">
+                        Open DigiChat <span aria-hidden="true">&rarr;</span>
+                    </a>
+                </p>
+            </div>
+            <aside class="act-side">
+                <div id="term-digichat" class="term-host" data-title="digichat/app/api/chat/route.ts"></div>
+                <div class="chat-embed-slot">
+                    <iframe
+                        src="https://chat.digithings.ai/embed"
+                        title="DigiChat — ask the DigiThings stack"
+                        loading="lazy"
+                        referrerpolicy="no-referrer"
+                        allow="clipboard-write"></iframe>
                 </div>
-            </div>
-            <div class="hero-divider scroll-trigger" data-direction="zoom"></div>
-        </header>
-
-        <!-- Ecosystem overview -->
-        <section id="ecosystem" class="ecosystem-section scroll-trigger" data-direction="zoom">
-            <h2 class="section-title">Ten modules. One stack.</h2>
-            <p class="section-lede">
-                Every component ships as a standalone service with clear contracts, or as a Python library you can import. Pick the ones you need.
-            </p>
-            <div class="module-grid">
-                <a href="#digigraph" class="module-card accent-digigraph scroll-trigger" data-direction="bottom">
-                    <h3>DigiGraph</h3>
-                    <p>Orchestration brain. LangGraph supervisor with sub-graphs, MCP tool discovery, OpenAI-compatible API.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digiquant" class="module-card accent-digiquant scroll-trigger" data-direction="bottom">
-                    <h3>DigiQuant</h3>
-                    <p>Quant engine on NautilusTrader. Family of research + execution agents: Atlas, Hermes, Kairos.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digisearch" class="module-card accent-digisearch scroll-trigger" data-direction="bottom">
-                    <h3>DigiSearch</h3>
-                    <p>Retrieval and RAG layer. Ingest, chunk, embed, and search &mdash; with a pluggable vector store registry.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digichat" class="module-card accent-digichat scroll-trigger" data-direction="bottom">
-                    <h3>DigiChat</h3>
-                    <p>Next.js chat UI and BFF for DigiGraph. Auth.js, Drizzle, adaptive UI via JWT scopes, BYOK settings panel.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digikey" class="module-card accent-digikey scroll-trigger" data-direction="bottom">
-                    <h3>DigiKey</h3>
-                    <p>Auth and identity. RS256 JWTs, scoped API keys, JWKS, org + project membership, row-level resource access.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digismith" class="module-card accent-digismith scroll-trigger" data-direction="bottom">
-                    <h3>DigiSmith</h3>
-                    <p>Observability. Correlation IDs, Prometheus metrics, PII redaction, structured logging, `/v1/status`.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digiclaw" class="module-card accent-digiclaw scroll-trigger" data-direction="bottom">
-                    <h3>DigiClaw</h3>
-                    <p>Always-on agent runtime. Heartbeat, immutable audit logs, Atlas runner scheduling, drift detection.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digibase" class="module-card accent-digibase scroll-trigger" data-direction="bottom">
-                    <h3>DigiBase</h3>
-                    <p>Shared Python library. HTTP middleware, audit redaction, error conventions &mdash; the bedrock every service imports.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digistore" class="module-card accent-digistore scroll-trigger" data-direction="bottom">
-                    <h3>DigiStore</h3>
-                    <p>Storage abstraction. One API over S3, MinIO, Postgres, and SQLite. Swap backends without touching the business code.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-
-                <a href="#digilink" class="module-card accent-digilink scroll-trigger" data-direction="bottom">
-                    <h3>DigiLink</h3>
-                    <p>Protocol translation. Bridges external tools and transports into the DigiGraph + MCP world.</p>
-                    <span class="module-card-link">Learn more &rarr;</span>
-                </a>
-            </div>
-            <div class="hero-divider scroll-trigger" data-direction="zoom"></div>
+            </aside>
         </section>
 
-        <!-- Deep dives -->
-        <section id="digigraph" class="module-section accent-digigraph scroll-trigger" data-direction="left">
-            <h2>DigiGraph</h2>
-            <p>The orchestration brain. A LangGraph supervisor with a sub-graph registry routes every request through the right specialist agents, with structured Pydantic v2 outputs and LangGraph checkpointing throughout.</p>
-            <ul class="module-features">
-                <li>MCP-based tool registry: builtins plus vertical capabilities exposed via <code>POST /v1/orchestrator_tools</code>.</li>
-                <li>LiteLLM routing with caching; pick your model tier with <code>DIGI_LLM_MODE</code>.</li>
-                <li>OpenAI-compatible surface so any existing SDK can drive it.</li>
-            </ul>
-        </section>
-
-        <section id="digiquant" class="module-section accent-digiquant scroll-trigger" data-direction="right">
-            <h2>DigiQuant</h2>
-            <p>Quantitative strategy engine powered by NautilusTrader &mdash; a Rust core for ultra-low-latency backtest, optimize, and execute. The flagship vertical, and the highest quality bar on the stack.</p>
-            <ul class="module-features">
-                <li><span class="accent-atlas module-family-tag" id="atlas">Atlas</span> &mdash; high-level fundamental and research engine feeding strategy biases.</li>
-                <li><span class="accent-hermes module-family-tag" id="hermes">Hermes</span> &mdash; delivery layer: deliberation pipelines, delta updates, and signal publishing.</li>
-                <li><span class="accent-kairos module-family-tag" id="kairos">Kairos</span> &mdash; timing and execution layer; loopback-only by default, human gates before any live trade.</li>
-            </ul>
-        </section>
-
-        <section id="digisearch" class="module-section accent-digisearch scroll-trigger" data-direction="left">
-            <h2>DigiSearch</h2>
-            <p>Retrieval-Augmented Generation and document search, built on Polars for massive-scale ingest without pandas overhead. Selective indexing rules keep relevance high and cost low.</p>
-            <ul class="module-features">
-                <li>Pluggable vector store registry: pgvector, Qdrant, in-memory, and more.</li>
-                <li>Multi-mode retrieval &mdash; dense, sparse, hybrid &mdash; selected per query.</li>
-                <li>Entity-neutral API: <code>Document</code>, <code>Chunk</code>, <code>Query</code>, <code>Result</code>.</li>
-            </ul>
-        </section>
-
-        <section id="digichat" class="module-section accent-digichat scroll-trigger" data-direction="right">
-            <h2>DigiChat</h2>
-            <p>Production Next.js chat UI and BFF for DigiGraph. Deployed at chat.digithings.ai, it adapts to whatever scopes your JWT grants and supports bring-your-own-key against any LiteLLM-routed provider.</p>
-            <ul class="module-features">
-                <li>Auth.js + Drizzle, with scoped API keys from DigiKey.</li>
-                <li>AI SDK streaming, structured tool calls, embedded surfaces.</li>
-                <li>BYOK settings panel &mdash; keys stay client-side.</li>
-            </ul>
-        </section>
-
-        <section id="digikey" class="module-section accent-digikey scroll-trigger" data-direction="left">
-            <h2>DigiKey</h2>
-            <p>The auth plane for every service-to-service and user-to-service call. RS256 JWTs with a JWKS endpoint, scoped API keys, SSO identity federation, and an org + project membership model.</p>
-            <ul class="module-features">
-                <li>Row-level resource access baked into issued tokens.</li>
-                <li>Scoped keys for CI, agents, and end users.</li>
-                <li>Runs standalone or embedded; consumed by every other module.</li>
-            </ul>
-        </section>
-
-        <section id="digismith" class="module-section accent-digismith scroll-trigger" data-direction="right">
-            <h2>DigiSmith</h2>
-            <p>Observability across the stack. Correlation IDs propagate via <code>X-Request-ID</code>, spans carry <code>workflow_id</code>, <code>request_id</code>, and <code>session_id</code>, and PII is redacted before anything is written.</p>
-            <ul class="module-features">
-                <li>Prometheus <code>/metrics</code> with version and environment labels.</li>
-                <li>Public <code>/v1/status</code> endpoint &mdash; secret-free by contract.</li>
-                <li>Structured logging helpers every service imports.</li>
-            </ul>
-        </section>
-
-        <section id="digiclaw" class="module-section accent-digiclaw scroll-trigger" data-direction="left">
-            <h2>DigiClaw</h2>
-            <p>The always-on agent runtime. Heartbeats, immutable JSONL audit, and an MCP skill surface make long-running autonomous work safe and observable. Atlas runner scheduling and drift detection live here.</p>
-            <ul class="module-features">
-                <li>Strict loopback-only by default; human gates for anything consequential.</li>
-                <li>Audit via <code>digibase.audit.redact_mapping</code> &mdash; no raw prompts, keys, or document bodies persisted.</li>
-                <li>Deployment gateway for 24/7 agent work.</li>
-            </ul>
-        </section>
-
-        <section id="digibase" class="module-section accent-digibase scroll-trigger" data-direction="right">
-            <h2>DigiBase</h2>
-            <p>Shared Python library, deliberately minimal. Not a service &mdash; a common foundation of HTTP middleware, audit helpers, and error conventions so every other module behaves consistently.</p>
-            <ul class="module-features">
-                <li>Request-ID middleware and <code>ContextVar</code>-based log correlation.</li>
-                <li>Redacted audit logging used everywhere.</li>
-                <li>Future home of the multi-tenant credential broker.</li>
-            </ul>
-        </section>
-
-        <section id="digistore" class="module-section accent-digistore scroll-trigger" data-direction="left">
-            <h2>DigiStore</h2>
-            <p>Storage abstraction layer. One typed API over S3, MinIO, Postgres, and SQLite &mdash; so strategy artifacts, research outputs, and vector payloads travel the same path no matter where they land.</p>
-            <ul class="module-features">
-                <li>Multi-backend: swap S3 for MinIO or SQLite without touching business code.</li>
-                <li>Works alongside OpenBB-style data providers for financial datasets.</li>
-                <li>Single source of truth for blob, row, and vector storage contracts.</li>
-            </ul>
-        </section>
-
-        <section id="digilink" class="module-section accent-digilink scroll-trigger" data-direction="right">
-            <h2>DigiLink</h2>
-            <p>The protocol translation layer. When an external system speaks something DigiGraph doesn't &mdash; a proprietary broker feed, a legacy REST surface, an odd webhook &mdash; DigiLink adapts it into MCP tool calls the orchestrator already understands.</p>
-            <ul class="module-features">
-                <li>Built for bridging non-MCP transports cleanly.</li>
-                <li>Keeps the orchestrator's tool surface uniform.</li>
-                <li>Adapters are small, testable, and composable.</li>
-            </ul>
-            <div class="hero-divider scroll-trigger" data-direction="zoom"></div>
-        </section>
-
-        <!-- Embedded DigiChat -->
-        <section id="try" class="try-section scroll-trigger" data-direction="zoom">
-            <h2 class="section-title">Ask the stack about itself</h2>
-            <p class="section-lede">
-                DigiChat is embedded below, indexed against DigiThings documentation and component READMEs. Ask it how the pieces fit together &mdash; or pick a starter prompt.
-            </p>
-
-            <div class="prompt-chips accent-digichat">
-                <button type="button" class="prompt-chip">What does DigiGraph do?</button>
-                <button type="button" class="prompt-chip">How do I deploy DigiThings?</button>
-                <button type="button" class="prompt-chip">Show me the orchestration flow.</button>
-                <button type="button" class="prompt-chip">Which modules power a RAG use case?</button>
-            </div>
-
-            <div class="chat-embed-slot accent-digichat">
-                <iframe
-                    src="https://chat.digithings.ai/embed"
-                    title="DigiChat &mdash; ask the DigiThings stack"
-                    loading="lazy"
-                    referrerpolicy="no-referrer"
-                    allow="clipboard-write"></iframe>
-            </div>
-            <div class="hero-divider scroll-trigger" data-direction="zoom"></div>
-        </section>
-
-        <!-- Open core -->
-        <section id="open-core" class="open-core-section scroll-trigger" data-direction="bottom">
-            <h2 class="section-title">Open core, self-host first</h2>
-            <p class="section-lede">
-                Every module is MIT or Apache licensed. Clone the monorepo, run <code>make up</code>, and the core stack boots on loopback in under a minute. Run on a laptop, a single VM, or Kubernetes &mdash; the same images, the same config.
-            </p>
-            <div class="open-core-actions">
-                <a href="https://github.com/digithings-ai/digithings" class="hero-cta" target="_blank" rel="noopener noreferrer">
-                    digithings-ai on GitHub
-                    <span class="hero-cta-arrow" aria-hidden="true">&rarr;</span>
-                </a>
-                <a href="https://github.com/digithings-ai/digithings#readme" class="hero-cta hero-cta-ghost" target="_blank" rel="noopener noreferrer">
-                    Read the docs
-                </a>
+        <!-- ========== Act V — Ecosystem ========== -->
+        <section id="ecosystem" class="act act-ecosystem" data-act="ecosystem" aria-labelledby="act5-title">
+            <div class="act-copy act-copy-wide">
+                <p class="act-kicker">Act V — Ecosystem</p>
+                <h2 id="act5-title" class="tws-weight-shift editorial-title"
+                    data-weight-from="200" data-weight-to="600">Plug in. Expose. Ship.</h2>
+                <p class="lede">
+                    The same diagram, three deployment stories. Toggle a lens.
+                </p>
+                <div class="eco-toggles" role="tablist" aria-label="Deployment lens">
+                    <button type="button" class="eco-toggle" data-lens="plugin" role="tab" aria-selected="false">Plug in</button>
+                    <button type="button" class="eco-toggle" data-lens="mcp" role="tab" aria-selected="false">Expose as MCP</button>
+                    <button type="button" class="eco-toggle" data-lens="docker" role="tab" aria-selected="false">Ship as Docker</button>
+                </div>
+                <p class="eco-caption" id="eco-caption">
+                    Pick a lens above. Escape or the zoom-out button to reset.
+                </p>
             </div>
         </section>
+
     </main>
 
-    <footer class="footer scroll-trigger" data-direction="zoom">
-        <div class="container footer-content">
-            <div class="footer-links">
+    <!-- Support-module metadata (SSR-visible for SEO + semantic completeness).
+         The live detail panel below is click-driven on the diagram. -->
+    <aside class="sr-modules" aria-label="Support modules">
+        <ul>
+            <li data-module-id="digikey"><strong>DigiKey</strong> — auth + identity, RS256 JWTs, JWKS.</li>
+            <li data-module-id="digismith"><strong>DigiSmith</strong> — observability, correlation IDs, PII redaction.</li>
+            <li data-module-id="digiclaw"><strong>DigiClaw</strong> — always-on agent runtime, immutable audit.</li>
+            <li data-module-id="digibase"><strong>DigiBase</strong> — shared HTTP + audit Python library.</li>
+            <li data-module-id="digistore"><strong>DigiStore</strong> — one API over S3, MinIO, Postgres, SQLite.</li>
+            <li data-module-id="digilink"><strong>DigiLink</strong> — MCP protocol bridge for non-native transports.</li>
+        </ul>
+    </aside>
+
+    <!-- Support-module detail panel (click support node to open) -->
+    <aside id="detail-panel" class="detail-panel" aria-hidden="true" role="dialog" aria-labelledby="detail-title">
+        <button type="button" class="detail-close" aria-label="Close panel">&times;</button>
+        <h3 id="detail-title" class="detail-title">Module</h3>
+        <p class="detail-role" id="detail-role"></p>
+        <p class="detail-body" id="detail-body"></p>
+        <pre class="detail-code"><code id="detail-code"></code></pre>
+    </aside>
+
+    <footer class="dt-footer">
+        <div class="dt-footer-inner">
+            <div class="dt-footer-links">
                 <a href="https://github.com/digithings-ai/digithings" target="_blank" rel="noopener noreferrer">GitHub</a>
                 <a href="https://github.com/digithings-ai/digithings#readme" target="_blank" rel="noopener noreferrer">Docs</a>
                 <a href="https://digiquant.io" target="_blank" rel="noopener noreferrer">digiquant.io</a>
                 <a href="https://chat.digithings.ai" target="_blank" rel="noopener noreferrer">DigiChat</a>
             </div>
-            <p>&copy; 2026 digithings AI. Open Core.</p>
+            <p>&copy; 2026 digithings AI. Open core.</p>
         </div>
     </footer>
 

--- a/frontend/website/main.js
+++ b/frontend/website/main.js
@@ -1,39 +1,275 @@
 /**
- * digithings.ai landing page — loader.
+ * digithings.ai — architecture-editorial landing page orchestrator.
  *
- * Thin composition layer that initializes the extracted design-system
- * modules. No feature changes vs. the pre-extraction behavior.
+ * Wires the living-architecture diagram, typography motion, and per-module
+ * terminal widgets. Handles support-node click → detail panel, and the
+ * Act V ecosystem lens toggles (plug-in / MCP / Docker overlays).
  */
-import { initStarfield } from '../design-system/starfield.js';
-import { initScrollTrigger } from '../design-system/scroll-trigger.js';
-import { typeWriter } from '../design-system/typewriter.js';
 
-const TERMINAL_CODE =
-  'from digithings import digigraph\n\n' +
-  '# Initialize orchestrator\n' +
-  'agent = digigraph(mode="secure")\n\n' +
-  '# Connect execution engine\n' +
-  'agent.attach("nautilus_core")\n\n' +
-  'agent.run()';
+import { initDiagram } from '../design-system/living-architecture/index.js';
+import { initTerminal } from '../design-system/terminal/index.js';
+import { initTypographyMotion } from '../design-system/typography-motion/index.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  initStarfield({ canvasId: 'network-canvas' });
+// ---------------------------------------------------------------------------
+// Diagram data — 10 module nodes placed on the 1200x720 viewBox.
+// Core modules form the spine left→right; support modules orbit above/below.
+// ---------------------------------------------------------------------------
+const NODES = [
+    // Core (scroll acts)
+    { id: 'digigraph',  label: 'DigiGraph',  x: 300, y: 360, group: 'core', accentVar: '--accent-digigraph' },
+    { id: 'digiquant',  label: 'DigiQuant',  x: 540, y: 360, group: 'core', accentVar: '--accent-digiquant' },
+    { id: 'digisearch', label: 'DigiSearch', x: 780, y: 360, group: 'core', accentVar: '--accent-digisearch' },
+    { id: 'digichat',   label: 'DigiChat',   x: 1020, y: 360, group: 'core', accentVar: '--accent-digichat' },
+    // Support (click-to-focus panels)
+    { id: 'digikey',    label: 'DigiKey',    x: 180, y: 160, group: 'support', accentVar: '--accent-digikey' },
+    { id: 'digismith',  label: 'DigiSmith',  x: 420, y: 560, group: 'support', accentVar: '--accent-digismith' },
+    { id: 'digiclaw',   label: 'DigiClaw',   x: 660, y: 560, group: 'support', accentVar: '--accent-digiclaw' },
+    { id: 'digibase',   label: 'DigiBase',   x: 900, y: 560, group: 'support', accentVar: '--accent-digibase' },
+    { id: 'digistore',  label: 'DigiStore',  x: 1080, y: 160, group: 'support', accentVar: '--accent-digistore' },
+    { id: 'digilink',   label: 'DigiLink',   x: 180, y: 560, group: 'support', accentVar: '--accent-digilink' },
+];
 
-  let typeWriterStarted = false;
-  const heroVisual = document.querySelector('.hero-visual.scroll-trigger');
+const EDGES = [
+    // core spine
+    { source: 'digigraph',  target: 'digiquant' },
+    { source: 'digiquant',  target: 'digisearch' },
+    { source: 'digisearch', target: 'digichat' },
+    // orchestrator wiring
+    { source: 'digigraph',  target: 'digikey' },
+    { source: 'digigraph',  target: 'digismith' },
+    { source: 'digigraph',  target: 'digiclaw' },
+    { source: 'digigraph',  target: 'digilink' },
+    // cross-cuts
+    { source: 'digiquant',  target: 'digistore' },
+    { source: 'digisearch', target: 'digistore' },
+    { source: 'digichat',   target: 'digikey' },
+    { source: 'digismith',  target: 'digibase' },
+    { source: 'digiclaw',   target: 'digibase' },
+];
 
-  initScrollTrigger({
-    selector: '.scroll-trigger',
-    revealThreshold: 0.85,
-    activateSelector: '.timeline-event',
-    activationLineRatio: 0.7,
-    onProgress: (el, progress) => {
-      if (el === heroVisual && progress > 0.5 && !typeWriterStarted) {
-        typeWriterStarted = true;
-        setTimeout(() => {
-          typeWriter('typewriter-code', TERMINAL_CODE, { speed: 30 });
-        }, 400);
-      }
+// ---------------------------------------------------------------------------
+// Support-module detail panel content (source: AGENTS.md / ARCHITECTURE.md).
+// ---------------------------------------------------------------------------
+const SUPPORT = {
+    digikey: {
+        title: 'DigiKey',
+        role: 'Auth + identity plane.',
+        body: 'RS256 JWTs with a JWKS endpoint, scoped API keys, SSO federation, org + project membership, and row-level resource access baked straight into the issued tokens.',
+        code: 'DIGIKEY_ISSUER=https://digikey.example.com',
+        lang: 'sh',
     },
-  });
+    digismith: {
+        title: 'DigiSmith',
+        role: 'Observability + redaction.',
+        body: 'Correlation IDs propagate through every span; Prometheus /metrics is labeled by version and environment; PII is redacted before logs hit disk.',
+        code: 'app.add_middleware(DigiSmithRequestIdMiddleware)',
+        lang: 'py',
+    },
+    digiclaw: {
+        title: 'DigiClaw',
+        role: 'Always-on runtime + audit.',
+        body: 'Heartbeat, immutable JSONL audit, and MCP skill surface for long-running autonomous work. Atlas runner scheduling and drift detection live here.',
+        code: 'python -m digiclaw',
+        lang: 'sh',
+    },
+    digibase: {
+        title: 'DigiBase',
+        role: 'Shared HTTP + audit primitives.',
+        body: 'A deliberately minimal Python library — not a service. HTTP middleware, audit redaction, and error conventions so every other module behaves consistently.',
+        code: 'from digibase.audit import redact_mapping',
+        lang: 'py',
+    },
+    digistore: {
+        title: 'DigiStore',
+        role: 'One API over S3, MinIO, Postgres, SQLite.',
+        body: 'A typed storage facade. Strategy artifacts, research outputs, and vector payloads travel the same path no matter where they land. Swap backends without touching business code.',
+        code: 'store = DigiStore.configure(backend="s3", bucket="digi-artifacts")',
+        lang: 'py',
+    },
+    digilink: {
+        title: 'DigiLink',
+        role: 'MCP protocol bridge.',
+        body: 'When an external system speaks something DigiGraph does not — proprietary broker feeds, legacy REST surfaces, odd webhooks — DigiLink adapts it into MCP tool calls the orchestrator already understands.',
+        code: 'digilink.register_adapter("legacy-rest", RestToMcpAdapter(...))',
+        lang: 'py',
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Terminal snippets: load the real-code text fragments, wrap into terminal
+// line objects (kind=comment for #/// lines, kind=output for code lines).
+// ---------------------------------------------------------------------------
+async function loadSnippet(path, lang) {
+    const res = await fetch(path);
+    if (!res.ok) return [];
+    const text = await res.text();
+    return text.split('\n').map((raw) => {
+        const trimmed = raw.trimStart();
+        const isComment = trimmed.startsWith('#') || trimmed.startsWith('//');
+        return {
+            kind: isComment ? 'comment' : 'output',
+            text: isComment ? trimmed.replace(/^(#|\/\/)\s?/, '') : raw,
+            lang,
+        };
+    });
+}
+
+const HERO_LINES = [
+    { kind: 'prompt', text: 'digithings ask "where does a request go?"' },
+    { kind: 'output', text: '→ digigraph routes to digisearch + digiquant' },
+    { kind: 'comment', text: 'BYOK, loopback, audit on by default' },
+];
+
+// ---------------------------------------------------------------------------
+// Detail panel — open/close with a support-node focus.
+// ---------------------------------------------------------------------------
+function openDetailPanel(id) {
+    const panel = document.getElementById('detail-panel');
+    const spec = SUPPORT[id];
+    if (!panel || !spec) return;
+    document.getElementById('detail-title').textContent = spec.title;
+    document.getElementById('detail-role').textContent = spec.role;
+    document.getElementById('detail-body').textContent = spec.body;
+    document.getElementById('detail-code').textContent = spec.code;
+    panel.classList.add('is-open');
+    panel.setAttribute('aria-hidden', 'false');
+    panel.dataset.module = id;
+}
+
+function closeDetailPanel() {
+    const panel = document.getElementById('detail-panel');
+    if (!panel) return;
+    panel.classList.remove('is-open');
+    panel.setAttribute('aria-hidden', 'true');
+}
+
+// ---------------------------------------------------------------------------
+// Ecosystem lens toggles.
+// ---------------------------------------------------------------------------
+function initEcosystemToggles() {
+    const overlaysSvg = document.getElementById('arch-overlays');
+    const buttons = Array.from(document.querySelectorAll('.eco-toggle'));
+    const caption = document.getElementById('eco-caption');
+    if (!overlaysSvg || buttons.length === 0) return;
+
+    const CAPTIONS = {
+        plugin: 'Plug your app, DB, and auth into DigiGraph, DigiStore, and DigiKey.',
+        mcp:    'Every module exposes its capabilities as MCP tool calls.',
+        docker: 'One compose file — runs on laptop, VM, or Kubernetes.',
+    };
+
+    function setLens(lens) {
+        overlaysSvg.classList.toggle('is-plugin', lens === 'plugin');
+        overlaysSvg.classList.toggle('is-mcp', lens === 'mcp');
+        overlaysSvg.classList.toggle('is-docker', lens === 'docker');
+        overlaysSvg.setAttribute('aria-hidden', lens ? 'false' : 'true');
+        for (const btn of buttons) {
+            const on = btn.dataset.lens === lens;
+            btn.classList.toggle('is-active', on);
+            btn.setAttribute('aria-selected', on ? 'true' : 'false');
+        }
+        if (caption) caption.textContent = lens ? CAPTIONS[lens] : 'Pick a lens above.';
+    }
+
+    for (const btn of buttons) {
+        btn.addEventListener('click', () => {
+            const lens = btn.dataset.lens;
+            const already = btn.classList.contains('is-active');
+            setLens(already ? null : lens);
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scroll-driven camera focus: when a core act comes into view, focus the
+// diagram on that module. Support-node focus is click-driven only.
+// ---------------------------------------------------------------------------
+function initScrollActs(diagram) {
+    const acts = document.querySelectorAll('.act-core[data-act]');
+    if (acts.length === 0) return;
+
+    const observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+            if (entry.isIntersecting && entry.intersectionRatio > 0.4) {
+                const id = entry.target.dataset.act;
+                if (id) diagram.focus(id);
+            }
+        }
+    }, { threshold: [0.4, 0.6] });
+
+    for (const a of acts) observer.observe(a);
+}
+
+// ---------------------------------------------------------------------------
+// Boot.
+// ---------------------------------------------------------------------------
+document.addEventListener('DOMContentLoaded', async () => {
+    const diagram = initDiagram({
+        hostId: 'arch-host',
+        svgId: 'arch-svg',
+        nodes: NODES,
+        edges: EDGES,
+        onNodeFocus: (id) => {
+            const node = NODES.find((n) => n.id === id);
+            if (!node) return;
+            if (node.group === 'support') {
+                openDetailPanel(id);
+            } else {
+                closeDetailPanel();
+                // Keep URL hash in sync for deep-linking.
+                if (history && history.replaceState) {
+                    history.replaceState(null, '', `#${id}`);
+                }
+            }
+        },
+    });
+
+    // Hero terminal — small, placeholder-only.
+    initTerminal({ elementId: 'hero-term', lines: HERO_LINES, speed: 'slow' });
+
+    // Per-module terminals with real snippets.
+    const snippetMap = [
+        ['term-digigraph',  'snippets/digigraph.py.txt',  'py'],
+        ['term-digiquant',  'snippets/digiquant.py.txt',  'py'],
+        ['term-digisearch', 'snippets/digisearch.py.txt', 'py'],
+        ['term-digichat',   'snippets/digichat.ts.txt',   'ts'],
+    ];
+
+    for (const [elementId, path, lang] of snippetMap) {
+        // Wire each terminal to its real-code snippet. Lazy: only start typing
+        // when the act section enters view.
+        const host = document.getElementById(elementId);
+        if (!host) continue;
+        let started = false;
+        const obs = new IntersectionObserver(async (entries) => {
+            for (const e of entries) {
+                if (e.isIntersecting && !started) {
+                    started = true;
+                    const lines = await loadSnippet(path, lang);
+                    initTerminal({ elementId, lines, speed: 'fast' });
+                    obs.disconnect();
+                }
+            }
+        }, { threshold: 0.3 });
+        const parentAct = host.closest('.act');
+        if (parentAct) obs.observe(parentAct);
+    }
+
+    // Detail-panel close wiring.
+    const closeBtn = document.querySelector('.detail-close');
+    if (closeBtn) closeBtn.addEventListener('click', closeDetailPanel);
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeDetailPanel();
+    });
+
+    initEcosystemToggles();
+    initScrollActs(diagram);
+    initTypographyMotion();
+
+    // Deep-link support: if URL already has a module hash, focus it.
+    const hash = window.location.hash.replace('#', '');
+    if (hash && NODES.some((n) => n.id === hash)) {
+        // Defer so the diagram layout + scroll are settled.
+        setTimeout(() => diagram.focus(hash), 300);
+    }
 });

--- a/frontend/website/snippets/digichat.ts.txt
+++ b/frontend/website/snippets/digichat.ts.txt
@@ -1,0 +1,15 @@
+// frontend/digichat/src/app/api/chat/route.ts (L20-L108, elided)
+export async function POST(req: Request) {
+  const machine = await validateMachineApiKey(
+    req.headers.get("authorization"));
+  const session = await auth();
+  if (!machine && !session?.user) return unauthorized();
+
+  const { bearer, litellmProxyApiKey } =
+    await resolveDigigraphUpstreamAuth(req, tenantSlug, ownerSub);
+
+  const eco = await getEcosystemEndpoints();
+  const provider = createDigiGraphClient(eco.digigraphUrl, bearer);
+  const model = provider(digigraphModelName());
+  return streamText({ model, messages: coreMessages });
+}

--- a/frontend/website/snippets/digigraph.py.txt
+++ b/frontend/website/snippets/digigraph.py.txt
@@ -1,0 +1,15 @@
+# digigraph/src/digigraph/orchestration/registry.py (L28-L60, elided)
+@dataclass
+class ToolContext:
+    session_id: str | None
+    run_data_dir: str | None
+    index_name: str
+    state: dict[str, Any]
+    allowed_tool_names: frozenset[str] | None = None
+    request_id: str | None = None
+    workflow_id: str | None = None
+
+def register_tool(name, schema, handler, tags=None, schema_factory=None):
+    """Register an orchestrator tool (OpenAI function format)."""
+    _tools[name] = (schema, schema_factory, handler, set(tags or []))
+# ...

--- a/frontend/website/snippets/digiquant.py.txt
+++ b/frontend/website/snippets/digiquant.py.txt
@@ -1,0 +1,16 @@
+# digiquant/src/digiquant/strategies/registry.py (L13-L44, elided)
+@dataclass
+class StrategySpec:
+    strategy_cls: type
+    config_cls: type
+    default_params: dict[str, Any]
+    description: str
+
+def register(name, strategy_cls, config_cls, default_params,
+             *, aliases=None, description=""):
+    """Register a Nautilus strategy by name."""
+    _REGISTRY[name] = StrategySpec(strategy_cls, config_cls,
+                                    default_params, description)
+    for alias in aliases or []:
+        _ALIASES[alias] = name
+# ...

--- a/frontend/website/snippets/digisearch.py.txt
+++ b/frontend/website/snippets/digisearch.py.txt
@@ -1,0 +1,16 @@
+# digisearch/src/digisearch/client.py (L11-L40, elided)
+class DigiSearch:
+    """Unified client: indexes + embedding + search."""
+
+    def __init__(self, config: DigiSearchConfig | None = None):
+        self.config = config or DigiSearchConfig.from_env()
+        self._indexes: dict[str, Any] = {}
+
+    @classmethod
+    def from_config(cls, path: str) -> "DigiSearch":
+        return cls(DigiSearchConfig.from_config(path))
+
+    def get_index(self, name: str):
+        idx_cfg = self.config.get_index_config(name)
+        backend = idx_cfg.get("backend", "chroma")
+        # ... resolve backend, attach embedder, return handle

--- a/frontend/website/style.css
+++ b/frontend/website/style.css
@@ -1,8 +1,287 @@
 /* ==========================================================================
-   digithings.ai — page-local overrides
-   --------------------------------------------------------------------------
-   The design system lives in tokens.css (variables) and components.css
-   (primitives); both are loaded directly by index.html. This file is
-   intentionally empty and reserved for rules specific to the landing page
-   that don't belong in the shared primitives layer.
+   digithings.ai — architecture-editorial landing page glue.
+   Page-level layout only. Tokens + primitives own the rest.
    ========================================================================== */
+
+html, body { margin: 0; padding: 0; }
+
+body.dt-page {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: var(--font-family);
+    font-size: var(--font-size-body);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+/* ------------------ Grain overlay (retires starfield) ------------------- */
+.dt-grain {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0.22;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.9  0 0 0 0 0.9  0 0 0 0 0.9  0 0 0 0.55 0'/></filter><rect width='240' height='240' filter='url(%23n)'/></svg>");
+    background-size: 240px 240px;
+}
+
+/* ------------------ Nav ------------------ */
+.dt-nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 30;
+    background: color-mix(in oklab, var(--bg-primary) 88%, transparent);
+    border-bottom: 1px solid var(--border-color);
+    backdrop-filter: blur(6px);
+}
+.dt-nav-inner {
+    max-width: 1400px; margin: 0 auto;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.75rem 1.5rem;
+}
+.dt-logo { display: inline-flex; gap: 0.6rem; align-items: center;
+    color: var(--fg); text-decoration: none; font-weight: 500; font-size: 1.1rem; }
+.dt-logo-svg { width: 26px; height: 26px; }
+.dt-nav-links { display: flex; gap: 1.3rem; flex-wrap: wrap; }
+.dt-nav-links a {
+    color: var(--text-secondary); text-decoration: none; font-size: 0.95rem;
+    transition: color 0.2s ease;
+}
+.dt-nav-links a:hover { color: var(--fg); }
+
+/* ------------------ Spine (sticky diagram) ------------------ */
+.dt-spine { position: relative; z-index: 1; }
+.dt-spine-sticky {
+    position: sticky;
+    top: 68px;
+    height: calc(100vh - 68px);
+    display: flex; align-items: center; justify-content: center;
+    padding: 1rem 2rem;
+    pointer-events: none;
+}
+.dt-arch-host {
+    position: relative;
+    width: 100%;
+    max-width: 1400px;
+    height: 100%;
+    max-height: 80vh;
+    pointer-events: auto;
+}
+.dt-arch-host > svg { width: 100%; height: 100%; }
+
+.dt-arch-overlays {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; opacity: 0; transition: opacity 0.4s ease;
+}
+.dt-arch-overlays.is-plugin,
+.dt-arch-overlays.is-mcp,
+.dt-arch-overlays.is-docker { opacity: 1; }
+.dt-arch-overlays .overlay { display: none; }
+.dt-arch-overlays.is-plugin .overlay-plugin,
+.dt-arch-overlays.is-mcp .overlay-mcp,
+.dt-arch-overlays.is-docker .overlay-docker { display: inline; }
+
+.overlay-ring {
+    fill: none; stroke: var(--fg); stroke-width: 1.5;
+    stroke-dasharray: 3 6; opacity: 0.55;
+}
+.overlay-container {
+    fill: none; stroke: var(--fg); stroke-width: 1.5;
+    stroke-dasharray: 6 6; opacity: 0.4; rx: 16; ry: 16;
+}
+.overlay-text {
+    fill: var(--text-secondary); font-family: var(--font-family-mono);
+    font-size: 14px; text-anchor: middle;
+}
+
+/* ------------------ Main / acts ------------------ */
+.dt-main {
+    position: relative; z-index: 2;
+    margin-top: calc(-1 * (100vh - 68px));
+}
+
+.act {
+    position: relative;
+    min-height: 200vh;
+    padding: 7rem 2rem 4rem;
+    max-width: 1400px; margin: 0 auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 3rem; align-items: center;
+    pointer-events: none;
+}
+.act > * { pointer-events: auto; }
+
+.act-hero { padding-top: 9rem; min-height: 100vh;
+    grid-template-columns: minmax(0, 1fr); }
+.act-hero .act-copy { grid-column: 1 / 2; max-width: 620px; }
+
+.act-copy { max-width: 560px; }
+.act-copy-wide { max-width: 900px; grid-column: 1 / -1; }
+.act-side { display: flex; flex-direction: column; gap: 1.5rem; }
+
+.act-kicker {
+    font-family: var(--font-family-mono);
+    font-size: 0.85rem; color: var(--text-secondary);
+    text-transform: uppercase; letter-spacing: 0.08em;
+    margin: 0 0 0.5rem;
+}
+
+.editorial-title {
+    font-family: var(--font-family);
+    font-size: clamp(2.5rem, 5.5vw, 4.5rem);
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    margin: 0 0 1rem;
+    color: var(--fg);
+    font-weight: 200;
+}
+.sub-hero {
+    font-family: var(--font-family-mono);
+    color: var(--text-secondary);
+    font-size: 1rem; margin: 0 0 1.5rem;
+}
+.one-liner { font-size: 1.3rem; color: var(--fg); margin: 0 0 1rem; }
+.lede { font-size: 1.2rem; color: var(--text-secondary); margin: 0 0 1.5rem; }
+.body { font-size: 1.05rem; color: var(--text-secondary); margin: 0 0 1rem; }
+.body code {
+    font-family: var(--font-family-mono); font-size: 0.92em;
+    background: color-mix(in oklab, var(--accent, var(--fg)) 14%, transparent);
+    color: var(--fg);
+    padding: 0.1em 0.4em; border-radius: var(--radius-sm);
+}
+
+.hero-actions { display: flex; gap: 1rem; flex-wrap: wrap; margin: 1.5rem 0 2rem; }
+.cta {
+    display: inline-flex; gap: 0.4rem; align-items: center;
+    padding: 0.75rem 1.3rem;
+    background: var(--fg); color: var(--bg-primary);
+    border-radius: var(--radius-md);
+    text-decoration: none; font-weight: 500; font-size: 0.95rem;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+.cta:hover { transform: translateY(-1px); }
+.cta-ghost { background: transparent; color: var(--fg);
+    border: 1px solid var(--border-color); }
+.pass-through {
+    color: var(--accent, var(--fg));
+    font-family: var(--font-family-mono);
+    text-decoration: none; font-size: 0.95rem;
+}
+.pass-through:hover { text-decoration: underline; }
+
+/* ------------------ Terminal host sizing ------------------ */
+.term-host { width: 100%; max-width: 560px; }
+.term-hero { max-width: 440px; margin-top: 1.5rem; opacity: 0.9; }
+
+/* ------------------ DigiChat embed slot ------------------ */
+.chat-embed-slot {
+    width: 100%; aspect-ratio: 4 / 3; max-height: 480px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: var(--bg-secondary);
+}
+.chat-embed-slot iframe { width: 100%; height: 100%; border: 0; display: block; }
+
+/* ------------------ Detail panel ------------------ */
+.detail-panel {
+    position: fixed; top: 0; right: 0; bottom: 0; z-index: 40;
+    width: min(420px, 92vw);
+    background: var(--bg-secondary);
+    border-left: 1px solid var(--border-color);
+    padding: 3rem 2rem 2rem;
+    transform: translateX(100%);
+    transition: transform 0.3s var(--transition-ease);
+    overflow-y: auto;
+}
+.detail-panel.is-open { transform: translateX(0); }
+.detail-close {
+    position: absolute; top: 1rem; right: 1rem;
+    background: transparent; border: 0; color: var(--text-secondary);
+    font-size: 1.6rem; cursor: pointer;
+}
+.detail-close:hover { color: var(--fg); }
+.detail-title { margin: 0 0 0.3rem; font-weight: 500; color: var(--fg); }
+.detail-role {
+    margin: 0 0 1rem; color: var(--text-secondary);
+    font-family: var(--font-family-mono); font-size: 0.9rem;
+}
+.detail-body { color: var(--text-secondary); margin: 0 0 1.5rem; font-size: 1rem; }
+.detail-code {
+    background: var(--bg-primary); border: 1px solid var(--border-color);
+    padding: 0.75rem 1rem; border-radius: var(--radius-md);
+    font-family: var(--font-family-mono); font-size: 0.85rem;
+    color: var(--fg);
+    white-space: pre-wrap; word-break: break-word;
+    margin: 0;
+}
+
+/* ------------------ Ecosystem toggles ------------------ */
+.eco-toggles { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 1.5rem 0; }
+.eco-toggle {
+    background: transparent; color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    padding: 0.65rem 1.1rem; border-radius: var(--radius-md);
+    font-family: var(--font-family); font-size: 0.95rem;
+    cursor: pointer; transition: all 0.2s ease;
+}
+.eco-toggle:hover { color: var(--fg); border-color: var(--fg); }
+.eco-toggle.is-active {
+    color: var(--fg); border-color: var(--fg);
+    background: color-mix(in oklab, var(--fg) 8%, transparent);
+}
+.eco-caption {
+    color: var(--text-secondary);
+    font-family: var(--font-family-mono); font-size: 0.9rem;
+}
+
+/* ------------------ Screen-reader-only module list ------------------ */
+.sr-modules {
+    position: absolute; width: 1px; height: 1px; padding: 0;
+    margin: -1px; overflow: hidden; clip: rect(0,0,0,0);
+    white-space: nowrap; border: 0;
+}
+
+/* ------------------ Footer ------------------ */
+.dt-footer {
+    position: relative; z-index: 2;
+    border-top: 1px solid var(--border-color);
+    padding: 2rem; margin-top: 4rem;
+    background: var(--bg-secondary);
+}
+.dt-footer-inner {
+    max-width: 1400px; margin: 0 auto;
+    display: flex; justify-content: space-between; align-items: center;
+    flex-wrap: wrap; gap: 1rem;
+}
+.dt-footer-links { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+.dt-footer-links a { color: var(--text-secondary); text-decoration: none; }
+.dt-footer-links a:hover { color: var(--fg); }
+.dt-footer p { color: var(--text-secondary); margin: 0; font-size: 0.9rem; }
+
+/* ------------------ Responsive ------------------ */
+@media (max-width: 1024px) {
+    .act { grid-template-columns: minmax(0, 1fr); min-height: 160vh; }
+    .dt-spine-sticky { max-height: 60vh; padding: 1rem; }
+    .dt-arch-host { max-height: 55vh; }
+}
+
+@media (max-width: 768px) {
+    .dt-nav-links { display: none; }
+    .dt-spine-sticky { position: relative; top: 0; height: auto; max-height: 360px; }
+    .dt-main { margin-top: 0; }
+    .act { min-height: auto; padding: 3rem 1.2rem; gap: 1.5rem; }
+    .act-hero { padding-top: 5rem; }
+    .editorial-title { font-size: clamp(2rem, 8vw, 3rem); }
+}
+
+@media (max-width: 480px) {
+    .dt-spine-sticky { max-height: 280px; }
+    .la-zoom-out-btn { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .detail-panel, .dt-arch-overlays { transition: none; }
+}


### PR DESCRIPTION
## Summary

Rewrite `frontend/website/` against the three design-system primitives that landed in #274:
`living-architecture`, `terminal`, `typography-motion`.

- **Spine:** sticky living-architecture diagram tracks the user through every act. Scrolling into a core act pans the camera to that module; clicking a support node opens a detail panel; arrow-key nav + zoom-out button come from the primitive.
- **Core acts (I-IV):** DigiGraph / DigiQuant / DigiSearch / DigiChat — each with editorial weight-shift title, 2-3 supporting sentences, and a terminal widget streaming real code excerpted from the repo. Source file + line range noted in a leading comment of each snippet.
- **Support acts:** DigiKey / DigiSmith / DigiClaw / DigiBase / DigiStore / DigiLink — click-driven detail panels with a one-line config/code snippet and a short description.
- **Act V — Ecosystem:** three toggle buttons (Plug in / Expose as MCP / Ship as Docker) reveal SVG overlay groups on the same diagram.
- **Starfield retired** on this page; replaced with a subtle SVG grain overlay.
- **Passthrough CTAs** to digiquant.io and chat.digithings.ai; DigiChat iframe slot preserved.

Parent epic: #268
Fixes #270

## Acceptance

- [x] `frontend/website/index.html` fully rewritten
- [x] Consumes `living-architecture` as the spine
- [x] Consumes `terminal` for per-module snippets + hero widget
- [x] Consumes `typography-motion` for title weight transitions
- [x] All 10 modules appear; 4 core get scroll acts with real-code terminals; 6 support get click-to-focus panels
- [x] Click-to-zoom + arrow-key + zoom-out button all work (inherited from primitive)
- [x] Pass-through CTAs to DigiChat and digiquant.io present
- [x] Real code from `digigraph/`, `digiquant/`, `digisearch/`, `frontend/digichat/` in the four snippet files
- [x] DigiChat iframe embed slot included (the broken `/embed` fix stays tracked in #266)
- [x] No SITAAS mention anywhere in `frontend/website/`
- [x] Responsive breakpoints at 1024 / 768 / 480
- [x] `make doc-check` passes
- [x] `make score` 10/10/10/10 (thresholds 8/8/7/9)

## Test plan
- [x] `make doc-check`
- [x] Static e2e recipe from issue (fetch + grep all 10 module ids + primitives + no SITAAS)
- [x] `make score` on staged changes
- [ ] Manual browser review at `http://localhost:8765/website/` — scroll acts, click support nodes, arrow keys, eco toggles

## Gate sign-offs

- [x] /`simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /`review` completed — PR reviewed against scoring rubric; findings addressed

---

_Note: `make test-unit` has 14 pre-existing failures in `tests/ds/` and `tests/integration/test_digi_auth_contract.py` (auth-contract regressions); none relate to this frontend-only change — no Python was touched._