### PR TITLE
feat(digiquant-atlas): adopt quant-native flavor — Child 4 of #268

### DIFF
--- a/apps/digiquant-atlas/frontend/README.md
+++ b/apps/digiquant-atlas/frontend/README.md
@@ -1,0 +1,74 @@
+# digiquant-atlas / frontend
+
+Next.js 15 research console for Atlas. Joins the root npm workspace in place
+(`apps/*/frontend`) and consumes the shared design system via
+`@digithings/design-system` as a workspace dependency.
+
+## Quant-native visual layer
+
+Atlas matches the digiquant.io aesthetic by importing the shared tokens and
+the quant-native primitives directly in `app/globals.css`:
+
+```css
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+@import "@digithings/design-system/tokens.css";
+@import "@digithings/design-system/quant-native/styles.css";
+```
+
+The root layout scopes the page to the DigiQuant accent and blueprint
+background:
+
+```tsx
+<body className="qn-blueprint-bg accent-digiquant ...">
+```
+
+### Utilities adopted from the design-system
+
+- `.qn-blueprint-bg` — faint repeating hairline grid; dark by default, the
+  light-theme override lives under `html.light .qn-blueprint-bg` in
+  `globals.css` (the design-system tokens are dark-only).
+- `.accent-digiquant` — sets `--accent` to the muted emerald used across
+  digiquant.io. Individual routes may nest `.accent-atlas` to shift to the
+  Atlas-specific green where appropriate.
+- `.qn-metric` — tabular, mono, right-aligned numeric cells. Applied to the
+  server-metrics strip; extend to additional metric sites as needed.
+- `.qn-up` / `.qn-down` — muted emerald / copper for directional P&L. Do
+  **not** reuse these for error states — those still use the
+  existing `--color-fin-red` / `--color-fin-amber` tokens.
+
+### Page chrome
+
+`app/layout.tsx` renders a thin monospaced header strip (`.qn-page-chrome`)
+at the top of `<main>` with route crumbs on the left and an `Open digiquant.io`
+link plus version/env label on the right. The version label reads
+`process.env.NEXT_PUBLIC_ATLAS_VERSION` and falls back to `v0.1 · dev`.
+
+### Recharts theming
+
+Global `.recharts-*` overrides in `globals.css` now reference tokens
+(`--border-color`, `--text-secondary`, `--font-family-mono`) so charts follow
+the shared palette. No chart library was swapped.
+
+## Running
+
+```bash
+# From repo root
+npm install                  # links workspace packages
+cd apps/digiquant-atlas/frontend
+npm run dev                  # http://localhost:3000/digiquant-atlas/
+npm run build                # static export (output: 'export')
+npm run lint
+```
+
+No `test` script is configured for this workspace yet.
+
+## Token collision notes
+
+Atlas declares its own Tailwind v4 `@theme` palette
+(`--color-bg-primary`, `--color-text-primary`, etc). The design-system
+tokens live in the separate `--bg-primary` / `--text-primary` namespace, so
+they coexist without collision. Components that need the shared palette
+reference the design-system names (`var(--border-color)`,
+`var(--accent-digiquant)`), while Tailwind utilities continue to resolve
+the Atlas palette.

--- a/apps/digiquant-atlas/frontend/app/globals.css
+++ b/apps/digiquant-atlas/frontend/app/globals.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* ── DigiThings design-system (quant-native flavor) ────────────────────── */
+@import "@digithings/design-system/tokens.css";
+@import "@digithings/design-system/quant-native/styles.css";
+
 /* ── Custom Theme (preserves digiquant-atlas financial dark palette) ───── */
 @theme {
   /* Background */
@@ -76,12 +80,66 @@ body {
   border-color: var(--color-border-glow);
 }
 
-/* ── Recharts override (dark mode) ─────────────────────────────────────── */
+/* ── Recharts override (quant-native, token-driven) ────────────────────── */
 .recharts-cartesian-grid line {
-  stroke: rgba(255, 255, 255, 0.05);
+  stroke: var(--border-color);
+  stroke-opacity: 0.35;
+  stroke-width: 1;
 }
 .recharts-text {
-  fill: #71717a;
+  fill: var(--text-secondary);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+}
+.recharts-default-tooltip {
+  background: var(--bg-secondary) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: var(--radius-sm) !important;
+  font-family: var(--font-family-mono) !important;
+  font-size: 12px !important;
+}
+
+/* ── Light-mode blueprint grid override (tokens.css is dark-only) ──────── */
+html.light .qn-blueprint-bg {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.035) 0,
+    rgba(0, 0, 0, 0.035) 1px,
+    transparent 1px,
+    transparent 8px
+  );
+}
+
+/* ── Quant-native page chrome: thin header strip ───────────────────────── */
+.qn-page-chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-color);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: transparent;
+}
+.qn-page-chrome .qn-crumbs { color: var(--text-secondary); }
+.qn-page-chrome .qn-crumbs strong { color: var(--text-primary); font-weight: 500; }
+.qn-page-chrome .qn-env { color: var(--text-secondary); opacity: 0.8; }
+.qn-page-chrome a { color: var(--accent, var(--accent-digiquant)); text-decoration: none; }
+.qn-page-chrome a:hover { text-decoration: underline; }
+
+/* ── Quant-native sidebar accents ──────────────────────────────────────── */
+.qn-sidebar-label {
+  font-family: var(--font-family-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+.qn-sidebar-link-active {
+  border-left: 2px solid var(--accent, var(--accent-digiquant));
 }
 
 /* ── Markdown prose overrides ──────────────────────────────────────────── */

--- a/apps/digiquant-atlas/frontend/app/layout.tsx
+++ b/apps/digiquant-atlas/frontend/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT }} />
       </head>
-      <body className={`min-h-screen bg-bg-primary text-text-primary antialiased ${inter.variable} ${spaceMono.variable}`}>
+      <body className={`qn-blueprint-bg accent-digiquant min-h-screen bg-bg-primary text-text-primary antialiased ${inter.variable} ${spaceMono.variable}`}>
         <ThemeProvider>
           <Starfield />
           <DashboardProvider>
@@ -50,6 +50,21 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   <Sidebar />
                 </Suspense>
                 <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto max-h-screen">
+                  <div className="qn-page-chrome">
+                    <div className="qn-crumbs">
+                      <strong>Atlas</strong>
+                      <span aria-hidden="true"> / </span>
+                      <span>research console</span>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <a href="https://digiquant.io" target="_blank" rel="noopener noreferrer">
+                        Open digiquant.io -&gt;
+                      </a>
+                      <span className="qn-env">
+                        {process.env.NEXT_PUBLIC_ATLAS_VERSION ?? 'v0.1 · dev'}
+                      </span>
+                    </div>
+                  </div>
                   <MobileAppBar />
                   <CommandPalette />
                   <div className="flex min-h-0 flex-1 flex-col">{children}</div>

--- a/apps/digiquant-atlas/frontend/components/portfolio/server-metrics-strip.tsx
+++ b/apps/digiquant-atlas/frontend/components/portfolio/server-metrics-strip.tsx
@@ -13,37 +13,37 @@ export function ServerMetricsStrip({ m }: { m: ServerPortfolioMetrics }) {
       <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
         <span className="text-text-secondary">
           P&amp;L:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className={`qn-metric ${m.pnl_pct != null ? (m.pnl_pct >= 0 ? 'qn-up' : 'qn-down') : 'text-text-primary'}`}>
             {m.pnl_pct != null ? `${m.pnl_pct >= 0 ? '+' : ''}${m.pnl_pct.toFixed(2)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Sharpe:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className="qn-metric text-text-primary">
             {m.sharpe != null ? m.sharpe.toFixed(2) : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Vol:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className="qn-metric text-text-primary">
             {m.volatility != null ? `${m.volatility.toFixed(2)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Max DD:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className={`qn-metric ${m.max_drawdown != null && m.max_drawdown < 0 ? 'qn-down' : 'text-text-primary'}`}>
             {m.max_drawdown != null ? `${m.max_drawdown.toFixed(2)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Cash:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className="qn-metric text-text-primary">
             {m.cash_pct != null ? `${m.cash_pct.toFixed(1)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Invested:{' '}
-          <span className="text-text-primary font-mono tabular-nums">
+          <span className="qn-metric text-text-primary">
             {m.total_invested != null ? `${m.total_invested.toFixed(1)}%` : '—'}
           </span>
         </span>

--- a/apps/digiquant-atlas/frontend/components/sidebar.tsx
+++ b/apps/digiquant-atlas/frontend/components/sidebar.tsx
@@ -125,13 +125,13 @@ export default function Sidebar() {
                   ${sidebarCollapsed ? 'md:justify-center md:px-3' : 'px-6'}
                   ${
                     isActive
-                      ? 'text-text-primary bg-white/[0.04] border-r-2 border-text-primary'
+                      ? 'text-text-primary bg-white/[0.04] qn-sidebar-link-active'
                       : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.03]'
                   }
                 `}
               >
                 <Icon size={20} className="shrink-0" />
-                <span className={sidebarCollapsed ? 'md:sr-only' : ''}>{label}</span>
+                <span className={`qn-sidebar-label ${sidebarCollapsed ? 'md:sr-only' : ''}`}>{label}</span>
               </Link>
             );
           })}


### PR DESCRIPTION
## Summary

Child 4 of epic #268 — aligns the Atlas frontend with digiquant.io's quant-native visual language. Visual-only refactor (no UX/routing/backend changes).

- `app/globals.css` — import `@digithings/design-system/tokens.css` + `quant-native/styles.css` after Tailwind; recharts overrides upgraded to token-driven (`--border-color`, `--text-secondary`, `--font-family-mono`); light-theme blueprint-grid override added (tokens.css is dark-only); `.qn-page-chrome`, `.qn-sidebar-label`, `.qn-sidebar-link-active` utility classes.
- `app/layout.tsx` — body scoped to `qn-blueprint-bg accent-digiquant`; thin monospace page-chrome strip at top of `<main>` with crumbs, `Open digiquant.io` link, and version/env label (`NEXT_PUBLIC_ATLAS_VERSION`, fallback `v0.1 · dev`).
- `components/sidebar.tsx` — active route now uses an accent left-border (`var(--accent)`) instead of a hard-coded white right-border; labels uppercased + tracked in mono.
- `components/portfolio/server-metrics-strip.tsx` — first adoption of `.qn-metric` + `.qn-up`/`.qn-down` for P&L and drawdown. Pattern documented in the new README for follow-up sites.
- `README.md` — new; documents the token dependency, utility classes, collision notes (Atlas's `--color-*` Tailwind-v4 palette and the design-system's `--bg-*` / `--text-*` palette coexist without collision).

## Scope discipline

Per task body, raw hex was warned, not chased through the entire app. Central surfaces (globals.css recharts theme, sidebar active-state, page chrome, first metric site) use tokens. Remaining raw hex in component-level styling (~145 sites) is out of scope for this child and left for incremental follow-ups.

## Notes

- `npm run build` green (static export, all 13 routes).
- `npm run lint` fails on `next lint` ("Invalid project directory … /lint") — pre-existing on `origin/develop` before this change (Next 16 deprecation). No new errors introduced.
- No `npm run test` script exists in the atlas workspace.
- `make test-unit`: 14 pre-existing failures, 654 passed — unchanged.
- `make score`: 10/10 on all four dimensions.

## Gate sign-offs

- [x] /`simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /`review` completed — PR reviewed against scoring rubric; findings addressed

## Issue linkage

Fixes #272
Closes #263
Refs #268

## Test plan

- [ ] Visual smoke on `/digiquant-atlas/`, `/portfolio/`, `/research/`, `/performance/`, `/strategy/`, `/library/`, `/settings/`, `/architecture/` — blueprint grid visible, sidebar accent tick visible on active item, chrome strip shows crumbs + version
- [ ] Toggle light theme → blueprint grid still visible (dark-ink override)
- [ ] `server-metrics-strip` — positive P&L renders muted emerald, negative renders muted copper
- [ ] Recharts series on portfolio performance pages render with token-colored gridlines and monospace axis labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
