### PR TITLE
fix(digiquant): promote remaining #329 fixes to develop (volume-int + FRED retries)

### DIFF
--- a/digiquant/src/digiquant/data/prices/_utils.py
+++ b/digiquant/src/digiquant/data/prices/_utils.py
@@ -30,4 +30,16 @@ def safe_float(v: Any, decimals: int | None = 4) -> float | None:
     return round(f, decimals) if decimals is not None else f
 
 
-__all__ = ["safe_float"]
+def safe_int(v: Any) -> int | None:
+    """Coerce a value to an int, or return ``None``.
+
+    Volume columns in Supabase are ``bigint``; postgrest rejects float payloads
+    (``"127844500.0"``) with ``22P02`` invalid-syntax errors. yfinance sometimes
+    returns volume as float (NaN-coercion, unadjusted closes, pandas extension
+    dtypes), so we must cast before serializing.
+    """
+    f = safe_float(v, decimals=None)
+    return int(f) if f is not None else None
+
+
+__all__ = ["safe_float", "safe_int"]

--- a/digiquant/src/digiquant/data/prices/macro_ingest.py
+++ b/digiquant/src/digiquant/data/prices/macro_ingest.py
@@ -69,6 +69,42 @@ class MacroManifest:
         return cls.from_dict(data)
 
 
+# ─── HTTP session with retries (shared by all three upstreams) ──────────────
+
+
+def _retrying_session(
+    *,
+    total: int = 3,
+    backoff_factor: float = 1.5,
+) -> Any:
+    """``requests.Session`` with retry on 5xx / connection errors / read timeouts.
+
+    Upstream data providers (FRED in particular) occasionally return transient
+    5xx. Without retries, a single flake kills the whole daily job. Defaults
+    (3 tries, 1.5s exponential backoff) cover a window of roughly 0s → 1.5s →
+    4.5s → 10.5s before giving up.
+    """
+    import requests  # type: ignore[import-not-found]
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    retry = Retry(
+        total=total,
+        connect=total,
+        read=total,
+        status=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=frozenset(["GET"]),
+        raise_on_status=True,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    s = requests.Session()
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
 # ─── FRED ───────────────────────────────────────────────────────────────────
 
 
@@ -79,10 +115,9 @@ def fetch_fred_series(
     observation_end: str | None = None,
     *,
     timeout: float = 120.0,
+    session: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Single-series FRED observations fetch. Returns raw observation dicts."""
-    import requests  # type: ignore[import-not-found]
-
     params: dict[str, Any] = {
         "series_id": series_id,
         "api_key": api_key,
@@ -91,7 +126,8 @@ def fetch_fred_series(
     }
     if observation_end:
         params["observation_end"] = observation_end
-    r = requests.get(FRED_OBS_URL, params=params, timeout=timeout)
+    s = session if session is not None else _retrying_session()
+    r = s.get(FRED_OBS_URL, params=params, timeout=timeout)
     r.raise_for_status()
     return r.json().get("observations") or []
 
@@ -138,21 +174,50 @@ def fetch_fred(
     end: str | None = None,
     only_series: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch all FRED series in ``manifest`` and return unified observation rows."""
+    """Fetch all FRED series in ``manifest`` and return unified observation rows.
+
+    Per-series error isolation: if one series fails after retries, the remaining
+    series continue. Failures are logged to stderr. The run fails only if
+    **every** series failed (upstream-down signal) — partial data beats none.
+    """
     if not api_key:
         raise ValueError("fetch_fred requires api_key")
+    import sys
+
+    import requests  # type: ignore[import-not-found]
+
     rows: list[dict[str, Any]] = []
+    failed: list[tuple[str, str]] = []
+    attempted: list[str] = []
     end_s = end or date.today().isoformat()
+    sess = _retrying_session()
     for item in manifest.fred_series:
         if not isinstance(item, dict):
             continue
         sid = item.get("id")
         if not sid or (only_series and sid != only_series):
             continue
+        attempted.append(sid)
         start_s = start or manifest.fred_backfill_start
-        observations = fetch_fred_series(api_key, sid, start_s, end_s)
+        try:
+            observations = fetch_fred_series(api_key, sid, start_s, end_s, session=sess)
+        except (requests.RequestException, ValueError) as exc:
+            failed.append((sid, str(exc)[:200]))
+            print(f"  [fetch_fred] skipped {sid}: {exc}", file=sys.stderr)
+            continue
         rows.extend(
             fred_observations_to_rows(sid, item.get("unit"), item.get("title"), observations)
+        )
+    if attempted and len(failed) == len(attempted):
+        detail = "; ".join(f"{sid}: {msg}" for sid, msg in failed[:5])
+        raise RuntimeError(
+            f"fetch_fred: all {len(attempted)} series failed — upstream likely down. {detail}"
+        )
+    if failed:
+        print(
+            f"  [fetch_fred] partial: {len(attempted) - len(failed)}/{len(attempted)} series ok, "
+            f"{len(failed)} skipped",
+            file=sys.stderr,
         )
     return rows
 
@@ -179,11 +244,11 @@ def fetch_frankfurter_range(
     symbols: list[str],
     *,
     timeout: float = 120.0,
+    session: Any | None = None,
 ) -> dict[str, Any]:
-    import requests  # type: ignore[import-not-found]
-
     url = f"{FRANKFURTER_BASE}/{start}..{end}"
-    r = requests.get(url, params={"from": base, "to": ",".join(symbols)}, timeout=timeout)
+    s = session if session is not None else _retrying_session()
+    r = s.get(url, params={"from": base, "to": ",".join(symbols)}, timeout=timeout)
     r.raise_for_status()
     return r.json()
 
@@ -249,10 +314,11 @@ def fetch_frankfurter(
 # ─── Crypto Fear & Greed ───────────────────────────────────────────────────
 
 
-def fetch_fng_raw(limit: int, *, timeout: float = 60.0) -> list[dict[str, Any]]:
-    import requests  # type: ignore[import-not-found]
-
-    r = requests.get(FNG_URL, params={"limit": limit}, timeout=timeout)
+def fetch_fng_raw(
+    limit: int, *, timeout: float = 60.0, session: Any | None = None
+) -> list[dict[str, Any]]:
+    s = session if session is not None else _retrying_session()
+    r = s.get(FNG_URL, params={"limit": limit}, timeout=timeout)
     r.raise_for_status()
     data = r.json().get("data")
     return data if isinstance(data, list) else []

--- a/digiquant/src/digiquant/data/prices/supabase_writer.py
+++ b/digiquant/src/digiquant/data/prices/supabase_writer.py
@@ -21,6 +21,7 @@ from digibase.audit import redact_mapping
 
 from digiquant.data.prices import TECHNICAL_COLUMNS
 from digiquant.data.prices._utils import safe_float as _safe_float
+from digiquant.data.prices._utils import safe_int as _safe_int
 
 DEFAULT_CHUNK = 500
 
@@ -70,7 +71,7 @@ def ohlcv_to_price_history_rows(df: pl.DataFrame, ticker: str) -> list[dict[str,
                 "high": _safe_float(r.get("high")),
                 "low": _safe_float(r.get("low")),
                 "close": close,
-                "volume": _safe_float(r.get("volume"), decimals=None),
+                "volume": _safe_int(r.get("volume")),
             }
         )
     return rows

--- a/tests/dq/data/test_macro_ingest.py
+++ b/tests/dq/data/test_macro_ingest.py
@@ -156,3 +156,69 @@ def test_macro_manifest_defaults() -> None:
     assert mani.frankfurter_base == "USD"
     assert "EUR" in mani.frankfurter_symbols
     assert mani.fng_series_id == "FNG/value"
+
+
+# ─── Retry + per-series isolation ──────────────────────────────────────
+
+
+def _manifest_two_series() -> MacroManifest:
+    return MacroManifest.from_dict(
+        {
+            "fred": {
+                "series": [
+                    {"id": "DGS10", "title": "10Y", "unit": "percent"},
+                    {"id": "SOFR", "title": "SOFR", "unit": "percent"},
+                ],
+                "backfill_start": "2025-01-01",
+            },
+        }
+    )
+
+
+@pytest.mark.unit
+def test_fetch_fred_isolates_per_series_failure(monkeypatch) -> None:
+    # One series succeeds, the other raises. The succeeding series' rows are
+    # returned; the failing one is skipped (logged to stderr), not propagated.
+    import requests
+
+    from digiquant.data.prices import macro_ingest
+
+    def fake_fetch(api_key, series_id, *args, **kwargs):
+        if series_id == "SOFR":
+            raise requests.HTTPError("500 Server Error", response=None)
+        return [{"date": "2025-01-02", "value": "4.25"}]
+
+    monkeypatch.setattr(macro_ingest, "fetch_fred_series", fake_fetch)
+    rows = fetch_fred(_manifest_two_series(), api_key="test")
+    assert len(rows) == 1
+    assert rows[0]["series_id"] == "DGS10"
+
+
+@pytest.mark.unit
+def test_fetch_fred_fails_only_when_all_series_fail(monkeypatch) -> None:
+    import requests
+
+    from digiquant.data.prices import macro_ingest
+
+    def always_fail(*args, **kwargs):
+        raise requests.HTTPError("500 Server Error", response=None)
+
+    monkeypatch.setattr(macro_ingest, "fetch_fred_series", always_fail)
+    with pytest.raises(RuntimeError, match="all 2 series failed"):
+        fetch_fred(_manifest_two_series(), api_key="test")
+
+
+@pytest.mark.unit
+def test_retrying_session_retries_on_5xx(monkeypatch) -> None:
+    # Session-level 500 retry is opaque to callers — they see the eventual 200
+    # (or a final raised HTTPError if every retry exhausts). We verify the
+    # Retry adapter is configured for 500/502/503/504 on GET.
+    from digiquant.data.prices.macro_ingest import _retrying_session
+
+    s = _retrying_session(total=2, backoff_factor=0.1)
+    adapter = s.get_adapter("https://api.stlouisfed.org")
+    retry_cfg = adapter.max_retries
+    assert 500 in retry_cfg.status_forcelist
+    assert 503 in retry_cfg.status_forcelist
+    assert "GET" in retry_cfg.allowed_methods
+    assert retry_cfg.total == 2

--- a/tests/dq/data/test_supabase_writer.py
+++ b/tests/dq/data/test_supabase_writer.py
@@ -88,6 +88,16 @@ def test_ohlcv_to_price_history_rows_produces_atlas_schema() -> None:
 
 
 @pytest.mark.unit
+def test_ohlcv_to_price_history_rows_volume_is_int() -> None:
+    # price_history.volume is bigint; postgrest rejects float payloads with 22P02.
+    df = _ohlcv_df(2)
+    rows = ohlcv_to_price_history_rows(df, "SPY")
+    for r in rows:
+        assert isinstance(r["volume"], int)
+        assert not isinstance(r["volume"], bool)
+
+
+@pytest.mark.unit
 def test_ohlcv_to_price_history_rows_skips_null_close() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Fixes #329 (completing the fix in production).

## Why this PR exists

PR #330 merged three fixes for the failing `digiquant-prices` pipeline into `module/digiquant`. Only one of them (`pyarrow>=15`) reached `develop` — via the separate agentic PR #359 on 2026-04-22. The scheduled cron runs against `develop`, so since 2026-04-21 every 15-minute intraday run has been dying on the same bugs #329 reported, filing one `ci-failure` issue per run (#341–#363 and counting).

This PR cherry-picks the two missing commits from `module/digiquant` directly onto `develop`:

1. **`fix(digiquant): cast price_history.volume to int`** — postgrest rejects float payloads to `bigint` columns with `22P02 invalid input syntax for type bigint: "NNNNN.0"`. Adds `safe_int()` helper and uses it for the `volume` column in `ohlcv_to_price_history_rows`. Regression test added.
2. **`fix(digiquant): macro ingest resilience`** — shared `requests.Session` with `urllib3.Retry` for 5xx/connection errors on FRED/Frankfurter/FNG, plus per-series isolation in `fetch_fred` so one bad FRED series doesn't kill the whole 20-series macro job. Three new tests.

Both commits are clean cherry-picks from `module/digiquant` — no conflicts with the `pyarrow` commit already on `develop`.

## Verification

- `pytest tests/dq/ -m unit` → **259 passed** (unchanged from when these commits were tested in #330).
- `ruff check digiquant/src` → clean.
- Target branch rebase is clean (develop's pyarrow fix from #359 doesn't collide with these two).

## Post-merge

1. Re-dispatch `digiquant-prices` manually to confirm both jobs green against the now-complete fix set.
2. Bulk-close the `ci-failure` spam (~20 issues #341–#363 filed by the auto-failure handler).
3. Sync `module/digiquant` from `develop` as separate cleanup (it'll be 44-behind + 3-ahead after this; the 3-ahead become redundant once this merges).

## Quality gate

- [x] /simplify run — commits were reviewed and scored 10/10 in PR #330; no code changes from that review.
- [x] /review completed — commits were reviewed against scoring rubric in PR #330 (Security 10 / Quality 9 / Optimization 9 / Accuracy 10, all pass thresholds).

## Context

- Parent: #329 (reopened — fix was incomplete in production)
- Source PR: #330 (merged to `module/digiquant` on 2026-04-21)
- Pyarrow promotion: #359 (merged to `develop` 2026-04-22)
- Latest failing run: [24850848627](https://github.com/digithings-ai/digithings/actions/runs/24850848627) (2026-04-23 18:03 UTC)
