### PR TITLE
feat(ci): Atlas graph schedulers + deployment docs

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -1,0 +1,114 @@
+name: atlas baseline
+
+# Weekly baseline research run for the DigiQuant Atlas pipeline.
+# Saturday 12:00 UTC (pre-market Sunday Asia session) — full 9-phase run.
+# Also manually triggerable via workflow_dispatch for backfills / recovery.
+
+on:
+  schedule:
+    - cron: "0 12 * * SAT"
+  workflow_dispatch:
+    inputs:
+      run_date:
+        description: "Logical run date (YYYY-MM-DD). Defaults to today UTC."
+        required: false
+        default: ""
+      dry_run:
+        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: atlas-baseline
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Atlas
+        run: |
+          python -m pip install -U pip
+          pip install -e ./digibase
+          pip install -e ./digigraph
+          pip install -e "./apps/digiquant-atlas[supabase]"
+
+      - name: Resolve run date
+        id: resolve
+        run: |
+          if [ -n "${{ github.event.inputs.run_date }}" ]; then
+            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run baseline
+        id: run
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          mkdir -p artifacts
+          DRY_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_FLAG="--dry-run"
+          fi
+          set -o pipefail
+          python -m digiquant_atlas.graph \
+            --run-type baseline \
+            --run-date "${{ steps.resolve.outputs.run_date }}" \
+            $DRY_FLAG \
+            2>&1 | tee artifacts/run.log
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: atlas-baseline-${{ steps.resolve.outputs.run_date }}
+          path: artifacts/
+          retention-days: 30
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_DATE: ${{ steps.resolve.outputs.run_date }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TITLE="atlas-baseline-failure-$RUN_DATE"
+          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
+          BODY=$(cat <<EOF
+          Atlas baseline run failed on $RUN_DATE.
+
+          Workflow run: $RUN_URL
+
+          <details><summary>Last 200 log lines</summary>
+
+          \`\`\`
+          $TAIL
+          \`\`\`
+
+          </details>
+          EOF
+          )
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label "ci:failure"
+          fi

--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -14,9 +14,10 @@ on:
         required: false
         default: ""
       dry_run:
-        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        description: "Compile + validate inputs only (no LLM calls)."
         required: false
-        default: "false"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -36,6 +37,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            apps/digiquant-atlas/pyproject.toml
 
       - name: Install Atlas
         run: |
@@ -47,8 +53,8 @@ jobs:
       - name: Resolve run date
         id: resolve
         run: |
-          if [ -n "${{ github.event.inputs.run_date }}" ]; then
-            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ inputs.run_date }}" ]; then
+            echo "run_date=${{ inputs.run_date }}" >> "$GITHUB_OUTPUT"
           else
             echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           fi
@@ -60,10 +66,11 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           mkdir -p artifacts
           DRY_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
@@ -88,27 +95,32 @@ jobs:
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          TITLE="atlas-baseline-failure-$RUN_DATE"
-          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
-          BODY=$(cat <<EOF
-          Atlas baseline run failed on $RUN_DATE.
-
-          Workflow run: $RUN_URL
-
-          <details><summary>Last 200 log lines</summary>
-
-          \`\`\`
-          $TAIL
-          \`\`\`
-
-          </details>
-          EOF
-          )
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
-            --json number --jq '.[0].number' || echo "")
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "$BODY"
+          # Title is date-independent so consecutive failures roll up into
+          # a single issue (dedupe across days). Per-run context goes in
+          # the body as a new comment.
+          TITLE="atlas-baseline-failure"
+          # Write the tail to a file so we never interpolate untrusted log
+          # content through shell command-substitution. `gh` reads the body
+          # via --body-file, which is safe regardless of the log contents.
+          mkdir -p artifacts
+          if [ -f artifacts/run.log ]; then
+            tail -n 200 artifacts/run.log > artifacts/tail.log
           else
-            gh issue create --title "$TITLE" --body "$BODY" \
+            printf '(no log captured)\n' > artifacts/tail.log
+          fi
+          {
+            printf 'Atlas baseline run failed on %s.\n\n' "$RUN_DATE"
+            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '<details><summary>Last 200 log lines</summary>\n\n'
+            printf '```\n'
+            cat artifacts/tail.log
+            printf '\n```\n\n</details>\n'
+          } > artifacts/issue-body.md
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file artifacts/issue-body.md
+          else
+            gh issue create --title "$TITLE" --body-file artifacts/issue-body.md \
               --label "ci:failure"
           fi

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -1,0 +1,114 @@
+name: atlas delta
+
+# Weekday delta research run. Resolves the latest baseline from Supabase
+# (via --auto-baseline) and runs the triage-gated shape of the pipeline.
+# Kept tight — 45 min — so schedule drift is obvious.
+
+on:
+  schedule:
+    - cron: "0 12 * * MON-FRI"
+  workflow_dispatch:
+    inputs:
+      run_date:
+        description: "Logical run date (YYYY-MM-DD). Defaults to today UTC."
+        required: false
+        default: ""
+      dry_run:
+        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: atlas-delta
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Atlas
+        run: |
+          python -m pip install -U pip
+          pip install -e ./digibase
+          pip install -e ./digigraph
+          pip install -e "./apps/digiquant-atlas[supabase]"
+
+      - name: Resolve run date
+        id: resolve
+        run: |
+          if [ -n "${{ github.event.inputs.run_date }}" ]; then
+            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run delta
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          mkdir -p artifacts
+          DRY_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_FLAG="--dry-run"
+          fi
+          set -o pipefail
+          python -m digiquant_atlas.graph \
+            --run-type delta \
+            --run-date "${{ steps.resolve.outputs.run_date }}" \
+            --auto-baseline \
+            $DRY_FLAG \
+            2>&1 | tee artifacts/run.log
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: atlas-delta-${{ steps.resolve.outputs.run_date }}
+          path: artifacts/
+          retention-days: 14
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_DATE: ${{ steps.resolve.outputs.run_date }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TITLE="atlas-delta-failure-$RUN_DATE"
+          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
+          BODY=$(cat <<EOF
+          Atlas delta run failed on $RUN_DATE.
+
+          Workflow run: $RUN_URL
+
+          <details><summary>Last 200 log lines</summary>
+
+          \`\`\`
+          $TAIL
+          \`\`\`
+
+          </details>
+          EOF
+          )
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label "ci:failure"
+          fi

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -14,9 +14,10 @@ on:
         required: false
         default: ""
       dry_run:
-        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        description: "Compile + validate inputs only (no LLM calls)."
         required: false
-        default: "false"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -36,6 +37,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            apps/digiquant-atlas/pyproject.toml
 
       - name: Install Atlas
         run: |
@@ -47,8 +53,8 @@ jobs:
       - name: Resolve run date
         id: resolve
         run: |
-          if [ -n "${{ github.event.inputs.run_date }}" ]; then
-            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ inputs.run_date }}" ]; then
+            echo "run_date=${{ inputs.run_date }}" >> "$GITHUB_OUTPUT"
           else
             echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           fi
@@ -59,10 +65,11 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           mkdir -p artifacts
           DRY_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
@@ -88,27 +95,32 @@ jobs:
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          TITLE="atlas-delta-failure-$RUN_DATE"
-          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
-          BODY=$(cat <<EOF
-          Atlas delta run failed on $RUN_DATE.
-
-          Workflow run: $RUN_URL
-
-          <details><summary>Last 200 log lines</summary>
-
-          \`\`\`
-          $TAIL
-          \`\`\`
-
-          </details>
-          EOF
-          )
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
-            --json number --jq '.[0].number' || echo "")
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "$BODY"
+          # Title is date-independent so consecutive failures roll up into
+          # a single issue (dedupe across days). Per-run context goes in
+          # the body as a new comment.
+          TITLE="atlas-delta-failure"
+          # Write the tail to a file so we never interpolate untrusted log
+          # content through shell command-substitution. `gh` reads the body
+          # via --body-file, which is safe regardless of the log contents.
+          mkdir -p artifacts
+          if [ -f artifacts/run.log ]; then
+            tail -n 200 artifacts/run.log > artifacts/tail.log
           else
-            gh issue create --title "$TITLE" --body "$BODY" \
+            printf '(no log captured)\n' > artifacts/tail.log
+          fi
+          {
+            printf 'Atlas delta run failed on %s.\n\n' "$RUN_DATE"
+            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '<details><summary>Last 200 log lines</summary>\n\n'
+            printf '```\n'
+            cat artifacts/tail.log
+            printf '\n```\n\n</details>\n'
+          } > artifacts/issue-body.md
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file artifacts/issue-body.md
+          else
+            gh issue create --title "$TITLE" --body-file artifacts/issue-body.md \
               --label "ci:failure"
           fi

--- a/.github/workflows/atlas-graph-ci.yml
+++ b/.github/workflows/atlas-graph-ci.yml
@@ -1,0 +1,57 @@
+name: atlas graph ci
+
+# Unit tests + lint + actionlint for the Atlas sub-graph package and its
+# scheduler workflows. Scoped with path filters so it only runs when
+# something in apps/digiquant-atlas/ or .github/workflows/atlas-*.yml changes.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "apps/digiquant-atlas/**"
+      - ".github/workflows/atlas-*.yml"
+  pull_request:
+    paths:
+      - "apps/digiquant-atlas/**"
+      - ".github/workflows/atlas-*.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -e ./digibase
+          pip install -e ./digigraph
+          pip install -e "./apps/digiquant-atlas[dev]"
+
+      - name: Ruff check
+        run: ruff check apps/digiquant-atlas/
+
+      - name: Ruff format check
+        run: ruff format --check apps/digiquant-atlas/
+
+      - name: Pytest
+        run: pytest -m unit apps/digiquant-atlas/tests/ -v --tb=short
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@v2
+        with:
+          files: ".github/workflows/atlas-*.yml"

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -1,12 +1,15 @@
 name: atlas monthly
 
 # Monthly synthesis. Fires daily on the 28th-31st at 14:00 UTC; the guard
-# step gates the actual run to the last weekday of the month (Mon-Fri
-# AND "tomorrow is the 1st"). The double condition means:
-#   - if the 31st is a Fri → only that date passes the guard;
-#   - if the 31st is a Sun → the Fri of the 29th passes (next-weekday fallback).
-# Keeping the window 28-31 instead of `L` because cron doesn't support `L`
-# on GitHub's scheduler.
+# job below gates the actual run to the **last weekday of the month** —
+# i.e. today is a weekday (Mon-Fri) AND no later weekday remains before
+# the 1st of next month. That correctly handles every month layout,
+# including cases where the last calendar day falls on a Sat/Sun (we
+# then run on the Fri that precedes it) and 28/29-day Februaries.
+#
+# Why the 28-31 window? GitHub's scheduler doesn't support cron's `L`
+# (last-day) specifier, so we fire every eligible date and let the
+# guard short-circuit the non-matching ones.
 
 on:
   schedule:
@@ -18,13 +21,15 @@ on:
         required: false
         default: ""
       force:
-        description: "Set 'true' to skip the last-weekday guard (manual backfills)."
+        description: "Skip the last-weekday guard (manual backfills)."
         required: false
-        default: "false"
+        type: boolean
+        default: false
       dry_run:
-        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        description: "Compile + validate inputs only (no LLM calls)."
         required: false
-        default: "false"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,44 +40,77 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run:
+  guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
     steps:
       - name: Last-weekday-of-month guard
-        id: guard
-        # Run if one of:
-        #   (a) workflow_dispatch with force=true — operator backfill;
-        #   (b) today is a weekday AND the 1st of next month is tomorrow.
-        # GitHub runners ship GNU date, so `date -d` is available.
+        id: check
+        env:
+          FORCE: ${{ inputs.force }}
         run: |
-          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+          # Proceed if either:
+          #   (a) operator forced via workflow_dispatch; or
+          #   (b) today is a weekday AND no later weekday remains this month
+          #       (i.e. every day from tomorrow through end-of-month is Sat/Sun).
+          if [ "$FORCE" = "true" ]; then
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             echo "reason=forced via workflow_dispatch"
             exit 0
           fi
-          dow=$(date -u +%u)         # 1-7, Mon-Sun
-          tomorrow=$(date -u -d "+1 day" +%d)
-          if [ "$dow" -le 5 ] && [ "$tomorrow" = "01" ]; then
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            echo "reason=last weekday of month (dow=$dow, tomorrow=$tomorrow)"
-          else
+
+          today_dow=$(date -u +%u)          # 1=Mon … 7=Sun
+          if [ "$today_dow" -gt 5 ]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping — not the last weekday (dow=$dow, tomorrow=$tomorrow)"
+            echo "Skipping — today is a weekend (dow=$today_dow)"
+            exit 0
           fi
 
-      - name: Checkout
-        if: steps.guard.outputs.proceed == 'true'
-        uses: actions/checkout@v4
+          this_month=$(date -u +%Y-%m)
+          # Walk tomorrow..+7 days and check if any weekday remains in the
+          # current calendar month. If one does, today is NOT the last
+          # weekday and we skip.
+          later_weekday=""
+          for offset in 1 2 3 4 5 6 7; do
+            candidate=$(date -u -d "+$offset day" +%Y-%m-%d)
+            cand_month=$(printf '%s' "$candidate" | cut -d- -f1-2)
+            if [ "$cand_month" != "$this_month" ]; then
+              break
+            fi
+            cand_dow=$(date -u -d "$candidate" +%u)
+            if [ "$cand_dow" -le 5 ]; then
+              later_weekday="$candidate"
+              break
+            fi
+          done
 
-      - name: Setup Python
-        if: steps.guard.outputs.proceed == 'true'
-        uses: actions/setup-python@v5
+          if [ -z "$later_weekday" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "reason=last weekday of $this_month"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping — later weekday $later_weekday remains in $this_month"
+          fi
+
+  run:
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            apps/digiquant-atlas/pyproject.toml
 
       - name: Install Atlas
-        if: steps.guard.outputs.proceed == 'true'
         run: |
           python -m pip install -U pip
           pip install -e ./digibase
@@ -80,26 +118,25 @@ jobs:
           pip install -e "./apps/digiquant-atlas[supabase]"
 
       - name: Resolve run date
-        if: steps.guard.outputs.proceed == 'true'
         id: resolve
         run: |
-          if [ -n "${{ github.event.inputs.run_date }}" ]; then
-            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ inputs.run_date }}" ]; then
+            echo "run_date=${{ inputs.run_date }}" >> "$GITHUB_OUTPUT"
           else
             echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run monthly
-        if: steps.guard.outputs.proceed == 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           mkdir -p artifacts
           DRY_FLAG=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
@@ -110,7 +147,7 @@ jobs:
             2>&1 | tee artifacts/run.log
 
       - name: Upload logs
-        if: always() && steps.guard.outputs.proceed == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: atlas-monthly-${{ steps.resolve.outputs.run_date }}
@@ -118,33 +155,38 @@ jobs:
           retention-days: 90
 
       - name: Open or update failure issue
-        if: failure() && steps.guard.outputs.proceed == 'true'
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          TITLE="atlas-monthly-failure-$RUN_DATE"
-          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
-          BODY=$(cat <<EOF
-          Atlas monthly run failed on $RUN_DATE.
-
-          Workflow run: $RUN_URL
-
-          <details><summary>Last 200 log lines</summary>
-
-          \`\`\`
-          $TAIL
-          \`\`\`
-
-          </details>
-          EOF
-          )
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
-            --json number --jq '.[0].number' || echo "")
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "$BODY"
+          # Title is date-independent so consecutive failures roll up into
+          # a single issue (dedupe across months). Per-run context goes in
+          # the body as a new comment.
+          TITLE="atlas-monthly-failure"
+          # Write the tail to a file so we never interpolate untrusted log
+          # content through shell command-substitution. `gh` reads the body
+          # via --body-file, which is safe regardless of the log contents.
+          mkdir -p artifacts
+          if [ -f artifacts/run.log ]; then
+            tail -n 200 artifacts/run.log > artifacts/tail.log
           else
-            gh issue create --title "$TITLE" --body "$BODY" \
+            printf '(no log captured)\n' > artifacts/tail.log
+          fi
+          {
+            printf 'Atlas monthly run failed on %s.\n\n' "$RUN_DATE"
+            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '<details><summary>Last 200 log lines</summary>\n\n'
+            printf '```\n'
+            cat artifacts/tail.log
+            printf '\n```\n\n</details>\n'
+          } > artifacts/issue-body.md
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq '[.[] | select(.title == "'"$TITLE"'")][0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file artifacts/issue-body.md
+          else
+            gh issue create --title "$TITLE" --body-file artifacts/issue-body.md \
               --label "ci:failure"
           fi

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -1,0 +1,150 @@
+name: atlas monthly
+
+# Monthly synthesis. Fires daily on the 28th-31st at 14:00 UTC; the guard
+# step gates the actual run to the last weekday of the month (Mon-Fri
+# AND "tomorrow is the 1st"). The double condition means:
+#   - if the 31st is a Fri → only that date passes the guard;
+#   - if the 31st is a Sun → the Fri of the 29th passes (next-weekday fallback).
+# Keeping the window 28-31 instead of `L` because cron doesn't support `L`
+# on GitHub's scheduler.
+
+on:
+  schedule:
+    - cron: "0 14 28-31 * *"
+  workflow_dispatch:
+    inputs:
+      run_date:
+        description: "Logical run date (YYYY-MM-DD). Defaults to today UTC."
+        required: false
+        default: ""
+      force:
+        description: "Set 'true' to skip the last-weekday guard (manual backfills)."
+        required: false
+        default: "false"
+      dry_run:
+        description: "Set 'true' to compile + validate inputs only (no LLM calls)."
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: atlas-monthly
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Last-weekday-of-month guard
+        id: guard
+        # Run if one of:
+        #   (a) workflow_dispatch with force=true — operator backfill;
+        #   (b) today is a weekday AND the 1st of next month is tomorrow.
+        # GitHub runners ship GNU date, so `date -d` is available.
+        run: |
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "reason=forced via workflow_dispatch"
+            exit 0
+          fi
+          dow=$(date -u +%u)         # 1-7, Mon-Sun
+          tomorrow=$(date -u -d "+1 day" +%d)
+          if [ "$dow" -le 5 ] && [ "$tomorrow" = "01" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "reason=last weekday of month (dow=$dow, tomorrow=$tomorrow)"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping — not the last weekday (dow=$dow, tomorrow=$tomorrow)"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        if: steps.guard.outputs.proceed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Atlas
+        if: steps.guard.outputs.proceed == 'true'
+        run: |
+          python -m pip install -U pip
+          pip install -e ./digibase
+          pip install -e ./digigraph
+          pip install -e "./apps/digiquant-atlas[supabase]"
+
+      - name: Resolve run date
+        if: steps.guard.outputs.proceed == 'true'
+        id: resolve
+        run: |
+          if [ -n "${{ github.event.inputs.run_date }}" ]; then
+            echo "run_date=${{ github.event.inputs.run_date }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run monthly
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          mkdir -p artifacts
+          DRY_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_FLAG="--dry-run"
+          fi
+          set -o pipefail
+          python -m digiquant_atlas.graph \
+            --run-type monthly \
+            --run-date "${{ steps.resolve.outputs.run_date }}" \
+            $DRY_FLAG \
+            2>&1 | tee artifacts/run.log
+
+      - name: Upload logs
+        if: always() && steps.guard.outputs.proceed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: atlas-monthly-${{ steps.resolve.outputs.run_date }}
+          path: artifacts/
+          retention-days: 90
+
+      - name: Open or update failure issue
+        if: failure() && steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_DATE: ${{ steps.resolve.outputs.run_date }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TITLE="atlas-monthly-failure-$RUN_DATE"
+          TAIL="$(tail -n 200 artifacts/run.log 2>/dev/null || echo '(no log captured)')"
+          BODY=$(cat <<EOF
+          Atlas monthly run failed on $RUN_DATE.
+
+          Workflow run: $RUN_URL
+
+          <details><summary>Last 200 log lines</summary>
+
+          \`\`\`
+          $TAIL
+          \`\`\`
+
+          </details>
+          EOF
+          )
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label "ci:failure"
+          fi

--- a/apps/digiquant-atlas/docs/DEPLOYMENT.md
+++ b/apps/digiquant-atlas/docs/DEPLOYMENT.md
@@ -1,0 +1,169 @@
+# Atlas — Deployment & Scheduling
+
+This document covers the GitHub Actions schedulers that drive the Atlas
+research pipeline, the secrets they need, how to test locally, and the
+rollback / monitoring procedures.
+
+Companion workflows (in `.github/workflows/`):
+
+| Workflow | Trigger | Command | Timeout |
+| --- | --- | --- | --- |
+| `atlas-baseline.yml` | `cron '0 12 * * SAT'` + `workflow_dispatch` | `python -m digiquant_atlas.graph --run-type baseline --run-date <today>` | 120 min |
+| `atlas-delta.yml` | `cron '0 12 * * MON-FRI'` + `workflow_dispatch` | `python -m digiquant_atlas.graph --run-type delta --auto-baseline --run-date <today>` | 45 min |
+| `atlas-monthly.yml` | `cron '0 14 28-31 * *'` + last-weekday guard | `python -m digiquant_atlas.graph --run-type monthly --run-date <today>` | 60 min |
+| `atlas-graph-ci.yml` | `push` / `pull_request` touching `apps/digiquant-atlas/**` | unit tests + ruff + `actionlint` | 15 min |
+
+## Required repo secrets
+
+Set once per repository — the schedulers reference them by name. Prefer
+GitHub **environment** secrets (`environment: atlas-prod`) when you're
+ready to gate production runs behind a reviewer.
+
+```bash
+gh secret set SUPABASE_URL                 --body "https://<project>.supabase.co"
+gh secret set SUPABASE_SERVICE_ROLE_KEY    --body "<service-role-key>"   # server-side only, never ship to frontend
+gh secret set LITELLM_PROXY_API_KEY        --body "<litellm-key>"        # LiteLLM proxy bearer
+gh secret set OPENAI_API_KEY               --body "<openai-key>"         # BYOK fallback / override
+```
+
+Verify:
+
+```bash
+gh secret list | grep -E 'SUPABASE|LITELLM|OPENAI'
+```
+
+Rotation: re-run `gh secret set <NAME>` with a new value; in-flight runs
+keep their copy, new runs pick up the rotated secret.
+
+## Testing a workflow
+
+### Manual `workflow_dispatch` (recommended for first-time validation)
+
+Trigger a dry-run delta (compiles the graph, prints a JSON summary, makes
+no LLM calls):
+
+```bash
+gh workflow run atlas-delta.yml \
+  --ref task/219-w1d-atlas-schedulers \
+  -f run_date=2026-04-20 \
+  -f dry_run=true
+```
+
+Watch the run:
+
+```bash
+gh run watch --exit-status
+```
+
+Baseline dry-run on the same branch:
+
+```bash
+gh workflow run atlas-baseline.yml \
+  --ref task/219-w1d-atlas-schedulers \
+  -f run_date=2026-04-20 \
+  -f dry_run=true
+```
+
+### `act` (fully local, optional)
+
+```bash
+brew install act
+act -W .github/workflows/atlas-delta.yml \
+    -j run \
+    --secret-file .secrets \
+    -e <(echo '{"inputs":{"run_date":"2026-04-20","dry_run":"true"}}')
+```
+
+`act` is best-effort — macOS/Linux container differences occasionally
+surface issues that don't appear on GitHub-hosted runners. Treat `act`
+as a fast pre-check, not a substitute for a real `workflow_dispatch`.
+
+### `actionlint` (static check, pre-push)
+
+```bash
+brew install actionlint
+actionlint .github/workflows/atlas-*.yml
+```
+
+CI also runs `actionlint` on every PR that touches Atlas workflows (see
+`atlas-graph-ci.yml`).
+
+## Rollback plan
+
+A run can fail in two shapes:
+
+1. **Crashed fast** (import error, schema mismatch, missing secret). No
+   partial writes. Remediation: re-run the workflow once the fix is
+   merged, or revert the offending commit and let the next cron tick.
+2. **Crashed mid-pipeline** (half-written `documents`, a stray
+   `daily_snapshots` row). Atlas writes are idempotent per `(date,
+   document_key)` — re-running the same `run_date` will overwrite the
+   partial row. If rollback is still required:
+
+   ```bash
+   # Point at a Supabase read-replica / staging DB first to verify.
+   python3 apps/digiquant-atlas/scripts/validate_db_first.py \
+     --date <run-date> --mode full
+   ```
+
+   To purge a bad run:
+
+   ```sql
+   -- Run against Supabase via the service role.
+   DELETE FROM daily_snapshots WHERE date = '<run-date>' AND run_type = '<type>';
+   DELETE FROM documents       WHERE date = '<run-date>' AND created_at > '<run-started-at>';
+   ```
+
+   Then re-trigger the same workflow via `workflow_dispatch` with the
+   original `run_date`.
+
+3. **Scheduler is the problem** (bad cron, runaway cost): disable the
+   workflow from the Actions UI (`Disable workflow`) or via CLI:
+
+   ```bash
+   gh workflow disable atlas-delta.yml
+   ```
+
+   Keep it disabled until the triggering issue is resolved. `gh workflow
+   enable atlas-delta.yml` to resume.
+
+## Failure issue convention
+
+Each scheduler opens (or comments on) an issue titled
+`atlas-<kind>-failure-YYYY-MM-DD` on failure, with the last 200 log
+lines attached. Close the issue manually after remediation; the next
+successful run will not auto-close it.
+
+## Cost monitoring
+
+Cost telemetry is owned by Atlas **Phase 9** (see
+`src/digiquant_atlas/phases/phase9_evolution.py`). Each run emits
+per-phase token counts + USD estimates into the `evolution` document.
+
+Recommended weekly check:
+
+```bash
+python3 apps/digiquant-atlas/scripts/fetch_research_library.py \
+  --category evolution --limit 10
+```
+
+Flag runs where `phase9.cost_usd` exceeds the rolling 4-week median by
+more than 3x — that's usually a triage miss (delta behaving like
+baseline) or a cache-control regression.
+
+The broader observability story (Prometheus + DigiSmith spans, PR
+quality gate, BYOK override) is documented in
+`docs/agents/GUARDRAILS.md` and `digismith/`.
+
+## Changing the schedule
+
+Cron strings live at the top of each workflow. UTC always. Remember:
+
+- Anthropic's API is busiest 16:00–22:00 UTC (US afternoon). The 12:00
+  UTC slots are chosen for capacity + latency.
+- Monthly runs use a `28-31 * *` window plus a shell guard that only
+  fires on the last weekday of the month — per-platform `date` flags
+  differ, so the guard uses a single POSIX-friendly calculation.
+
+After edits, re-run `actionlint` and trigger a `workflow_dispatch`
+dry-run to validate the new schedule hasn't broken wiring.

--- a/apps/digiquant-atlas/docs/DEPLOYMENT.md
+++ b/apps/digiquant-atlas/docs/DEPLOYMENT.md
@@ -19,12 +19,23 @@ Set once per repository — the schedulers reference them by name. Prefer
 GitHub **environment** secrets (`environment: atlas-prod`) when you're
 ready to gate production runs behind a reviewer.
 
+**Always pipe secret values via stdin** (`--body-file -`) — `--body "<value>"`
+leaks the raw secret into your shell history, process list, and any
+terminal recording.
+
 ```bash
-gh secret set SUPABASE_URL                 --body "https://<project>.supabase.co"
-gh secret set SUPABASE_SERVICE_ROLE_KEY    --body "<service-role-key>"   # server-side only, never ship to frontend
-gh secret set LITELLM_PROXY_API_KEY        --body "<litellm-key>"        # LiteLLM proxy bearer
-gh secret set OPENAI_API_KEY               --body "<openai-key>"         # BYOK fallback / override
+# URLs are non-secret but use the same convention for consistency.
+printf 'https://<project>.supabase.co' | gh secret set SUPABASE_URL --body-file -
+
+# Paste the service-role JWT when prompted, then Ctrl-D:
+gh secret set SUPABASE_SERVICE_ROLE_KEY --body-file -   # server-side only, never ship to frontend
+gh secret set LITELLM_PROXY_API_KEY     --body-file -   # LiteLLM proxy bearer
+gh secret set OPENAI_API_KEY            --body-file -   # BYOK fallback / override
 ```
+
+If you already have the value in a file (for example, a 1Password export),
+pass the path directly: `gh secret set OPENAI_API_KEY --body-file ~/openai.key`.
+Delete the file immediately after.
 
 Verify:
 
@@ -32,8 +43,34 @@ Verify:
 gh secret list | grep -E 'SUPABASE|LITELLM|OPENAI'
 ```
 
-Rotation: re-run `gh secret set <NAME>` with a new value; in-flight runs
-keep their copy, new runs pick up the rotated secret.
+Rotation: re-run `gh secret set <NAME> --body-file -` with a new value;
+in-flight runs keep their copy, new runs pick up the rotated secret.
+
+## Bootstrap (first-run)
+
+The delta scheduler invokes `--auto-baseline`, which resolves the most
+recent `research_baseline_manifest` document from Supabase. **Before the
+first weekday delta can succeed, a baseline run must have landed at
+least one manifest.** If you trigger the delta first, it raises
+`SystemExit("--auto-baseline could not resolve a baseline date …")`
+and the failure-issue step fires.
+
+Bootstrap a fresh environment in this order:
+
+```bash
+# 1. Set secrets (see above).
+# 2. Kick a baseline manually — wait for it to succeed before enabling delta.
+gh workflow run atlas-baseline.yml \
+  --ref task/219-w1d-atlas-schedulers \
+  -f run_date="$(date -u +%Y-%m-%d)"
+gh run watch --exit-status
+
+# 3. Verify a baseline manifest exists in Supabase:
+python3 apps/digiquant-atlas/scripts/fetch_research_library.py \
+  --category research_baseline_manifest --limit 1
+
+# 4. Delta can now schedule safely; the next 12:00 UTC Mon-Fri tick will run.
+```
 
 ## Testing a workflow
 
@@ -129,10 +166,13 @@ A run can fail in two shapes:
 
 ## Failure issue convention
 
-Each scheduler opens (or comments on) an issue titled
-`atlas-<kind>-failure-YYYY-MM-DD` on failure, with the last 200 log
-lines attached. Close the issue manually after remediation; the next
-successful run will not auto-close it.
+Each scheduler opens (or comments on) a single rolling issue titled
+`atlas-<kind>-failure` (no date in the title), with the failing run's
+date, run URL, and last 200 log lines appended as a new comment. That
+way consecutive daily failures stack in one place instead of spamming
+one issue per day. Close the issue manually after remediation; the next
+successful run will not auto-close it, and a later failure will reopen /
+reuse the same title.
 
 ## Cost monitoring
 
@@ -161,9 +201,13 @@ Cron strings live at the top of each workflow. UTC always. Remember:
 
 - Anthropic's API is busiest 16:00–22:00 UTC (US afternoon). The 12:00
   UTC slots are chosen for capacity + latency.
-- Monthly runs use a `28-31 * *` window plus a shell guard that only
-  fires on the last weekday of the month — per-platform `date` flags
-  differ, so the guard uses a single POSIX-friendly calculation.
+- Monthly runs use a `28-31 * *` window plus a `guard` job that only
+  proceeds on the **last weekday of the month**. The guard walks
+  tomorrow through end-of-month and proceeds only if no later weekday
+  remains in the current calendar month. That correctly covers the
+  case where the last calendar day falls on a Sat/Sun (we run on the
+  preceding Fri) and 28/29-day Februaries. Pass `force=true` via
+  `workflow_dispatch` to skip the guard for manual backfills.
 
 After edits, re-run `actionlint` and trigger a `workflow_dispatch`
 dry-run to validate the new schedule hasn't broken wiring.

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -328,10 +328,13 @@ def cli_main(argv: list[str] | None = None) -> int:
     atlas_input = AtlasInput(**kwargs)
     graph = build_atlas_graph(atlas_input.run_type, deps=deps, watchlist=atlas_input.watchlist)
     state = initial_state(atlas_input)
-    result = graph.invoke(state)
+    # graph.invoke raises on any phase failure; we let exceptions propagate
+    # to the CLI so the workflow step exits non-zero and the failure-issue
+    # step fires. A successful return here is the only success path.
+    graph.invoke(state)
     json.dump({"ok": True, "summary": _cli_summary(kwargs)}, sys.stdout, default=str)
     sys.stdout.write("\n")
-    return 0 if result is not None else 1
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -148,5 +148,191 @@ __all__ = [
     "AtlasGraphDeps",
     "AtlasInput",
     "build_atlas_graph",
+    "build_cli_parser",
+    "cli_main",
     "initial_state",
+    "resolve_cli_inputs",
 ]
+
+
+# ─── CLI entry point ────────────────────────────────────────────────────────
+#
+# Invoked as ``python -m digiquant_atlas.graph …`` by the GitHub Actions
+# schedulers (see ``.github/workflows/atlas-*.yml``). The CLI is kept
+# intentionally thin: parse flags → resolve baseline → build AtlasInput →
+# invoke the compiled graph. Heavy lifting stays in the graph itself.
+
+
+def _parse_cli_date(value: str):
+    from datetime import datetime as _dt
+
+    return _dt.strptime(value, "%Y-%m-%d").date()
+
+
+def build_cli_parser():
+    """Return the argparse parser.
+
+    Exposed for unit tests (``tests/test_cli.py``) to exercise flag
+    handling without invoking the graph.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m digiquant_atlas.graph",
+        description="Invoke the Atlas research sub-graph.",
+    )
+    parser.add_argument(
+        "--run-type",
+        required=True,
+        choices=("baseline", "delta", "monthly"),
+        help="Pipeline shape to compile and run.",
+    )
+    parser.add_argument(
+        "--run-date",
+        required=True,
+        type=_parse_cli_date,
+        help="YYYY-MM-DD — the logical date this run represents.",
+    )
+    parser.add_argument(
+        "--baseline-date",
+        type=_parse_cli_date,
+        default=None,
+        help="Explicit baseline date for delta runs. Ignored when --auto-baseline is set.",
+    )
+    parser.add_argument(
+        "--auto-baseline",
+        action="store_true",
+        help=(
+            "Resolve --baseline-date from Supabase by querying the latest "
+            "research_baseline_manifest document. Only meaningful for --run-type delta."
+        ),
+    )
+    parser.add_argument(
+        "--watchlist",
+        default="",
+        help="Comma-separated ticker list. Empty means Phase 7C fan-out is skipped.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve inputs + compile graph, print JSON summary, exit 0 (no LLM calls).",
+    )
+    return parser
+
+
+def _auto_resolve_baseline(run_date: date) -> date | None:
+    """Query Supabase for the latest ``research_baseline_manifest`` date.
+
+    Returns ``None`` when Supabase credentials are absent; the caller
+    decides whether that's a fatal condition (it is, for real runs; it's
+    tolerated under ``--dry-run`` so the scheduler smoke test stays
+    hermetic).
+    """
+    import os
+
+    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_ROLE_KEY"):
+        return None
+
+    from digiquant_atlas.supabase_io import SupabaseConfig, build_client
+
+    client = build_client(SupabaseConfig.from_env())
+    resp = (
+        client.table("documents")
+        .select("date")
+        .eq("doc_type", "research_baseline_manifest")
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .limit(1)
+        .execute()
+    )
+    rows = getattr(resp, "data", None) or []
+    if not rows:
+        return None
+    raw = rows[0].get("date")
+    if isinstance(raw, date):
+        return raw
+    if isinstance(raw, str):
+        return _parse_cli_date(raw)
+    return None
+
+
+def resolve_cli_inputs(args) -> dict:
+    """Translate argparse Namespace → AtlasInput kwargs.
+
+    Pure apart from the optional Supabase call behind ``--auto-baseline``;
+    ``tests/test_cli.py`` covers both the explicit and auto-baseline
+    paths by stubbing that call.
+    """
+    watchlist = tuple(t.strip() for t in args.watchlist.split(",") if t.strip())
+    baseline_date = args.baseline_date
+
+    if args.auto_baseline:
+        if args.run_type != "delta":
+            raise SystemExit("--auto-baseline only valid with --run-type delta")
+        resolved = _auto_resolve_baseline(args.run_date)
+        if resolved is None and not args.dry_run:
+            raise SystemExit(
+                "--auto-baseline could not resolve a baseline date; "
+                "is SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY set and is there "
+                "a prior research_baseline_manifest document?"
+            )
+        baseline_date = resolved
+
+    return {
+        "run_type": args.run_type,
+        "run_date": args.run_date,
+        "baseline_date": baseline_date,
+        "watchlist": watchlist,
+    }
+
+
+def _cli_summary(kwargs: dict) -> dict:
+    return {
+        "run_type": kwargs["run_type"],
+        "run_date": kwargs["run_date"].isoformat(),
+        "baseline_date": (kwargs["baseline_date"].isoformat() if kwargs["baseline_date"] else None),
+        "watchlist": list(kwargs["watchlist"]),
+    }
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    import json
+    import sys
+
+    parser = build_cli_parser()
+    args = parser.parse_args(argv)
+    kwargs = resolve_cli_inputs(args)
+
+    if args.dry_run:
+        # Confirm the graph compiles cleanly, but skip invocation — no LLM calls.
+        summary = _cli_summary(kwargs) | {"dry_run": True, "compiled": False}
+        try:
+            from digiquant_atlas.phases.preflight import PreflightDeps
+
+            deps = AtlasGraphDeps(preflight=PreflightDeps(client=None, config_loader=None))  # type: ignore[arg-type]
+            build_atlas_graph(kwargs["run_type"], deps=deps, watchlist=kwargs["watchlist"])
+            summary["compiled"] = True
+        except Exception as exc:  # pragma: no cover — keep dry-run non-fatal
+            summary["compile_error"] = repr(exc)
+
+        json.dump(summary, sys.stdout, default=str)
+        sys.stdout.write("\n")
+        return 0
+
+    from digiquant_atlas.phases.preflight import PreflightDeps
+    from digiquant_atlas.supabase_io import SupabaseConfig, build_client
+
+    client = build_client(SupabaseConfig.from_env())
+    deps = AtlasGraphDeps(preflight=PreflightDeps(client=client, config_loader=None))  # type: ignore[arg-type]
+    atlas_input = AtlasInput(**kwargs)
+    graph = build_atlas_graph(atlas_input.run_type, deps=deps, watchlist=atlas_input.watchlist)
+    state = initial_state(atlas_input)
+    result = graph.invoke(state)
+    json.dump({"ok": True, "summary": _cli_summary(kwargs)}, sys.stdout, default=str)
+    sys.stdout.write("\n")
+    return 0 if result is not None else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(cli_main())

--- a/apps/digiquant-atlas/tests/test_cli.py
+++ b/apps/digiquant-atlas/tests/test_cli.py
@@ -1,0 +1,120 @@
+"""Argparse smoke tests for the Atlas CLI.
+
+The GitHub Actions schedulers invoke this CLI; these tests protect the
+flag contract. Heavy behavior (graph compilation, Supabase calls) is
+covered elsewhere — here we only assert that flags parse + resolve into
+the right ``AtlasInput`` kwargs.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant_atlas.graph import build_cli_parser, resolve_cli_inputs
+
+pytestmark = pytest.mark.unit
+
+
+def _parse(*argv: str):
+    return build_cli_parser().parse_args(list(argv))
+
+
+def test_baseline_minimal():
+    args = _parse("--run-type", "baseline", "--run-date", "2026-04-20")
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["run_type"] == "baseline"
+    assert kwargs["run_date"] == date(2026, 4, 20)
+    assert kwargs["baseline_date"] is None
+    assert kwargs["watchlist"] == ()
+
+
+def test_delta_with_explicit_baseline():
+    args = _parse(
+        "--run-type",
+        "delta",
+        "--run-date",
+        "2026-04-20",
+        "--baseline-date",
+        "2026-04-18",
+        "--watchlist",
+        "AAPL,MSFT, TSLA",
+    )
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["run_type"] == "delta"
+    assert kwargs["baseline_date"] == date(2026, 4, 18)
+    assert kwargs["watchlist"] == ("AAPL", "MSFT", "TSLA")
+
+
+def test_auto_baseline_rejected_on_baseline_run():
+    args = _parse(
+        "--run-type",
+        "baseline",
+        "--run-date",
+        "2026-04-20",
+        "--auto-baseline",
+    )
+    with pytest.raises(SystemExit):
+        resolve_cli_inputs(args)
+
+
+def test_auto_baseline_dry_run_tolerates_missing_credentials(monkeypatch):
+    # No Supabase env → _auto_resolve_baseline returns None; because
+    # dry_run=True we expect a tolerant result (baseline_date stays None).
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    args = _parse(
+        "--run-type",
+        "delta",
+        "--run-date",
+        "2026-04-20",
+        "--auto-baseline",
+        "--dry-run",
+    )
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["baseline_date"] is None
+
+
+def test_auto_baseline_live_raises_without_credentials(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    args = _parse(
+        "--run-type",
+        "delta",
+        "--run-date",
+        "2026-04-20",
+        "--auto-baseline",
+    )
+    with pytest.raises(SystemExit):
+        resolve_cli_inputs(args)
+
+
+def test_auto_baseline_resolves_from_stub(monkeypatch):
+    from digiquant_atlas import graph as graph_mod
+
+    monkeypatch.setattr(graph_mod, "_auto_resolve_baseline", lambda run_date: date(2026, 4, 15))
+    args = _parse(
+        "--run-type",
+        "delta",
+        "--run-date",
+        "2026-04-20",
+        "--auto-baseline",
+    )
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["baseline_date"] == date(2026, 4, 15)
+
+
+def test_run_type_choices_enforced():
+    with pytest.raises(SystemExit):
+        _parse("--run-type", "bogus", "--run-date", "2026-04-20")
+
+
+def test_run_date_format_validated():
+    with pytest.raises(SystemExit):
+        _parse("--run-type", "baseline", "--run-date", "20260420")
+
+
+def test_dry_run_flag_parsed():
+    args = _parse("--run-type", "monthly", "--run-date", "2026-04-20", "--dry-run")
+    assert args.dry_run is True


### PR DESCRIPTION
## Summary

- Four new GitHub Actions workflows drive the Atlas → DigiGraph research pipeline: `atlas-baseline.yml` (Sat 12:00 UTC, full 9-phase, 120 min), `atlas-delta.yml` (MON-FRI 12:00 UTC with `--auto-baseline`, 45 min), `atlas-monthly.yml` (last-weekday-of-month guard, 60 min), and `atlas-graph-ci.yml` (tests + ruff + actionlint, path-filtered to `apps/digiquant-atlas/`).
- `digiquant_atlas.graph` gains an argparse CLI with `--auto-baseline` (resolves latest `research_baseline_manifest` from Supabase) and a hermetic `--dry-run` for scheduler smoke tests. 9 new tests in `apps/digiquant-atlas/tests/test_cli.py`.
- `apps/digiquant-atlas/docs/DEPLOYMENT.md` documents the required secrets (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `LITELLM_PROXY_API_KEY`, `OPENAI_API_KEY`), how to trigger manual runs via `workflow_dispatch` / `act`, rollback procedure, and cost-monitoring pointers (Phase 9).

Each scheduler opens (or comments on) an `atlas-<kind>-failure-<date>` issue on failure, labelled `ci:failure`, with the last 200 log lines attached.

Part of Wave 1 of the Atlas full migration — see \`docs/plans/atlas-full-migration-wave1.md\` (Unit W1-D).

Closes #219

## Test plan

- [x] \`pytest apps/digiquant-atlas/tests/ -m unit\` — 97 passed.
- [x] \`ruff check\` + \`ruff format --check\` on new/modified files — clean.
- [x] \`make score\` — 10/10 across all four dimensions.
- [x] YAML syntax validated (\`python3 -c "yaml.safe_load(...)"\`).
- [ ] \`actionlint .github/workflows/atlas-*.yml\` — runs in the new \`atlas-graph-ci\` job (not installed locally).
- [ ] Dry-run smoke test via \`gh workflow run atlas-delta.yml --ref task/219-w1d-atlas-schedulers -f run_date=2026-04-20 -f dry_run=true\` after merge prerequisites are unblocked.