### PR TITLE
feat(ci): atlas daily pipeline — scheduled GitHub Actions cron (#298)

### DIFF
--- a/.github/workflows/atlas-daily.yml
+++ b/.github/workflows/atlas-daily.yml
@@ -1,0 +1,111 @@
+# Atlas daily pipeline — scheduled refresh of price / technicals / macro tables in Supabase.
+#
+# Runs weekdays at 06:15 UTC (post-US-close data availability) and on-demand via workflow_dispatch.
+# All output is persisted to Supabase via the `digiquant prices --supabase` subcommands; nothing is
+# written back to the repo or uploaded as an artifact. The runner's `data/price-history/` directory
+# is scratch space that disappears with the runner.
+#
+# Tracking issue: #298. Supersedes (for now): #218 (DigiClaw cron scheduling, deferred to P3).
+
+name: atlas-daily
+
+on:
+  schedule:
+    - cron: "15 6 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run the pipeline without writing to Supabase (sanity check)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: atlas-daily
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+      WATCHLIST: apps/digiquant-atlas/config/watchlist.md
+      MACRO_MANIFEST: apps/digiquant-atlas/config/macro_series.yaml
+      CACHE_DIR: data/price-history
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # Cache the OHLCV CSV directory across runs so fetch-quotes only fetches
+      # each day's delta after the first run. Without this, every run would
+      # start cold with N days of history (insufficient for indicators like
+      # SMA_200). Bump the cache key suffix to force a cold rebuild.
+      - name: Restore price-history cache
+        uses: actions/cache@v4
+        with:
+          path: data/price-history
+          key: atlas-daily-price-cache-v1-${{ github.run_id }}
+          restore-keys: |
+            atlas-daily-price-cache-v1-
+
+      - name: Install digiquant
+        # digiquant[nautilus] excluded — the Nautilus C++ engine crashes on
+        # Linux CI (SIGABRT / exit 134, tracked in #42). The price pipeline
+        # CLI does not import Nautilus.
+        run: |
+          python -m pip install -U pip
+          pip install -e "./digibase[dev]"
+          pip install -e "./digiquant[dev]"
+
+      - name: Validate secrets (non-dry-run only)
+        if: ${{ github.event.inputs['dry-run'] != 'true' }}
+        run: |
+          missing=()
+          [[ -z "${SUPABASE_URL:-}" ]] && missing+=("SUPABASE_URL")
+          [[ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]] && missing+=("SUPABASE_SERVICE_ROLE_KEY")
+          [[ -z "${FRED_API_KEY:-}" ]] && missing+=("FRED_API_KEY")
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Fetch quotes (OHLCV → price_history)
+        # --period 1y is the cold-start fetch size for uncached tickers.
+        # When the actions/cache step above restores a prior cache,
+        # incremental_update only fetches each ticker's date-delta, so 1y
+        # only applies on first run or cache eviction.
+        run: |
+          args=(--watchlist "$WATCHLIST" --cache-dir "$CACHE_DIR" --period 1y)
+          if [[ "${{ github.event.inputs['dry-run'] }}" == "true" ]]; then
+            args+=(--dry-run)
+          else
+            args+=(--supabase)
+          fi
+          python -m digiquant prices fetch-quotes "${args[@]}"
+
+      - name: Compute technicals (→ price_technicals)
+        run: |
+          args=(--cache-dir "$CACHE_DIR")
+          if [[ "${{ github.event.inputs['dry-run'] }}" != "true" ]]; then
+            args+=(--supabase)
+          fi
+          python -m digiquant prices compute-technicals "${args[@]}"
+
+      - name: Fetch macro series (→ macro_series_observations)
+        run: |
+          args=(--manifest "$MACRO_MANIFEST")
+          if [[ "${{ github.event.inputs['dry-run'] }}" == "true" ]]; then
+            args+=(--dry-run)
+          else
+            args+=(--supabase)
+          fi
+          python -m digiquant prices fetch-macro "${args[@]}"

--- a/apps/digiquant-atlas/AGENTS.md
+++ b/apps/digiquant-atlas/AGENTS.md
@@ -69,6 +69,34 @@ python3 scripts/publish_research.py --key research/deep-dives/NVDA-DATE --title 
 
 ---
 
+## Daily cron — Atlas price + macro refresh
+
+Scheduled GitHub Actions workflow: [`.github/workflows/atlas-daily.yml`](../../.github/workflows/atlas-daily.yml).
+
+- **Schedule:** `15 6 * * 1-5` (06:15 UTC weekdays, post-US-close data availability).
+- **Manual trigger:** `gh workflow run atlas-daily` (or the Actions tab → "Run workflow"). A `dry-run` boolean input is available for sanity checks (skips all Supabase writes).
+- **What it does, in order:**
+  1. `digiquant prices fetch-quotes --watchlist config/watchlist.md --period 5d --supabase` → upserts OHLCV into `price_history`.
+  2. `digiquant prices compute-technicals --supabase` → computes 35+ indicators, upserts into `price_technicals`.
+  3. `digiquant prices fetch-macro --manifest config/macro_series.yaml --supabase` → fetches FRED / Frankfurter FX / Crypto FNG, upserts into `macro_series_observations`.
+- **Output destination:** Supabase only. The workflow never writes back to the repo, never uploads artifacts, and never persists local files between runs — the runner's `data/price-history/` is scratch space that disappears with the runner. All consumers (frontend, downstream agents) read from Supabase.
+- **Failure handling:** the job fails loudly with non-zero exit; GitHub's native workflow-failure notifications surface the failure on the Actions tab and via email to watchers.
+- **Cron-firing prerequisite:** GitHub only fires `schedule:` triggers from the workflow file on the repository's **default branch**. Until this workflow is merged all the way through `task/… → module/digiquant → develop → main`, the scheduled run won't fire. `workflow_dispatch` works from any branch that has the file — use it to smoke-test on the task branch (`gh workflow run atlas-daily --ref task/298-atlas-daily-pipeline…`).
+
+### Required repository secrets
+
+Configure these in `Settings → Secrets and variables → Actions`:
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `SUPABASE_URL` | all three steps | Supabase project URL for `price_history` / `price_technicals` / `macro_series_observations` upserts |
+| `SUPABASE_SERVICE_ROLE_KEY` | all three steps | Service-role key (bypasses RLS for writes). `SUPABASE_SERVICE_KEY` is accepted as a fallback by the CLI. |
+| `FRED_API_KEY` | fetch-macro | FRED series API key (required unless `--dry-run`) |
+
+Yahoo Finance quotes and Frankfurter FX are unauthenticated — no secret needed.
+
+---
+
 ## Full Documentation
 
 - Architecture: `docs/agentic/ARCHITECTURE.md`

--- a/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
+++ b/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
@@ -382,6 +382,31 @@ Supabase daily_snapshots/documents ───┐    │(all skills read)│
 
 ---
 
+## Daily update (scheduled pipeline)
+
+The price / technicals / macro layer underlying every phase is refreshed by a scheduled GitHub Actions workflow — [`.github/workflows/atlas-daily.yml`](../../../.github/workflows/atlas-daily.yml). Runs weekdays at 06:15 UTC and on-demand via `workflow_dispatch`.
+
+```
+atlas-daily workflow (cron "15 6 * * 1-5")
+  │
+  ├─ digiquant prices fetch-quotes      ──► Supabase price_history
+  │   (watchlist.md, --period 5d)
+  │
+  ├─ digiquant prices compute-technicals ──► Supabase price_technicals
+  │   (35+ indicators from cached OHLCV)
+  │
+  └─ digiquant prices fetch-macro        ──► Supabase macro_series_observations
+      (macro_series.yaml — FRED / Frankfurter FX / Crypto FNG)
+```
+
+**Rationale**: replaces the DigiClaw cron dependency (#218) for the initial ship. GitHub Actions' `schedule:` trigger is sufficient and reliable for a single daily job; a dedicated scheduler service is deferred until ≥3 recurring agent jobs exist.
+
+**Storage contract**: Supabase is the sole output destination. The workflow never commits to the repo, never uploads data artifacts, and never persists local files between runs. The runner's `data/price-history/` directory is scratch space internal to one job. Every consumer (frontend, downstream Atlas phases, other agents) reads from Supabase.
+
+**Secrets + configuration**: see [`../../AGENTS.md` § Daily cron](../../AGENTS.md#daily-cron--atlas-price--macro-refresh).
+
+---
+
 ## Signal Priority Hierarchy
 
 When signals conflict across phases, apply in order:


### PR DESCRIPTION
## Linked issue

<!--
Every PR must trace to a backlog issue on the Project board.
Either use a branch named  task/<N>-<slug>  (created by `make task ISSUE=N`),
or add a line below like:  Fixes #123   (also accepts Closes / Resolves).
CI check: .github/workflows/pr-linkage.yml
-->

Fixes #

---

## Component

<!-- Check all that apply -->
- [ ] digigraph
- [ ] digiquant
- [ ] digisearch
- [ ] digismith
- [ ] digiclaw
- [ ] digibase
- [ ] digikey
- [ ] digichat
- [ ] website / root docs
- [ ] config / infra

## Change Type

- [ ] feat — new capability
- [ ] fix — bug fix
- [ ] refactor — restructure without behavior change
- [ ] docs — documentation only
- [ ] test — tests only
- [ ] chore — build, CI, deps

## Agent Quality Gates

> Agents: check these **before** opening the PR. Both are required for `task/*` branches — CI will block merge if unchecked.

- [ ] `/simplify` run — code reviewed for reuse, quality, and efficiency; issues fixed
- [ ] `/review` completed — PR reviewed against scoring rubric; findings addressed

---

## Summary

<!-- 2–4 sentences: what changed and why -->

---

## Self-Score Checklist

Agents: score honestly using `docs/scoring/`. Do not check a box unless you fully satisfy the criterion. Leave unchecked criteria with a note if they are N/A.

### Security (target ≥ 8/10) — [`docs/scoring/SECURITY.md`](docs/scoring/SECURITY.md)
- [ ] 1. No secrets in code (no API keys, tokens, PEM strings)
- [ ] 2. No PII in spans or audit logs (no raw prompts, bearer tokens, full doc bodies)
- [ ] 3. Input validation at system boundaries (Pydantic models on all HTTP/MCP/CLI inputs)
- [ ] 4. No injection vectors (no `eval`, `exec`, f-string SQL, unguarded `subprocess`)
- [ ] 5. Scope-checked auth (new routes use `digikey.integrations.service_middleware`)
- [ ] 6. Fail-closed on missing auth config (returns 503, not 200)
- [ ] 7. No new loopback exceptions (no `0.0.0.0` bind without SECURITY.md approval)
- [ ] 8. No live-trading path touched without human gate ← **triggers human review if checked**
- [ ] 9. Least-privilege secret access (new secrets in `.env.example` with comments)
- [ ] 10. No debug back-doors in production paths

**Security score: __ / 10**

---

### Quality (target ≥ 8/10) — [`docs/scoring/QUALITY.md`](docs/scoring/QUALITY.md)
- [ ] 1. Pydantic v2 everywhere (no v1 `@validator`, no bare `dict` return on public APIs)
- [ ] 2. Polars only — no pandas
- [ ] 3. Strict typing — no untyped `Any` without inline justification
- [ ] 4. Ruff clean (`ruff check . && ruff format --check .` passes)
- [ ] 5. Tests added or updated for changed behavior
- [ ] 6. No orphaned code (removed symbols cleaned from exports and callers)
- [ ] 7. Files stay focused (no file > 400 lines, no function > 60 lines without justification)
- [ ] 8. Errors are structured (`digibase` error envelope or Pydantic error model)
- [ ] 9. ARCHITECTURE.md updated (new modules, endpoints, env vars reflected)
- [ ] 10. No backward-compat hacks (no `_old_` vars, no `# TODO: remove` left unfixed)

**Quality score: __ / 10**

---

### Optimization (target ≥ 7/10) — [`docs/scoring/OPTIMIZATION.md`](docs/scoring/OPTIMIZATION.md)
- [ ] 1. LiteLLM caching used (all LLM calls through `digigraph/llm.py`)
- [ ] 2. Model mode respected (`get_model_for_mode()` used; no hardcoded model strings)
- [ ] 3. Polars lazy evaluation (`.scan_csv` + single `.collect()` at end of pipeline)
- [ ] 4. No N+1 patterns (bulk/batch endpoints used; no per-item HTTP calls in loops)
- [ ] 5. Embedding cache used (`BatchEmbedder` + `EmbeddingCache` wrappers)
- [ ] 6. Parallel-safe tools tagged (`parallel_safe` tag on stateless orchestrator tools)
- [ ] 7. No synchronous blocking in async routes (`asyncio.to_thread` for unavoidable blocking)
- [ ] 8. Token efficiency (summaries/briefs in prompts, not full doc bodies)
- [ ] 9. Result caching where stable (JWKS, orchestrator manifests cached with TTL)
- [ ] 10. Backtest performance target maintained (10M rows < 2s; DigiQuant changes only)

**Optimization score: __ / 10**

---

### Accuracy (target ≥ 9/10) — [`docs/scoring/ACCURACY.md`](docs/scoring/ACCURACY.md)
- [ ] 1. Matches ARCHITECTURE.md spec (endpoints, models, flow order correct)
- [ ] 2. Workflow state transitions correct (LangGraph nodes read/write correct fields)
- [ ] 3. Audit events emitted for state changes (`audit_log()` on new side-effecting ops)
- [ ] 4. DigiSmith spans carry required attributes (`workflow_id`, `request_id`, `session_id`)
- [ ] 5. Error paths handled, not silenced (no bare `except: pass`)
- [ ] 6. API contracts unchanged or versioned (breaking changes use `/v2/` path)
- [ ] 7. Strategy invariants preserved (Nautilus event lifecycle unchanged; DigiQuant only)
- [ ] 8. JWT scope contract unchanged (new routes use existing scope naming convention)
- [ ] 9. Test assertions are meaningful (specific values checked, not just `is not None`)
- [ ] 10. No regression in existing tests (`make test-unit` passes with zero failures)

**Accuracy score: __ / 10**

---

## Testing Evidence

```
# Paste output of: make test-unit (and ruff check if code change)

```

---

## Documentation Updated

- [ ] `{component}/ARCHITECTURE.md` updated (Module Map, Public API, or Configuration changed)
- [ ] `{component}/AGENTS.md` updated (new patterns or anti-patterns discovered)
- [ ] Root `AGENTS.md` or `CLAUDE.md` updated (if cross-cutting rule changed)

---

## Human Gate

> If any box below is checked, this PR **requires human review** before merge — do not label `automerge-docs`.

- [ ] Live-trading path modified (broker adapters, order submission, execution gates)
- [ ] Auth or crypto modified (DigiKey signing, JWT generation, scope enforcement)
- [ ] New JWT scope added to a protected route
- [ ] `DIGI_ALLOW_CODE_EXEC` gate modified
- [ ] New network exposure (`0.0.0.0` bind or new published port)
- [ ] New external service dependency introduced
- [ ] `SECURITY.md` changed
- [ ] Novel architecture pattern introduced (not described in any existing ARCHITECTURE.md)

**Is human review required?** Yes / No