### PR TITLE
feat(atlas): first-class thesis + deliberation tables (migration 024)

### DIFF
--- a/apps/digiquant-atlas/supabase/SCHEMA.md
+++ b/apps/digiquant-atlas/supabase/SCHEMA.md
@@ -1,0 +1,104 @@
+# Atlas Supabase Schema
+
+Live Atlas Supabase schema. Source of truth: the numbered migrations under
+`apps/digiquant-atlas/supabase/migrations/`. This document inventories the
+17 live tables (12 pre-024 + 5 new in migration 024) and diagrams the
+high-value relationships.
+
+> ADRs: [ADR-0008 research schema](../../../docs/adr/0008-atlas-research-schema.md),
+> [ADR-0009 Supabase persistence](../../../docs/adr/0009-atlas-supabase-persistence.md),
+> [ADR-0010 first-class thesis + deliberation](../../../docs/adr/0010-atlas-first-class-thesis-deliberation.md).
+
+## ERD (primary relationships)
+
+```mermaid
+erDiagram
+    daily_snapshots  ||--o{ positions             : "date"
+    daily_snapshots  ||--o{ theses                : "date"
+    daily_snapshots  ||--o{ position_events       : "date"
+    daily_snapshots  ||--o{ documents             : "date"
+    daily_snapshots  ||--o{ portfolio_metrics     : "date"
+
+    theses           ||--o{ thesis_vehicles       : "(date, thesis_id)"
+    theses           ||--o{ positions             : "thesis_id"
+
+    documents        ||..o{ thesis_vehicles       : "source_exploration_key"
+    documents        ||..o{ deliberation_rounds   : "deep_dive_document_key"
+    documents        ||..o{ analyst_coverage      : "current_recommendation_key"
+    documents        ||..o{ deep_dive_triggers    : "deep_dive_document_key"
+
+    deliberation_sessions ||--o{ deliberation_rounds : "session_id"
+    deliberation_sessions ||--o{ deep_dive_triggers  : "session_id"
+
+    price_history        ||--o{ price_technicals : "(date, ticker)"
+    price_history_tickers ||..|| price_history   : "view"
+
+    nav_history          ||..|| benchmark_history : "date"
+    macro_series_observations ||..|| daily_snapshots : "obs_date"
+```
+
+> Solid lines are FKs; dashed lines are logical pointers (documents.document_key
+> strings — not enforced by FK because `documents` is partitioned and the
+> pointer target may be in any partition).
+
+## Per-table inventory
+
+### Portfolio core (migration 001, partitioned since 011)
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `daily_snapshots` | `(date)` | One consolidated JSON snapshot per calendar day. Root of the daily pipeline. |
+| `positions` | `(date, ticker)` | Daily position book; one row per held ticker. |
+| `theses` | `(date, thesis_id)` | Active investment theses per day; referenced by `positions` and now by `thesis_vehicles`. |
+| `position_events` | `(id BIGSERIAL)` | Every open / close / rebalance against a position with reason tag. |
+| `documents` | `(date, document_key)` | JSONB payload store for every narrative / structured artifact. Doc-type CHECK set by migration 023. |
+| `nav_history` | `(date)` | Daily portfolio NAV. |
+| `benchmark_history` | `(date, benchmark)` | Benchmark close series (SPY / QQQ / IWM etc). |
+| `portfolio_metrics` | `(date, metric)` | Pre-computed Sharpe, vol, drawdown, exposure metrics. |
+
+### Market data (migrations 005 / 007 / 015 / 018)
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `price_history` | `(date, ticker)` | OHLCV history for all watchlist tickers. |
+| `price_technicals` | `(date, ticker)` | 35+ pre-computed TA indicators per (date, ticker). |
+| `macro_series_observations` | `(source, series_id, obs_date)` | FRED / Frankfurter / crypto FNG time series. |
+| `price_history_tickers` | _(view)_ | Distinct tickers currently in `price_history`. |
+
+### Hermes deliberation — new in migration 024
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `thesis_vehicles` | `(date, thesis_id, ticker)` | Per-thesis vehicle map; FK → `theses (date, thesis_id)`. |
+| `deliberation_sessions` | `(session_id UUID)` | One row per Hermes deliberation session; kind ∈ {baseline, delta_scoped, monthly}. |
+| `deliberation_rounds` | `(id BIGSERIAL)` | Round-loop persistence; unique on `(session_id, ticker, round_number)`. |
+| `analyst_coverage` | `(date, ticker)` | Daily denormalized analyst ↔ ticker index. |
+| `deep_dive_triggers` | `(id BIGSERIAL)` | Audit trail of every recess- or delta-watch- or manually- forced deep-dive. |
+
+## RLS (consistent across all tables above)
+
+- Every table has `ENABLE ROW LEVEL SECURITY`.
+- Reads: per-table `{table}_anon_select` (or legacy `anon_read` on the
+  001-era tables) policy granting `SELECT TO anon USING (true)`.
+- Writes: require the Supabase `service_role` key. Supabase grants
+  service_role bypass at the GRANT layer, so there is no explicit
+  `service_role` policy on any Atlas table.
+
+## Dead / deprecated
+
+- `sec_recent_filings` — dropped in migration 017.
+- `'Portfolio Recommendation'` doc_type — removed by migration 021.
+- Partitioned children (`daily_snapshots_y2025`, `documents_y2026`, …) are
+  implementation details of the partition strategy and are not inventoried
+  here. See migration 004 and 006.
+
+## How to extend
+
+1. Create a new migration under `supabase/migrations/NNN_description.sql`.
+2. Follow the RLS pattern above.
+3. If the new table holds a structured projection of a `documents` payload,
+   add a reference to it in this file under the "Hermes deliberation"
+   section pattern and cite the source ADR.
+4. Add a test under `apps/digiquant-atlas/tests/test_migration_NNN.py`
+   following the pattern in `test_migration_024.py` — pure-SQL parse check
+   for offline unit tests, or `psycopg` round-trip for integration.

--- a/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
+++ b/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
@@ -1,30 +1,12 @@
 -- 024_thesis_deliberation_first_class.sql — First-class tables for the
 -- thesis-first pipeline (Atlas Wave 1, UNIT W1-B).
 --
--- Context:
---   Track B doc_types (`market_thesis_exploration`, `thesis_vehicle_map`,
---   `deliberation_transcript`, `deliberation_session_index`, `pm_allocation_memo`,
---   `asset_recommendation`) have so far been persisted only as `documents` rows
---   with JSONB payloads. That keeps the publish path cheap but makes analytics,
---   dashboards, and historical thesis-tracking queries expensive.
+-- See docs/adr/0010-atlas-first-class-thesis-deliberation.md for the full
+-- rationale, doc_type mapping, and Wave 2 write-path contract. This file is
+-- schema-only; rollback lives in the commented DROP block at the end.
 --
---   This migration introduces dual persistence: a structured, indexable row per
---   high-query subset (vehicles per thesis, deliberation rounds, recess triggers)
---   while the full document bodies continue to land in `documents` for the
---   frontend and for blob retrieval. See docs/adr/0010-atlas-first-class-thesis-deliberation.md.
---
--- Scope of this migration:
---   • thesis_vehicles         — per-vehicle mapping of each thesis
---   • deliberation_sessions   — one row per (date, kind, pipeline_run_id)
---   • deliberation_rounds     — one row per ticker × round within a session
---   • analyst_coverage        — daily analyst↔ticker cross-reference
---   • deep_dive_triggers      — audit trail of recess-forced deep dives
---
--- RLS convention (matches migrations 005/007/015/023): per-table `anon` SELECT
--- policy; writes require the service_role key (bypass is grant-based, not a
--- policy, so we do not declare an explicit service_role policy).
---
--- Rollback: commented-out DROP block at the end of this file.
+-- Requires: pgcrypto extension (for gen_random_uuid()). Supabase projects
+-- ship this enabled; bare Postgres needs `CREATE EXTENSION IF NOT EXISTS pgcrypto;` first.
 
 BEGIN;
 
@@ -54,8 +36,8 @@ CREATE TABLE IF NOT EXISTS thesis_vehicles (
 CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_ticker_date
   ON thesis_vehicles (ticker, date DESC);
 
-CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_date
-  ON thesis_vehicles (date DESC);
+-- Note: the PRIMARY KEY (date, thesis_id, ticker) already covers leading-date
+-- range scans, so a separate `(date DESC)` index would be redundant.
 
 ALTER TABLE thesis_vehicles ENABLE ROW LEVEL SECURITY;
 
@@ -96,8 +78,8 @@ CREATE TABLE IF NOT EXISTS deliberation_sessions (
     UNIQUE (date, kind, pipeline_run_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_deliberation_sessions_date
-  ON deliberation_sessions (date DESC);
+-- Note: UNIQUE (date, kind, pipeline_run_id) already covers leading-date
+-- scans, so a separate `(date DESC)` index would be redundant.
 
 ALTER TABLE deliberation_sessions ENABLE ROW LEVEL SECURITY;
 
@@ -160,11 +142,15 @@ CREATE TABLE IF NOT EXISTS analyst_coverage (
   date                         date        NOT NULL,
   ticker                       text        NOT NULL,
   thesis_ids                   jsonb,       -- array of linked thesis_ids
-  analyst_role                 text,
+  analyst_role                 text,        -- see docs/agentic/HERMES_SUBGRAPH.md for canonical roles
   current_recommendation_key   text,        -- documents.document_key pointer
   last_updated                 timestamptz NOT NULL DEFAULT now(),
 
-  PRIMARY KEY (date, ticker)
+  PRIMARY KEY (date, ticker),
+  CONSTRAINT chk_analyst_coverage_role CHECK (
+    analyst_role IS NULL
+    OR analyst_role IN ('asset_analyst', 'sector_analyst', 'macro_analyst')
+  )
 );
 
 CREATE INDEX IF NOT EXISTS idx_analyst_coverage_ticker_date
@@ -206,6 +192,16 @@ CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_ticker
 
 CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_session
   ON deep_dive_triggers (session_id);
+
+-- Hot path: "show unresolved triggers" operator dashboards.
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_unresolved
+  ON deep_dive_triggers (session_id)
+  WHERE resolved_at IS NULL;
+
+-- "Which trigger resolved to which deep-dive document" reverse lookup.
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_doc_key
+  ON deep_dive_triggers (deep_dive_document_key)
+  WHERE deep_dive_document_key IS NOT NULL;
 
 ALTER TABLE deep_dive_triggers ENABLE ROW LEVEL SECURITY;
 

--- a/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
+++ b/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
@@ -1,0 +1,240 @@
+-- 024_thesis_deliberation_first_class.sql — First-class tables for the
+-- thesis-first pipeline (Atlas Wave 1, UNIT W1-B).
+--
+-- Context:
+--   Track B doc_types (`market_thesis_exploration`, `thesis_vehicle_map`,
+--   `deliberation_transcript`, `deliberation_session_index`, `pm_allocation_memo`,
+--   `asset_recommendation`) have so far been persisted only as `documents` rows
+--   with JSONB payloads. That keeps the publish path cheap but makes analytics,
+--   dashboards, and historical thesis-tracking queries expensive.
+--
+--   This migration introduces dual persistence: a structured, indexable row per
+--   high-query subset (vehicles per thesis, deliberation rounds, recess triggers)
+--   while the full document bodies continue to land in `documents` for the
+--   frontend and for blob retrieval. See docs/adr/0010-atlas-first-class-thesis-deliberation.md.
+--
+-- Scope of this migration:
+--   • thesis_vehicles         — per-vehicle mapping of each thesis
+--   • deliberation_sessions   — one row per (date, kind, pipeline_run_id)
+--   • deliberation_rounds     — one row per ticker × round within a session
+--   • analyst_coverage        — daily analyst↔ticker cross-reference
+--   • deep_dive_triggers      — audit trail of recess-forced deep dives
+--
+-- RLS convention (matches migrations 005/007/015/023): per-table `anon` SELECT
+-- policy; writes require the service_role key (bypass is grant-based, not a
+-- policy, so we do not declare an explicit service_role policy).
+--
+-- Rollback: commented-out DROP block at the end of this file.
+
+BEGIN;
+
+-- ─── thesis_vehicles ────────────────────────────────────────────────────────
+-- Captures the vehicles (ETFs, stocks, futures) attached to each thesis on
+-- each day. FKs to the existing `theses` (date, thesis_id) unique key so that
+-- backfilling or evolving thesis rows preserves referential integrity.
+
+CREATE TABLE IF NOT EXISTS thesis_vehicles (
+  date                     date        NOT NULL,
+  thesis_id                text        NOT NULL,
+  ticker                   text        NOT NULL,
+
+  rationale                text,
+  exclusion_reasons        jsonb,       -- array of {reason, source} entries
+  candidate_rank           integer,     -- 1 = top pick; NULL = not ranked
+  user_mandate_notes       jsonb,       -- mandate-derived constraints / notes
+  source_exploration_key   text,        -- pointer into documents (market_thesis_exploration)
+
+  created_at               timestamptz NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (date, thesis_id, ticker),
+  FOREIGN KEY (date, thesis_id) REFERENCES theses (date, thesis_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_ticker_date
+  ON thesis_vehicles (ticker, date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_date
+  ON thesis_vehicles (date DESC);
+
+ALTER TABLE thesis_vehicles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "thesis_vehicles_anon_select" ON thesis_vehicles;
+CREATE POLICY "thesis_vehicles_anon_select"
+  ON thesis_vehicles FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE thesis_vehicles IS
+  'Vehicles (tickers) linked to each active thesis per day. Populated from '
+  'the thesis_vehicle_map document payload during the Hermes sub-graph. '
+  'Writes via service_role; anon may SELECT.';
+
+COMMENT ON COLUMN thesis_vehicles.source_exploration_key IS
+  'documents.document_key pointer to the market_thesis_exploration row that '
+  'produced this vehicle mapping.';
+
+-- ─── deliberation_sessions ──────────────────────────────────────────────────
+-- One row per deliberation session. `kind` partitions baseline (weekly),
+-- delta_scoped (weekday) and monthly review sessions.
+
+CREATE TABLE IF NOT EXISTS deliberation_sessions (
+  session_id        uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  date              date        NOT NULL,
+  kind              text        NOT NULL,
+  all_converged     boolean,
+  roster            jsonb,       -- {analysts: [...], pm: "..."} roster snapshot
+  started_at        timestamptz,
+  finished_at       timestamptz,
+  pipeline_run_id   uuid,
+
+  created_at        timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT chk_deliberation_sessions_kind CHECK (
+    kind IN ('baseline', 'delta_scoped', 'monthly')
+  ),
+  CONSTRAINT uq_deliberation_sessions_date_kind_run
+    UNIQUE (date, kind, pipeline_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_sessions_date
+  ON deliberation_sessions (date DESC);
+
+ALTER TABLE deliberation_sessions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deliberation_sessions_anon_select" ON deliberation_sessions;
+CREATE POLICY "deliberation_sessions_anon_select"
+  ON deliberation_sessions FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deliberation_sessions IS
+  'One row per Hermes deliberation session (baseline, delta_scoped, or monthly). '
+  'Indexed subset of the deliberation_session_index document.';
+
+-- ─── deliberation_rounds ────────────────────────────────────────────────────
+-- Round-loop persistence. Each ticker within a session can loop up to
+-- ATLAS_DELIBERATION_MAX_ROUNDS rounds. Sections blob holds the analyst/PM
+-- section pair for that round.
+
+CREATE TABLE IF NOT EXISTS deliberation_rounds (
+  id                         bigserial   PRIMARY KEY,
+  session_id                 uuid        NOT NULL
+    REFERENCES deliberation_sessions (session_id) ON DELETE CASCADE,
+  ticker                     text        NOT NULL,
+  round_number               integer     NOT NULL,
+  label                      text,
+  sections                   jsonb       NOT NULL,
+  converged                  boolean     NOT NULL DEFAULT false,
+  recess_triggered           boolean     NOT NULL DEFAULT false,
+  deep_dive_document_key     text,
+  created_at                 timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT uq_deliberation_rounds UNIQUE (session_id, ticker, round_number),
+  CONSTRAINT chk_deliberation_rounds_round_number CHECK (round_number >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_rounds_ticker_session
+  ON deliberation_rounds (ticker, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_rounds_session
+  ON deliberation_rounds (session_id, round_number);
+
+ALTER TABLE deliberation_rounds ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deliberation_rounds_anon_select" ON deliberation_rounds;
+CREATE POLICY "deliberation_rounds_anon_select"
+  ON deliberation_rounds FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deliberation_rounds IS
+  'One row per (session, ticker, round). Mirrors the deliberation_transcript '
+  'document at round granularity for dashboards and convergence analytics.';
+
+COMMENT ON COLUMN deliberation_rounds.deep_dive_document_key IS
+  'When recess_triggered=true and a deep-dive document has been published, '
+  'documents.document_key pointer to that row.';
+
+-- ─── analyst_coverage ───────────────────────────────────────────────────────
+-- Small denormalized row for "which analyst covers AAPL today" frontend query.
+
+CREATE TABLE IF NOT EXISTS analyst_coverage (
+  date                         date        NOT NULL,
+  ticker                       text        NOT NULL,
+  thesis_ids                   jsonb,       -- array of linked thesis_ids
+  analyst_role                 text,
+  current_recommendation_key   text,        -- documents.document_key pointer
+  last_updated                 timestamptz NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (date, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analyst_coverage_ticker_date
+  ON analyst_coverage (ticker, date DESC);
+
+ALTER TABLE analyst_coverage ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "analyst_coverage_anon_select" ON analyst_coverage;
+CREATE POLICY "analyst_coverage_anon_select"
+  ON analyst_coverage FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE analyst_coverage IS
+  'Daily denormalized analyst↔ticker index. Supports frontend "coverage by '
+  'analyst" queries without scanning every documents payload.';
+
+-- ─── deep_dive_triggers ─────────────────────────────────────────────────────
+-- Audit log for every time a deliberation round (or a manual operator action
+-- or a delta-watch rule) forced a deep-dive to be generated.
+
+CREATE TABLE IF NOT EXISTS deep_dive_triggers (
+  id                       bigserial   PRIMARY KEY,
+  session_id               uuid
+    REFERENCES deliberation_sessions (session_id) ON DELETE SET NULL,
+  ticker                   text        NOT NULL,
+  triggered_by             text        NOT NULL,
+  trigger_reason           text,
+  deep_dive_document_key   text,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  resolved_at              timestamptz,
+
+  CONSTRAINT chk_deep_dive_triggers_source CHECK (
+    triggered_by IN ('pm_recess', 'delta_watch', 'manual')
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_ticker
+  ON deep_dive_triggers (ticker, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_session
+  ON deep_dive_triggers (session_id);
+
+ALTER TABLE deep_dive_triggers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deep_dive_triggers_anon_select" ON deep_dive_triggers;
+CREATE POLICY "deep_dive_triggers_anon_select"
+  ON deep_dive_triggers FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deep_dive_triggers IS
+  'Audit trail: every time deliberation, delta-watch, or a human operator '
+  'forced a deep-dive to be generated. resolved_at stamped when the deep-dive '
+  'document lands.';
+
+COMMIT;
+
+-- ─── Rollback (commented) ───────────────────────────────────────────────────
+-- Run in reverse dependency order. DROP POLICY first so the DROP TABLE path
+-- is clean even on older PostgREST revisions that error on policy leftovers.
+--
+-- BEGIN;
+-- DROP POLICY IF EXISTS "deep_dive_triggers_anon_select"     ON deep_dive_triggers;
+-- DROP POLICY IF EXISTS "analyst_coverage_anon_select"       ON analyst_coverage;
+-- DROP POLICY IF EXISTS "deliberation_rounds_anon_select"    ON deliberation_rounds;
+-- DROP POLICY IF EXISTS "deliberation_sessions_anon_select"  ON deliberation_sessions;
+-- DROP POLICY IF EXISTS "thesis_vehicles_anon_select"        ON thesis_vehicles;
+--
+-- DROP TABLE IF EXISTS deep_dive_triggers;
+-- DROP TABLE IF EXISTS deliberation_rounds;
+-- DROP TABLE IF EXISTS deliberation_sessions;
+-- DROP TABLE IF EXISTS analyst_coverage;
+-- DROP TABLE IF EXISTS thesis_vehicles;
+-- COMMIT;

--- a/apps/digiquant-atlas/tests/test_migration_024.py
+++ b/apps/digiquant-atlas/tests/test_migration_024.py
@@ -1,0 +1,240 @@
+"""Unit tests for migration 024 (thesis + deliberation first-class tables).
+
+These tests are deliberately hermetic: they parse the migration SQL file and
+assert structural properties (CREATE TABLE presence, PKs / FKs / CHECK
+clauses, RLS enablement, per-table anon SELECT policy, rollback block).
+
+They do NOT spin up Postgres. A live round-trip test (`psycopg` against a
+throwaway DB) belongs in a separate integration test once Wave 2 lands the
+Python adapters — see ADR-0010. Keeping this suite pure-SQL avoids marking a
+new `integration` pytest marker (the project registers only `unit` and
+`e2e`) and lets `make test-unit` stay offline.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "supabase"
+    / "migrations"
+    / "024_thesis_deliberation_first_class.sql"
+)
+
+EXPECTED_TABLES = (
+    "thesis_vehicles",
+    "deliberation_sessions",
+    "deliberation_rounds",
+    "analyst_coverage",
+    "deep_dive_triggers",
+)
+
+
+@pytest.fixture(scope="module")
+def sql() -> str:
+    assert MIGRATION_PATH.is_file(), f"migration missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _strip_comments(sql: str) -> str:
+    """Strip SQL line comments so assertions don't match rollback-block text."""
+    return "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+
+
+def _table_block(sql: str, table: str) -> str:
+    """Extract the `CREATE TABLE ... );` block for a single table.
+
+    Scopes per-table column / constraint assertions so a column that exists
+    on a later table does not satisfy a check for an earlier one. Returns the
+    block including the closing paren of the CREATE TABLE statement plus any
+    immediately-following CREATE INDEX / ALTER TABLE / CREATE POLICY lines up
+    to the next `CREATE TABLE` or end-of-file.
+    """
+    body = _strip_comments(sql)
+    start = re.search(rf"CREATE TABLE IF NOT EXISTS\s+{table}\b", body)
+    assert start, f"CREATE TABLE for {table} not found"
+    next_tbl = re.search(r"CREATE TABLE IF NOT EXISTS\s+\w+", body[start.end() :])
+    end = start.end() + next_tbl.start() if next_tbl else len(body)
+    return body[start.start() : end]
+
+
+@pytest.mark.unit
+class TestMigrationFilePresent:
+    def test_file_exists_and_nonempty(self, sql: str) -> None:
+        assert len(sql) > 500, "migration file looks truncated"
+
+    def test_begin_commit_wraps_body(self, sql: str) -> None:
+        body = _strip_comments(sql)
+        assert body.count("BEGIN;") >= 1
+        assert body.count("COMMIT;") >= 1
+
+    def test_rollback_block_present_but_commented(self, sql: str) -> None:
+        """Rollback DROP TABLEs must be commented so re-running the migration
+        does not drop the tables it just created.
+
+        DROP POLICY IF EXISTS is allowed uncommented — existing Atlas
+        migrations (005/007/015/023) use it for idempotent policy replace.
+        """
+        assert "Rollback" in sql, "no rollback section header"
+        for idx, line in enumerate(sql.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("DROP TABLE"):
+                pytest.fail(f"line {idx}: uncommented DROP TABLE in migration: {stripped!r}")
+
+
+@pytest.mark.unit
+class TestExpectedTablesCreated:
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_create_table(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        assert re.search(rf"CREATE TABLE IF NOT EXISTS\s+{table}\b", body), (
+            f"missing CREATE TABLE for {table}"
+        )
+
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_rls_enabled(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        assert re.search(rf"ALTER TABLE\s+{table}\s+ENABLE ROW LEVEL SECURITY", body), (
+            f"RLS not enabled on {table}"
+        )
+
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_anon_select_policy(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        # Policy name matches the convention used by migrations 005/007/015/023.
+        assert re.search(
+            rf'CREATE POLICY\s+"{table}_anon_select"\s+ON\s+{table}\s+FOR SELECT\s+TO anon',
+            body,
+        ), f"anon select policy missing on {table}"
+
+
+@pytest.mark.unit
+class TestThesisVehiclesShape:
+    def test_composite_pk(self, sql: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(r"PRIMARY KEY\s*\(\s*date\s*,\s*thesis_id\s*,\s*ticker\s*\)", block)
+
+    def test_fk_to_theses(self, sql: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(
+            r"FOREIGN KEY\s*\(\s*date\s*,\s*thesis_id\s*\)"
+            r"\s*REFERENCES\s+theses\s*\(\s*date\s*,\s*thesis_id\s*\)",
+            block,
+        )
+
+    @pytest.mark.parametrize(
+        "col",
+        [
+            "rationale",
+            "exclusion_reasons",
+            "candidate_rank",
+            "user_mandate_notes",
+            "source_exploration_key",
+            "created_at",
+        ],
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(rf"\b{col}\b", block), f"thesis_vehicles missing {col}"
+
+
+@pytest.mark.unit
+class TestDeliberationSessionsShape:
+    def test_primary_key_uuid(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(r"session_id\s+uuid\s+PRIMARY KEY", block)
+
+    def test_kind_check_constraint(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(
+            r"kind IN\s*\(\s*'baseline'\s*,\s*'delta_scoped'\s*,\s*'monthly'\s*\)",
+            block,
+        )
+
+    def test_unique_triple(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(r"UNIQUE\s*\(\s*date\s*,\s*kind\s*,\s*pipeline_run_id\s*\)", block)
+
+
+@pytest.mark.unit
+class TestDeliberationRoundsShape:
+    def test_fk_to_sessions(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(r"REFERENCES\s+deliberation_sessions\s*\(\s*session_id\s*\)", block)
+
+    def test_unique_triple(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(
+            r"UNIQUE\s*\(\s*session_id\s*,\s*ticker\s*,\s*round_number\s*\)",
+            block,
+        )
+
+    def test_indexed_on_ticker_session(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(
+            r"CREATE INDEX[\s\S]*?ON\s+deliberation_rounds\s*\(\s*ticker\s*,\s*session_id\s*\)",
+            block,
+        )
+
+    @pytest.mark.parametrize(
+        "col", ["converged", "recess_triggered", "deep_dive_document_key", "sections"]
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(rf"\b{col}\b", block), f"deliberation_rounds missing {col}"
+
+
+@pytest.mark.unit
+class TestAnalystCoverageShape:
+    def test_composite_pk(self, sql: str) -> None:
+        block = _table_block(sql, "analyst_coverage")
+        assert re.search(r"PRIMARY KEY\s*\(\s*date\s*,\s*ticker\s*\)", block)
+
+    @pytest.mark.parametrize(
+        "col",
+        ["thesis_ids", "analyst_role", "current_recommendation_key", "last_updated"],
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "analyst_coverage")
+        assert re.search(rf"\b{col}\b", block), f"analyst_coverage missing {col}"
+
+
+@pytest.mark.unit
+class TestDeepDiveTriggersShape:
+    def test_triggered_by_check(self, sql: str) -> None:
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(
+            r"triggered_by IN\s*\(\s*'pm_recess'\s*,\s*'delta_watch'\s*,\s*'manual'\s*\)",
+            block,
+        )
+
+    def test_session_fk_nullable(self, sql: str) -> None:
+        """session_id may be NULL (manual triggers without a session)."""
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(
+            r"session_id\s+uuid\b(?![^\n]*NOT NULL)[\s\S]*?REFERENCES\s+deliberation_sessions",
+            block,
+        ), "deep_dive_triggers.session_id should be nullable FK"
+
+    @pytest.mark.parametrize(
+        "col", ["ticker", "trigger_reason", "deep_dive_document_key", "resolved_at"]
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(rf"\b{col}\b", block), f"deep_dive_triggers missing {col}"
+
+
+@pytest.mark.unit
+class TestMigrationNumbering:
+    def test_no_duplicate_number(self) -> None:
+        migrations_dir = MIGRATION_PATH.parent
+        prefixes = [p.name.split("_", 1)[0] for p in migrations_dir.glob("*.sql")]
+        # 024 must appear exactly once.
+        assert prefixes.count("024") == 1
+
+    def test_file_prefix_is_024(self) -> None:
+        assert MIGRATION_PATH.name.startswith("024_")

--- a/docs/adr/0010-atlas-first-class-thesis-deliberation.md
+++ b/docs/adr/0010-atlas-first-class-thesis-deliberation.md
@@ -1,0 +1,200 @@
+# ADR-0010 — Atlas first-class thesis + deliberation tables
+
+- **Status:** Accepted
+- **Date:** 2026-04-20
+- **Deciders:** Chris Stefan (founder), Atlas Wave 1 worktree agents
+- **Related:** [ADR-0008 Atlas research schema](0008-atlas-research-schema.md), [ADR-0009 Atlas Supabase persistence](0009-atlas-supabase-persistence.md)
+- **Supersedes:** nothing. Complements ADR-0009.
+
+## Context
+
+Through migration 023 the Atlas Track B pipeline (`market_thesis_exploration`,
+`thesis_vehicle_map`, `deliberation_transcript`, `deliberation_session_index`,
+`pm_allocation_memo`, `asset_recommendation`) persists exclusively through the
+`documents` table as JSONB payload rows. That shape is fine for publish-time
+(one upsert per artifact) and for the frontend (one read for the full blob),
+but it is expensive for four classes of query we now need:
+
+1. **Dashboards that join theses to vehicles** (e.g. "which tickers are in the
+   long-growth thesis over the last 90 days") require repeated JSONB unpacking
+   and ticker-level indexing on the `thesis_vehicle_map` payload.
+2. **Deliberation analytics** ("average rounds to convergence", "recess-trigger
+   rate by sector") require scanning every transcript and parsing rounds.
+3. **Historical thesis tracking** across `theses` → vehicles → analyst
+   recommendations → rebalance decisions is chained across five JSONB
+   payloads with no join keys.
+4. **"Which analyst covers AAPL today"** is a 1-row query that today requires
+   scanning all `asset_recommendation` documents for the date.
+
+Wave 1 of the Atlas → DigiGraph migration moves the Hermes sub-graph
+(deliberation round-loop, deep-dive recess, PM memo) into first-class
+LangGraph state. That work creates the natural opportunity to also land
+structured persistence alongside the existing documents-only writes.
+
+## Decision
+
+Adopt **dual persistence** for a defined subset of Track B doc_types:
+payloads continue to land in `documents` (no regression for frontend, no
+schema migration for blob consumers) **and** a structured subset lands in
+new first-class tables (migration 024).
+
+### Which doc_types get first-class tables
+
+| doc_type                       | Goes into           | Rationale                                                   |
+|--------------------------------|---------------------|-------------------------------------------------------------|
+| `thesis_vehicle_map`           | `thesis_vehicles`   | High query volume by `(thesis_id, ticker)` join             |
+| `deliberation_session_index`   | `deliberation_sessions` | Needs `(date, kind)` filters for analytics             |
+| `deliberation_transcript`      | `deliberation_rounds`   | Per-round convergence + recess analytics               |
+| `asset_recommendation`         | `analyst_coverage`  | Denormalized analyst ↔ ticker index                         |
+| _(synthetic)_ deep-dive trigger | `deep_dive_triggers` | New audit log — no prior documents payload existed         |
+
+### Which doc_types stay documents-only (for now)
+
+- `market_thesis_exploration` — narrative-heavy; the structured slice we need
+  is the vehicle list, which lands in `thesis_vehicles` via its
+  `source_exploration_key` back-pointer. The exploration itself stays a
+  document because it is read holistically.
+- `pm_allocation_memo` — narrative memo with bulk text + targets. Low query
+  volume at the sub-structure level; frontend reads the whole payload.
+- `rebalance_decision` — already mapped through `position_events` first-class
+  table since migration 022.
+- `research_delta`, `research_baseline_manifest`, `document_delta`,
+  `research_changelog`, `evolution_*`, `sector_report`, `deep_dive`,
+  `pipeline_review`, `weekly_digest`, `monthly_digest`, `delta_digest`,
+  `master_digest`, `delta_segment` — infrequent query access, bulk-narrative
+  content, no denormalization benefit.
+
+### Write path (Wave 2)
+
+The Python adapters are explicitly out of scope for this ADR / migration
+(they land in Wave 2, UNIT W2-A). The contract for Wave 2:
+
+- The existing `publish_document` adapter in
+  `apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py` remains the single
+  entry point for writing Track B artifacts.
+- New extractor functions per doc_type read the just-upserted payload, project
+  the structured subset, and upsert into the matching first-class table in the
+  same logical operation.
+- All secondary writes pass through `digibase.audit.redact_mapping` before
+  logging, consistent with ADR-0009.
+
+### RLS
+
+Every new table gets `ENABLE ROW LEVEL SECURITY` + a per-table `anon` SELECT
+policy named `{table}_anon_select` — matching migrations 005 / 007 / 015 / 023.
+Writes require the Supabase service_role key; service_role bypass is grant-
+based in Supabase (not a policy), so we do not declare an explicit
+`service_role` policy (consistent with every existing Atlas migration).
+
+## Consequences
+
+### Positive
+
+- Two-index-hop for common dashboard queries (vs. JSONB scan).
+- Deliberation and deep-dive analytics become tractable.
+- Wave 2 implementers get a clean contract: same publish entrypoint, new
+  extractor next to each doc_type.
+- Frontend is not disrupted — `documents` reads keep working unchanged.
+- Rollback is a single commented-out block in migration 024.
+
+### Negative
+
+- Every Track B publish becomes a 2-row write (documents + first-class).
+  Mitigated because the writes are serialized within a single Python
+  invocation; failure rolls back both (transaction per publish).
+- Drift between `documents.payload` and first-class rows is possible if a
+  future author forgets to extend both. Wave 2 adds a validation test that
+  for every row in the first-class tables there is a matching `documents`
+  row at the same `(date, document_key)`.
+- Two sources of truth for the structured subset. We treat `documents` as
+  the canonical artifact and the first-class rows as a derived projection —
+  documents wins in any reconciliation.
+
+### Neutral
+
+- Pre-existing casing conventions are inherited, not re-opened:
+  - `documents.doc_type` CHECK constraint uses **Title Case** (e.g.
+    `'Deliberation Transcript'`) for human-readable labels.
+  - Payload `doc_type` fields use **snake_case** (e.g. `deliberation_transcript`)
+    for programmatic matching.
+  - Migration 024 does not touch either. First-class tables use neither; they
+    reference `documents` by `document_key` strings.
+
+## Alternatives considered
+
+1. **Generated columns on `documents`** — would avoid a second table but
+   indexes on JSONB-generated columns don't compose cleanly across rows and
+   we'd still have no FK to `theses`.
+2. **Materialized views** — readable but refresh latency and cost grow with
+   `documents` size; we'd need the same indexes anyway.
+3. **Replace documents with first-class tables entirely** — would disrupt the
+   frontend and lose the blob-retrieval affordance. Rejected.
+
+## Implementation
+
+- Migration: `apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql`
+- Schema map: `apps/digiquant-atlas/supabase/SCHEMA.md`
+- Test: `apps/digiquant-atlas/tests/test_migration_024.py`
+- Rollback: commented-out DROP block at the bottom of migration 024.
+
+## Appendix A — Dead doc_type audit (2026-04-20)
+
+Scan of `apps/digiquant-atlas/` (src/, scripts/, frontend/, tests/, templates/)
+for every string literal that appears as a `doc_type` value, compared against
+the `chk_documents_doc_type` CHECK constraint (migration 023).
+
+**Decision for this migration: freeze. Do not drop any doc_type.** A follow-up
+migration (025) drops any that are still unreferenced after one sprint.
+
+### Live doc_types (referenced in code + allowed by CHECK)
+
+Payload-side snake_case (referenced in `src/digiquant_atlas/` or `scripts/`):
+`deliberation_session_index`, `deliberation_transcript`,
+`market_thesis_exploration`, `thesis_vehicle_map`, `pm_allocation_memo`,
+`asset_recommendation`, `rebalance_decision`, `research_delta`,
+`research_baseline_manifest`, `document_delta`, `research_changelog`,
+`evolution_sources`, `evolution_quality_log`, `evolution_proposals`,
+`pipeline_review`, `weekly_digest`, `monthly_digest`, `master_digest`,
+`delta_digest`, `delta_segment`, `deep_dive`, `sector_report`,
+`opportunity_screen`, `research_closeout`.
+
+Title-Case labels persisted in `documents.doc_type` column (checked by
+`chk_documents_doc_type`):
+`'Daily Digest'`, `'Daily Delta'`, `'Weekly Rollup'`, `'Monthly Summary'`,
+`'Deep Dive'`, `'Research Delta'`, `'Research Baseline Manifest'`,
+`'Document Delta'`, `'Research Changelog'`, `'Rebalance Decision'`,
+`'Asset Recommendation'`, `'Deliberation Transcript'`,
+`'Deliberation Session Index'`, `'Market Thesis Exploration'`,
+`'Thesis Vehicle Map'`, `'PM Allocation Memo'`, `'Sector Report'`,
+`'Evolution Sources'`, `'Evolution Quality Log'`, `'Evolution Proposals'`,
+`'Pipeline Review'`.
+
+### Potentially orphaned (allowed by CHECK but no live writer)
+
+- `'Daily Delta'` — no producer found in current `src/digiquant_atlas/`; one
+  reference in `frontend/lib/queries.ts` as a literal. Likely historical.
+  **Freeze for 1 sprint; candidate for drop in 025.**
+- `'Weekly Rollup'` vs payload `weekly_digest` — title/payload mismatch; the
+  writer uses `weekly_digest`. Likely a legacy label. **Freeze; candidate for
+  drop in 025.**
+- `'Monthly Summary'` vs payload `monthly_digest` — same pattern as above.
+  **Freeze; candidate for drop in 025.**
+
+### Referenced in payloads but not in CHECK constraint
+
+The following payload `doc_type` values appear in scripts/ but are *not* in
+the `chk_documents_doc_type` allow-list, so they land with `documents.doc_type
+IS NULL` (the CHECK allows NULL):
+
+- `opportunity_screen` — emitted in Track B phase 3 (validate_pipeline_step.py).
+  Intentional: the opportunity screen is an intermediate payload, not a
+  first-class document label. **No action.**
+- `markdown_legacy` — legacy transitional payloads (pre-db-first). **No action.**
+- `digest_snapshot`, `delta_request` — classifier kinds, never written as
+  `documents.doc_type`. **No action.**
+
+### Not dropped in this migration
+
+Per the plan, doc_types are **frozen for one sprint**. Any drop happens in a
+future migration (025) with its own ADR addendum, after Wave 1 lands and we've
+verified no backfill scripts still produce the questionable labels.

--- a/docs/adr/0010-atlas-first-class-thesis-deliberation.md
+++ b/docs/adr/0010-atlas-first-class-thesis-deliberation.md
@@ -129,6 +129,10 @@ based in Supabase (not a policy), so we do not declare an explicit
    `documents` size; we'd need the same indexes anyway.
 3. **Replace documents with first-class tables entirely** — would disrupt the
    frontend and lose the blob-retrieval affordance. Rejected.
+4. **Natural PK `(session_id, ticker, round_number)` on `deliberation_rounds`** —
+   `deliberation_rounds.id` surrogate `BIGSERIAL` chosen over the natural
+   `(session_id, ticker, round_number)` PK for simpler FK-back references
+   and ORM ergonomics. The natural triple is preserved as a UNIQUE constraint.
 
 ## Implementation
 
@@ -198,3 +202,15 @@ IS NULL` (the CHECK allows NULL):
 Per the plan, doc_types are **frozen for one sprint**. Any drop happens in a
 future migration (025) with its own ADR addendum, after Wave 1 lands and we've
 verified no backfill scripts still produce the questionable labels.
+
+## Appendix B — Follow-up work
+
+- **Wave 2:** psycopg live round-trip test for migration 024 before any
+  adapter writes land. The existing `tests/test_migration_024.py` is hermetic
+  (SQL text assertions only); a throwaway Postgres round-trip is needed once
+  the Wave 2 adapters start writing to these tables.
+- `analyst_coverage.analyst_role` carries a CHECK constraint listing the
+  canonical taxonomy (`asset_analyst`, `sector_analyst`, `macro_analyst`) +
+  NULL. Canonical role definitions live in `docs/agentic/HERMES_SUBGRAPH.md`;
+  a new role requires both an ADR addendum and a migration to extend the
+  CHECK list.


### PR DESCRIPTION
## Summary

Wave 1 Unit W1-B of the Atlas → DigiGraph full migration
(`docs/plans/atlas-full-migration-wave1.md`). Adds migration 024 plus an
ADR and schema inventory so the Hermes sub-graph (Wave 2) can land its
Python adapters against a stable first-class schema.

- **Migration 024** creates `thesis_vehicles`, `deliberation_sessions`,
  `deliberation_rounds`, `analyst_coverage`, `deep_dive_triggers`. RLS
  matches the `{table}_anon_select` convention used by 005/007/015/023;
  rollback DROP block is commented at the bottom.
- **ADR-0010** records the dual-persistence decision (documents JSONB
  + first-class projection), which doc_types get tables vs stay
  documents-only, and a frozen dead-doc_type audit (no drops in this
  migration — candidates listed for a future 025 migration).
- **`apps/digiquant-atlas/supabase/SCHEMA.md`** — new file. ERD + per-
  table purpose for all 17 live tables (12 pre-024 + 5 new).
- **`tests/test_migration_024.py`** — 49 hermetic parse-based
  assertions, all `@pytest.mark.unit` (offline). No Postgres required;
  the live round-trip test lands in Wave 2 alongside the adapters.

Scope is explicitly **SQL + docs only**. Python adapters are Wave 2
Unit W2-A.

## Links

- Plan: `docs/plans/atlas-full-migration-wave1.md` (UNIT W1-B)
- ADR: `docs/adr/0010-atlas-first-class-thesis-deliberation.md`
- Complements ADR-0009 (Atlas Supabase persistence).

## Test plan

- [x] `pytest apps/digiquant-atlas/tests/test_migration_024.py` — 49 passed
- [x] `ruff check apps/digiquant-atlas/tests/test_migration_024.py apps/digiquant-atlas/supabase/` — clean
- [x] `ruff format --check` on the test file — clean
- [x] `make score` (staged) — Security 10, Quality 10, Optimization 10, Accuracy 10
- [ ] Apply migration on a fresh Supabase project (reviewer)
- [ ] Apply migration on a DB at state-023 (reviewer)
- [ ] Confirm rollback block executes cleanly when uncommented (reviewer)

Closes #178 (schema portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)