### PR TITLE
fix(ci): make cursor-agent-dispatch resilient to install failures

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -78,12 +78,15 @@ jobs:
           echo "branch=cursor/${ISSUE_NUMBER}-${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
 
       - name: Install Cursor CLI
+        id: install_cli
+        continue-on-error: true
         run: |
           curl -fsSL "https://cursor.com/install" | bash
           echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
 
       - name: Run cursor-agent
         id: run_agent
+        continue-on-error: true
         if: ${{ secrets.CURSOR_API_KEY != '' }}
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
@@ -118,20 +121,25 @@ jobs:
       - name: Post dispatch comment
         if: always()
         env:
-          GH_TOKEN:       ${{ github.token }}
-          REPO:           ${{ github.repository }}
-          ISSUE_NUMBER:   ${{ github.event.issue.number }}
-          TEST_CMD:       ${{ steps.meta.outputs.test_cmd }}
-          BRANCH:         ${{ steps.meta.outputs.branch }}
-          REPO_URL:       ${{ github.server_url }}/${{ github.repository }}
-          ISSUE_URL:      ${{ github.event.issue.html_url }}
-          AGENT_OUTCOME:  ${{ steps.run_agent.outcome }}
+          GH_TOKEN:        ${{ github.token }}
+          REPO:            ${{ github.repository }}
+          ISSUE_NUMBER:    ${{ github.event.issue.number }}
+          TEST_CMD:        ${{ steps.meta.outputs.test_cmd }}
+          BRANCH:          ${{ steps.meta.outputs.branch }}
+          REPO_URL:        ${{ github.server_url }}/${{ github.repository }}
+          ISSUE_URL:       ${{ github.event.issue.html_url }}
+          INSTALL_OUTCOME: ${{ steps.install_cli.outcome }}
+          AGENT_OUTCOME:   ${{ steps.run_agent.outcome }}
         run: |
           LINK="cursor://anysphere.cursor-deeplink/open-agent?repoUrl=${REPO_URL}.git&issueUrl=${ISSUE_URL}"
-          case "$AGENT_OUTCOME" in
-            success) STATUS="CLI dispatched" ;;
-            skipped) STATUS="Add CURSOR_API_KEY secret to enable CLI dispatch" ;;
-            *)       STATUS="CLI dispatch failed — check Actions log" ;;
-          esac
+          if [ "$INSTALL_OUTCOME" != "success" ]; then
+            STATUS="CLI install failed — using deep-link fallback below"
+          elif [ "$AGENT_OUTCOME" = "success" ]; then
+            STATUS="CLI dispatched"
+          elif [ "$AGENT_OUTCOME" = "skipped" ]; then
+            STATUS="Add CURSOR_API_KEY secret to enable CLI dispatch"
+          else
+            STATUS="CLI dispatch failed — check Actions log"
+          fi
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
             --body "**Cursor dispatch** | ${STATUS} | Branch: \`${BRANCH}\` | Gate: \`make score && ${TEST_CMD} && ruff check .\` | [Open manually in Cursor](${LINK})"


### PR DESCRIPTION
## Summary

The `Post dispatch comment` step (which has `if: always()`) was still not running when the `Install Cursor CLI` step failed, because GitHub Actions propagates the failure state and blocks `if: always()` steps when the runner itself errors — adding `continue-on-error: true` is required to decouple step failure from job failure.

Changes:
- `Install Cursor CLI` → `id: install_cli` + `continue-on-error: true`
- `Run cursor-agent` → `continue-on-error: true`
- `Post dispatch comment` → reads `INSTALL_OUTCOME` and `AGENT_OUTCOME`, surfaces which step failed so the comment tells us exactly what went wrong (and still always posts the deep-link fallback)

After this merge, even if `cursor.com/install` is inaccessible from the runner, the issue will get a comment like:
> "CLI install failed — using deep-link fallback below | [Open manually in Cursor](...)"

That comment will tell us the root cause and let agents be dispatched manually while we investigate the install path.

## Test plan

- [ ] Merge this PR
- [ ] Re-label issue #342 with `exec:cursor`
- [ ] Confirm a comment appears on #342 (regardless of whether install succeeds)
- [ ] Read the status in the comment to determine next fix

Closes #342

https://claude.ai/code/session_014zP1P2Y1c21X71dx6wExoo