### PR TITLE
fix(digiquant): add pyarrow>=15 to [prices] extra

### DIFF
--- a/digiquant/pyproject.toml
+++ b/digiquant/pyproject.toml
@@ -30,6 +30,7 @@ prices = [
     "pyyaml>=6",
     "supabase>=2.0",
     "python-dotenv>=1",
+    "pyarrow>=15",
 ]
 optimize = ["optuna>=3.0"]
 all = ["digiquant[nautilus]"]


### PR DESCRIPTION
pl.from_pandas() fails on yfinance DataFrames because they use pandas
extension dtypes (Int64/Float64) that require pyarrow for the Polars
conversion. Without it every scheduled intraday run crashes at the
"Fetch quotes -> update cache -> upsert price_history" step with:

  ImportError: pyarrow is required for converting a pandas dataframe to Polars

Fixes #329. See also the CI-failure issues #322–#358.

https://claude.ai/code/session_0114szFFikaVSoPoKRYVVDjy