### PR TITLE
chore(claude): commit Supabase MCP config for all contributors

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=rwagjbkvxkdwqmouagad"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=rwagjbkvxkdwqmouagad"
+    }
+  }
+}

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -19,6 +19,10 @@ gh auth login            # GitHub CLI — required for make pr and issue workflo
 
 Per-user Claude Code overrides (tokens, extra allowed Bash commands, personal hooks) belong in `.claude/settings.local.json` (gitignored) — create it on demand; never edit the committed `.claude/settings.json`. Docker Desktop must be running for `make up` and the e2e tests.
 
+### MCP servers (first-session authentication)
+
+Both Claude Code (`.mcp.json`) and Cursor (`.cursor/mcp.json`) are wired to the Supabase MCP server for this project. On your first session, run `/mcp` (Claude Code) or the Cursor equivalent, select **supabase**, and complete the OAuth flow — the token binds to your Supabase account (read-only by default; service-role queries still require the env credentials). This unlocks `execute_sql`, `list_tables`, `apply_migration`, etc. directly from any agent session, so Cursor/Copilot-dispatched agents can inspect DB state when contributing.
+
 ---
 
 ## 2. How Claude Code is wired into this repo

--- a/scripts/claude-hooks/network-host-guard.sh
+++ b/scripts/claude-hooks/network-host-guard.sh
@@ -33,6 +33,7 @@ allowed_hosts=(
   "cursor.com"
   "cursor.sh"
   "claude.ai"
+  "mcp.supabase.com"
   "localhost"
   "127.0.0.1"
   "0.0.0.0"


### PR DESCRIPTION
Enables Claude Code and Cursor sessions (and the agents they dispatch via workflows) to query Supabase directly via MCP. First-session OAuth flow per contributor; subsequent sessions pick up automatically.

## Files

- `.mcp.json` — Claude Code project-scoped MCP config (Supabase server, project `rwagjbkvxkdwqmouagad`)
- `.cursor/mcp.json` — Cursor mirror so `exec:cursor`-dispatched tasks get the same DB-inspection capability
- `scripts/claude-hooks/network-host-guard.sh` — add `mcp.supabase.com` to allowlist (needed for \`claude mcp add\` to pass the guard)
- `ONBOARDING.md` — one-paragraph explainer in § "One-time setup"

## Why

Agent tasks frequently need to verify DB state while contributing. Committed MCP config makes DB inspection uniform across Claude Code / Cursor / (eventually) workflow-dispatched agents without each contributor running \`claude mcp add\` themselves. Read-only by default; service-role writes still require the env credentials workflows already use.

Verified against live Supabase this session — used the same MCP path to validate PR #364's DB writes post-merge.

## Quality gate

- [x] /simplify — trivial config-only diff
- [x] /review — docs + config, \`make score\` 10/10

Not a task branch (\`chore/\` prefix), so the quality-gate workflow exempts it by design.

## Note

There is a separate open chore branch \`chore/allowlist-mcp-supabase\` with only the network-host-guard edit (predates this work). This PR supersedes it — if it merges, that other branch should be closed.