### PR TITLE
fix(ci): repair cursor-agent-dispatch comment step

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -83,6 +83,7 @@ jobs:
           echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
 
       - name: Run cursor-agent
+        id: run_agent
         if: ${{ secrets.CURSOR_API_KEY != '' }}
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
@@ -96,7 +97,7 @@ jobs:
           BRANCH:         ${{ steps.meta.outputs.branch }}
           REPO:           ${{ github.repository }}
         run: |
-          cursor-agent \
+          cursor-agent --force \
             -p "You are working on the DigiThings repository ($REPO).
           Task: $ISSUE_TITLE
           Issue: $ISSUE_URL
@@ -117,15 +118,20 @@ jobs:
       - name: Post dispatch comment
         if: always()
         env:
-          GH_TOKEN:     ${{ github.token }}
-          REPO:         ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          TEST_CMD:     ${{ steps.meta.outputs.test_cmd }}
-          BRANCH:       ${{ steps.meta.outputs.branch }}
-          REPO_URL:     ${{ github.server_url }}/${{ github.repository }}
-          ISSUE_URL:    ${{ github.event.issue.html_url }}
+          GH_TOKEN:       ${{ github.token }}
+          REPO:           ${{ github.repository }}
+          ISSUE_NUMBER:   ${{ github.event.issue.number }}
+          TEST_CMD:       ${{ steps.meta.outputs.test_cmd }}
+          BRANCH:         ${{ steps.meta.outputs.branch }}
+          REPO_URL:       ${{ github.server_url }}/${{ github.repository }}
+          ISSUE_URL:      ${{ github.event.issue.html_url }}
+          AGENT_OUTCOME:  ${{ steps.run_agent.outcome }}
         run: |
           LINK="cursor://anysphere.cursor-deeplink/open-agent?repoUrl=${REPO_URL}.git&issueUrl=${ISSUE_URL}"
-          KEY_STATUS=$( [ -n "${{CURSOR_API_KEY:-}}" ] && echo "CLI dispatched" || echo "Add CURSOR_API_KEY secret to enable CLI dispatch" )
+          case "$AGENT_OUTCOME" in
+            success) STATUS="CLI dispatched" ;;
+            skipped) STATUS="Add CURSOR_API_KEY secret to enable CLI dispatch" ;;
+            *)       STATUS="CLI dispatch failed — check Actions log" ;;
+          esac
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-            --body "**Cursor dispatch** | $KEY_STATUS | Branch: \`$BRANCH\` | Gate: \`make score && $TEST_CMD && ruff check .\` | [Open manually in Cursor]($LINK)"
+            --body "**Cursor dispatch** | ${STATUS} | Branch: \`${BRANCH}\` | Gate: \`make score && ${TEST_CMD} && ruff check .\` | [Open manually in Cursor](${LINK})"


### PR DESCRIPTION
## Summary

- `${{CURSOR_API_KEY:-}}` in the "Post dispatch comment" `run:` block was invalid — GitHub Actions template evaluation fails on `{{CURSOR_API_KEY:-}}` because `:-` is not valid GH expression syntax, and the variable wasn't in the step's `env:` anyway. This caused the comment step to fail before posting anything, marking the whole workflow red.
- Added `id: run_agent` to the cursor-agent step so the comment step can read `steps.run_agent.outcome`.
- Replaced the broken `KEY_STATUS` line with a `case "$AGENT_OUTCOME"` that maps `success` / `skipped` / `failure` to human-readable status strings.
- Added `--force` to `cursor-agent` (required for headless mode to actually write files).

## Test plan

- [ ] Merge this PR
- [ ] Re-label issue #342 with `exec:cursor`
- [ ] Confirm workflow runs green and posts the status comment on #342

Closes #342

https://claude.ai/code/session_014zP1P2Y1c21X71dx6wExoo