### PR TITLE
fix(digiquant): pyarrow in [prices] extra + document digiquant-prices workflow (#329)

### DIFF
--- a/apps/digiquant-atlas/AGENTS.md
+++ b/apps/digiquant-atlas/AGENTS.md
@@ -69,6 +69,39 @@ python3 scripts/publish_research.py --key research/deep-dives/NVDA-DATE --title 
 
 ---
 
+## Scheduled price + macro pipeline
+
+Atlas's price_history / price_technicals / macro_series_observations tables are refreshed by the repo-level workflow [`.github/workflows/digiquant-prices.yml`](../../.github/workflows/digiquant-prices.yml) (owned by the `digiquant` component — not Atlas-specific code). Two separate jobs:
+
+| Job | Schedule | What it does |
+|---|---|---|
+| **intraday** | `*/15 13-20 * * MON-FRI` (every 15 min during US cash session, 13:00–20:00 UTC) | `digiquant prices fetch-quotes` → `price_history`; `digiquant prices compute-technicals` → `price_technicals` |
+| **eod-macro** | `0 21 * * MON-FRI` (weekdays at 21:00 UTC; FRED is day-delayed) | `digiquant prices fetch-macro` (FRED + Frankfurter FX + Crypto FNG) → `macro_series_observations` |
+
+**Manual trigger:** `gh workflow run digiquant-prices -f mode=intraday` (or `-f mode=eod-macro`). Both jobs gate on the `mode` input so only the selected one runs.
+
+**Output destination:** Supabase only. The workflow never writes back to the repo, never uploads artifacts, and never persists local files between runs — the runner's `data/price-history/` is scratch space internal to a single job. Every consumer (the Atlas frontend, downstream phase skills, other agents) reads from Supabase.
+
+**Failure handling:** on step failure a dedicated `actions/github-script` step opens a new issue labeled `ci-failure`, `component:digiquant`, `pipeline:prices` (or `pipeline:macro`), with a link to the failed run.
+
+### Required repository secrets
+
+Configure at `Settings → Secrets and variables → Actions` (repo scope, not environment scope, unless the workflow is updated to reference a named environment):
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `SUPABASE_URL` | both jobs | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | both jobs | Service-role key (bypasses RLS for writes) |
+| `FRED_API_KEY` | eod-macro | Free registration at fred.stlouisfed.org; used by the FRED branch of `fetch-macro`. Rate-limit identifier only — no private data access. |
+
+Yahoo Finance and Frankfurter FX are unauthenticated — no secret needed. Crypto Fear & Greed (`api.alternative.me/fng/`) is also unauthenticated.
+
+### Cron-firing prerequisite
+
+GitHub only fires `schedule:` triggers from the workflow file on the repository's **default branch** (`main`). A workflow change on a feature branch will not run on cron until merged all the way through `task/… → module/digiquant → develop → main`. `workflow_dispatch` works from any branch that has the file — use it to smoke-test ahead of merge.
+
+---
+
 ## Full Documentation
 
 - Architecture: `docs/agentic/ARCHITECTURE.md`

--- a/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
+++ b/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
@@ -382,6 +382,32 @@ Supabase daily_snapshots/documents ───┐    │(all skills read)│
 
 ---
 
+## Upstream price + macro refresh (scheduled)
+
+The `price_history`, `price_technicals`, and `macro_series_observations` tables that the phases above consume are populated by the `digiquant-prices` scheduled workflow at the repo root ([`.github/workflows/digiquant-prices.yml`](../../../.github/workflows/digiquant-prices.yml)). Not Atlas-specific code — owned by the `digiquant` component.
+
+```
+digiquant-prices workflow
+  │
+  ├─ intraday job      (*/15 13–20 UTC MON–FRI — US cash session)
+  │   ├─ digiquant prices fetch-quotes       ──► Supabase price_history
+  │   └─ digiquant prices compute-technicals ──► Supabase price_technicals
+  │
+  └─ eod-macro job     (0 21 UTC MON–FRI — post-FRED update)
+      └─ digiquant prices fetch-macro        ──► Supabase macro_series_observations
+          (FRED + Frankfurter FX + Crypto FNG)
+```
+
+**Storage contract**: Supabase is the sole output destination. Nothing is written back to the repo, no artifacts, no local files persist between runs. The runner's `data/price-history/` is scratch space for one job. All downstream Atlas phases read from Supabase.
+
+**Failure handling**: a failure in either job opens a new issue labeled `ci-failure` via `actions/github-script` with a link to the failed run.
+
+**Secrets + configuration**: see [`../../AGENTS.md` § "Scheduled price + macro pipeline"](../../AGENTS.md#scheduled-price--macro-pipeline).
+
+**Rationale (why GitHub Actions, not DigiClaw)**: DigiClaw (#218) is an OpenClaw-wrapper agent orchestration layer for multiple autonomous agents needing drift/perf supervision. This pipeline is a handful of scheduled ingests; a dedicated scheduler service is a solution looking for a problem until ≥3 recurring agent jobs need coordinated scheduling.
+
+---
+
 ## Signal Priority Hierarchy
 
 When signals conflict across phases, apply in order:

--- a/digiquant/pyproject.toml
+++ b/digiquant/pyproject.toml
@@ -30,6 +30,9 @@ prices = [
     "pyyaml>=6",
     "supabase>=2.0",
     "python-dotenv>=1",
+    # yfinance returns pandas DataFrames with Int64/Float64 extension dtypes;
+    # pl.from_pandas() requires pyarrow to convert them to polars.
+    "pyarrow>=15",
 ]
 optimize = ["optuna>=3.0"]
 all = ["digiquant[nautilus]"]

--- a/digiquant/src/digiquant/data/prices/_utils.py
+++ b/digiquant/src/digiquant/data/prices/_utils.py
@@ -30,4 +30,16 @@ def safe_float(v: Any, decimals: int | None = 4) -> float | None:
     return round(f, decimals) if decimals is not None else f
 
 
-__all__ = ["safe_float"]
+def safe_int(v: Any) -> int | None:
+    """Coerce a value to an int, or return ``None``.
+
+    Volume columns in Supabase are ``bigint``; postgrest rejects float payloads
+    (``"127844500.0"``) with ``22P02`` invalid-syntax errors. yfinance sometimes
+    returns volume as float (NaN-coercion, unadjusted closes, pandas extension
+    dtypes), so we must cast before serializing.
+    """
+    f = safe_float(v, decimals=None)
+    return int(f) if f is not None else None
+
+
+__all__ = ["safe_float", "safe_int"]

--- a/digiquant/src/digiquant/data/prices/macro_ingest.py
+++ b/digiquant/src/digiquant/data/prices/macro_ingest.py
@@ -69,6 +69,42 @@ class MacroManifest:
         return cls.from_dict(data)
 
 
+# ─── HTTP session with retries (shared by all three upstreams) ──────────────
+
+
+def _retrying_session(
+    *,
+    total: int = 3,
+    backoff_factor: float = 1.5,
+) -> Any:
+    """``requests.Session`` with retry on 5xx / connection errors / read timeouts.
+
+    Upstream data providers (FRED in particular) occasionally return transient
+    5xx. Without retries, a single flake kills the whole daily job. Defaults
+    (3 tries, 1.5s exponential backoff) cover a window of roughly 0s → 1.5s →
+    4.5s → 10.5s before giving up.
+    """
+    import requests  # type: ignore[import-not-found]
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    retry = Retry(
+        total=total,
+        connect=total,
+        read=total,
+        status=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=frozenset(["GET"]),
+        raise_on_status=True,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s = requests.Session()
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
 # ─── FRED ───────────────────────────────────────────────────────────────────
 
 
@@ -79,10 +115,9 @@ def fetch_fred_series(
     observation_end: str | None = None,
     *,
     timeout: float = 120.0,
+    session: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Single-series FRED observations fetch. Returns raw observation dicts."""
-    import requests  # type: ignore[import-not-found]
-
     params: dict[str, Any] = {
         "series_id": series_id,
         "api_key": api_key,
@@ -91,7 +126,8 @@ def fetch_fred_series(
     }
     if observation_end:
         params["observation_end"] = observation_end
-    r = requests.get(FRED_OBS_URL, params=params, timeout=timeout)
+    s = session if session is not None else _retrying_session()
+    r = s.get(FRED_OBS_URL, params=params, timeout=timeout)
     r.raise_for_status()
     return r.json().get("observations") or []
 
@@ -138,21 +174,50 @@ def fetch_fred(
     end: str | None = None,
     only_series: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch all FRED series in ``manifest`` and return unified observation rows."""
+    """Fetch all FRED series in ``manifest`` and return unified observation rows.
+
+    Per-series error isolation: if one series fails after retries, the remaining
+    series continue. Failures are logged to stderr. The run fails only if
+    **every** series failed (upstream-down signal) — partial data beats none.
+    """
     if not api_key:
         raise ValueError("fetch_fred requires api_key")
+    import sys
+
+    import requests  # type: ignore[import-not-found]
+
     rows: list[dict[str, Any]] = []
+    failed: list[tuple[str, str]] = []
+    attempted: list[str] = []
     end_s = end or date.today().isoformat()
+    sess = _retrying_session()
     for item in manifest.fred_series:
         if not isinstance(item, dict):
             continue
         sid = item.get("id")
         if not sid or (only_series and sid != only_series):
             continue
+        attempted.append(sid)
         start_s = start or manifest.fred_backfill_start
-        observations = fetch_fred_series(api_key, sid, start_s, end_s)
+        try:
+            observations = fetch_fred_series(api_key, sid, start_s, end_s, session=sess)
+        except (requests.RequestException, ValueError) as exc:
+            failed.append((sid, str(exc)[:200]))
+            print(f"  [fetch_fred] skipped {sid}: {exc}", file=sys.stderr)
+            continue
         rows.extend(
             fred_observations_to_rows(sid, item.get("unit"), item.get("title"), observations)
+        )
+    if attempted and len(failed) == len(attempted):
+        detail = "; ".join(f"{sid}: {msg}" for sid, msg in failed[:5])
+        raise RuntimeError(
+            f"fetch_fred: all {len(attempted)} series failed — upstream likely down. {detail}"
+        )
+    if failed:
+        print(
+            f"  [fetch_fred] partial: {len(attempted) - len(failed)}/{len(attempted)} series ok, "
+            f"{len(failed)} skipped",
+            file=sys.stderr,
         )
     return rows
 
@@ -179,11 +244,11 @@ def fetch_frankfurter_range(
     symbols: list[str],
     *,
     timeout: float = 120.0,
+    session: Any | None = None,
 ) -> dict[str, Any]:
-    import requests  # type: ignore[import-not-found]
-
     url = f"{FRANKFURTER_BASE}/{start}..{end}"
-    r = requests.get(url, params={"from": base, "to": ",".join(symbols)}, timeout=timeout)
+    s = session if session is not None else _retrying_session()
+    r = s.get(url, params={"from": base, "to": ",".join(symbols)}, timeout=timeout)
     r.raise_for_status()
     return r.json()
 
@@ -249,10 +314,11 @@ def fetch_frankfurter(
 # ─── Crypto Fear & Greed ───────────────────────────────────────────────────
 
 
-def fetch_fng_raw(limit: int, *, timeout: float = 60.0) -> list[dict[str, Any]]:
-    import requests  # type: ignore[import-not-found]
-
-    r = requests.get(FNG_URL, params={"limit": limit}, timeout=timeout)
+def fetch_fng_raw(
+    limit: int, *, timeout: float = 60.0, session: Any | None = None
+) -> list[dict[str, Any]]:
+    s = session if session is not None else _retrying_session()
+    r = s.get(FNG_URL, params={"limit": limit}, timeout=timeout)
     r.raise_for_status()
     data = r.json().get("data")
     return data if isinstance(data, list) else []

--- a/digiquant/src/digiquant/data/prices/supabase_writer.py
+++ b/digiquant/src/digiquant/data/prices/supabase_writer.py
@@ -21,6 +21,7 @@ from digibase.audit import redact_mapping
 
 from digiquant.data.prices import TECHNICAL_COLUMNS
 from digiquant.data.prices._utils import safe_float as _safe_float
+from digiquant.data.prices._utils import safe_int as _safe_int
 
 DEFAULT_CHUNK = 500
 
@@ -70,7 +71,7 @@ def ohlcv_to_price_history_rows(df: pl.DataFrame, ticker: str) -> list[dict[str,
                 "high": _safe_float(r.get("high")),
                 "low": _safe_float(r.get("low")),
                 "close": close,
-                "volume": _safe_float(r.get("volume"), decimals=None),
+                "volume": _safe_int(r.get("volume")),
             }
         )
     return rows

--- a/tests/dq/data/test_macro_ingest.py
+++ b/tests/dq/data/test_macro_ingest.py
@@ -156,3 +156,69 @@ def test_macro_manifest_defaults() -> None:
     assert mani.frankfurter_base == "USD"
     assert "EUR" in mani.frankfurter_symbols
     assert mani.fng_series_id == "FNG/value"
+
+
+# ─── Retry + per-series isolation ──────────────────────────────────────
+
+
+def _manifest_two_series() -> MacroManifest:
+    return MacroManifest.from_dict(
+        {
+            "fred": {
+                "series": [
+                    {"id": "DGS10", "title": "10Y", "unit": "percent"},
+                    {"id": "SOFR", "title": "SOFR", "unit": "percent"},
+                ],
+                "backfill_start": "2025-01-01",
+            },
+        }
+    )
+
+
+@pytest.mark.unit
+def test_fetch_fred_isolates_per_series_failure(monkeypatch) -> None:
+    # One series succeeds, the other raises. The succeeding series' rows are
+    # returned; the failing one is skipped (logged to stderr), not propagated.
+    import requests
+
+    from digiquant.data.prices import macro_ingest
+
+    def fake_fetch(api_key, series_id, *args, **kwargs):
+        if series_id == "SOFR":
+            raise requests.HTTPError("500 Server Error", response=None)
+        return [{"date": "2025-01-02", "value": "4.25"}]
+
+    monkeypatch.setattr(macro_ingest, "fetch_fred_series", fake_fetch)
+    rows = fetch_fred(_manifest_two_series(), api_key="test")
+    assert len(rows) == 1
+    assert rows[0]["series_id"] == "DGS10"
+
+
+@pytest.mark.unit
+def test_fetch_fred_fails_only_when_all_series_fail(monkeypatch) -> None:
+    import requests
+
+    from digiquant.data.prices import macro_ingest
+
+    def always_fail(*args, **kwargs):
+        raise requests.HTTPError("500 Server Error", response=None)
+
+    monkeypatch.setattr(macro_ingest, "fetch_fred_series", always_fail)
+    with pytest.raises(RuntimeError, match="all 2 series failed"):
+        fetch_fred(_manifest_two_series(), api_key="test")
+
+
+@pytest.mark.unit
+def test_retrying_session_retries_on_5xx(monkeypatch) -> None:
+    # Session-level 500 retry is opaque to callers — they see the eventual 200
+    # (or a final raised HTTPError if every retry exhausts). We verify the
+    # Retry adapter is configured for 500/502/503/504 on GET.
+    from digiquant.data.prices.macro_ingest import _retrying_session
+
+    s = _retrying_session(total=2, backoff_factor=0.1)
+    adapter = s.get_adapter("https://api.stlouisfed.org")
+    retry_cfg = adapter.max_retries
+    assert 500 in retry_cfg.status_forcelist
+    assert 503 in retry_cfg.status_forcelist
+    assert "GET" in retry_cfg.allowed_methods
+    assert retry_cfg.total == 2

--- a/tests/dq/data/test_supabase_writer.py
+++ b/tests/dq/data/test_supabase_writer.py
@@ -88,6 +88,16 @@ def test_ohlcv_to_price_history_rows_produces_atlas_schema() -> None:
 
 
 @pytest.mark.unit
+def test_ohlcv_to_price_history_rows_volume_is_int() -> None:
+    # price_history.volume is bigint; postgrest rejects float payloads with 22P02.
+    df = _ohlcv_df(2)
+    rows = ohlcv_to_price_history_rows(df, "SPY")
+    for r in rows:
+        assert isinstance(r["volume"], int)
+        assert not isinstance(r["volume"], bool)
+
+
+@pytest.mark.unit
 def test_ohlcv_to_price_history_rows_skips_null_close() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Fixes #329.

## What broke

The `digiquant-prices` scheduled workflow (15-min intraday + EOD macro) had been failing on every scheduled run since #149 merged — three stacked bugs.

## Fixes in this PR

1. **`pyarrow` missing from `digiquant[prices]` extra** — `pl.from_pandas()` in `fetchers.py` needs it for yfinance's pandas extension dtypes. `ImportError` killed every run before Supabase was touched.
   - File: `digiquant/pyproject.toml`
2. **`price_history.volume` cast to int** — column is `bigint`, writer was sending float (`"127844500.0"`). Postgrest rejected with `22P02 invalid input syntax for type bigint`.
   - Files: `digiquant/src/digiquant/data/prices/_utils.py` (new `safe_int`), `supabase_writer.py`
   - Regression test in `tests/dq/data/test_supabase_writer.py`
3. **Macro ingest resilience** — shared `requests.Session` with `urllib3.Retry` for 5xx/connection errors (3 tries, exponential backoff), plus per-series isolation in `fetch_fred` so one bad FRED series doesn't kill the other 19. Escalates to `RuntimeError` only if every series fails (true upstream-down signal).
   - File: `digiquant/src/digiquant/data/prices/macro_ingest.py`
   - 3 new tests in `tests/dq/data/test_macro_ingest.py`

Plus docs describing the actual `digiquant-prices` workflow (schedule, secrets, storage contract, cron-from-default-branch caveat) in `apps/digiquant-atlas/AGENTS.md` and `ARCHITECTURE.md`.

## Verification

- `pytest tests/dq/ -m unit` → **259 passed** (up from 256)
- `ruff check digiquant/src` → clean
- `make score` → **10/10** Security, Quality, Optimization, Accuracy
- Live `workflow_dispatch` runs on `task/329-fix-digiquant-prices`:
  - **Intraday job green** — 78/78 tickers written to `price_history` + `price_technicals` for 2026-04-21
  - **EOD macro job green** — FRED + Frankfurter + FNG rows landed in `macro_series_observations`
- DB validation via Supabase MCP confirmed:
  - `volume` stored as `bigint` (int8) — no `.0` in samples
  - `price_history` now has 78 tickers × full history (oldest: 1993-01-29 SPY; latest: 2026-04-21)
  - `price_technicals` has 78/78 tickers written for today
  - FRED latest is 2026-04-20 (expected — FRED is day-delayed)

## Quality gate

- [x] /simplify run — code reviewed for reuse, quality, and efficiency; issues fixed
- [x] /review completed — PR reviewed against scoring rubric; findings addressed

## Out of scope (separate follow-ups)

- **Weekend equity rows** — DB validation caught a separate pre-existing regression: since ~2026-04-05 the pipeline stops writing weekend rows for equity tickers (crypto weekend rows are still written). Predates this PR; tracked in the epic #335 child issues.
- **`trading_calendar` design revision** — the existing `price_history.is_trading_day` per-ticker flag is smarter than the separate-table design originally sketched in epic #335. The epic will be revised post-merge.

## Context

- Duplicate PR #327 closed (rediscovered the workflow existed).
- Parent issue #298 closed as already-implemented by #286 (the #149 migration).
