### PR TITLE
feat(atlas): Wave 1 — schema 024 + Hermes spec (module/digiquant-atlas → develop)

### DIFF
--- a/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
+++ b/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
@@ -475,30 +475,9 @@ Atlas research sub-graph and produces `state.phase_hermes.pm_allocation_memo`,
 which `phase7d_rebalance` then deterministically turns into the
 `RebalanceDecision`.
 
-Full spec: [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md). Wave 2 implementation
-units: [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md).
-
-```
-  phase6_consolidate
-        │
-        ▼
-  phase_h1_thesis_review ─► phase_h2_market_thesis_exploration
-        │                         │
-        ▼                         ▼
-  phase_h3_thesis_vehicle_map ─► phase_h4_opportunity_screener
-        │
-        ▼
-  phase_h5_asset_analyst (×N tickers)
-        │
-        ▼
-  phase_h6_deliberation (×N tickers; cyclic round loop per ticker)
-        │                         │
-        ▼                         ▼
-  deep_dive_batch (cond.)   phase_h7_pm_allocation_memo
-                                  │
-                                  ▼
-                          phase7d_rebalance
-```
+Full spec: [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) (topology diagram in §1.2,
+persistence mapping in §5). Wave 2 implementation units:
+[`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md).
 
 Persistence lands in both `documents` (full payload) and the first-class
 tables introduced by migration 024: `theses`, `thesis_vehicles`,

--- a/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
+++ b/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
@@ -462,3 +462,45 @@ DigiClaw (issue #219) invokes this on a cron schedule.
 The Cowork-based manual runs described above remain valid as an escape
 hatch for backfills and operator scenarios, but the scheduled cadence
 now flows through the sub-graph.
+
+---
+
+## Hermes sub-graph (portfolio deliberation)
+
+The portfolio side of the pipeline — thesis review, vehicle mapping,
+opportunity screening, blinded per-ticker analysis, analyst↔PM
+deliberation, and the allocation memo — is orchestrated by the
+**Hermes sub-graph**. Hermes consumes `state.phase6_bias_row` from the
+Atlas research sub-graph and produces `state.phase_hermes.pm_allocation_memo`,
+which `phase7d_rebalance` then deterministically turns into the
+`RebalanceDecision`.
+
+Full spec: [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md). Wave 2 implementation
+units: [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md).
+
+```
+  phase6_consolidate
+        │
+        ▼
+  phase_h1_thesis_review ─► phase_h2_market_thesis_exploration
+        │                         │
+        ▼                         ▼
+  phase_h3_thesis_vehicle_map ─► phase_h4_opportunity_screener
+        │
+        ▼
+  phase_h5_asset_analyst (×N tickers)
+        │
+        ▼
+  phase_h6_deliberation (×N tickers; cyclic round loop per ticker)
+        │                         │
+        ▼                         ▼
+  deep_dive_batch (cond.)   phase_h7_pm_allocation_memo
+                                  │
+                                  ▼
+                          phase7d_rebalance
+```
+
+Persistence lands in both `documents` (full payload) and the first-class
+tables introduced by migration 024: `theses`, `thesis_vehicles`,
+`deliberation_sessions`, `deliberation_rounds`, `analyst_coverage`,
+`deep_dive_triggers`.

--- a/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
+++ b/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
@@ -1,0 +1,346 @@
+# Hermes — Portfolio Deliberation Sub-graph
+
+> **Status:** architectural spec. Planning-only — no implementation yet.
+> **Implementing units:** Wave 2 (see [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md)).
+> **Predecessor:** Atlas research pipeline (phases 1–6, consolidated bias row). Hermes begins at `phase_h1_thesis_review`, which consumes `state.phase6_bias_row`.
+> **Refs:** parent plan [`docs/plans/atlas-full-migration-wave1.md`](../../../../docs/plans/atlas-full-migration-wave1.md); ADR-0009 (sub-graph orchestration); migration 024 first-class tables (unit W1-B).
+
+Hermes turns Atlas research into an allocation memo and rebalance decision. It replaces the single-call `phase7c_analyst` + `phase7d_pm` pair with a seven-phase flow: thesis review, vehicle mapping, opportunity screening, blinded per-ticker analysis, cyclic analyst↔PM deliberation, and the PM memo.
+
+---
+
+## 1. Topology
+
+### 1.1 ASCII diagram
+
+```
+  phase6_consolidate (Atlas; existing)
+            │
+            ▼
+  phase_h1_thesis_review ─────────► theses CRUD
+            │
+            ▼
+  phase_h2_market_thesis_exploration
+            │
+            ▼
+  phase_h3_thesis_vehicle_map ─────► thesis_vehicles (×N)
+            │
+            ▼
+  phase_h4_opportunity_screener
+            │
+     fan-out per ticker
+   ┌────────┴────────┐
+   ▼        …        ▼
+  phase_h5_asset_analyst (×N)       ← batchable (W3-C)
+   │                 │
+   └────── fan-in ───┘
+            │
+     fan-out per ticker
+   ┌────────┴────────┐
+   ▼        …        ▼
+  phase_h6_deliberation (×N)        ← internal round-loop per ticker
+   │                 │
+   │  ┌──── round loop (cyclic) ─────┐
+   │  │  PM challenge                │
+   │  │  analyst defend              │
+   │  │  converge? ─── yes ──► exit  │
+   │  │  recess? ─── emit RecessReq  │
+   │  └──────────────────────────────┘
+   │                 │
+   └────── fan-in ───┘
+            │
+            ▼
+  deep_dive_batch (deferred; conditional)
+            │
+            ▼
+  phase_h7_pm_allocation_memo
+            │
+            ▼
+  phase7d_rebalance (existing; input swapped in W2-G)
+```
+
+### 1.2 Mermaid
+
+```mermaid
+flowchart TD
+    P6[phase6_consolidate] --> H1[phase_h1_thesis_review]
+    H1 --> H2[phase_h2_market_thesis_exploration]
+    H2 --> H3[phase_h3_thesis_vehicle_map]
+    H3 --> H4[phase_h4_opportunity_screener]
+    H4 --> FAN1{fan-out per ticker}
+    FAN1 --> H5A[phase_h5_asset_analyst · AAPL]
+    FAN1 --> H5B[phase_h5_asset_analyst · TSLA]
+    FAN1 --> H5N[phase_h5_asset_analyst · …]
+    H5A --> JOIN1((join))
+    H5B --> JOIN1
+    H5N --> JOIN1
+    JOIN1 --> FAN2{fan-out per ticker}
+    FAN2 --> H6A[phase_h6_deliberation · AAPL]
+    FAN2 --> H6B[phase_h6_deliberation · TSLA]
+    FAN2 --> H6N[phase_h6_deliberation · …]
+    H6A --> JOIN2((join))
+    H6B --> JOIN2
+    H6N --> JOIN2
+    JOIN2 --> DD{any recess<br/>requests?}
+    DD -- yes --> DDB[deep_dive_batch]
+    DD -- no --> H7
+    DDB --> H7[phase_h7_pm_allocation_memo]
+    H7 --> P7D[phase7d_rebalance]
+
+    subgraph round_loop["phase_h6 round loop (per ticker)"]
+        R1[analyst present] --> R2[PM challenge]
+        R2 --> R3{converged?}
+        R3 -- yes --> R4[exit]
+        R3 -- no --> R5{recess?}
+        R5 -- no --> R1
+        R5 -- yes --> R6[emit RecessRequest]
+        R6 --> R4
+    end
+```
+
+### 1.3 Phase directory
+
+| Phase | Role | Skill(s) | Fan-out | Primary output |
+|-------|------|----------|---------|----------------|
+| `phase_h1_thesis_review` | Re-score active theses; mark CONFIRMED / CHALLENGED / CLOSED | [`thesis`](../../skills/thesis/SKILL.md), [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | 1 | `ThesisReviewOutput` |
+| `phase_h2_market_thesis_exploration` | Discover new theses from macro + sector research | [`market-thesis-exploration`](../../skills/market-thesis-exploration/SKILL.md) | 1 | `MarketThesisExploration` |
+| `phase_h3_thesis_vehicle_map` | Map each thesis to candidate tickers | [`thesis-vehicle-map`](../../skills/thesis-vehicle-map/SKILL.md) | 1 | `ThesisVehicleMap` |
+| `phase_h4_opportunity_screener` | Rank universe; pick analyst roster | [`opportunity-screener`](../../skills/opportunity-screener/SKILL.md) | 1 | `OpportunityScreen` |
+| `phase_h5_asset_analyst` | Per-ticker blinded analyst recommendation | [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | N tickers | `AssetRecommendation` per ticker |
+| `phase_h6_deliberation` | PM↔analyst cyclic deliberation per ticker | [`deliberation`](../../skills/deliberation/SKILL.md), [`portfolio-manager`](../../skills/portfolio-manager/SKILL.md), [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | N tickers (× rounds) | `DeliberationSession` per ticker |
+| `deep_dive_batch` | Resolve recess requests | [`deep-dive`](../../skills/deep-dive/SKILL.md) | M recesses | `DeepDiveNote` rows |
+| `phase_h7_pm_allocation_memo` | PM-authored allocation memo | [`pm-allocation-memo`](../../skills/pm-allocation-memo/SKILL.md) | 1 | `PMAllocationMemo` |
+
+---
+
+## 2. Round-loop design (phase_h6)
+
+### 2.1 Structure
+
+Each per-ticker deliberation node is itself a **cyclic LangGraph sub-graph** with three nodes and a conditional edge:
+
+```
+  enter
+    │
+    ▼
+  analyst_present ──► pm_challenge ──► converge_check
+                                          │
+                      ┌───────────────────┤
+                      │ converged=true    │ converged=false
+                      ▼                   ▼
+                   exit               recess_check
+                                          │
+                      ┌───────────────────┤
+                      │ recess=true       │ recess=false
+                      ▼                   ▼
+              emit RecessRequest    loop back to analyst_present
+                      │                   │
+                      └───► exit          └───► (next round)
+```
+
+- The **conditional edge** reads `meta.converged` (`True` → `exit`) and `meta.recess_triggered` (`True` → emit `RecessRequest` then `exit`; the ticker's loop pauses and resumes after `deep_dive_batch`).
+- Personas are loaded as **two separate skill files** so neither side sees the other's system prompt: `asset-analyst/SKILL.md` for the presenter, `portfolio-manager/SKILL.md` for the challenger. This keeps the PM adversarial instead of inheriting the analyst's framing.
+
+### 2.2 Safety cap
+
+- `MAX_ROUNDS = 6`, overrideable via env `ATLAS_DELIBERATION_MAX_ROUNDS` (int).
+- On cap hit: the node sets `meta.escalated = True`, records `meta.cap_reason = "max_rounds"`, forces `meta.converged = True` with the last analyst recommendation as the final stance, and emits a warning into `state.errors` (retryable=False) that Phase 9 evolution surfaces in the post-mortem.
+
+### 2.3 Recess semantics
+
+- When a round sets `recess_triggered = True` with `reason`, the node returns a `RecessRequest(ticker, reason, trigger_round_number)` marker and exits the loop for this ticker.
+- A pipeline-level collector appends each `RecessRequest` to `state.phase_hermes.recess_requests` via the list-append reducer.
+- After the fan-in barrier on `phase_h6`, a conditional router checks `len(state.phase_hermes.recess_requests) > 0`:
+  - **yes** → run `deep_dive_batch` (W3-C dispatches via Anthropic Batches; until then, synchronous fan-out via the existing `research_agent`).
+  - **no** → skip to `phase_h7`.
+- `deep_dive_batch` writes one `deep-dive` document per request and fills `deep_dive_document_key` on the corresponding `deliberation_rounds` row. A follow-up round is **not** auto-run in Wave 2; the next-day delta-triage picks up challenged tickers naturally. Re-entering the round loop in the same run is deferred to Wave 3.
+
+---
+
+## 3. State additions to `AtlasResearchState`
+
+A new nested block is added to [`state.py`](../../src/digiquant_atlas/state.py):
+
+```python
+class PhaseHermesState(BaseModel):
+    thesis_review: ThesisReviewOutput | None = None
+    market_thesis_exploration: MarketThesisExploration | None = None
+    thesis_vehicle_map: ThesisVehicleMap | None = None
+    opportunity_screen: OpportunityScreen | None = None
+    asset_recommendations: Annotated[dict[str, AssetRecommendation], _merge_analyst_dict] = Field(default_factory=dict)
+    deliberation_sessions: Annotated[dict[str, DeliberationSession], _merge_session_dict] = Field(default_factory=dict)
+    pm_allocation_memo: PMAllocationMemo | None = None
+    recess_requests: Annotated[list[RecessRequest], _append_list] = Field(default_factory=list)
+
+class AtlasResearchState(BaseModel):
+    ...
+    phase_hermes: PhaseHermesState = Field(default_factory=PhaseHermesState)
+```
+
+Two new reducers (same file):
+
+- `_merge_session_dict` — ticker-keyed session dict; right-wins on collision (same policy as `_merge_analyst_dict`).
+- `_append_list` — concatenates parallel list writes; order is commit-order from LangGraph (not semantically significant — consumers sort by `ticker`).
+
+`RecessRequest`, the Hermes sub-models, and `_merge_session_dict` / `_append_list` live alongside `SegmentSlot` in `state.py` so they share the same import boundary.
+
+---
+
+## 4. Pydantic output models
+
+One model per H-phase. Each is validated against the schema under [`templates/schemas/`](../../templates/schemas/). Every schema enforces the envelope `{schema_version, doc_type, date, meta, body}` — the Pydantic models mirror that split.
+
+### 4.1 `ThesisReviewOutput` (phase_h1)
+
+- **Schema:** `thesis-review.schema.json` *(to create in W2-B — the `thesis` skill has no dedicated schema today; the envelope matches the `thesis` doc_type already registered).*
+- **Fields (body):** `reviewed_theses: list[ThesisStatusUpdate]`, `new_candidate_theses: list[str]` (thesis_ids discovered mid-review), `notes: str`.
+- **`ThesisStatusUpdate`:** `thesis_id`, `prior_status`, `new_status ∈ {ACTIVE, CONFIRMED, CHALLENGED, CLOSED-WIN, CLOSED-LOSS, EXPIRED}`, `evidence: list[str]`, `challenged_by: list[str] | None`.
+- **Validation:** `thesis_id` must match an existing `theses` row (looked up in `prior_context.active_theses`) *or* appear in `new_candidate_theses`; closed theses require `evidence` length ≥ 1.
+
+### 4.2 `MarketThesisExploration` (phase_h2)
+
+- **Schema:** [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
+- **Fields (body):** `executive_digest_pointer: str`, `deeper_dives: list[str]`, `theses: list[ThesisProposal]`.
+- **`ThesisProposal`:** `thesis_id` (≤32), `title` (≤200), `direction`, `statement` (≤4000), `validation_criteria: list[str]` (required, ≥1), `invalidation_criteria: list[str]` (required, ≥1), optional `headwinds / tailwinds / bull_case / bear_case`.
+- **Validation:** `thesis_id` unique within the run; direction ∈ {`long`, `short`, `pair`, `hedge`, `avoid`}.
+
+### 4.3 `ThesisVehicleMap` (phase_h3)
+
+- **Schema:** [`thesis-vehicle-map.schema.json`](../../templates/schemas/thesis-vehicle-map.schema.json).
+- **Fields (body):** `mappings: list[ThesisVehicleMapping]`.
+- **`ThesisVehicleMapping`:** `thesis_id` (must reference h1+h2 theses), `candidate_tickers: list[str]` (min 1; each ≤12 chars, must be in `config.watchlist` or flagged as `extra-universe`), `rationale` (≤4000), `exclusion_reasons: list[str]`, `user_mandate_notes: list[str]`.
+- **Validation:** every `thesis_id` in the output must appear in `state.phase_hermes.thesis_review.reviewed_theses` with non-`CLOSED` status, or in `market_thesis_exploration.theses`.
+
+### 4.4 `OpportunityScreen` (phase_h4)
+
+- **Schema:** `opportunity-screen.schema.json` *(create in W2-D — the screener currently emits ad-hoc JSON).*
+- **Fields (body):** `roster: list[RosterPick]`, `excluded: list[ExcludedTicker]`, `notes: str`.
+- **`RosterPick`:** `ticker`, `rank: int` (1 = highest), `score: float` (0–1), `source_thesis_ids: list[str]`, `rationale: str` (≤800).
+- **Validation:** `roster` is non-empty when any non-CLOSED thesis exists; `rank` unique and dense (1..N); `source_thesis_ids` must reference thesis IDs present in h1 or h2.
+
+### 4.5 `AssetRecommendation` (phase_h5)
+
+- **Schema:** [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+- **Fields (body):** `context: PriceContext` (`price`, `day_pct`, `segment_bias`), `bull_case: list[str]`, `bear_case: list[str]`, `verdict: Verdict`, optional `catalysts`, `risk_flags`.
+- **`Verdict`:** `bias`, `thesis_status`, `recommended_weight_pct: float` (0–100), `rationale` (≤2000).
+- **Validation:** blinded — must **not** reference `current_weights` or `portfolio.json`; `recommended_weight_pct` ignored if `bias == "avoid"`. This model replaces `phase7c_analyst.AnalystPayload` (see §7).
+
+### 4.6 `DeliberationSession` (phase_h6)
+
+- **Schema (transcript):** [`deliberation-transcript.schema.json`](../../templates/schemas/deliberation-transcript.schema.json).
+- **Schema (session index):** [`deliberation-session-index.schema.json`](../../templates/schemas/deliberation-session-index.schema.json).
+- **Fields:**
+  - Transcript `body`: `trigger_summary: list[str]`, `rounds: list[DeliberationRound]`, `final_decisions: list[FinalDecision]`.
+  - `DeliberationRound`: `label`, `sections: list[{heading, markdown}]`, plus Hermes-added `converged: bool`, `recess_triggered: bool`, `deep_dive_document_key: str | None`, `round_number: int`.
+  - `FinalDecision`: `ticker`, `analyst_recommendation`, `pm_decision`, `invalidation_condition`.
+  - `meta`: `converged: bool`, `escalated: bool` (true when cap hit), `rounds_completed: int`.
+- **Validation:** `rounds_completed == len(rounds)`; exactly one round has `converged=True` unless `escalated=True`; `deep_dive_document_key` only set when the round emitted a `RecessRequest`.
+
+### 4.7 `PMAllocationMemo` (phase_h7)
+
+- **Schema:** [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json).
+- **Fields (body):** `narrative: str` (≤12000), `turnover_discipline: str` (≤4000), `target_weights_rationale: list[TargetWeightRationale]`, `open_questions: list[str]`.
+- **`TargetWeightRationale`:** `ticker`, `target_weight_pct` (0–100), `prior_weight_pct: float | None`, `rationale` (≤2000), `deliberation_document_key: str | None`.
+- **Validation:** sum of `target_weight_pct` ≤ 100 + cash tolerance (configurable, default 101); every non-null `deliberation_document_key` must resolve to a row in `deliberation_sessions`.
+
+### 4.8 Ancillary models (state-only, not documents)
+
+- `RecessRequest` — `ticker`, `reason`, `trigger_round_number: int`.
+- `ThesisStatusUpdate` — see §4.1.
+
+---
+
+## 5. Persistence mapping
+
+Each H-phase's Supabase adapter (to be added in W2-A) writes to both `documents` (full JSON payload, backward-compat) **and** the first-class tables from migration 024 (subset of structured fields for indexed query). Atlas's `supabase_io.py` gains one writer function per H-phase.
+
+| Phase | `documents` row | First-class table(s) |
+|-------|-----------------|----------------------|
+| `phase_h1_thesis_review` | `doc_type=thesis_review` (payload = full output) | `theses` — upsert one row per `ThesisStatusUpdate` (`(date, thesis_id)` key); update `status`, append to `evidence_log`. |
+| `phase_h2_market_thesis_exploration` | `doc_type=market_thesis_exploration` | `theses` — insert one row per new `ThesisProposal` with `status='ACTIVE'`. |
+| `phase_h3_thesis_vehicle_map` | `doc_type=thesis_vehicle_map` | `thesis_vehicles` — one row per `(thesis_id, ticker)` with `rationale`, `exclusion_reasons`, `candidate_rank` (derived from position in `candidate_tickers`), `user_mandate_notes`, `source_exploration_key` = the `documents.key` of the h2 output. |
+| `phase_h4_opportunity_screener` | `doc_type=opportunity_screen` | `analyst_coverage` — upsert `(date, ticker)` for each `RosterPick`; set `thesis_ids`, `analyst_role='roster'`. |
+| `phase_h5_asset_analyst` | `doc_type=asset_recommendation` (one per ticker) | `analyst_coverage` — update `current_recommendation_key` + `last_updated`. |
+| `phase_h6_deliberation` | `doc_type=deliberation_transcript` (one per ticker) **+** one `doc_type=deliberation_session_index` (run-level) | `deliberation_sessions` (one row per run) + `deliberation_rounds` (one per round per ticker) + `deep_dive_triggers` (one per `RecessRequest`). |
+| `deep_dive_batch` | `doc_type=deep_dive` (one per recess) | `deep_dive_triggers` — update `deep_dive_document_key` + `resolved_at`. |
+| `phase_h7_pm_allocation_memo` | `doc_type=pm_allocation_memo` | *(none — narrative-heavy; no first-class table. Table-queryable fields live in the phase7d `rebalance_decision` row.)* |
+
+Each row is also appended to `state.published: list[PublishedArtifact]` so Phase 9 evolution can audit write volume.
+
+---
+
+## 6. Delta-run behavior
+
+Triage ([`triage.py`](../../src/digiquant_atlas/triage.py)) is extended with Hermes-tier rules in W2-H:
+
+| Phase | Baseline (Sun) | Delta (Mon–Fri) | Monthly |
+|-------|----------------|-----------------|---------|
+| `phase_h1_thesis_review` | run | **run daily** — thesis drift is material | run |
+| `phase_h2_market_thesis_exploration` | run | skip unless `prior_context.latest_segments["macro"]` shows regime shift | run |
+| `phase_h3_thesis_vehicle_map` | run | skip unless h1 produced a `CHALLENGED` or `CLOSED` transition *or* h2 ran | run |
+| `phase_h4_opportunity_screener` | run | skip if h3 skipped and no ticker had bias flip | run |
+| `phase_h5_asset_analyst` (per-ticker) | all roster | only tickers on `analyst_coverage` whose segment bias flipped OR whose linked thesis is `CHALLENGED` | all roster |
+| `phase_h6_deliberation` (per-ticker) | all roster | only tickers whose `AssetRecommendation` changed versus the prior run *or* whose thesis is `CHALLENGED` | all roster |
+| `phase_h7_pm_allocation_memo` | run | run **only if** any `phase_h6` node actually ran (otherwise carry the prior memo) | run |
+
+**New triage rule kinds (added to `_rule_for_segment`):**
+
+- `hermes_thesis_drift` (for h2/h3) — evaluates whether h1 produced any status transitions.
+- `hermes_ticker_filter` (for h5/h6) — evaluates per-ticker instead of per-segment; the gate returns a `Carried` marker keyed by ticker. Requires extending the gate signature from `(state, segment) → Carried | None` to also accept `(state, ticker) → Carried | None`; W2-H tracks the split.
+- `hermes_memo_gate` (for h7) — regenerate iff `state.phase_hermes.deliberation_sessions` has any fresh (non-Carried) entry for this run.
+
+Carried entries still surface in the Phase 9 post-mortem so operators can see what didn't run.
+
+---
+
+## 7. Integration with existing phases
+
+### 7.1 `phase7c_analyst` (current) → `phase_h5_asset_analyst` (new)
+
+**Decision: replace.** The existing [`phase7c_analyst.py`](../../src/digiquant_atlas/phases/phase7c_analyst.py) emits a minimal `AnalystPayload` (`conviction_score`, `stance`, `thesis`, `risks`). `phase_h5` emits the richer `AssetRecommendation` governed by the existing [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json) — bull/bear cases, context block, verdict with `recommended_weight_pct`, thesis linkage.
+
+- **W2-E deletes** `phase7c_analyst.py` and `state.phase7c_analysts`.
+- Callers move to `state.phase_hermes.asset_recommendations`.
+- The `AnalystPayload` Pydantic class is removed; no backward-compat shim — callers are in-repo and migrate in the same PR.
+- A thin-wrapper option (keeping `phase7c_analyst` as a call through to `phase_h5`) was rejected: adds indirection with no consumer, and the state-field rename is a one-line change at the call sites.
+
+### 7.2 `phase7d_rebalance` (current) consumes `phase_h7_pm_allocation_memo`
+
+[`phase7d_pm.py`](../../src/digiquant_atlas/phases/phase7d_pm.py) currently reads `state.phase7c_analysts` directly and re-derives allocations. Under Hermes, phase_h7 writes the allocation memo and phase7d becomes a **pure transform**:
+
+- New input to `phase7d`: `state.phase_hermes.pm_allocation_memo`.
+- `phase7d` maps `PMAllocationMemo.target_weights_rationale` → `RebalanceDecision.recommended_portfolio` + derives `RebalanceAction` list by diffing against `config.preferences.current_weights`.
+- `phase7d` no longer invokes the LLM; it becomes deterministic. The node factory keeps the `PipelinePhase` shape so the graph assembly in `graph.py` doesn't change.
+- W2-G owns the code swap and the test updates.
+
+---
+
+## 8. Cost + quality guardrails
+
+- **Cache-control:** every H-phase passes `shared_context=_shared_context(state)` so the frozen `config`, `prior_context`, and `data_layer` blocks are `cache_control: ephemeral` on the first call. The deliberation round loop reuses the same shared context across rounds — per-round deltas are the only cache-miss surface.
+- **Per-phase LLM mode** (`DIGI_LLM_MODE`):
+  - h1, h2, h4 — `medium`
+  - h3 — `test` (structural mapping; small output)
+  - h5 — `medium`
+  - h6, h7 — `best` (deliberation quality + memo voice matter)
+  - `deep_dive_batch` — `medium`
+- **Max-rounds cap:** `ATLAS_DELIBERATION_MAX_ROUNDS = 6`. Escalation surfaces in Phase 9.
+- **Batching plan (Wave 3):** h5 per-ticker and h6 round batches become single Anthropic Batches submissions; `deep_dive_batch` likewise. The `NodeSpec(batch=True)` flag lands in W3-C — Hermes only needs to declare the intent in node metadata, which the pipeline builder picks up.
+- **Per-run cost telemetry:** Hermes phases emit token counts into `state.phase9_evolution.cost_by_phase[phase_name]`. Phase 9 post-mortem prints a cost trend line per phase so regressions show up against prior baselines.
+
+---
+
+## Appendix A — skill ↔ phase crosswalk
+
+| Skill slug | Used by |
+|------------|---------|
+| [`thesis`](../../skills/thesis/SKILL.md) | h1 (structure + status vocabulary) |
+| [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | h1 (fast re-score) |
+| [`thesis-vehicle-map`](../../skills/thesis-vehicle-map/SKILL.md) | h3 |
+| [`market-thesis-exploration`](../../skills/market-thesis-exploration/SKILL.md) | h2 |
+| [`opportunity-screener`](../../skills/opportunity-screener/SKILL.md) | h4 |
+| [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | h5, h6 (analyst persona) |
+| [`deliberation`](../../skills/deliberation/SKILL.md) | h6 (round protocol) |
+| [`portfolio-manager`](../../skills/portfolio-manager/SKILL.md) | h6 (PM persona), h7 |
+| [`pm-allocation-memo`](../../skills/pm-allocation-memo/SKILL.md) | h7 |
+| [`deep-dive`](../../skills/deep-dive/SKILL.md) | `deep_dive_batch` |

--- a/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
+++ b/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
@@ -102,7 +102,7 @@ flowchart TD
 
 | Phase | Role | Skill(s) | Fan-out | Primary output |
 |-------|------|----------|---------|----------------|
-| `phase_h1_thesis_review` | Re-score active theses; mark CONFIRMED / CHALLENGED / CLOSED | [`thesis`](../../skills/thesis/SKILL.md), [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | 1 | `ThesisReviewOutput` |
+| `phase_h1_thesis_review` | Re-score active theses; update status (`ACTIVE` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED`) per `chk_theses_status` | [`thesis`](../../skills/thesis/SKILL.md), [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | 1 | `ThesisReviewOutput` |
 | `phase_h2_market_thesis_exploration` | Discover new theses from macro + sector research | [`market-thesis-exploration`](../../skills/market-thesis-exploration/SKILL.md) | 1 | `MarketThesisExploration` |
 | `phase_h3_thesis_vehicle_map` | Map each thesis to candidate tickers | [`thesis-vehicle-map`](../../skills/thesis-vehicle-map/SKILL.md) | 1 | `ThesisVehicleMap` |
 | `phase_h4_opportunity_screener` | Rank universe; pick analyst roster | [`opportunity-screener`](../../skills/opportunity-screener/SKILL.md) | 1 | `OpportunityScreen` |
@@ -194,8 +194,9 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 
 - **Schema:** `thesis-review.schema.json` *(to create in W2-B — the `thesis` skill has no dedicated schema today; the envelope matches the `thesis` doc_type already registered).*
 - **Fields (body):** `reviewed_theses: list[ThesisStatusUpdate]`, `new_candidate_theses: list[str]` (thesis_ids discovered mid-review), `notes: str`.
-- **`ThesisStatusUpdate`:** `thesis_id`, `prior_status`, `new_status ∈ {ACTIVE, CONFIRMED, CHALLENGED, CLOSED-WIN, CLOSED-LOSS, EXPIRED}`, `evidence: list[str]`, `challenged_by: list[str] | None`.
-- **Validation:** `thesis_id` must match an existing `theses` row (looked up in `prior_context.active_theses`) *or* appear in `new_candidate_theses`; closed theses require `evidence` length ≥ 1.
+- **`ThesisStatusUpdate`:** `thesis_id`, `prior_status`, `new_status ∈ {ACTIVE, MONITORING, CHALLENGED, CLOSED, INVALIDATED, PAUSED, NEW}` (matches live `chk_theses_status`, migration 002 — do NOT introduce new status tokens without a migration), `evidence: list[str]`, `challenged_by: list[str] | None`, optional `resolution: Literal["win", "loss"] | None` (set when `new_status == "CLOSED"` to capture win/loss granularity in the document payload), optional `reason: str | None` (e.g. `"time_expired"` when transitioning to `INVALIDATED`).
+- **Status mapping from research vocabulary:** the skills can say "confirmed / expired / closed-win / closed-loss" in their prose; the Pydantic adapter MUST normalize those onto the seven allowed tokens before persistence. Canonical mapping: `CONFIRMED` → `ACTIVE` (plus an incremented per-document `evidence_count` in the payload — "confirmed" is implicit in a still-`ACTIVE` thesis with fresh evidence); `CLOSED-WIN` → `CLOSED` with `resolution="win"`; `CLOSED-LOSS` → `CLOSED` with `resolution="loss"`; `EXPIRED` → `INVALIDATED` with `reason="time_expired"`.
+- **Validation:** `thesis_id` must match an existing `theses` row (looked up in `prior_context.active_theses`) *or* appear in `new_candidate_theses`; `new_status == "CLOSED"` requires `evidence` length ≥ 1 AND `resolution ∈ {"win", "loss"}`; `new_status == "INVALIDATED"` requires `reason` non-empty.
 
 ### 4.2 `MarketThesisExploration` (phase_h2)
 
@@ -254,18 +255,47 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 
 Each H-phase's Supabase adapter (to be added in W2-A) writes to both `documents` (full JSON payload, backward-compat) **and** the first-class tables from migration 024 (subset of structured fields for indexed query). Atlas's `supabase_io.py` gains one writer function per H-phase.
 
-| Phase | `documents` row | First-class table(s) |
+> **doc_type vocabulary:** strings below are the **exact Title-Case tokens** enforced by `chk_documents_doc_type` (migration 023, live in prod). Do not change case or spacing — the CHECK constraint will reject the insert.
+>
+> **`'Thesis Review'` is NOT yet in the allowlist.** A stub migration **025** (see §5.1 below) must be written and applied in Wave 2 as part of W2-A before W2-B can persist `phase_h1_thesis_review` output. Until 025 ships, W2-B tests run against a FakeSupabase fixture that mirrors the proposed extended allowlist.
+
+| Phase | `documents` row (`doc_type`) | First-class table(s) |
 |-------|-----------------|----------------------|
-| `phase_h1_thesis_review` | `doc_type=thesis_review` (payload = full output) | `theses` — upsert one row per `ThesisStatusUpdate` (`(date, thesis_id)` key); update `status`, append to `evidence_log`. |
-| `phase_h2_market_thesis_exploration` | `doc_type=market_thesis_exploration` | `theses` — insert one row per new `ThesisProposal` with `status='ACTIVE'`. |
-| `phase_h3_thesis_vehicle_map` | `doc_type=thesis_vehicle_map` | `thesis_vehicles` — one row per `(thesis_id, ticker)` with `rationale`, `exclusion_reasons`, `candidate_rank` (derived from position in `candidate_tickers`), `user_mandate_notes`, `source_exploration_key` = the `documents.key` of the h2 output. |
-| `phase_h4_opportunity_screener` | `doc_type=opportunity_screen` | `analyst_coverage` — upsert `(date, ticker)` for each `RosterPick`; set `thesis_ids`, `analyst_role='roster'`. |
-| `phase_h5_asset_analyst` | `doc_type=asset_recommendation` (one per ticker) | `analyst_coverage` — update `current_recommendation_key` + `last_updated`. |
-| `phase_h6_deliberation` | `doc_type=deliberation_transcript` (one per ticker) **+** one `doc_type=deliberation_session_index` (run-level) | `deliberation_sessions` (one row per run) + `deliberation_rounds` (one per round per ticker) + `deep_dive_triggers` (one per `RecessRequest`). |
-| `deep_dive_batch` | `doc_type=deep_dive` (one per recess) | `deep_dive_triggers` — update `deep_dive_document_key` + `resolved_at`. |
-| `phase_h7_pm_allocation_memo` | `doc_type=pm_allocation_memo` | *(none — narrative-heavy; no first-class table. Table-queryable fields live in the phase7d `rebalance_decision` row.)* |
+| `phase_h1_thesis_review` | `'Thesis Review'` (payload = full output; requires migration 025 — see §5.1) | `theses` — upsert one row per `ThesisStatusUpdate` (`(date, thesis_id)` key); update **only canonical columns** present in migration 001: `status`, `invalidation`, `notes`, `vehicle`. Per-day evidence trail lives in the `'Thesis Review'` **document payload** (`body.reviewed_theses[].evidence[]`) — it is NOT duplicated into a relational column. There is no `evidence_log` column on `theses`, and we do not add one: the document is the right home for the narrative evidence list. |
+| `phase_h2_market_thesis_exploration` | `'Market Thesis Exploration'` | `theses` — insert one row per new `ThesisProposal` with `status='ACTIVE'`. |
+| `phase_h3_thesis_vehicle_map` | `'Thesis Vehicle Map'` | `thesis_vehicles` — one row per `(thesis_id, ticker)` with `rationale`, `exclusion_reasons`, `candidate_rank` (derived from position in `candidate_tickers`), `user_mandate_notes`, `source_exploration_key` = the `documents.key` of the h2 output. |
+| `phase_h4_opportunity_screener` | `'Opportunity Screen'` (requires migration 025 — see §5.1) | `analyst_coverage` — upsert `(date, ticker)` for each `RosterPick`; set `thesis_ids`, `analyst_role='roster'`. |
+| `phase_h5_asset_analyst` | `'Asset Recommendation'` (one per ticker) | `analyst_coverage` — update `current_recommendation_key` + `last_updated`. |
+| `phase_h6_deliberation` | `'Deliberation Transcript'` (one per ticker) **+** one `'Deliberation Session Index'` (run-level) | `deliberation_sessions` (one row per run) + `deliberation_rounds` (one per round per ticker) + `deep_dive_triggers` (one per `RecessRequest`). |
+| `deep_dive_batch` | `'Deep Dive'` (one per recess — **reuses** the existing allowlist entry; we do NOT mint a separate `'Deep Dive Batch'` doc_type, because each individual recess writes its own document) | `deep_dive_triggers` — update `deep_dive_document_key` + `resolved_at`. |
+| `phase_h7_pm_allocation_memo` | `'PM Allocation Memo'` | *(none — narrative-heavy; no first-class table. Table-queryable fields live in the phase7d `rebalance_decision` row.)* |
 
 Each row is also appended to `state.published: list[PublishedArtifact]` so Phase 9 evolution can audit write volume.
+
+### 5.1 Migration 025 — Hermes doc_type additions (stub, implemented in W2-A)
+
+Migration 023 is the current live state of `chk_documents_doc_type`. Two Hermes outputs are not yet covered:
+
+- `'Thesis Review'` — output of `phase_h1_thesis_review`.
+- `'Opportunity Screen'` — output of `phase_h4_opportunity_screener`.
+
+All other Hermes doc_types (`'Market Thesis Exploration'`, `'Thesis Vehicle Map'`, `'Asset Recommendation'`, `'Deliberation Transcript'`, `'Deliberation Session Index'`, `'PM Allocation Memo'`, `'Deep Dive'`) are already in the migration-023 allowlist — **no action required for them**.
+
+**W2-A deliverable (stub spec; W2-A authors the full SQL):**
+
+```sql
+-- apps/digiquant-atlas/supabase/migrations/025_hermes_doc_types.sql
+ALTER TABLE documents DROP CONSTRAINT IF EXISTS chk_documents_doc_type;
+ALTER TABLE documents ADD CONSTRAINT chk_documents_doc_type CHECK (
+  doc_type IS NULL OR doc_type IN (
+    -- … all tokens from migration 023 …
+    'Thesis Review',
+    'Opportunity Screen'
+  )
+);
+```
+
+W2-A applies 025 to dev before W2-B / W2-D can green their persistence tests. No other Hermes writer is blocked on 025.
 
 ---
 

--- a/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
+++ b/apps/digiquant-atlas/docs/agentic/HERMES_SUBGRAPH.md
@@ -1,9 +1,6 @@
 # Hermes — Portfolio Deliberation Sub-graph
 
-> **Status:** architectural spec. Planning-only — no implementation yet.
-> **Implementing units:** Wave 2 (see [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md)).
-> **Predecessor:** Atlas research pipeline (phases 1–6, consolidated bias row). Hermes begins at `phase_h1_thesis_review`, which consumes `state.phase6_bias_row`.
-> **Refs:** parent plan [`docs/plans/atlas-full-migration-wave1.md`](../../../../docs/plans/atlas-full-migration-wave1.md); ADR-0009 (sub-graph orchestration); migration 024 first-class tables (unit W1-B).
+> **Status:** architectural spec — Wave 2 implements (see [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md)). Predecessor: Atlas phases 1–6 consolidated bias row consumed at `phase_h1_thesis_review`. Refs: [`docs/plans/atlas-full-migration-wave1.md`](../../../../docs/plans/atlas-full-migration-wave1.md); ADR-0009; migration 024 (W1-B); migration 025 (§5.1, W2-A).
 
 Hermes turns Atlas research into an allocation memo and rebalance decision. It replaces the single-call `phase7c_analyst` + `phase7d_pm` pair with a seven-phase flow: thesis review, vehicle mapping, opportunity screening, blinded per-ticker analysis, cyclic analyst↔PM deliberation, and the PM memo.
 
@@ -28,6 +25,7 @@ Hermes turns Atlas research into an allocation memo and rebalance decision. It r
             ▼
   phase_h4_opportunity_screener
             │
+            ▼
      fan-out per ticker
    ┌────────┴────────┐
    ▼        …        ▼
@@ -50,9 +48,10 @@ Hermes turns Atlas research into an allocation memo and rebalance decision. It r
    └────── fan-in ───┘
             │
             ▼
-  deep_dive_batch (deferred; conditional)
-            │
-            ▼
+    any recess requests? ─── yes ──► deep_dive_batch (conditional)
+            │                              │
+            │ no                           │
+            ▼◄─────────────────────────────┘
   phase_h7_pm_allocation_memo
             │
             ▼
@@ -167,8 +166,8 @@ class PhaseHermesState(BaseModel):
     market_thesis_exploration: MarketThesisExploration | None = None
     thesis_vehicle_map: ThesisVehicleMap | None = None
     opportunity_screen: OpportunityScreen | None = None
-    asset_recommendations: Annotated[dict[str, AssetRecommendation], _merge_analyst_dict] = Field(default_factory=dict)
-    deliberation_sessions: Annotated[dict[str, DeliberationSession], _merge_session_dict] = Field(default_factory=dict)
+    asset_recommendations: Annotated[dict[str, AssetRecommendation], _merge_ticker_dict] = Field(default_factory=dict)
+    deliberation_sessions: Annotated[dict[str, DeliberationSession], _merge_ticker_dict] = Field(default_factory=dict)
     pm_allocation_memo: PMAllocationMemo | None = None
     recess_requests: Annotated[list[RecessRequest], _append_list] = Field(default_factory=list)
 
@@ -177,12 +176,12 @@ class AtlasResearchState(BaseModel):
     phase_hermes: PhaseHermesState = Field(default_factory=PhaseHermesState)
 ```
 
-Two new reducers (same file):
+Two reducer changes (same file):
 
-- `_merge_session_dict` — ticker-keyed session dict; right-wins on collision (same policy as `_merge_analyst_dict`).
-- `_append_list` — concatenates parallel list writes; order is commit-order from LangGraph (not semantically significant — consumers sort by `ticker`).
+- `_merge_analyst_dict` is **renamed** to `_merge_ticker_dict` in W2-E (see [WAVE2_UNIT_SPECS.md §W2-E](WAVE2_UNIT_SPECS.md#w2-e--phase_h5_asset_analyst-replaces-phase7c)) — one ticker-keyed, right-wins-on-collision reducer shared by `asset_recommendations` (h5) and `deliberation_sessions` (h6). No separate `_merge_session_dict`.
+- `_append_list` (new) — concatenates parallel list writes; order is commit-order from LangGraph (not semantically significant — consumers sort by `ticker`).
 
-`RecessRequest`, the Hermes sub-models, and `_merge_session_dict` / `_append_list` live alongside `SegmentSlot` in `state.py` so they share the same import boundary.
+`RecessRequest`, the Hermes sub-models, and `_merge_ticker_dict` / `_append_list` live alongside `SegmentSlot` in `state.py` so they share the same import boundary.
 
 ---
 
@@ -232,7 +231,7 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 - **Schema (session index):** [`deliberation-session-index.schema.json`](../../templates/schemas/deliberation-session-index.schema.json).
 - **Fields:**
   - Transcript `body`: `trigger_summary: list[str]`, `rounds: list[DeliberationRound]`, `final_decisions: list[FinalDecision]`.
-  - `DeliberationRound`: `label`, `sections: list[{heading, markdown}]`, plus Hermes-added `converged: bool`, `recess_triggered: bool`, `deep_dive_document_key: str | None`, `round_number: int`.
+  - `DeliberationRound`: `label`, `sections: list[{heading, markdown}]` — canonical heading values, in round order: `"analyst"` (analyst-present), `"pm_challenge"` (PM push-back), `"analyst_defense"` (analyst rebuttal), `"pm_decision"` (PM commit to converge/continue), optional `"recess_reason"` (populated only when `recess_triggered=True`). Writers MUST use these exact strings so downstream readers can index by heading without a regex. Plus Hermes-added `converged: bool`, `recess_triggered: bool`, `deep_dive_document_key: str | None`, `round_number: int`.
   - `FinalDecision`: `ticker`, `analyst_recommendation`, `pm_decision`, `invalidation_condition`.
   - `meta`: `converged: bool`, `escalated: bool` (true when cap hit), `rounds_completed: int`.
 - **Validation:** `rounds_completed == len(rounds)`; exactly one round has `converged=True` unless `escalated=True`; `deep_dive_document_key` only set when the round emitted a `RecessRequest`.
@@ -271,6 +270,12 @@ Each H-phase's Supabase adapter (to be added in W2-A) writes to both `documents`
 | `phase_h7_pm_allocation_memo` | `'PM Allocation Memo'` | *(none — narrative-heavy; no first-class table. Table-queryable fields live in the phase7d `rebalance_decision` row.)* |
 
 Each row is also appended to `state.published: list[PublishedArtifact]` so Phase 9 evolution can audit write volume.
+
+**Canonical literal values (for row writers):**
+
+- `deliberation_sessions.kind ∈ {'baseline', 'delta_scoped', 'monthly'}` — `baseline` on Sunday full runs, `delta_scoped` on Mon–Sat triaged runs, `monthly` on month-end synthesis.
+- `deep_dive_triggers.triggered_by = 'pm_recess'` for recess requests emitted by `phase_h6` — that is the only producer in Wave 2. (Other producers, e.g. operator-initiated, are deferred.)
+- `analyst_coverage.analyst_role = 'roster'` for the default screener-driven entries in `phase_h4`.
 
 ### 5.1 Migration 025 — Hermes doc_type additions (stub, implemented in W2-A)
 
@@ -354,23 +359,10 @@ Carried entries still surface in the Phase 9 post-mortem so operators can see wh
   - h5 — `medium`
   - h6, h7 — `best` (deliberation quality + memo voice matter)
   - `deep_dive_batch` — `medium`
-- **Max-rounds cap:** `ATLAS_DELIBERATION_MAX_ROUNDS = 6`. Escalation surfaces in Phase 9.
+- **Max-rounds cap:** see §2.2 (canonical). Escalation surfaces in Phase 9.
 - **Batching plan (Wave 3):** h5 per-ticker and h6 round batches become single Anthropic Batches submissions; `deep_dive_batch` likewise. The `NodeSpec(batch=True)` flag lands in W3-C — Hermes only needs to declare the intent in node metadata, which the pipeline builder picks up.
 - **Per-run cost telemetry:** Hermes phases emit token counts into `state.phase9_evolution.cost_by_phase[phase_name]`. Phase 9 post-mortem prints a cost trend line per phase so regressions show up against prior baselines.
 
 ---
 
-## Appendix A — skill ↔ phase crosswalk
-
-| Skill slug | Used by |
-|------------|---------|
-| [`thesis`](../../skills/thesis/SKILL.md) | h1 (structure + status vocabulary) |
-| [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | h1 (fast re-score) |
-| [`thesis-vehicle-map`](../../skills/thesis-vehicle-map/SKILL.md) | h3 |
-| [`market-thesis-exploration`](../../skills/market-thesis-exploration/SKILL.md) | h2 |
-| [`opportunity-screener`](../../skills/opportunity-screener/SKILL.md) | h4 |
-| [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | h5, h6 (analyst persona) |
-| [`deliberation`](../../skills/deliberation/SKILL.md) | h6 (round protocol) |
-| [`portfolio-manager`](../../skills/portfolio-manager/SKILL.md) | h6 (PM persona), h7 |
-| [`pm-allocation-memo`](../../skills/pm-allocation-memo/SKILL.md) | h7 |
-| [`deep-dive`](../../skills/deep-dive/SKILL.md) | `deep_dive_batch` |
+*(Skill ↔ phase crosswalk lives in the §1.3 phase directory "Skill(s)" column — no separate appendix.)*

--- a/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
+++ b/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
@@ -37,7 +37,8 @@ W2-H — parallel after W2-A
   - `write_deliberation_rounds(rows: list[DeliberationRoundRow]) -> list[PublishedArtifact]`
   - `upsert_analyst_coverage(rows: list[AnalystCoverageRow]) -> list[PublishedArtifact]`
   - `write_deep_dive_triggers(rows: list[DeepDiveTriggerRow]) -> list[PublishedArtifact]`
-  - `upsert_theses(rows: list[ThesisRow]) -> list[PublishedArtifact]` (may already exist; extend with `evidence_log` append semantics).
+  - `upsert_theses(rows: list[ThesisRow]) -> list[PublishedArtifact]` (may already exist). Writes **only** the canonical `theses` columns from migration 001: `date`, `thesis_id`, `name`, `vehicle`, `invalidation`, `status`, `notes`. There is **no** `evidence_log` column on `theses` — the per-day evidence trail lives in the `'Thesis Review'` document payload (`body.reviewed_theses[].evidence[]`), not in a relational column. Do NOT add an `evidence_log` column; if a future reader wants indexed evidence, propose it in a separate migration.
+- Create: `apps/digiquant-atlas/supabase/migrations/025_hermes_doc_types.sql` — extends `chk_documents_doc_type` to include `'Thesis Review'` and `'Opportunity Screen'` (see [HERMES_SUBGRAPH §5.1](HERMES_SUBGRAPH.md#51-migration-025--hermes-doc_type-additions-stub-implemented-in-w2-a)). Keep every existing token from migration 023 in the new CHECK. Apply to dev DB before W2-B / W2-D start.
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/supabase_rows.py` — typed dataclasses/Pydantic for the five row types above.
 - Modify: tests FakeSupabaseClient in `apps/digiquant-atlas/tests/conftest.py` — record writes per-table for assertion.
 
@@ -60,7 +61,7 @@ W2-H — parallel after W2-A
 **Files:**
 
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h1_thesis_review.py` — single-node phase; loads `thesis` + `thesis-tracker` skills; outputs `ThesisReviewOutput`.
-- Create: `apps/digiquant-atlas/templates/schemas/thesis-review.schema.json` — envelope `{schema_version, doc_type="thesis_review", date, meta, body}`; body per [HERMES_SUBGRAPH §4.1](HERMES_SUBGRAPH.md#41-thesisreviewoutput-phase_h1).
+- Create: `apps/digiquant-atlas/templates/schemas/thesis-review.schema.json` — envelope `{schema_version, doc_type="Thesis Review", date, meta, body}` (Title-Case token matching migration 025's extension to `chk_documents_doc_type`; see [HERMES_SUBGRAPH §5.1](HERMES_SUBGRAPH.md#51-migration-025--hermes-doc_type-additions-stub-implemented-in-w2-a)); body per [HERMES_SUBGRAPH §4.1](HERMES_SUBGRAPH.md#41-thesisreviewoutput-phase_h1). `body.reviewed_theses[].new_status` is constrained to the seven tokens allowed by `chk_theses_status` (`ACTIVE` / `MONITORING` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED` / `NEW`); `body.reviewed_theses[].resolution` (optional) is `"win" | "loss"`, required iff `new_status == "CLOSED"`. Persistence writes the status to the `theses` row and the evidence list to the document payload — there is no relational `evidence_log` field.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — add `PhaseHermesState` scaffold + `RecessRequest` + new reducers `_merge_session_dict`, `_append_list`. Add `phase_hermes: PhaseHermesState` field to `AtlasResearchState`.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire `phase_h1_thesis_review` after `phase6_consolidate`.
 
@@ -155,7 +156,7 @@ W2-H — parallel after W2-A
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/_deliberation_loop.py` — nested graph builder; isolated for unit-testing the loop independently.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h6 after h5.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — confirm `RecessRequest` + `_append_list` from W2-B are used.
-- Persistence: writes `documents` (`deliberation_transcript` per ticker + one `deliberation_session_index`) + `deliberation_sessions` (run-level) + `deliberation_rounds` (per round per ticker) + `deep_dive_triggers` (per `RecessRequest`). Adapters from W2-A.
+- Persistence: writes `documents` (`doc_type='Deliberation Transcript'` per ticker + one `doc_type='Deliberation Session Index'`; Title-Case tokens already in migration-023 allowlist) + `deliberation_sessions` (run-level; `kind` ∈ `{'baseline', 'delta_scoped', 'monthly'}`) + `deliberation_rounds` (per round per ticker) + `deep_dive_triggers` (per `RecessRequest`; `triggered_by='pm_recess'` — see W2-F phase_h6). Adapters from W2-A.
 - Env var reader: `ATLAS_DELIBERATION_MAX_ROUNDS` with default 6.
 
 **Tests:**

--- a/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
+++ b/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
@@ -12,14 +12,15 @@ Each unit below is ready to copy-paste into an agent prompt (set the branch, rea
 ## Parallelism map
 
 ```
-W2-A (adapters) ──► W2-B, W2-C, W2-D, W2-E, W2-F, W2-G, W2-H
-W2-E (h5) ─────────► W2-F (h6 reads AssetRecommendation)
-W2-F (h6) ─────────► W2-G (h7 reads DeliberationSession)
+W2-A (adapters + migration 025) ──► W2-B, W2-C, W2-D, W2-E, W2-F, W2-G, W2-H
+W2-B (state scaffold: PhaseHermesState, RecessRequest, _append_list) ──► W2-F
+W2-E (h5) ───────────────────────► W2-F (h6 reads AssetRecommendation)
+W2-F (h6) ───────────────────────► W2-G (h7 reads DeliberationSession)
 W2-B, W2-C, W2-D — parallel (read h1/h2/h3 only)
 W2-H — parallel after W2-A
 ```
 
-- **Strictly sequential:** W2-A → (everything else). W2-E → W2-F → W2-G.
+- **Strictly sequential:** W2-A → (everything else). W2-E → W2-F → W2-G. W2-B → W2-F (the state scaffold containing `PhaseHermesState`, `RecessRequest`, and `_append_list` is authored in W2-B; W2-F consumes it instead of re-declaring).
 - **Fully parallel after W2-A:** W2-B, W2-C, W2-D, W2-H.
 
 ---
@@ -65,10 +66,29 @@ W2-H — parallel after W2-A
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — add `PhaseHermesState` scaffold + `RecessRequest` + new reducers `_merge_session_dict`, `_append_list`. Add `phase_hermes: PhaseHermesState` field to `AtlasResearchState`.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire `phase_h1_thesis_review` after `phase6_consolidate`.
 
+**Inline Pydantic contract (authoritative for W2-B):**
+
+```python
+class ThesisStatusUpdate(BaseModel):
+    thesis_id: str
+    prior_status: Literal["ACTIVE", "MONITORING", "CHALLENGED", "CLOSED", "INVALIDATED", "PAUSED", "NEW"] | None
+    new_status:   Literal["ACTIVE", "MONITORING", "CHALLENGED", "CLOSED", "INVALIDATED", "PAUSED", "NEW"]
+    evidence: list[str]
+    challenged_by: list[str] | None = None
+    resolution: Literal["win", "loss"] | None = None   # required iff new_status=="CLOSED"
+    reason: str | None = None                           # required iff new_status=="INVALIDATED"
+
+class ThesisReviewOutput(BaseModel):
+    reviewed_theses: list[ThesisStatusUpdate]
+    new_candidate_theses: list[str] = Field(default_factory=list)
+    notes: str = ""
+```
+
 **Tests:**
 
 - `tests/phases/test_phase_h1_thesis_review.py` — skill-load + node-run with a stub `run_research_agent` returning a `ThesisReviewOutput`; asserts `state.phase_hermes.thesis_review` is set and `upsert_theses` writer is called.
 - State round-trip test for `PhaseHermesState`.
+- Validation test: `new_status="CLOSED"` without `resolution` raises; `new_status="INVALIDATED"` without `reason` raises.
 
 **Acceptance:** phase runs standalone; `theses` table upsert invoked with correct status transitions; schema validates a golden fixture.
 
@@ -86,6 +106,27 @@ W2-H — parallel after W2-A
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h2_market_thesis_exploration.py`.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire after h1.
 - Pydantic model `MarketThesisExploration` in the phase module, validated against existing [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
+
+**Inline Pydantic contract:**
+
+```python
+class ThesisProposal(BaseModel):
+    thesis_id: constr(max_length=32)
+    title: constr(max_length=200)
+    direction: Literal["long", "short", "pair", "hedge", "avoid"]
+    statement: constr(max_length=4000)
+    validation_criteria: list[str] = Field(min_length=1)
+    invalidation_criteria: list[str] = Field(min_length=1)
+    headwinds: list[str] = Field(default_factory=list)
+    tailwinds: list[str] = Field(default_factory=list)
+    bull_case: str | None = None
+    bear_case: str | None = None
+
+class MarketThesisExploration(BaseModel):
+    executive_digest_pointer: str
+    deeper_dives: list[str] = Field(default_factory=list)
+    theses: list[ThesisProposal]
+```
 
 **Tests:**
 
@@ -106,8 +147,34 @@ W2-H — parallel after W2-A
 
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h3_thesis_vehicle_map.py`.
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h4_opportunity_screener.py`.
-- Create: `apps/digiquant-atlas/templates/schemas/opportunity-screen.schema.json`.
+- Create: `apps/digiquant-atlas/templates/schemas/opportunity-screen.schema.json` — envelope `{schema_version, doc_type="Opportunity Screen", date, meta, body}` (Title-Case token; added to `chk_documents_doc_type` by migration 025).
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h3→h4.
+
+**Inline Pydantic contracts:**
+
+```python
+class ThesisVehicleMapping(BaseModel):
+    thesis_id: str
+    candidate_tickers: list[constr(max_length=12)] = Field(min_length=1)
+    rationale: constr(max_length=4000)
+    exclusion_reasons: list[str] = Field(default_factory=list)
+    user_mandate_notes: list[str] = Field(default_factory=list)
+
+class ThesisVehicleMap(BaseModel):
+    mappings: list[ThesisVehicleMapping]
+
+class RosterPick(BaseModel):
+    ticker: str
+    rank: int  # 1 = highest; unique + dense across roster
+    score: float = Field(ge=0, le=1)
+    source_thesis_ids: list[str] = Field(min_length=1)
+    rationale: constr(max_length=800)
+
+class OpportunityScreen(BaseModel):
+    roster: list[RosterPick]
+    excluded: list[dict] = Field(default_factory=list)  # ExcludedTicker — ticker + reason
+    notes: str = ""
+```
 
 **Tests:**
 
@@ -129,8 +196,32 @@ W2-H — parallel after W2-A
 **Files:**
 
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+
+**Inline Pydantic contract:**
+
+```python
+class PriceContext(BaseModel):
+    price: float
+    day_pct: float
+    segment_bias: str
+
+class Verdict(BaseModel):
+    bias: Literal["overweight", "neutral", "underweight", "avoid"]
+    thesis_status: str  # same 7-token vocabulary as chk_theses_status
+    recommended_weight_pct: float = Field(ge=0, le=100)  # ignored iff bias=="avoid"
+    rationale: constr(max_length=2000)
+
+class AssetRecommendation(BaseModel):
+    context: PriceContext
+    bull_case: list[str]
+    bear_case: list[str]
+    verdict: Verdict
+    catalysts: list[str] = Field(default_factory=list)
+    risk_flags: list[str] = Field(default_factory=list)
+    # Blinded rule: MUST NOT read config/portfolio.json current_weights.
+```
 - **Delete:** `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7c_analyst.py`.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — remove `phase7c_analysts` field and `AnalystPayload`; remove `_merge_analyst_dict` if no other caller (keep if h5 + h6 reuse it — rename to `_merge_ticker_dict` for clarity).
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — remove `phase7c_analysts` field and `AnalystPayload`. **Decision (pre-made — do not re-litigate):** `_merge_analyst_dict` is kept AND renamed to `_merge_ticker_dict`; both h5 (`asset_recommendations`) and h6 (`deliberation_sessions`) reuse it — there is only one ticker-keyed merge policy in Hermes so the neutral name is clearer. Update [`HERMES_SUBGRAPH §3`](HERMES_SUBGRAPH.md#3-state-additions-to-atlasresearchstate) to reference `_merge_ticker_dict` in the same PR (replace the two `_merge_analyst_dict` / `_merge_session_dict` annotations with one shared reducer).
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — swap `build_phase7c` call for `build_phase_h5`.
 - Modify: any tests referencing `phase7c_analysts` or `AnalystPayload`.
 
@@ -157,7 +248,38 @@ W2-H — parallel after W2-A
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h6 after h5.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — confirm `RecessRequest` + `_append_list` from W2-B are used.
 - Persistence: writes `documents` (`doc_type='Deliberation Transcript'` per ticker + one `doc_type='Deliberation Session Index'`; Title-Case tokens already in migration-023 allowlist) + `deliberation_sessions` (run-level; `kind` ∈ `{'baseline', 'delta_scoped', 'monthly'}`) + `deliberation_rounds` (per round per ticker) + `deep_dive_triggers` (per `RecessRequest`; `triggered_by='pm_recess'` — see W2-F phase_h6). Adapters from W2-A.
-- Env var reader: `ATLAS_DELIBERATION_MAX_ROUNDS` with default 6.
+- Env var reader: `ATLAS_DELIBERATION_MAX_ROUNDS` with default 6 (canonical definition: [HERMES_SUBGRAPH §2.2](HERMES_SUBGRAPH.md#22-safety-cap)).
+
+**Inline Pydantic contracts:**
+
+```python
+class RecessRequest(BaseModel):       # state-only marker
+    ticker: str
+    reason: str
+    trigger_round_number: int
+
+class DeliberationRound(BaseModel):
+    label: str
+    round_number: int
+    sections: list[dict]  # each {"heading": one of {"analyst","pm_challenge","analyst_defense","pm_decision","recess_reason"}, "markdown": str}
+    converged: bool
+    recess_triggered: bool
+    deep_dive_document_key: str | None = None
+
+class FinalDecision(BaseModel):
+    ticker: str
+    analyst_recommendation: str
+    pm_decision: str
+    invalidation_condition: str
+
+class DeliberationSession(BaseModel):
+    trigger_summary: list[str]
+    rounds: list[DeliberationRound]
+    final_decisions: list[FinalDecision]
+    converged: bool
+    escalated: bool = False           # True iff cap hit
+    rounds_completed: int             # == len(rounds)
+```
 
 **Tests:**
 
@@ -180,6 +302,24 @@ W2-H — parallel after W2-A
 **Files:**
 
 - Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
+
+**Inline Pydantic contract:**
+
+```python
+class TargetWeightRationale(BaseModel):
+    ticker: str
+    target_weight_pct: float = Field(ge=0, le=100)
+    prior_weight_pct: float | None = None
+    rationale: constr(max_length=2000)
+    deliberation_document_key: str | None = None  # must resolve to a deliberation_sessions row when non-null
+
+class PMAllocationMemo(BaseModel):
+    narrative: constr(max_length=12000)
+    turnover_discipline: constr(max_length=4000)
+    target_weights_rationale: list[TargetWeightRationale]
+    open_questions: list[str] = Field(default_factory=list)
+    # Validation: sum(target_weight_pct) <= 100 + cash tolerance (default 101).
+```
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py` — replace LLM call with deterministic transform that reads `state.phase_hermes.pm_allocation_memo` and current weights, emits `RebalanceDecision`. Remove skill loading.
 - Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h7 after h6 (or after `deep_dive_batch` when present); phase7d consumes h7.
 

--- a/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
+++ b/apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md
@@ -1,0 +1,231 @@
+# Wave 2 Unit Specs — Hermes implementation
+
+> **Parent spec:** [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md).
+> **Parent plan:** [`docs/plans/atlas-full-migration-wave1.md`](../../../../docs/plans/atlas-full-migration-wave1.md) §"Wave 2 preview".
+> **Prereqs:** Wave 1 units W1-A-PLAN (this spec), W1-B (migration 024). W1-D and W1-E are independent.
+> **Branch convention:** each unit branches `module/digiquant-atlas` → `task/w2X-<slug>`; PR back into `module/digiquant-atlas`.
+
+Each unit below is ready to copy-paste into an agent prompt (set the branch, read the two parent docs, execute).
+
+---
+
+## Parallelism map
+
+```
+W2-A (adapters) ──► W2-B, W2-C, W2-D, W2-E, W2-F, W2-G, W2-H
+W2-E (h5) ─────────► W2-F (h6 reads AssetRecommendation)
+W2-F (h6) ─────────► W2-G (h7 reads DeliberationSession)
+W2-B, W2-C, W2-D — parallel (read h1/h2/h3 only)
+W2-H — parallel after W2-A
+```
+
+- **Strictly sequential:** W2-A → (everything else). W2-E → W2-F → W2-G.
+- **Fully parallel after W2-A:** W2-B, W2-C, W2-D, W2-H.
+
+---
+
+## W2-A — Supabase adapters for migration 024
+
+**Branch:** `task/w2a-adapters-024`
+**Complexity:** M — blocking, run first.
+
+**Files (create/modify):**
+
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py` — add writer functions:
+  - `write_thesis_vehicles(rows: list[ThesisVehicleRow]) -> list[PublishedArtifact]`
+  - `write_deliberation_session(row: DeliberationSessionRow) -> PublishedArtifact`
+  - `write_deliberation_rounds(rows: list[DeliberationRoundRow]) -> list[PublishedArtifact]`
+  - `upsert_analyst_coverage(rows: list[AnalystCoverageRow]) -> list[PublishedArtifact]`
+  - `write_deep_dive_triggers(rows: list[DeepDiveTriggerRow]) -> list[PublishedArtifact]`
+  - `upsert_theses(rows: list[ThesisRow]) -> list[PublishedArtifact]` (may already exist; extend with `evidence_log` append semantics).
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/supabase_rows.py` — typed dataclasses/Pydantic for the five row types above.
+- Modify: tests FakeSupabaseClient in `apps/digiquant-atlas/tests/conftest.py` — record writes per-table for assertion.
+
+**Tests:**
+
+- `tests/test_supabase_io_024.py` — one happy-path test per writer (insert, assert FakeSupabase recorded the row).
+- `tests/test_supabase_io_idempotency.py` — re-running with the same `(session_id, ticker, round_number)` updates in place (deliberation_rounds unique constraint).
+
+**Acceptance:** all writers callable against FakeSupabase; rows land under the expected table name; `PublishedArtifact` records returned with table + row_id + key.
+
+**Depends on:** W1-B (migration 024 applied in dev DB).
+
+---
+
+## W2-B — phase_h1_thesis_review + theses CRUD
+
+**Branch:** `task/w2b-phase-h1-thesis-review`
+**Complexity:** M.
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h1_thesis_review.py` — single-node phase; loads `thesis` + `thesis-tracker` skills; outputs `ThesisReviewOutput`.
+- Create: `apps/digiquant-atlas/templates/schemas/thesis-review.schema.json` — envelope `{schema_version, doc_type="thesis_review", date, meta, body}`; body per [HERMES_SUBGRAPH §4.1](HERMES_SUBGRAPH.md#41-thesisreviewoutput-phase_h1).
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — add `PhaseHermesState` scaffold + `RecessRequest` + new reducers `_merge_session_dict`, `_append_list`. Add `phase_hermes: PhaseHermesState` field to `AtlasResearchState`.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire `phase_h1_thesis_review` after `phase6_consolidate`.
+
+**Tests:**
+
+- `tests/phases/test_phase_h1_thesis_review.py` — skill-load + node-run with a stub `run_research_agent` returning a `ThesisReviewOutput`; asserts `state.phase_hermes.thesis_review` is set and `upsert_theses` writer is called.
+- State round-trip test for `PhaseHermesState`.
+
+**Acceptance:** phase runs standalone; `theses` table upsert invoked with correct status transitions; schema validates a golden fixture.
+
+**Depends on:** W2-A.
+
+---
+
+## W2-C — phase_h2_market_thesis_exploration
+
+**Branch:** `task/w2c-phase-h2-market-thesis`
+**Complexity:** S.
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h2_market_thesis_exploration.py`.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire after h1.
+- Pydantic model `MarketThesisExploration` in the phase module, validated against existing [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
+
+**Tests:**
+
+- `tests/phases/test_phase_h2_market_thesis.py` — stub `run_research_agent`; assert new thesis rows are inserted into `theses` via W2-A.
+
+**Acceptance:** new `ThesisProposal`s create `theses` rows with `status='ACTIVE'`; `thesis_id` uniqueness enforced within the run.
+
+**Depends on:** W2-A. Parallel with W2-B and W2-D.
+
+---
+
+## W2-D — phase_h3_thesis_vehicle_map + phase_h4_opportunity_screener
+
+**Branch:** `task/w2d-phase-h3-h4-vehicle-screener`
+**Complexity:** M — two phases but tightly coupled (h4 reads h3).
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h3_thesis_vehicle_map.py`.
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h4_opportunity_screener.py`.
+- Create: `apps/digiquant-atlas/templates/schemas/opportunity-screen.schema.json`.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h3→h4.
+
+**Tests:**
+
+- `tests/phases/test_phase_h3_vehicle_map.py` — asserts `thesis_vehicles` writer called with `candidate_rank` derived from list position.
+- `tests/phases/test_phase_h4_opportunity_screener.py` — asserts `analyst_coverage` upsert called for each `RosterPick`.
+- Cross-phase: `roster` members must all have a `thesis_vehicles` row covering them.
+
+**Acceptance:** h3 produces mappings; h4 produces non-empty roster when any thesis is ACTIVE/CHALLENGED.
+
+**Depends on:** W2-A. Parallel with W2-B, W2-C.
+
+---
+
+## W2-E — phase_h5_asset_analyst (replaces phase7c)
+
+**Branch:** `task/w2e-phase-h5-asset-analyst`
+**Complexity:** M — includes deletion of old phase7c.
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+- **Delete:** `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7c_analyst.py`.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — remove `phase7c_analysts` field and `AnalystPayload`; remove `_merge_analyst_dict` if no other caller (keep if h5 + h6 reuse it — rename to `_merge_ticker_dict` for clarity).
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — swap `build_phase7c` call for `build_phase_h5`.
+- Modify: any tests referencing `phase7c_analysts` or `AnalystPayload`.
+
+**Tests:**
+
+- `tests/phases/test_phase_h5_asset_analyst.py` — parallel fan-out produces one `AssetRecommendation` per roster ticker; blinded-rule assertion (no `current_weights` key leaks into `phase_inputs`).
+- `tests/test_migration_phase7c_removed.py` — imports fail fast (regression guard).
+
+**Acceptance:** no references to `phase7c_analysts` remain in repo; `state.phase_hermes.asset_recommendations` populated; `analyst_coverage` gets `current_recommendation_key` update.
+
+**Depends on:** W2-A. **Blocks:** W2-F.
+
+---
+
+## W2-F — phase_h6_deliberation (cyclic round loop)
+
+**Branch:** `task/w2f-phase-h6-deliberation`
+**Complexity:** L — the centerpiece.
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h6_deliberation.py` — per-ticker fan-out; each ticker node is a nested `StateGraph` (analyst_present → pm_challenge → converge_check → loop/exit) compiled once at phase-build time.
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/_deliberation_loop.py` — nested graph builder; isolated for unit-testing the loop independently.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h6 after h5.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — confirm `RecessRequest` + `_append_list` from W2-B are used.
+- Persistence: writes `documents` (`deliberation_transcript` per ticker + one `deliberation_session_index`) + `deliberation_sessions` (run-level) + `deliberation_rounds` (per round per ticker) + `deep_dive_triggers` (per `RecessRequest`). Adapters from W2-A.
+- Env var reader: `ATLAS_DELIBERATION_MAX_ROUNDS` with default 6.
+
+**Tests:**
+
+- `tests/phases/test_phase_h6_round_loop.py` — stubbed LLM returns `converged=True` at round 1; assert single round recorded.
+- `tests/phases/test_phase_h6_escalation.py` — stub returns `converged=False` every round; assert cap hit at 6, `meta.escalated=True`, warning in `state.errors`.
+- `tests/phases/test_phase_h6_recess.py` — stub emits `recess_triggered=True` at round 2; assert `RecessRequest` appended to `state.phase_hermes.recess_requests`, `deep_dive_triggers` row written.
+- `tests/phases/test_phase_h6_fanout.py` — 3 tickers run in parallel, results merged under correct ticker keys.
+
+**Acceptance:** converged, escalated, and recess paths all write consistent `deliberation_sessions`/`deliberation_rounds`; `deep_dive_triggers` audit log populated.
+
+**Depends on:** W2-A, W2-E. **Blocks:** W2-G.
+
+---
+
+## W2-G — phase_h7_pm_allocation_memo + phase7d integration
+
+**Branch:** `task/w2g-phase-h7-pm-memo`
+**Complexity:** M.
+
+**Files:**
+
+- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py` — replace LLM call with deterministic transform that reads `state.phase_hermes.pm_allocation_memo` and current weights, emits `RebalanceDecision`. Remove skill loading.
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h7 after h6 (or after `deep_dive_batch` when present); phase7d consumes h7.
+
+**Tests:**
+
+- `tests/phases/test_phase_h7_pm_memo.py` — asserts memo references at least one `deliberation_document_key`; sum of `target_weight_pct` within tolerance.
+- `tests/phases/test_phase7d_transform.py` — given fixture `PMAllocationMemo` + current weights, asserts `RebalanceDecision.actions` list is correctly diffed (hold/add/trim/exit/new).
+- `tests/test_phase7d_no_llm.py` — regression guard: `run_research_agent` not called during phase7d.
+
+**Acceptance:** phase7d produces the same `RebalanceDecision` shape as before, no schema break for downstream consumers; phase_h7 gated off when no deliberation ran.
+
+**Depends on:** W2-A, W2-F.
+
+---
+
+## W2-H — delta-triage extensions for Hermes tier
+
+**Branch:** `task/w2h-triage-hermes`
+**Complexity:** S.
+
+**Files:**
+
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/triage.py` — add rule kinds `hermes_thesis_drift`, `hermes_ticker_filter`, `hermes_memo_gate`. Extend gate signature to support ticker-keyed Carried markers; document the split (per-segment vs per-ticker).
+- Modify: `apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py` — accept per-ticker triage gate for h5/h6 builders.
+- Add Hermes phases to the canonical rule table in `_default_rules()` per HERMES_SUBGRAPH §6.
+
+**Tests:**
+
+- `tests/test_triage_hermes.py` — delta run where h1 produces no status transitions → h2/h3 carry; h1 with a CHALLENGED transition → h2/h3 regenerate.
+- `tests/test_triage_ticker_filter.py` — per-ticker gate carries tickers without bias flip and regenerates those with.
+- `tests/test_triage_memo_gate.py` — h7 carries the prior memo when no h6 session ran.
+
+**Acceptance:** on a delta day with quiet theses, token spend drops to h1 + (if triggered) h5/h6 for a single ticker; baseline day still regenerates all phases.
+
+**Depends on:** W2-A (for row reads in evaluators). Parallel with W2-B/C/D/E/F/G once W2-A lands.
+
+---
+
+## Copy-paste checklist (per Wave 2 unit prompt)
+
+Every Wave 2 unit prompt should include:
+
+1. Read [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) and your unit's section in this file.
+2. Read the skill file(s) your phase loads.
+3. Follow the `task/<slug>` branch convention; PR target is `module/digiquant-atlas`.
+4. Tests pass: `pytest apps/digiquant-atlas/tests -m unit -v`.
+5. `make doc-check` passes (no link regressions).
+6. `make score` passes the 4-dim gate.
+7. Commit message: `feat(atlas): <unit title>` + `Refs #178`.
+8. End with `PR: <url>` on its own line.

--- a/apps/digiquant-atlas/supabase/SCHEMA.md
+++ b/apps/digiquant-atlas/supabase/SCHEMA.md
@@ -1,0 +1,104 @@
+# Atlas Supabase Schema
+
+Live Atlas Supabase schema. Source of truth: the numbered migrations under
+`apps/digiquant-atlas/supabase/migrations/`. This document inventories the
+17 live tables (12 pre-024 + 5 new in migration 024) and diagrams the
+high-value relationships.
+
+> ADRs: [ADR-0008 research schema](../../../docs/adr/0008-atlas-research-schema.md),
+> [ADR-0009 Supabase persistence](../../../docs/adr/0009-atlas-supabase-persistence.md),
+> [ADR-0010 first-class thesis + deliberation](../../../docs/adr/0010-atlas-first-class-thesis-deliberation.md).
+
+## ERD (primary relationships)
+
+```mermaid
+erDiagram
+    daily_snapshots  ||--o{ positions             : "date"
+    daily_snapshots  ||--o{ theses                : "date"
+    daily_snapshots  ||--o{ position_events       : "date"
+    daily_snapshots  ||--o{ documents             : "date"
+    daily_snapshots  ||--o{ portfolio_metrics     : "date"
+
+    theses           ||--o{ thesis_vehicles       : "(date, thesis_id)"
+    theses           ||--o{ positions             : "thesis_id"
+
+    documents        ||..o{ thesis_vehicles       : "source_exploration_key"
+    documents        ||..o{ deliberation_rounds   : "deep_dive_document_key"
+    documents        ||..o{ analyst_coverage      : "current_recommendation_key"
+    documents        ||..o{ deep_dive_triggers    : "deep_dive_document_key"
+
+    deliberation_sessions ||--o{ deliberation_rounds : "session_id"
+    deliberation_sessions ||--o{ deep_dive_triggers  : "session_id"
+
+    price_history        ||--o{ price_technicals : "(date, ticker)"
+    price_history_tickers ||..|| price_history   : "view"
+
+    nav_history          ||..|| benchmark_history : "date"
+    macro_series_observations ||..|| daily_snapshots : "obs_date"
+```
+
+> Solid lines are FKs; dashed lines are logical pointers (documents.document_key
+> strings — not enforced by FK because `documents` is partitioned and the
+> pointer target may be in any partition).
+
+## Per-table inventory
+
+### Portfolio core (migration 001, partitioned since 011)
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `daily_snapshots` | `(date)` | One consolidated JSON snapshot per calendar day. Root of the daily pipeline. |
+| `positions` | `(date, ticker)` | Daily position book; one row per held ticker. |
+| `theses` | `(date, thesis_id)` | Active investment theses per day; referenced by `positions` and now by `thesis_vehicles`. |
+| `position_events` | `(id BIGSERIAL)` | Every open / close / rebalance against a position with reason tag. |
+| `documents` | `(date, document_key)` | JSONB payload store for every narrative / structured artifact. Doc-type CHECK set by migration 023. |
+| `nav_history` | `(date)` | Daily portfolio NAV. |
+| `benchmark_history` | `(date, benchmark)` | Benchmark close series (SPY / QQQ / IWM etc). |
+| `portfolio_metrics` | `(date, metric)` | Pre-computed Sharpe, vol, drawdown, exposure metrics. |
+
+### Market data (migrations 005 / 007 / 015 / 018)
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `price_history` | `(date, ticker)` | OHLCV history for all watchlist tickers. |
+| `price_technicals` | `(date, ticker)` | 35+ pre-computed TA indicators per (date, ticker). |
+| `macro_series_observations` | `(source, series_id, obs_date)` | FRED / Frankfurter / crypto FNG time series. |
+| `price_history_tickers` | _(view)_ | Distinct tickers currently in `price_history`. |
+
+### Hermes deliberation — new in migration 024
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `thesis_vehicles` | `(date, thesis_id, ticker)` | Per-thesis vehicle map; FK → `theses (date, thesis_id)`. |
+| `deliberation_sessions` | `(session_id UUID)` | One row per Hermes deliberation session; kind ∈ {baseline, delta_scoped, monthly}. |
+| `deliberation_rounds` | `(id BIGSERIAL)` | Round-loop persistence; unique on `(session_id, ticker, round_number)`. |
+| `analyst_coverage` | `(date, ticker)` | Daily denormalized analyst ↔ ticker index. |
+| `deep_dive_triggers` | `(id BIGSERIAL)` | Audit trail of every recess- or delta-watch- or manually- forced deep-dive. |
+
+## RLS (consistent across all tables above)
+
+- Every table has `ENABLE ROW LEVEL SECURITY`.
+- Reads: per-table `{table}_anon_select` (or legacy `anon_read` on the
+  001-era tables) policy granting `SELECT TO anon USING (true)`.
+- Writes: require the Supabase `service_role` key. Supabase grants
+  service_role bypass at the GRANT layer, so there is no explicit
+  `service_role` policy on any Atlas table.
+
+## Dead / deprecated
+
+- `sec_recent_filings` — dropped in migration 017.
+- `'Portfolio Recommendation'` doc_type — removed by migration 021.
+- Partitioned children (`daily_snapshots_y2025`, `documents_y2026`, …) are
+  implementation details of the partition strategy and are not inventoried
+  here. See migration 004 and 006.
+
+## How to extend
+
+1. Create a new migration under `supabase/migrations/NNN_description.sql`.
+2. Follow the RLS pattern above.
+3. If the new table holds a structured projection of a `documents` payload,
+   add a reference to it in this file under the "Hermes deliberation"
+   section pattern and cite the source ADR.
+4. Add a test under `apps/digiquant-atlas/tests/test_migration_NNN.py`
+   following the pattern in `test_migration_024.py` — pure-SQL parse check
+   for offline unit tests, or `psycopg` round-trip for integration.

--- a/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
+++ b/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
@@ -1,30 +1,12 @@
 -- 024_thesis_deliberation_first_class.sql — First-class tables for the
 -- thesis-first pipeline (Atlas Wave 1, UNIT W1-B).
 --
--- Context:
---   Track B doc_types (`market_thesis_exploration`, `thesis_vehicle_map`,
---   `deliberation_transcript`, `deliberation_session_index`, `pm_allocation_memo`,
---   `asset_recommendation`) have so far been persisted only as `documents` rows
---   with JSONB payloads. That keeps the publish path cheap but makes analytics,
---   dashboards, and historical thesis-tracking queries expensive.
+-- See docs/adr/0010-atlas-first-class-thesis-deliberation.md for the full
+-- rationale, doc_type mapping, and Wave 2 write-path contract. This file is
+-- schema-only; rollback lives in the commented DROP block at the end.
 --
---   This migration introduces dual persistence: a structured, indexable row per
---   high-query subset (vehicles per thesis, deliberation rounds, recess triggers)
---   while the full document bodies continue to land in `documents` for the
---   frontend and for blob retrieval. See docs/adr/0010-atlas-first-class-thesis-deliberation.md.
---
--- Scope of this migration:
---   • thesis_vehicles         — per-vehicle mapping of each thesis
---   • deliberation_sessions   — one row per (date, kind, pipeline_run_id)
---   • deliberation_rounds     — one row per ticker × round within a session
---   • analyst_coverage        — daily analyst↔ticker cross-reference
---   • deep_dive_triggers      — audit trail of recess-forced deep dives
---
--- RLS convention (matches migrations 005/007/015/023): per-table `anon` SELECT
--- policy; writes require the service_role key (bypass is grant-based, not a
--- policy, so we do not declare an explicit service_role policy).
---
--- Rollback: commented-out DROP block at the end of this file.
+-- Requires: pgcrypto extension (for gen_random_uuid()). Supabase projects
+-- ship this enabled; bare Postgres needs `CREATE EXTENSION IF NOT EXISTS pgcrypto;` first.
 
 BEGIN;
 
@@ -54,8 +36,8 @@ CREATE TABLE IF NOT EXISTS thesis_vehicles (
 CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_ticker_date
   ON thesis_vehicles (ticker, date DESC);
 
-CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_date
-  ON thesis_vehicles (date DESC);
+-- Note: the PRIMARY KEY (date, thesis_id, ticker) already covers leading-date
+-- range scans, so a separate `(date DESC)` index would be redundant.
 
 ALTER TABLE thesis_vehicles ENABLE ROW LEVEL SECURITY;
 
@@ -96,8 +78,8 @@ CREATE TABLE IF NOT EXISTS deliberation_sessions (
     UNIQUE (date, kind, pipeline_run_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_deliberation_sessions_date
-  ON deliberation_sessions (date DESC);
+-- Note: UNIQUE (date, kind, pipeline_run_id) already covers leading-date
+-- scans, so a separate `(date DESC)` index would be redundant.
 
 ALTER TABLE deliberation_sessions ENABLE ROW LEVEL SECURITY;
 
@@ -160,11 +142,15 @@ CREATE TABLE IF NOT EXISTS analyst_coverage (
   date                         date        NOT NULL,
   ticker                       text        NOT NULL,
   thesis_ids                   jsonb,       -- array of linked thesis_ids
-  analyst_role                 text,
+  analyst_role                 text,        -- see docs/agentic/HERMES_SUBGRAPH.md for canonical roles
   current_recommendation_key   text,        -- documents.document_key pointer
   last_updated                 timestamptz NOT NULL DEFAULT now(),
 
-  PRIMARY KEY (date, ticker)
+  PRIMARY KEY (date, ticker),
+  CONSTRAINT chk_analyst_coverage_role CHECK (
+    analyst_role IS NULL
+    OR analyst_role IN ('asset_analyst', 'sector_analyst', 'macro_analyst')
+  )
 );
 
 CREATE INDEX IF NOT EXISTS idx_analyst_coverage_ticker_date
@@ -206,6 +192,16 @@ CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_ticker
 
 CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_session
   ON deep_dive_triggers (session_id);
+
+-- Hot path: "show unresolved triggers" operator dashboards.
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_unresolved
+  ON deep_dive_triggers (session_id)
+  WHERE resolved_at IS NULL;
+
+-- "Which trigger resolved to which deep-dive document" reverse lookup.
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_doc_key
+  ON deep_dive_triggers (deep_dive_document_key)
+  WHERE deep_dive_document_key IS NOT NULL;
 
 ALTER TABLE deep_dive_triggers ENABLE ROW LEVEL SECURITY;
 

--- a/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
+++ b/apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql
@@ -1,0 +1,240 @@
+-- 024_thesis_deliberation_first_class.sql — First-class tables for the
+-- thesis-first pipeline (Atlas Wave 1, UNIT W1-B).
+--
+-- Context:
+--   Track B doc_types (`market_thesis_exploration`, `thesis_vehicle_map`,
+--   `deliberation_transcript`, `deliberation_session_index`, `pm_allocation_memo`,
+--   `asset_recommendation`) have so far been persisted only as `documents` rows
+--   with JSONB payloads. That keeps the publish path cheap but makes analytics,
+--   dashboards, and historical thesis-tracking queries expensive.
+--
+--   This migration introduces dual persistence: a structured, indexable row per
+--   high-query subset (vehicles per thesis, deliberation rounds, recess triggers)
+--   while the full document bodies continue to land in `documents` for the
+--   frontend and for blob retrieval. See docs/adr/0010-atlas-first-class-thesis-deliberation.md.
+--
+-- Scope of this migration:
+--   • thesis_vehicles         — per-vehicle mapping of each thesis
+--   • deliberation_sessions   — one row per (date, kind, pipeline_run_id)
+--   • deliberation_rounds     — one row per ticker × round within a session
+--   • analyst_coverage        — daily analyst↔ticker cross-reference
+--   • deep_dive_triggers      — audit trail of recess-forced deep dives
+--
+-- RLS convention (matches migrations 005/007/015/023): per-table `anon` SELECT
+-- policy; writes require the service_role key (bypass is grant-based, not a
+-- policy, so we do not declare an explicit service_role policy).
+--
+-- Rollback: commented-out DROP block at the end of this file.
+
+BEGIN;
+
+-- ─── thesis_vehicles ────────────────────────────────────────────────────────
+-- Captures the vehicles (ETFs, stocks, futures) attached to each thesis on
+-- each day. FKs to the existing `theses` (date, thesis_id) unique key so that
+-- backfilling or evolving thesis rows preserves referential integrity.
+
+CREATE TABLE IF NOT EXISTS thesis_vehicles (
+  date                     date        NOT NULL,
+  thesis_id                text        NOT NULL,
+  ticker                   text        NOT NULL,
+
+  rationale                text,
+  exclusion_reasons        jsonb,       -- array of {reason, source} entries
+  candidate_rank           integer,     -- 1 = top pick; NULL = not ranked
+  user_mandate_notes       jsonb,       -- mandate-derived constraints / notes
+  source_exploration_key   text,        -- pointer into documents (market_thesis_exploration)
+
+  created_at               timestamptz NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (date, thesis_id, ticker),
+  FOREIGN KEY (date, thesis_id) REFERENCES theses (date, thesis_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_ticker_date
+  ON thesis_vehicles (ticker, date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_vehicles_date
+  ON thesis_vehicles (date DESC);
+
+ALTER TABLE thesis_vehicles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "thesis_vehicles_anon_select" ON thesis_vehicles;
+CREATE POLICY "thesis_vehicles_anon_select"
+  ON thesis_vehicles FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE thesis_vehicles IS
+  'Vehicles (tickers) linked to each active thesis per day. Populated from '
+  'the thesis_vehicle_map document payload during the Hermes sub-graph. '
+  'Writes via service_role; anon may SELECT.';
+
+COMMENT ON COLUMN thesis_vehicles.source_exploration_key IS
+  'documents.document_key pointer to the market_thesis_exploration row that '
+  'produced this vehicle mapping.';
+
+-- ─── deliberation_sessions ──────────────────────────────────────────────────
+-- One row per deliberation session. `kind` partitions baseline (weekly),
+-- delta_scoped (weekday) and monthly review sessions.
+
+CREATE TABLE IF NOT EXISTS deliberation_sessions (
+  session_id        uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  date              date        NOT NULL,
+  kind              text        NOT NULL,
+  all_converged     boolean,
+  roster            jsonb,       -- {analysts: [...], pm: "..."} roster snapshot
+  started_at        timestamptz,
+  finished_at       timestamptz,
+  pipeline_run_id   uuid,
+
+  created_at        timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT chk_deliberation_sessions_kind CHECK (
+    kind IN ('baseline', 'delta_scoped', 'monthly')
+  ),
+  CONSTRAINT uq_deliberation_sessions_date_kind_run
+    UNIQUE (date, kind, pipeline_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_sessions_date
+  ON deliberation_sessions (date DESC);
+
+ALTER TABLE deliberation_sessions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deliberation_sessions_anon_select" ON deliberation_sessions;
+CREATE POLICY "deliberation_sessions_anon_select"
+  ON deliberation_sessions FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deliberation_sessions IS
+  'One row per Hermes deliberation session (baseline, delta_scoped, or monthly). '
+  'Indexed subset of the deliberation_session_index document.';
+
+-- ─── deliberation_rounds ────────────────────────────────────────────────────
+-- Round-loop persistence. Each ticker within a session can loop up to
+-- ATLAS_DELIBERATION_MAX_ROUNDS rounds. Sections blob holds the analyst/PM
+-- section pair for that round.
+
+CREATE TABLE IF NOT EXISTS deliberation_rounds (
+  id                         bigserial   PRIMARY KEY,
+  session_id                 uuid        NOT NULL
+    REFERENCES deliberation_sessions (session_id) ON DELETE CASCADE,
+  ticker                     text        NOT NULL,
+  round_number               integer     NOT NULL,
+  label                      text,
+  sections                   jsonb       NOT NULL,
+  converged                  boolean     NOT NULL DEFAULT false,
+  recess_triggered           boolean     NOT NULL DEFAULT false,
+  deep_dive_document_key     text,
+  created_at                 timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT uq_deliberation_rounds UNIQUE (session_id, ticker, round_number),
+  CONSTRAINT chk_deliberation_rounds_round_number CHECK (round_number >= 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_rounds_ticker_session
+  ON deliberation_rounds (ticker, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_deliberation_rounds_session
+  ON deliberation_rounds (session_id, round_number);
+
+ALTER TABLE deliberation_rounds ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deliberation_rounds_anon_select" ON deliberation_rounds;
+CREATE POLICY "deliberation_rounds_anon_select"
+  ON deliberation_rounds FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deliberation_rounds IS
+  'One row per (session, ticker, round). Mirrors the deliberation_transcript '
+  'document at round granularity for dashboards and convergence analytics.';
+
+COMMENT ON COLUMN deliberation_rounds.deep_dive_document_key IS
+  'When recess_triggered=true and a deep-dive document has been published, '
+  'documents.document_key pointer to that row.';
+
+-- ─── analyst_coverage ───────────────────────────────────────────────────────
+-- Small denormalized row for "which analyst covers AAPL today" frontend query.
+
+CREATE TABLE IF NOT EXISTS analyst_coverage (
+  date                         date        NOT NULL,
+  ticker                       text        NOT NULL,
+  thesis_ids                   jsonb,       -- array of linked thesis_ids
+  analyst_role                 text,
+  current_recommendation_key   text,        -- documents.document_key pointer
+  last_updated                 timestamptz NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (date, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_analyst_coverage_ticker_date
+  ON analyst_coverage (ticker, date DESC);
+
+ALTER TABLE analyst_coverage ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "analyst_coverage_anon_select" ON analyst_coverage;
+CREATE POLICY "analyst_coverage_anon_select"
+  ON analyst_coverage FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE analyst_coverage IS
+  'Daily denormalized analyst↔ticker index. Supports frontend "coverage by '
+  'analyst" queries without scanning every documents payload.';
+
+-- ─── deep_dive_triggers ─────────────────────────────────────────────────────
+-- Audit log for every time a deliberation round (or a manual operator action
+-- or a delta-watch rule) forced a deep-dive to be generated.
+
+CREATE TABLE IF NOT EXISTS deep_dive_triggers (
+  id                       bigserial   PRIMARY KEY,
+  session_id               uuid
+    REFERENCES deliberation_sessions (session_id) ON DELETE SET NULL,
+  ticker                   text        NOT NULL,
+  triggered_by             text        NOT NULL,
+  trigger_reason           text,
+  deep_dive_document_key   text,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  resolved_at              timestamptz,
+
+  CONSTRAINT chk_deep_dive_triggers_source CHECK (
+    triggered_by IN ('pm_recess', 'delta_watch', 'manual')
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_ticker
+  ON deep_dive_triggers (ticker, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_deep_dive_triggers_session
+  ON deep_dive_triggers (session_id);
+
+ALTER TABLE deep_dive_triggers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "deep_dive_triggers_anon_select" ON deep_dive_triggers;
+CREATE POLICY "deep_dive_triggers_anon_select"
+  ON deep_dive_triggers FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE deep_dive_triggers IS
+  'Audit trail: every time deliberation, delta-watch, or a human operator '
+  'forced a deep-dive to be generated. resolved_at stamped when the deep-dive '
+  'document lands.';
+
+COMMIT;
+
+-- ─── Rollback (commented) ───────────────────────────────────────────────────
+-- Run in reverse dependency order. DROP POLICY first so the DROP TABLE path
+-- is clean even on older PostgREST revisions that error on policy leftovers.
+--
+-- BEGIN;
+-- DROP POLICY IF EXISTS "deep_dive_triggers_anon_select"     ON deep_dive_triggers;
+-- DROP POLICY IF EXISTS "analyst_coverage_anon_select"       ON analyst_coverage;
+-- DROP POLICY IF EXISTS "deliberation_rounds_anon_select"    ON deliberation_rounds;
+-- DROP POLICY IF EXISTS "deliberation_sessions_anon_select"  ON deliberation_sessions;
+-- DROP POLICY IF EXISTS "thesis_vehicles_anon_select"        ON thesis_vehicles;
+--
+-- DROP TABLE IF EXISTS deep_dive_triggers;
+-- DROP TABLE IF EXISTS deliberation_rounds;
+-- DROP TABLE IF EXISTS deliberation_sessions;
+-- DROP TABLE IF EXISTS analyst_coverage;
+-- DROP TABLE IF EXISTS thesis_vehicles;
+-- COMMIT;

--- a/apps/digiquant-atlas/tests/test_migration_024.py
+++ b/apps/digiquant-atlas/tests/test_migration_024.py
@@ -1,0 +1,240 @@
+"""Unit tests for migration 024 (thesis + deliberation first-class tables).
+
+These tests are deliberately hermetic: they parse the migration SQL file and
+assert structural properties (CREATE TABLE presence, PKs / FKs / CHECK
+clauses, RLS enablement, per-table anon SELECT policy, rollback block).
+
+They do NOT spin up Postgres. A live round-trip test (`psycopg` against a
+throwaway DB) belongs in a separate integration test once Wave 2 lands the
+Python adapters — see ADR-0010. Keeping this suite pure-SQL avoids marking a
+new `integration` pytest marker (the project registers only `unit` and
+`e2e`) and lets `make test-unit` stay offline.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "supabase"
+    / "migrations"
+    / "024_thesis_deliberation_first_class.sql"
+)
+
+EXPECTED_TABLES = (
+    "thesis_vehicles",
+    "deliberation_sessions",
+    "deliberation_rounds",
+    "analyst_coverage",
+    "deep_dive_triggers",
+)
+
+
+@pytest.fixture(scope="module")
+def sql() -> str:
+    assert MIGRATION_PATH.is_file(), f"migration missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _strip_comments(sql: str) -> str:
+    """Strip SQL line comments so assertions don't match rollback-block text."""
+    return "\n".join(line for line in sql.splitlines() if not line.lstrip().startswith("--"))
+
+
+def _table_block(sql: str, table: str) -> str:
+    """Extract the `CREATE TABLE ... );` block for a single table.
+
+    Scopes per-table column / constraint assertions so a column that exists
+    on a later table does not satisfy a check for an earlier one. Returns the
+    block including the closing paren of the CREATE TABLE statement plus any
+    immediately-following CREATE INDEX / ALTER TABLE / CREATE POLICY lines up
+    to the next `CREATE TABLE` or end-of-file.
+    """
+    body = _strip_comments(sql)
+    start = re.search(rf"CREATE TABLE IF NOT EXISTS\s+{table}\b", body)
+    assert start, f"CREATE TABLE for {table} not found"
+    next_tbl = re.search(r"CREATE TABLE IF NOT EXISTS\s+\w+", body[start.end() :])
+    end = start.end() + next_tbl.start() if next_tbl else len(body)
+    return body[start.start() : end]
+
+
+@pytest.mark.unit
+class TestMigrationFilePresent:
+    def test_file_exists_and_nonempty(self, sql: str) -> None:
+        assert len(sql) > 500, "migration file looks truncated"
+
+    def test_begin_commit_wraps_body(self, sql: str) -> None:
+        body = _strip_comments(sql)
+        assert body.count("BEGIN;") >= 1
+        assert body.count("COMMIT;") >= 1
+
+    def test_rollback_block_present_but_commented(self, sql: str) -> None:
+        """Rollback DROP TABLEs must be commented so re-running the migration
+        does not drop the tables it just created.
+
+        DROP POLICY IF EXISTS is allowed uncommented — existing Atlas
+        migrations (005/007/015/023) use it for idempotent policy replace.
+        """
+        assert "Rollback" in sql, "no rollback section header"
+        for idx, line in enumerate(sql.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("DROP TABLE"):
+                pytest.fail(f"line {idx}: uncommented DROP TABLE in migration: {stripped!r}")
+
+
+@pytest.mark.unit
+class TestExpectedTablesCreated:
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_create_table(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        assert re.search(rf"CREATE TABLE IF NOT EXISTS\s+{table}\b", body), (
+            f"missing CREATE TABLE for {table}"
+        )
+
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_rls_enabled(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        assert re.search(rf"ALTER TABLE\s+{table}\s+ENABLE ROW LEVEL SECURITY", body), (
+            f"RLS not enabled on {table}"
+        )
+
+    @pytest.mark.parametrize("table", EXPECTED_TABLES)
+    def test_anon_select_policy(self, sql: str, table: str) -> None:
+        body = _strip_comments(sql)
+        # Policy name matches the convention used by migrations 005/007/015/023.
+        assert re.search(
+            rf'CREATE POLICY\s+"{table}_anon_select"\s+ON\s+{table}\s+FOR SELECT\s+TO anon',
+            body,
+        ), f"anon select policy missing on {table}"
+
+
+@pytest.mark.unit
+class TestThesisVehiclesShape:
+    def test_composite_pk(self, sql: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(r"PRIMARY KEY\s*\(\s*date\s*,\s*thesis_id\s*,\s*ticker\s*\)", block)
+
+    def test_fk_to_theses(self, sql: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(
+            r"FOREIGN KEY\s*\(\s*date\s*,\s*thesis_id\s*\)"
+            r"\s*REFERENCES\s+theses\s*\(\s*date\s*,\s*thesis_id\s*\)",
+            block,
+        )
+
+    @pytest.mark.parametrize(
+        "col",
+        [
+            "rationale",
+            "exclusion_reasons",
+            "candidate_rank",
+            "user_mandate_notes",
+            "source_exploration_key",
+            "created_at",
+        ],
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "thesis_vehicles")
+        assert re.search(rf"\b{col}\b", block), f"thesis_vehicles missing {col}"
+
+
+@pytest.mark.unit
+class TestDeliberationSessionsShape:
+    def test_primary_key_uuid(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(r"session_id\s+uuid\s+PRIMARY KEY", block)
+
+    def test_kind_check_constraint(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(
+            r"kind IN\s*\(\s*'baseline'\s*,\s*'delta_scoped'\s*,\s*'monthly'\s*\)",
+            block,
+        )
+
+    def test_unique_triple(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_sessions")
+        assert re.search(r"UNIQUE\s*\(\s*date\s*,\s*kind\s*,\s*pipeline_run_id\s*\)", block)
+
+
+@pytest.mark.unit
+class TestDeliberationRoundsShape:
+    def test_fk_to_sessions(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(r"REFERENCES\s+deliberation_sessions\s*\(\s*session_id\s*\)", block)
+
+    def test_unique_triple(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(
+            r"UNIQUE\s*\(\s*session_id\s*,\s*ticker\s*,\s*round_number\s*\)",
+            block,
+        )
+
+    def test_indexed_on_ticker_session(self, sql: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(
+            r"CREATE INDEX[\s\S]*?ON\s+deliberation_rounds\s*\(\s*ticker\s*,\s*session_id\s*\)",
+            block,
+        )
+
+    @pytest.mark.parametrize(
+        "col", ["converged", "recess_triggered", "deep_dive_document_key", "sections"]
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "deliberation_rounds")
+        assert re.search(rf"\b{col}\b", block), f"deliberation_rounds missing {col}"
+
+
+@pytest.mark.unit
+class TestAnalystCoverageShape:
+    def test_composite_pk(self, sql: str) -> None:
+        block = _table_block(sql, "analyst_coverage")
+        assert re.search(r"PRIMARY KEY\s*\(\s*date\s*,\s*ticker\s*\)", block)
+
+    @pytest.mark.parametrize(
+        "col",
+        ["thesis_ids", "analyst_role", "current_recommendation_key", "last_updated"],
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "analyst_coverage")
+        assert re.search(rf"\b{col}\b", block), f"analyst_coverage missing {col}"
+
+
+@pytest.mark.unit
+class TestDeepDiveTriggersShape:
+    def test_triggered_by_check(self, sql: str) -> None:
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(
+            r"triggered_by IN\s*\(\s*'pm_recess'\s*,\s*'delta_watch'\s*,\s*'manual'\s*\)",
+            block,
+        )
+
+    def test_session_fk_nullable(self, sql: str) -> None:
+        """session_id may be NULL (manual triggers without a session)."""
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(
+            r"session_id\s+uuid\b(?![^\n]*NOT NULL)[\s\S]*?REFERENCES\s+deliberation_sessions",
+            block,
+        ), "deep_dive_triggers.session_id should be nullable FK"
+
+    @pytest.mark.parametrize(
+        "col", ["ticker", "trigger_reason", "deep_dive_document_key", "resolved_at"]
+    )
+    def test_expected_columns(self, sql: str, col: str) -> None:
+        block = _table_block(sql, "deep_dive_triggers")
+        assert re.search(rf"\b{col}\b", block), f"deep_dive_triggers missing {col}"
+
+
+@pytest.mark.unit
+class TestMigrationNumbering:
+    def test_no_duplicate_number(self) -> None:
+        migrations_dir = MIGRATION_PATH.parent
+        prefixes = [p.name.split("_", 1)[0] for p in migrations_dir.glob("*.sql")]
+        # 024 must appear exactly once.
+        assert prefixes.count("024") == 1
+
+    def test_file_prefix_is_024(self) -> None:
+        assert MIGRATION_PATH.name.startswith("024_")

--- a/docs/adr/0010-atlas-first-class-thesis-deliberation.md
+++ b/docs/adr/0010-atlas-first-class-thesis-deliberation.md
@@ -1,0 +1,200 @@
+# ADR-0010 — Atlas first-class thesis + deliberation tables
+
+- **Status:** Accepted
+- **Date:** 2026-04-20
+- **Deciders:** Chris Stefan (founder), Atlas Wave 1 worktree agents
+- **Related:** [ADR-0008 Atlas research schema](0008-atlas-research-schema.md), [ADR-0009 Atlas Supabase persistence](0009-atlas-supabase-persistence.md)
+- **Supersedes:** nothing. Complements ADR-0009.
+
+## Context
+
+Through migration 023 the Atlas Track B pipeline (`market_thesis_exploration`,
+`thesis_vehicle_map`, `deliberation_transcript`, `deliberation_session_index`,
+`pm_allocation_memo`, `asset_recommendation`) persists exclusively through the
+`documents` table as JSONB payload rows. That shape is fine for publish-time
+(one upsert per artifact) and for the frontend (one read for the full blob),
+but it is expensive for four classes of query we now need:
+
+1. **Dashboards that join theses to vehicles** (e.g. "which tickers are in the
+   long-growth thesis over the last 90 days") require repeated JSONB unpacking
+   and ticker-level indexing on the `thesis_vehicle_map` payload.
+2. **Deliberation analytics** ("average rounds to convergence", "recess-trigger
+   rate by sector") require scanning every transcript and parsing rounds.
+3. **Historical thesis tracking** across `theses` → vehicles → analyst
+   recommendations → rebalance decisions is chained across five JSONB
+   payloads with no join keys.
+4. **"Which analyst covers AAPL today"** is a 1-row query that today requires
+   scanning all `asset_recommendation` documents for the date.
+
+Wave 1 of the Atlas → DigiGraph migration moves the Hermes sub-graph
+(deliberation round-loop, deep-dive recess, PM memo) into first-class
+LangGraph state. That work creates the natural opportunity to also land
+structured persistence alongside the existing documents-only writes.
+
+## Decision
+
+Adopt **dual persistence** for a defined subset of Track B doc_types:
+payloads continue to land in `documents` (no regression for frontend, no
+schema migration for blob consumers) **and** a structured subset lands in
+new first-class tables (migration 024).
+
+### Which doc_types get first-class tables
+
+| doc_type                       | Goes into           | Rationale                                                   |
+|--------------------------------|---------------------|-------------------------------------------------------------|
+| `thesis_vehicle_map`           | `thesis_vehicles`   | High query volume by `(thesis_id, ticker)` join             |
+| `deliberation_session_index`   | `deliberation_sessions` | Needs `(date, kind)` filters for analytics             |
+| `deliberation_transcript`      | `deliberation_rounds`   | Per-round convergence + recess analytics               |
+| `asset_recommendation`         | `analyst_coverage`  | Denormalized analyst ↔ ticker index                         |
+| _(synthetic)_ deep-dive trigger | `deep_dive_triggers` | New audit log — no prior documents payload existed         |
+
+### Which doc_types stay documents-only (for now)
+
+- `market_thesis_exploration` — narrative-heavy; the structured slice we need
+  is the vehicle list, which lands in `thesis_vehicles` via its
+  `source_exploration_key` back-pointer. The exploration itself stays a
+  document because it is read holistically.
+- `pm_allocation_memo` — narrative memo with bulk text + targets. Low query
+  volume at the sub-structure level; frontend reads the whole payload.
+- `rebalance_decision` — already mapped through `position_events` first-class
+  table since migration 022.
+- `research_delta`, `research_baseline_manifest`, `document_delta`,
+  `research_changelog`, `evolution_*`, `sector_report`, `deep_dive`,
+  `pipeline_review`, `weekly_digest`, `monthly_digest`, `delta_digest`,
+  `master_digest`, `delta_segment` — infrequent query access, bulk-narrative
+  content, no denormalization benefit.
+
+### Write path (Wave 2)
+
+The Python adapters are explicitly out of scope for this ADR / migration
+(they land in Wave 2, UNIT W2-A). The contract for Wave 2:
+
+- The existing `publish_document` adapter in
+  `apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py` remains the single
+  entry point for writing Track B artifacts.
+- New extractor functions per doc_type read the just-upserted payload, project
+  the structured subset, and upsert into the matching first-class table in the
+  same logical operation.
+- All secondary writes pass through `digibase.audit.redact_mapping` before
+  logging, consistent with ADR-0009.
+
+### RLS
+
+Every new table gets `ENABLE ROW LEVEL SECURITY` + a per-table `anon` SELECT
+policy named `{table}_anon_select` — matching migrations 005 / 007 / 015 / 023.
+Writes require the Supabase service_role key; service_role bypass is grant-
+based in Supabase (not a policy), so we do not declare an explicit
+`service_role` policy (consistent with every existing Atlas migration).
+
+## Consequences
+
+### Positive
+
+- Two-index-hop for common dashboard queries (vs. JSONB scan).
+- Deliberation and deep-dive analytics become tractable.
+- Wave 2 implementers get a clean contract: same publish entrypoint, new
+  extractor next to each doc_type.
+- Frontend is not disrupted — `documents` reads keep working unchanged.
+- Rollback is a single commented-out block in migration 024.
+
+### Negative
+
+- Every Track B publish becomes a 2-row write (documents + first-class).
+  Mitigated because the writes are serialized within a single Python
+  invocation; failure rolls back both (transaction per publish).
+- Drift between `documents.payload` and first-class rows is possible if a
+  future author forgets to extend both. Wave 2 adds a validation test that
+  for every row in the first-class tables there is a matching `documents`
+  row at the same `(date, document_key)`.
+- Two sources of truth for the structured subset. We treat `documents` as
+  the canonical artifact and the first-class rows as a derived projection —
+  documents wins in any reconciliation.
+
+### Neutral
+
+- Pre-existing casing conventions are inherited, not re-opened:
+  - `documents.doc_type` CHECK constraint uses **Title Case** (e.g.
+    `'Deliberation Transcript'`) for human-readable labels.
+  - Payload `doc_type` fields use **snake_case** (e.g. `deliberation_transcript`)
+    for programmatic matching.
+  - Migration 024 does not touch either. First-class tables use neither; they
+    reference `documents` by `document_key` strings.
+
+## Alternatives considered
+
+1. **Generated columns on `documents`** — would avoid a second table but
+   indexes on JSONB-generated columns don't compose cleanly across rows and
+   we'd still have no FK to `theses`.
+2. **Materialized views** — readable but refresh latency and cost grow with
+   `documents` size; we'd need the same indexes anyway.
+3. **Replace documents with first-class tables entirely** — would disrupt the
+   frontend and lose the blob-retrieval affordance. Rejected.
+
+## Implementation
+
+- Migration: `apps/digiquant-atlas/supabase/migrations/024_thesis_deliberation_first_class.sql`
+- Schema map: `apps/digiquant-atlas/supabase/SCHEMA.md`
+- Test: `apps/digiquant-atlas/tests/test_migration_024.py`
+- Rollback: commented-out DROP block at the bottom of migration 024.
+
+## Appendix A — Dead doc_type audit (2026-04-20)
+
+Scan of `apps/digiquant-atlas/` (src/, scripts/, frontend/, tests/, templates/)
+for every string literal that appears as a `doc_type` value, compared against
+the `chk_documents_doc_type` CHECK constraint (migration 023).
+
+**Decision for this migration: freeze. Do not drop any doc_type.** A follow-up
+migration (025) drops any that are still unreferenced after one sprint.
+
+### Live doc_types (referenced in code + allowed by CHECK)
+
+Payload-side snake_case (referenced in `src/digiquant_atlas/` or `scripts/`):
+`deliberation_session_index`, `deliberation_transcript`,
+`market_thesis_exploration`, `thesis_vehicle_map`, `pm_allocation_memo`,
+`asset_recommendation`, `rebalance_decision`, `research_delta`,
+`research_baseline_manifest`, `document_delta`, `research_changelog`,
+`evolution_sources`, `evolution_quality_log`, `evolution_proposals`,
+`pipeline_review`, `weekly_digest`, `monthly_digest`, `master_digest`,
+`delta_digest`, `delta_segment`, `deep_dive`, `sector_report`,
+`opportunity_screen`, `research_closeout`.
+
+Title-Case labels persisted in `documents.doc_type` column (checked by
+`chk_documents_doc_type`):
+`'Daily Digest'`, `'Daily Delta'`, `'Weekly Rollup'`, `'Monthly Summary'`,
+`'Deep Dive'`, `'Research Delta'`, `'Research Baseline Manifest'`,
+`'Document Delta'`, `'Research Changelog'`, `'Rebalance Decision'`,
+`'Asset Recommendation'`, `'Deliberation Transcript'`,
+`'Deliberation Session Index'`, `'Market Thesis Exploration'`,
+`'Thesis Vehicle Map'`, `'PM Allocation Memo'`, `'Sector Report'`,
+`'Evolution Sources'`, `'Evolution Quality Log'`, `'Evolution Proposals'`,
+`'Pipeline Review'`.
+
+### Potentially orphaned (allowed by CHECK but no live writer)
+
+- `'Daily Delta'` — no producer found in current `src/digiquant_atlas/`; one
+  reference in `frontend/lib/queries.ts` as a literal. Likely historical.
+  **Freeze for 1 sprint; candidate for drop in 025.**
+- `'Weekly Rollup'` vs payload `weekly_digest` — title/payload mismatch; the
+  writer uses `weekly_digest`. Likely a legacy label. **Freeze; candidate for
+  drop in 025.**
+- `'Monthly Summary'` vs payload `monthly_digest` — same pattern as above.
+  **Freeze; candidate for drop in 025.**
+
+### Referenced in payloads but not in CHECK constraint
+
+The following payload `doc_type` values appear in scripts/ but are *not* in
+the `chk_documents_doc_type` allow-list, so they land with `documents.doc_type
+IS NULL` (the CHECK allows NULL):
+
+- `opportunity_screen` — emitted in Track B phase 3 (validate_pipeline_step.py).
+  Intentional: the opportunity screen is an intermediate payload, not a
+  first-class document label. **No action.**
+- `markdown_legacy` — legacy transitional payloads (pre-db-first). **No action.**
+- `digest_snapshot`, `delta_request` — classifier kinds, never written as
+  `documents.doc_type`. **No action.**
+
+### Not dropped in this migration
+
+Per the plan, doc_types are **frozen for one sprint**. Any drop happens in a
+future migration (025) with its own ADR addendum, after Wave 1 lands and we've
+verified no backfill scripts still produce the questionable labels.

--- a/docs/adr/0010-atlas-first-class-thesis-deliberation.md
+++ b/docs/adr/0010-atlas-first-class-thesis-deliberation.md
@@ -129,6 +129,10 @@ based in Supabase (not a policy), so we do not declare an explicit
    `documents` size; we'd need the same indexes anyway.
 3. **Replace documents with first-class tables entirely** — would disrupt the
    frontend and lose the blob-retrieval affordance. Rejected.
+4. **Natural PK `(session_id, ticker, round_number)` on `deliberation_rounds`** —
+   `deliberation_rounds.id` surrogate `BIGSERIAL` chosen over the natural
+   `(session_id, ticker, round_number)` PK for simpler FK-back references
+   and ORM ergonomics. The natural triple is preserved as a UNIQUE constraint.
 
 ## Implementation
 
@@ -198,3 +202,15 @@ IS NULL` (the CHECK allows NULL):
 Per the plan, doc_types are **frozen for one sprint**. Any drop happens in a
 future migration (025) with its own ADR addendum, after Wave 1 lands and we've
 verified no backfill scripts still produce the questionable labels.
+
+## Appendix B — Follow-up work
+
+- **Wave 2:** psycopg live round-trip test for migration 024 before any
+  adapter writes land. The existing `tests/test_migration_024.py` is hermetic
+  (SQL text assertions only); a throwaway Postgres round-trip is needed once
+  the Wave 2 adapters start writing to these tables.
+- `analyst_coverage.analyst_role` carries a CHECK constraint listing the
+  canonical taxonomy (`asset_analyst`, `sector_analyst`, `macro_analyst`) +
+  NULL. Canonical role definitions live in `docs/agentic/HERMES_SUBGRAPH.md`;
+  a new role requires both an ADR addendum and a migration to extend the
+  CHECK list.


### PR DESCRIPTION
## Summary

Wave 1 of the Atlas → DigiGraph full migration. Bundles two merged task PRs:

- **#283** — Migration 024: first-class thesis + deliberation tables + ADR-0010 + SCHEMA.md.
- **#284** — Hermes portfolio deliberation sub-graph spec + 8 Wave 2 unit specs.

## Scoring

Both task PRs: 10/10/10/10.

## Follow-ups

- Wave 2 per `apps/digiquant-atlas/docs/agentic/WAVE2_UNIT_SPECS.md`.
- Migration 025 stub for new doc_types.

Closes #178.