### PR TITLE
fix(ci): align atlas workflow env var name with supabase_io expectation

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -61,7 +61,7 @@ jobs:
         id: run
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run delta
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run monthly
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           LITELLM_PROXY_API_KEY: ${{ secrets.LITELLM_PROXY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -230,7 +230,7 @@ def _auto_resolve_baseline(run_date: date) -> date | None:
     """
     import os
 
-    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_ROLE_KEY"):
+    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_KEY"):
         return None
 
     from digiquant_atlas.supabase_io import SupabaseConfig, build_client
@@ -273,7 +273,7 @@ def resolve_cli_inputs(args) -> dict:
         if resolved is None and not args.dry_run:
             raise SystemExit(
                 "--auto-baseline could not resolve a baseline date; "
-                "is SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY set and is there "
+                "is SUPABASE_URL/SUPABASE_SERVICE_KEY set and is there "
                 "a prior research_baseline_manifest document?"
             )
         baseline_date = resolved


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- All three atlas scheduler workflows (`atlas-delta`, `atlas-baseline`, `atlas-monthly`) exposed the Supabase service key as `SUPABASE_SERVICE_ROLE_KEY` in the job `env:` block
- `supabase_io.SupabaseConfig.from_env()` reads `SUPABASE_SERVICE_KEY` — the process never saw the value and raised `SupabaseNotConfiguredError` before any LLM call
- Renames the env var key in each workflow's run step; the secret reference (`${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}`) is unchanged

## Test plan

- [ ] Confirm `atlas-delta` workflow_dispatch with `dry_run: true` passes the preflight/resolve step without `SupabaseNotConfiguredError`
- [ ] Verify no other workflow references `SUPABASE_SERVICE_ROLE_KEY` as a process env var (grep shows none)

Fixes #350
Closes #349

https://claude.ai/code/session_014hssou3QFTaAuw2NiYCBwz
EOF
)