### PR TITLE
feat(root): three-tier delegation — labels, Claude dispatch (OAuth+API), status automation, CI dedup

### DIFF
--- a/.github/workflows/claude-code-dispatch.yml
+++ b/.github/workflows/claude-code-dispatch.yml
@@ -84,21 +84,74 @@ jobs:
           echo "test_cmd=$TEST"                           >> "$GITHUB_OUTPUT"
           echo "branch=task/${ISSUE_NUMBER}-${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
 
-      - name: Check API key
+      # Prefer CLAUDE_CODE_OAUTH_TOKEN (Claude Code Max subscription — no API
+       # billing). Fall back to ANTHROPIC_API_KEY if only the API key is set.
+      - name: Check auth
         id: keycheck
         env:
-          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -n "${KEY:-}" ]; then
+          if [ -n "${OAUTH:-}" ]; then
+            echo "auth=oauth" >> "$GITHUB_OUTPUT"
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "${APIKEY:-}" ]; then
+            echo "auth=apikey" >> "$GITHUB_OUTPUT"
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
+            echo "auth=" >> "$GITHUB_OUTPUT"
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::ANTHROPIC_API_KEY not set — cloud dispatch disabled. Label still marks tier; run \`make task ISSUE=${{ github.event.issue.number }}\` locally."
+            echo "::notice::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set — cloud dispatch disabled. Label still marks tier; run \`make task ISSUE=${{ github.event.issue.number }}\` locally."
           fi
 
-      - name: Run Claude Code
-        id: run_claude
-        if: steps.keycheck.outputs.present == 'true'
+      - name: Run Claude Code (OAuth / subscription)
+        id: run_claude_oauth
+        if: steps.keycheck.outputs.auth == 'oauth'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token:            ${{ secrets.GITHUB_TOKEN }}
+          base_branch:             develop
+          claude_args:             "--max-turns 25 --model claude-opus-4-7"
+          prompt: |
+            You are working on the DigiThings repository (${{ github.repository }}) as Tier 3 (Claude Code).
+
+            Task: ${{ github.event.issue.title }}
+            Issue: ${{ github.event.issue.html_url }}
+            Component: ${{ steps.meta.outputs.component }}
+            Branch to create: ${{ steps.meta.outputs.branch }}
+
+            Issue body:
+            ${{ github.event.issue.body }}
+
+            Pre-flight (non-negotiable):
+            - Read CLAUDE.md and ${{ steps.meta.outputs.agents_path }} before writing any code
+            - Read docs/agents/EXECUTION_TIERS.md — confirm this issue actually requires Tier 3
+            - If the task turns out to be cursor-sized, relabel exec:cursor and stop
+
+            Rules:
+            - Polars only (no pandas), Pydantic v2, ruff-clean
+            - No comments unless the WHY is non-obvious
+            - Never touch SECURITY.md, docs/scoring/, config/litellm.yaml, projects/ without human approval
+            - Live-trading paths (digiquant/live/, config/live*, execute_trade, place_order) require
+              a Human-Approved-By commit trailer — do not touch without it
+
+            Gate before PR:
+            - make score  (must pass: Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9)
+            - ${{ steps.meta.outputs.test_cmd }}
+            - ruff check .
+
+            PR format:
+            - Title: feat(${{ steps.meta.outputs.component }}): <description> (#${{ github.event.issue.number }})
+            - Body must contain: Closes #${{ github.event.issue.number }}
+            - Target branch: develop (or the active module/<component> branch if one is ahead)
+
+            Full protocol: docs/agents/CLAUDE_CODE_ONBOARDING.md
+
+      - name: Run Claude Code (API key)
+        id: run_claude_apikey
+        if: steps.keycheck.outputs.auth == 'apikey'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -141,22 +194,27 @@ jobs:
 
             Full protocol: docs/agents/CLAUDE_CODE_ONBOARDING.md
 
-      # Only posts when the key is present. When disabled, the exec:claude
-      # label remains as a silent tier marker and `make task ISSUE=N`
-      # remains the local human path — no issue-comment noise.
+      # Only posts when an auth path is present. When disabled, the
+      # exec:claude label remains as a silent tier marker and
+      # `make task ISSUE=N` remains the local human path — no comment noise.
       - name: Post dispatch comment
         if: always() && steps.keycheck.outputs.present == 'true'
         env:
-          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
-          REPO:            ${{ github.repository }}
-          ISSUE_NUMBER:    ${{ github.event.issue.number }}
-          BRANCH:          ${{ steps.meta.outputs.branch }}
-          TEST_CMD:        ${{ steps.meta.outputs.test_cmd }}
-          RUN_URL:         ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          AGENT_OUTCOME:   ${{ steps.run_claude.outcome }}
+          GH_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
+          REPO:          ${{ github.repository }}
+          ISSUE_NUMBER:  ${{ github.event.issue.number }}
+          BRANCH:        ${{ steps.meta.outputs.branch }}
+          TEST_CMD:      ${{ steps.meta.outputs.test_cmd }}
+          RUN_URL:       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          AUTH:          ${{ steps.keycheck.outputs.auth }}
+          OAUTH_OUTCOME: ${{ steps.run_claude_oauth.outcome }}
+          APIKEY_OUTCOME: ${{ steps.run_claude_apikey.outcome }}
         run: |
-          if [ "$AGENT_OUTCOME" = "success" ]; then
-            STATUS="Claude Code dispatched — see run log"
+          OUTCOME="${OAUTH_OUTCOME:-$APIKEY_OUTCOME}"
+          AUTH_LABEL="Claude Code Max subscription"
+          [ "$AUTH" = "apikey" ] && AUTH_LABEL="Anthropic API key"
+          if [ "$OUTCOME" = "success" ]; then
+            STATUS="Claude Code dispatched via ${AUTH_LABEL} — see run log"
           else
             STATUS="Dispatch failed — check Actions log"
           fi

--- a/.github/workflows/claude-code-dispatch.yml
+++ b/.github/workflows/claude-code-dispatch.yml
@@ -1,0 +1,164 @@
+name: Claude Code dispatch
+
+# Fires when exec:claude label is applied to an issue.
+# Uses the official anthropics/claude-code-action to dispatch a Claude Code
+# session that reads the issue, implements the change, and opens a PR.
+# Ref: https://github.com/anthropics/claude-code-action
+#
+# Feature-flagged: requires the ANTHROPIC_API_KEY secret. When absent
+# (default), the workflow exits silently — the exec:claude label still
+# serves as a tier marker for local human dispatch via `make task ISSUE=N`.
+#
+# To enable cloud dispatch later:
+#   1. console.anthropic.com -> Settings -> API Keys -> Create Key
+#   2. GitHub repo Settings -> Secrets -> Actions -> ANTHROPIC_API_KEY
+#
+# Note: this dispatch targets the highest-judgment tier (architecture,
+# cross-module, security-sensitive). Issues tagged exec:claude typically
+# also carry risk:high or epic labels and warrant human review of the PR.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    name: Dispatch to Claude Code
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'exec:claude'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+
+      - name: Resolve component metadata
+        id: meta
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE:  ${{ github.event.issue.title }}
+        run: |
+          LABELS='${{ toJson(github.event.issue.labels) }}'
+          COMPONENT=$(echo "$LABELS" | python3 -c "
+          import json, sys, re
+          labels = json.load(sys.stdin)
+          for l in labels:
+              m = re.match(r'^component:(.+)$', l['name'])
+              if m:
+                  print(m.group(1))
+                  break
+          " 2>/dev/null || echo "root")
+
+          declare -A AGENTS_MD=(
+            [digigraph]="digigraph/AGENTS.md"   [digiquant]="digiquant/AGENTS.md"
+            [digisearch]="digisearch/AGENTS.md" [digikey]="digikey/AGENTS.md"
+            [digismith]="digismith/AGENTS.md"   [digiclaw]="digiclaw/AGENTS.md"
+            [digibase]="digibase/AGENTS.md"     [digichat]="frontend/digichat/AGENTS.md"
+            [root]="AGENTS.md"
+          )
+          declare -A TEST_CMD=(
+            [digigraph]="pytest -m unit -k digigraph -v --tb=short"
+            [digiquant]="pytest -m unit -k digiquant -v --tb=short"
+            [digisearch]="pytest -m unit -k digisearch -v --tb=short"
+            [digikey]="pytest -m unit -k digikey -v --tb=short"
+            [digismith]="pytest -m unit -k digismith -v --tb=short"
+            [digiclaw]="pytest -m unit -k digiclaw -v --tb=short"
+            [digibase]="pytest -m unit -k digibase -v --tb=short"
+            [digichat]="npm run test --prefix frontend/digichat"
+            [root]="pytest -m unit -v --tb=short"
+          )
+
+          AGENTS_PATH="${AGENTS_MD[$COMPONENT]:-AGENTS.md}"
+          TEST="${TEST_CMD[$COMPONENT]:-pytest -m unit -v --tb=short}"
+          BRANCH_SLUG=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' |
+                        sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
+
+          echo "component=$COMPONENT"                     >> "$GITHUB_OUTPUT"
+          echo "agents_path=$AGENTS_PATH"                 >> "$GITHUB_OUTPUT"
+          echo "test_cmd=$TEST"                           >> "$GITHUB_OUTPUT"
+          echo "branch=task/${ISSUE_NUMBER}-${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check API key
+        id: keycheck
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "${KEY:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ANTHROPIC_API_KEY not set — cloud dispatch disabled. Label still marks tier; run \`make task ISSUE=${{ github.event.issue.number }}\` locally."
+          fi
+
+      - name: Run Claude Code
+        id: run_claude
+        if: steps.keycheck.outputs.present == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token:      ${{ secrets.GITHUB_TOKEN }}
+          base_branch:       develop
+          claude_args:       "--max-turns 25 --model claude-opus-4-7"
+          prompt: |
+            You are working on the DigiThings repository (${{ github.repository }}) as Tier 3 (Claude Code).
+
+            Task: ${{ github.event.issue.title }}
+            Issue: ${{ github.event.issue.html_url }}
+            Component: ${{ steps.meta.outputs.component }}
+            Branch to create: ${{ steps.meta.outputs.branch }}
+
+            Issue body:
+            ${{ github.event.issue.body }}
+
+            Pre-flight (non-negotiable):
+            - Read CLAUDE.md and ${{ steps.meta.outputs.agents_path }} before writing any code
+            - Read docs/agents/EXECUTION_TIERS.md — confirm this issue actually requires Tier 3
+            - If the task turns out to be cursor-sized, relabel exec:cursor and stop
+
+            Rules:
+            - Polars only (no pandas), Pydantic v2, ruff-clean
+            - No comments unless the WHY is non-obvious
+            - Never touch SECURITY.md, docs/scoring/, config/litellm.yaml, projects/ without human approval
+            - Live-trading paths (digiquant/live/, config/live*, execute_trade, place_order) require
+              a Human-Approved-By commit trailer — do not touch without it
+
+            Gate before PR:
+            - make score  (must pass: Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9)
+            - ${{ steps.meta.outputs.test_cmd }}
+            - ruff check .
+
+            PR format:
+            - Title: feat(${{ steps.meta.outputs.component }}): <description> (#${{ github.event.issue.number }})
+            - Body must contain: Closes #${{ github.event.issue.number }}
+            - Target branch: develop (or the active module/<component> branch if one is ahead)
+
+            Full protocol: docs/agents/CLAUDE_CODE_ONBOARDING.md
+
+      # Only posts when the key is present. When disabled, the exec:claude
+      # label remains as a silent tier marker and `make task ISSUE=N`
+      # remains the local human path — no issue-comment noise.
+      - name: Post dispatch comment
+        if: always() && steps.keycheck.outputs.present == 'true'
+        env:
+          GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+          REPO:            ${{ github.repository }}
+          ISSUE_NUMBER:    ${{ github.event.issue.number }}
+          BRANCH:          ${{ steps.meta.outputs.branch }}
+          TEST_CMD:        ${{ steps.meta.outputs.test_cmd }}
+          RUN_URL:         ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          AGENT_OUTCOME:   ${{ steps.run_claude.outcome }}
+        run: |
+          if [ "$AGENT_OUTCOME" = "success" ]; then
+            STATUS="Claude Code dispatched — see run log"
+          else
+            STATUS="Dispatch failed — check Actions log"
+          fi
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+            --body "**Claude Code dispatch** | ${STATUS} | Branch: \`${BRANCH}\` | Gate: \`make score && ${TEST_CMD} && ruff check .\` | [Run log](${RUN_URL})"

--- a/.github/workflows/digiquant-prices.yml
+++ b/.github/workflows/digiquant-prices.yml
@@ -74,19 +74,54 @@ jobs:
             --cache-dir data/price-history \
             --days 365 \
             --supabase
-      - name: Open failure issue
+      - name: Update persistent failure issue
         if: failure()
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              title: `digiquant-prices intraday run failed (${new Date().toISOString().slice(0,16)})`,
-              body:  `Scheduled intraday price pipeline failed.\n\nRun: ${runUrl}\n\nLikely causes: upstream yfinance rate-limit, Supabase outage, schema drift.`,
-              labels: ['ci-failure', 'component:digiquant', 'pipeline:prices'],
+            const runUrl   = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stamp    = new Date().toISOString().slice(0, 16);
+            const title    = 'digiquant-prices intraday — recurring failures';
+            const labels   = ['ci-failure', 'component:digiquant', 'pipeline:prices', 'exec:copilot'];
+            const marker   = '<!-- digiquant-prices-intraday-tracker -->';
+            const failLine = `- ${stamp} — [run ${context.runId}](${runUrl})`;
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'ci-failure,pipeline:prices', per_page: 100,
             });
+            const tracker = existing.find(i => (i.body || '').includes(marker));
+
+            if (tracker) {
+              const MAX_LINES = 20;
+              const body    = tracker.body || '';
+              const parts   = body.split('## Recent failures');
+              const header  = parts[0];
+              const tailRaw = (parts[1] || '').split('\n').filter(l => l.startsWith('- '));
+              const tail    = [failLine, ...tailRaw].slice(0, MAX_LINES).join('\n');
+              const newBody = `${header.trim()}\n\n## Recent failures (latest first)\n${tail}`;
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: tracker.number, body: newBody,
+              });
+            } else {
+              const body = [
+                marker,
+                '## Persistent tracker for digiquant-prices intraday failures',
+                '',
+                'Scheduled intraday price pipeline (`*/15 13-20 * * MON-FRI`) has been failing.',
+                'This issue is updated on each failed run instead of opening new issues.',
+                '',
+                '**Likely causes:** upstream yfinance rate-limit, Supabase outage, schema drift.',
+                '',
+                '## Recent failures (latest first)',
+                failLine,
+              ].join('\n');
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels,
+              });
+            }
 
   eod-macro:
     name: EOD macro ingest
@@ -121,16 +156,51 @@ jobs:
             --sources fred,frankfurter,fng \
             --manifest apps/digiquant-atlas/config/macro_series.yaml \
             --supabase
-      - name: Open failure issue
+      - name: Update persistent failure issue
         if: failure()
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              title: `digiquant-prices EOD macro run failed (${new Date().toISOString().slice(0,10)})`,
-              body:  `Scheduled EOD macro ingest failed.\n\nRun: ${runUrl}\n\nLikely causes: FRED API_KEY missing, Frankfurter outage, Supabase RLS misconfig.`,
-              labels: ['ci-failure', 'component:digiquant', 'pipeline:macro'],
+            const runUrl   = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stamp    = new Date().toISOString().slice(0, 10);
+            const title    = 'digiquant-prices EOD macro — recurring failures';
+            const labels   = ['ci-failure', 'component:digiquant', 'pipeline:macro', 'exec:copilot'];
+            const marker   = '<!-- digiquant-prices-eod-macro-tracker -->';
+            const failLine = `- ${stamp} — [run ${context.runId}](${runUrl})`;
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'ci-failure,pipeline:macro', per_page: 100,
             });
+            const tracker = existing.find(i => (i.body || '').includes(marker));
+
+            if (tracker) {
+              const MAX_LINES = 20;
+              const body    = tracker.body || '';
+              const parts   = body.split('## Recent failures');
+              const header  = parts[0];
+              const tailRaw = (parts[1] || '').split('\n').filter(l => l.startsWith('- '));
+              const tail    = [failLine, ...tailRaw].slice(0, MAX_LINES).join('\n');
+              const newBody = `${header.trim()}\n\n## Recent failures (latest first)\n${tail}`;
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: tracker.number, body: newBody,
+              });
+            } else {
+              const body = [
+                marker,
+                '## Persistent tracker for digiquant-prices EOD macro failures',
+                '',
+                'Scheduled EOD macro ingest (`0 21 * * MON-FRI`) has been failing.',
+                'This issue is updated on each failed run instead of opening new issues.',
+                '',
+                '**Likely causes:** FRED API_KEY missing/rotated, Frankfurter outage, Supabase RLS misconfig.',
+                '',
+                '## Recent failures (latest first)',
+                failLine,
+              ].join('\n');
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels,
+              });
+            }

--- a/.github/workflows/project-status-automation.yml
+++ b/.github/workflows/project-status-automation.yml
@@ -1,0 +1,195 @@
+name: Project status automation
+
+# Moves issues through the project board status pipeline automatically.
+#
+#   Todo         ← default when an issue is opened / added to a project
+#   In Progress  ← when a task branch (task/N-*, cursor/N-*, claude/N-*) is
+#                  pushed, or when the issue is assigned to someone
+#   Review       ← when a PR is opened that closes/fixes/resolves the issue
+#   Done         ← when that PR is merged (closed as completed)
+#
+# One workflow covers all 11 org project boards (digithings #1, digiquant #2,
+# digigraph #3, digisearch #4, digichat #5, digikey #6, digismith #7,
+# digiclaw #8, digibase #9, sitaas #10, maintenance #11). Epics appear on
+# multiple boards, so we update the status on every project that contains
+# the issue.
+#
+# Requires: DIGITHINGS_PROJECT_TOKEN (PAT with `project` + `repo` scopes).
+# Without the token, the workflow exits with a notice — no failures.
+
+on:
+  issues:
+    types: [assigned, opened, reopened]
+  pull_request:
+    types: [opened, reopened, closed, ready_for_review]
+  push:
+    branches:
+      - 'task/**'
+      - 'cursor/**'
+      - 'claude/**'
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  transition:
+    name: Update project-board status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token present
+        id: token
+        env:
+          TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+        run: |
+          if [ -n "${TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::DIGITHINGS_PROJECT_TOKEN not set — skipping project-status automation."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Derive issue numbers and target status
+        id: derive
+        if: steps.token.outputs.present == 'true'
+        env:
+          EVENT_NAME:   ${{ github.event_name }}
+          ACTION:       ${{ github.event.action }}
+          PR_MERGED:    ${{ github.event.pull_request.merged }}
+          PR_BODY:      ${{ github.event.pull_request.body }}
+          PR_TITLE:     ${{ github.event.pull_request.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PUSH_REF:     ${{ github.ref_name }}
+        run: |
+          python3 <<'PY' >> "$GITHUB_OUTPUT"
+          import os, re
+
+          event = os.environ["EVENT_NAME"]
+          action = os.environ.get("ACTION", "")
+          issues = []
+          status = ""
+
+          if event == "issues":
+              n = os.environ.get("ISSUE_NUMBER", "")
+              if n:
+                  issues = [int(n)]
+              if action == "assigned":
+                  status = "In Progress"
+              elif action in ("opened", "reopened"):
+                  status = "Todo"
+
+          elif event == "pull_request":
+              body = (os.environ.get("PR_BODY") or "") + " " + (os.environ.get("PR_TITLE") or "")
+              issues = [int(m) for m in
+                        re.findall(r"(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", body)]
+              merged = os.environ.get("PR_MERGED", "false") == "true"
+              if action == "closed" and merged:
+                  status = "Done"
+              elif action in ("opened", "reopened", "ready_for_review"):
+                  status = "Review"
+
+          elif event == "push":
+              ref = os.environ.get("PUSH_REF", "")
+              m = re.match(r"^(?:task|cursor|claude)/(\d+)[-/]", ref)
+              if m:
+                  issues = [int(m.group(1))]
+                  status = "In Progress"
+
+          print(f"issues={','.join(str(i) for i in issues)}")
+          print(f"status={status}")
+          PY
+
+      - name: Apply status update across projects
+        if: steps.token.outputs.present == 'true' && steps.derive.outputs.issues != '' && steps.derive.outputs.status != ''
+        env:
+          GH_TOKEN: ${{ secrets.DIGITHINGS_PROJECT_TOKEN }}
+          REPO:     ${{ github.repository }}
+          ISSUES:   ${{ steps.derive.outputs.issues }}
+          STATUS:   ${{ steps.derive.outputs.status }}
+        run: |
+          set -euo pipefail
+
+          OWNER="digithings-ai"
+
+          # Status option IDs are stable per project; fetch once and cache.
+          declare -A STATUS_FIELD_ID
+          declare -A STATUS_OPTION_ID
+          declare -A PROJECT_NODE_ID
+
+          for proj_num in 1 2 3 4 5 6 7 8 9 10 11; do
+            # Fetch project + status field metadata
+            FIELD_JSON=$(gh api graphql -f query='
+              query($owner: String!, $num: Int!) {
+                organization(login: $owner) {
+                  projectV2(number: $num) {
+                    id
+                    field(name: "Status") {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }' -f owner="$OWNER" -F num="$proj_num" 2>/dev/null || echo '{}')
+
+            PROJ_ID=$(echo "$FIELD_JSON" | jq -r '.data.organization.projectV2.id // empty')
+            FIELD_ID=$(echo "$FIELD_JSON" | jq -r '.data.organization.projectV2.field.id // empty')
+            OPT_ID=$(echo "$FIELD_JSON" | jq -r --arg s "$STATUS" \
+              '.data.organization.projectV2.field.options[]? | select(.name == $s) | .id' | head -1)
+
+            [ -z "$PROJ_ID" ] && continue
+            [ -z "$FIELD_ID" ] && continue
+            [ -z "$OPT_ID" ] && continue
+            PROJECT_NODE_ID[$proj_num]="$PROJ_ID"
+            STATUS_FIELD_ID[$proj_num]="$FIELD_ID"
+            STATUS_OPTION_ID[$proj_num]="$OPT_ID"
+          done
+
+          # For each issue, find its project-item ID in each project, then update.
+          IFS=',' read -ra ISSUE_NUMS <<< "$ISSUES"
+          for ISSUE_NUM in "${ISSUE_NUMS[@]}"; do
+            REPO_OWNER="${REPO%/*}"
+            REPO_NAME="${REPO#*/}"
+
+            # Fetch this issue's projectItems and their project numbers.
+            ITEM_JSON=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $num: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $num) {
+                    projectItems(first: 20) {
+                      nodes {
+                        id
+                        project { number }
+                      }
+                    }
+                  }
+                }
+              }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F num="$ISSUE_NUM" 2>/dev/null || echo '{}')
+
+            # Walk each project-item, update status if the project is known.
+            echo "$ITEM_JSON" | jq -r '.data.repository.issue.projectItems.nodes[]? | "\(.project.number) \(.id)"' |
+            while read -r proj_num item_id; do
+              [ -z "${PROJECT_NODE_ID[$proj_num]:-}" ] && continue
+
+              gh api graphql -f query='
+                mutation($proj: ID!, $item: ID!, $field: ID!, $opt: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $proj,
+                      itemId: $item,
+                      fieldId: $field,
+                      value: { singleSelectOptionId: $opt }
+                    }
+                  ) { projectV2Item { id } }
+                }' \
+                -f proj="${PROJECT_NODE_ID[$proj_num]}" \
+                -f item="$item_id" \
+                -f field="${STATUS_FIELD_ID[$proj_num]}" \
+                -f opt="${STATUS_OPTION_ID[$proj_num]}" \
+                >/dev/null 2>&1 \
+                && echo "  ✓ #$ISSUE_NUM → $STATUS on Project #$proj_num" \
+                || echo "::warning::Failed to update #$ISSUE_NUM → $STATUS on Project #$proj_num"
+            done
+          done

--- a/docs/agents/CLAUDE_CODE_ONBOARDING.md
+++ b/docs/agents/CLAUDE_CODE_ONBOARDING.md
@@ -41,24 +41,52 @@ workflow (PR #253).
 
 ### 1b. Cloud dispatch (feature-flagged)
 
-When the `ANTHROPIC_API_KEY` secret is set in the repo, applying `exec:claude`
-to an issue fires `.github/workflows/claude-code-dispatch.yml`, which runs
-`anthropics/claude-code-action@v1` (pinned to the GA v1 tag). Claude executes
-in the Action runner, creates a `task/N-*` branch, and opens a PR.
+Applying `exec:claude` to an issue fires `.github/workflows/claude-code-dispatch.yml`,
+which runs `anthropics/claude-code-action@v1` (pinned to the GA v1 tag). Claude
+executes in the Action runner, creates a `task/N-*` branch, and opens a PR.
 
-When the secret is absent (default state), the workflow exits silently with a
+The workflow accepts two auth paths, preferring the subscription one:
+
+1. **`CLAUDE_CODE_OAUTH_TOKEN` (preferred)** — authenticates against a Claude
+   Code Max subscription. No separate billing, uses the seat you already pay
+   for. Generate with `claude setup-token` in a local Claude Code session.
+2. **`ANTHROPIC_API_KEY` (fallback)** — direct Anthropic API billing. Use
+   this only if you don't have a Claude Code Max seat.
+
+When neither secret is set (default state), the workflow exits silently with a
 `::notice::` in the run log. No issue comment is posted; the label still
 serves as a tier marker for the local path.
 
-**To enable cloud dispatch later:**
+**To enable cloud dispatch:**
 
-1. `console.anthropic.com` → Settings → API Keys → Create Key
-2. GitHub repo Settings → Secrets → Actions → New secret → name:
-   `ANTHROPIC_API_KEY`, value: the created key
-3. Apply `exec:claude` to any test issue to verify dispatch fires
+```bash
+# In a Claude Code session on your machine:
+claude setup-token
+# copy the printed token
 
-The subscription-based `CLAUDE_CODE_OAUTH_TOKEN` is **not** accepted by the
-official action; `ANTHROPIC_API_KEY` is the only supported auth.
+# Then add to repo secrets:
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo digithings-ai/digithings
+# paste the token when prompted
+```
+
+Apply `exec:claude` to a test issue to verify dispatch fires. OAuth tokens
+expire periodically — re-run `claude setup-token` and update the secret
+when that happens.
+
+### 1c. Related workflows (installed by the Claude Code GitHub App)
+
+If the official Claude Code GitHub App is installed on the repo, it ships two
+more workflows that share the same `CLAUDE_CODE_OAUTH_TOKEN`:
+
+- `.github/workflows/claude.yml` — fires on `@claude` mentions in issue /
+  PR-review / comment bodies, or in issue titles and bodies. Claude reads
+  the surrounding context and executes the mentioned instruction.
+- `.github/workflows/claude-code-review.yml` — auto-runs `/code-review` on
+  every PR open / sync / ready-for-review / reopen.
+
+All three Claude workflows (`claude.yml`, `claude-code-review.yml`, and this
+repo's `claude-code-dispatch.yml`) share the same OAuth token and subscription
+compute.
 
 ---
 

--- a/docs/agents/CLAUDE_CODE_ONBOARDING.md
+++ b/docs/agents/CLAUDE_CODE_ONBOARDING.md
@@ -1,0 +1,186 @@
+# Claude Code Onboarding — Tier 3 Delegation
+
+This document covers everything needed to dispatch Claude Code (Tier 3) against
+DigiThings backlog issues — both the local interactive path and the cloud
+GitHub-Action path.
+
+Parallel to `docs/agents/CURSOR_AGENT_ONBOARDING.md`, but Claude is reserved
+for the highest-judgment tier: architecture, cross-module, security-sensitive,
+and milestone-decomposition work.
+
+## Prerequisites
+
+- Claude Code Max subscription (for local dispatch) **or** an Anthropic API
+  key (for cloud dispatch via GitHub Action)
+- GitHub account with write access to `digithings-ai/digithings`
+- `develop` branch checked out locally (Claude branches from it)
+
+---
+
+## 1. Two dispatch paths
+
+### 1a. Local dispatch (primary path)
+
+Applying the `exec:claude` label to a GitHub issue marks it as Tier 3. From a
+Claude Code session on the local machine:
+
+```bash
+make task ISSUE=<N>
+```
+
+This creates a task worktree on `task/N-<slug>` from `develop` (or the active
+`module/<component>` branch), pre-loads the component's `AGENTS.md` /
+`ARCHITECTURE.md`, and lands Claude in the worktree with the branch already set
+up for workflow-edit permissions. Implement, run `make score`, commit, and
+open the PR via `make pr`.
+
+The local path does **not** require any repo secret. The Claude Code Max
+subscription covers compute; the `CLAUDE_CODE_OAUTH_TOKEN` repo secret
+is unrelated to this path and is only used by the `@claude`-mention comment
+workflow (PR #253).
+
+### 1b. Cloud dispatch (feature-flagged)
+
+When the `ANTHROPIC_API_KEY` secret is set in the repo, applying `exec:claude`
+to an issue fires `.github/workflows/claude-code-dispatch.yml`, which runs
+`anthropics/claude-code-action@v1` (pinned to the GA v1 tag). Claude executes
+in the Action runner, creates a `task/N-*` branch, and opens a PR.
+
+When the secret is absent (default state), the workflow exits silently with a
+`::notice::` in the run log. No issue comment is posted; the label still
+serves as a tier marker for the local path.
+
+**To enable cloud dispatch later:**
+
+1. `console.anthropic.com` → Settings → API Keys → Create Key
+2. GitHub repo Settings → Secrets → Actions → New secret → name:
+   `ANTHROPIC_API_KEY`, value: the created key
+3. Apply `exec:claude` to any test issue to verify dispatch fires
+
+The subscription-based `CLAUDE_CODE_OAUTH_TOKEN` is **not** accepted by the
+official action; `ANTHROPIC_API_KEY` is the only supported auth.
+
+---
+
+## 2. What the agent must do
+
+Claude Code operating on this repo (local or cloud) **must follow this sequence**:
+
+### 2a. Pre-flight (before writing any code)
+
+```
+1. Read CLAUDE.md                         ← repo rules + workflows
+2. Read {component}/AGENTS.md             ← per-module pre-flight checklist
+3. Read {component}/ARCHITECTURE.md       ← module map, extension points
+4. Read docs/agents/EXECUTION_TIERS.md    ← confirm this task actually needs Tier 3
+5. If the task is cursor-sized (single paragraph, clear criteria, <5 files):
+   relabel exec:cursor, comment why, stop.
+```
+
+### 2b. Branch naming
+
+```bash
+git checkout -b task/<issue-number>-<slug>
+# Example: task/208-org-project-membership-api
+```
+
+Branch from `develop` (or the active `module/<component>` branch if one is
+ahead). The cloud action does this automatically; for local, `make task
+ISSUE=N` handles it.
+
+### 2c. Implementation rules
+
+Canonical rules in `CLAUDE.md` + `agents.yml`. Key constraints:
+
+- **Polars only** — never import pandas
+- **Pydantic v2** — model_validator, field_validator; no v1 syntax
+- **LangGraph supervisor + sub-graphs** for orchestration
+- **LiteLLM** for LLM routing with caching
+- **NautilusTrader** for quant
+- **No comments** unless the WHY is non-obvious
+- **No error handling for impossible scenarios** — trust framework guarantees
+- **Ruff clean** — `ruff check . && ruff format .` must pass
+- **Tests required** — every change needs a unit test where applicable
+- **Never touch without human approval:** `SECURITY.md`, `docs/scoring/`,
+  `config/litellm.yaml`, `projects/`, live-trading paths
+
+### 2d. Scoring gate
+
+Before opening the PR, run the self-score:
+
+```bash
+make score          # must pass: Security ≥8, Quality ≥8, Optimization ≥7, Accuracy ≥9
+make test-unit      # all unit tests green (or component-specific test-cmd)
+ruff check .        # zero violations
+```
+
+### 2e. PR submission
+
+```bash
+git push origin task/<issue-number>-<slug>
+make pr             # opens PR via gh CLI, pre-fills template
+```
+
+PR must:
+- Target `develop` (or the active `module/<component>` branch)
+- Body must contain `Closes #<issue-number>`
+- Body must fill the PR template checklist (scoring, test evidence, doc flag)
+- Title format: `feat(<component>): <description> (#<issue-number>)`
+
+The `PR quality gate` CI check enforces scoring and linkage.
+
+---
+
+## 3. Scope constraints — what even Claude Code must escalate
+
+| Constraint | Required |
+|---|---|
+| Live-trading path edits | `Human-Approved-By:` commit trailer |
+| Any `digikey/` auth or crypto change | security-review comment before PR |
+| New external service dependency | ADR in `docs/adr/` |
+| Novel architecture not covered by existing ARCHITECTURE.md | ADR + human sign-off |
+| Changes to `SECURITY.md`, `docs/scoring/`, `config/litellm.yaml` | DIGI_ALLOW_PROTECTED=1 override |
+
+---
+
+## 4. Issue quality checklist (for the human filing exec:claude issues)
+
+For Claude to succeed, the issue body must have:
+
+- [ ] **Component** field filled in (from the issue template dropdown)
+- [ ] **Goal** — one paragraph, ambiguity acceptable here (that's why it's Tier 3)
+- [ ] **Acceptance criteria** — can include "design an approach for X"
+- [ ] **Risk** set honestly (`high` requires human gate at merge time)
+- [ ] **Related ADRs / epics** linked
+
+Use `/spec` in Claude Code to generate a compliant issue body.
+
+---
+
+## 5. Monitoring running agents
+
+- **Local:** the Claude Code session itself
+- **Cloud:** Actions tab → `Claude Code dispatch` workflow
+- **Issue board:** the dispatch comment is posted with a run-log link when
+  cloud dispatch fires with a valid key
+- **PR board:** branches named `task/N-*` (both local and cloud) appear in the
+  PR list and are subject to the standard PR quality gate
+
+If a cloud dispatch appears stuck or wrong, cancel the Action run and file a
+follow-up `exec:claude` issue with the error logs.
+
+---
+
+## 6. Reference
+
+| Resource | Path |
+|---|---|
+| Execution tiers | `docs/agents/EXECUTION_TIERS.md` |
+| Cursor tier onboarding | `docs/agents/CURSOR_AGENT_ONBOARDING.md` |
+| Component routing | `docs/agents/COMPONENT_ROUTING.md` |
+| Agent workflow | `docs/agents/AGENT_WORKFLOW.md` |
+| Claude rules | `CLAUDE.md` + `.claude/agents/` + `.claude/skills/` |
+| Scoring rubrics | `docs/scoring/` |
+| Cloud dispatch | `.github/workflows/claude-code-dispatch.yml` |
+| Project-status automation | `.github/workflows/project-status-automation.yml` |
+| Issue template | `.github/ISSUE_TEMPLATE/agent_task.yml` |

--- a/docs/agents/EXECUTION_TIERS.md
+++ b/docs/agents/EXECUTION_TIERS.md
@@ -33,9 +33,9 @@ Interactive, local, human-in-the-loop. The top tier; takes everything above and 
 
 **Setup & operations:** see `docs/agents/CLAUDE_CODE_ONBOARDING.md`.
 **Dispatch:** applying the `exec:claude` label triggers `.github/workflows/claude-code-dispatch.yml`.
-When `ANTHROPIC_API_KEY` is set in repo secrets, Claude Code is dispatched in the cloud via the
-official `anthropics/claude-code-action`. Without the key, the workflow is silently disabled and
-the label serves as a tier marker for the local path: `make task ISSUE=N`.
+The workflow accepts either `CLAUDE_CODE_OAUTH_TOKEN` (preferred — uses your Claude Code Max
+subscription, no API billing) or `ANTHROPIC_API_KEY` (fallback). Without either, the workflow is
+silently disabled and the label serves as a tier marker for the local path: `make task ISSUE=N`.
 
 ## Decision tree
 

--- a/docs/agents/EXECUTION_TIERS.md
+++ b/docs/agents/EXECUTION_TIERS.md
@@ -31,6 +31,12 @@ Interactive, local, human-in-the-loop. The top tier; takes everything above and 
 
 **Fits:** architecture and new-module scaffolding; complex debugging; cross-module integration; security review; strategy/iterative design; milestone decomposition; reviewing agent PRs.
 
+**Setup & operations:** see `docs/agents/CLAUDE_CODE_ONBOARDING.md`.
+**Dispatch:** applying the `exec:claude` label triggers `.github/workflows/claude-code-dispatch.yml`.
+When `ANTHROPIC_API_KEY` is set in repo secrets, Claude Code is dispatched in the cloud via the
+official `anthropics/claude-code-action`. Without the key, the workflow is silently disabled and
+the label serves as a tier marker for the local path: `make task ISSUE=N`.
+
 ## Decision tree
 
 ```
@@ -76,8 +82,26 @@ Applied by `scripts/create_issue.sh` and the `spec-writer` subagent:
 
 See `docs/agents/CURSOR_AGENT_ONBOARDING.md` for the full agent operating protocol.
 
+## Project-board status automation
+
+Tier labels pair with project-board status transitions. `.github/workflows/project-status-automation.yml`
+drives the pipeline across all 11 org project boards:
+
+| Event | Target status |
+|---|---|
+| Issue opened / reopened | `Todo` |
+| Issue assigned to a user (incl. `@Copilot`) | `In Progress` |
+| Branch pushed to `task/N-*`, `cursor/N-*`, or `claude/N-*` | `In Progress` |
+| PR opened that `Closes #N` / `Fixes #N` / `Resolves #N` | `Review` |
+| That PR merged | `Done` |
+
+Epics appear on multiple boards; the workflow updates every project that contains the issue.
+Requires `DIGITHINGS_PROJECT_TOKEN` (PAT with `project` + `repo` scopes); workflow exits silently
+if the token is missing.
+
 ## Cost note
 
 - Copilot: flat subscription — use freely.
 - Cursor: burns compute credits — keep tasks scoped; 15 min good, 2 h bad.
-- Claude Code Max: reserve for the hard work.
+- Claude Code Max: reserve for the hard work. Cloud dispatch via GH Action is feature-flagged off
+  by default (no `ANTHROPIC_API_KEY`); local dispatch via `make task ISSUE=N` always works.


### PR DESCRIPTION
## Summary

Operationalizes the three-tier agent delegation framework end-to-end. Closes #366.

## Pre-merge checklist

- [x] /simplify run — reviewed via advisor pass during development; no simplification findings addressed separately in-session
- [x] /review completed — reviewed via advisor before declaring done; token-gap and roadmap caveats flagged (captured below)
- [x] `make score` passes — Security 9/10, Quality 10/10, Optimization 10/10, Accuracy 10/10 (scorer's Security annotation is a false-positive match on `execute_trade|place_order` in a prompt template *describing* what Claude must not touch)

## Secrets status

Both required secrets are now set (confirmed this session):

| Secret | Location | Status | Enables |
|---|---|---|---|
| `DIGITHINGS_PROJECT_TOKEN` | repo | ✅ set | routing + orphan sweep + status automation |
| `CLAUDE_CODE_OAUTH_TOKEN` | org | ✅ set | cloud Claude dispatch on `exec:claude` label |
| `CURSOR_API_KEY` | org | ✅ set | `exec:cursor` label dispatch |
| `ANTHROPIC_API_KEY` | — | intentionally unset | dispatch falls back to OAuth path |

## Commits in this PR

1. **Claude Code dispatch workflow** — `exec:claude` label fires `anthropics/claude-code-action@v1`. Accepts both `CLAUDE_CODE_OAUTH_TOKEN` (preferred, subscription) and `ANTHROPIC_API_KEY` (fallback). Silent-exits when neither is set. Mirrors `cursor-agent-dispatch.yml` shape.
2. **`digiquant-prices.yml` dedup** — intraday + eod-macro now maintain one persistent tracker issue each instead of opening a fresh issue per failed run.
3. **Project-status automation** — new `.github/workflows/project-status-automation.yml` drives `Todo → In Progress → Review → Done` across all 11 org project boards via GraphQL.
4. **Docs** — `docs/agents/CLAUDE_CODE_ONBOARDING.md` (parallel to Cursor) + `docs/agents/EXECUTION_TIERS.md` updated with Tier 3 dispatch section and auth-path details.

## Applied out-of-band (API, not in diff)

5. **Tier-labeled all 113 open issues** — 38 `exec:claude`, 74 `exec:cursor`, 1 pre-existing. Preview reviewed before apply; one manual flip (#182).
6. **Filled label gaps** — #360 got `component:digiquant,complexity:S,priority:medium,risk:low`; 12 legacy Phase-1 digiquant issues (#150-#161) got `risk:low`.
7. **Routed 10 orphan issues** into their correct project boards.

Final audit: every open non-epic issue has `exec:*`, `complexity:*`, `priority:*`, `component:*`, `risk:*`. Epics carry exec + priority + type + phase only.

## Roadmap-alignment caveat

Tier labels were derived from existing issue metadata (complexity, risk, component, epic status). A deep cross-check against `docs/VISION.md` and per-module roadmaps was **not** performed this pass. Spot-check: 12 of 16 `priority:critical` issues (#150-#161) carry the legacy `phase:1` label — possibly stale, worth a human demotion pass as a follow-up.

## Test plan

- [x] `exec:*` labels applied and audited (all 113 issues covered)
- [x] Orphan issues routed into correct projects
- [x] `make score` passes
- [x] Live: `route-issues-to-projects.yml` verified working with `DIGITHINGS_PROJECT_TOKEN` (run 24855018144 succeeded post-token)
- [ ] Post-merge: `digiquant-prices` next failed scheduled run updates the persistent tracker (not a new issue)
- [ ] Post-merge: label a test issue `exec:claude` — expect cloud dispatch on OAuth path + status comment
- [ ] Post-merge: push a `task/N-*` branch — expect status automation to move linked issue to "In Progress"

## Follow-ups (separate PRs)

- Roadmap-alignment pass on #150-#161 `phase:1` criticals — possibly demote to `priority:high`
- Narrow `@Copilot` auto-assign whitelist for `housekeeping`/`cleanup`/`ci:failure` issues
- Add `timeout-minutes: 15` to `cursor-agent-dispatch.yml` for consistency (flagged during /simplify of PR #371)

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)