### PR TITLE
chore(root): allowlist mcp.supabase.com in network-host-guard

### DIFF
--- a/scripts/claude-hooks/network-host-guard.sh
+++ b/scripts/claude-hooks/network-host-guard.sh
@@ -33,6 +33,7 @@ allowed_hosts=(
   "cursor.com"
   "cursor.sh"
   "claude.ai"
+  "mcp.supabase.com"
   "localhost"
   "127.0.0.1"
   "0.0.0.0"


### PR DESCRIPTION
## Summary

- Adds `mcp.supabase.com` to the PreToolUse network-host-guard allowlist
- Supabase MCP server is used from Claude Code sessions for DB and edge-function operations; it was being blocked by the guard

## Test plan

- [x] Hook script syntax-clean (one-line addition to existing `allowed_hosts` array)
- [ ] Verify subsequent Claude Code sessions can hit `mcp.supabase.com` without a guard block

🤖 Generated with [Claude Code](https://claude.com/claude-code)