### PR TITLE
feat(ci): digiquant.io deploy via split publish repo (#301)

### DIFF
--- a/.github/workflows/deploy-digiquant.yml
+++ b/.github/workflows/deploy-digiquant.yml
@@ -1,0 +1,91 @@
+# Deploy digiquant.io static landing page to its own publish repo.
+#
+# GitHub Pages supports one custom domain per repo; digithings.ai already owns
+# the slot on this monorepo (see static.yml). digiquant.io is served from a
+# separate publish repo (digithings-ai/digiquant.io) whose Pages config serves
+# its `main` branch root. This workflow builds dist/ here and pushes it there.
+#
+# Source of truth: frontend/digiquant/ + frontend/design/ in this monorepo.
+# The publish repo is a deploy target only — never commit there directly.
+#
+# Secret: DIGIQUANT_IO_DEPLOY_TOKEN — fine-grained PAT scoped to
+# digithings-ai/digiquant.io with Contents: Read and write.
+
+name: Deploy digiquant.io
+
+on:
+  push:
+    branches: ["develop", "main"]
+    paths:
+      - "frontend/digiquant/**"
+      - "frontend/design/**"
+      - ".github/workflows/deploy-digiquant.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: digiquant-io-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PUBLISH_REPO: digithings-ai/digiquant.io
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Validate deploy token
+        run: |
+          if [[ -z "${{ secrets.DIGIQUANT_IO_DEPLOY_TOKEN }}" ]]; then
+            echo "::error::DIGIQUANT_IO_DEPLOY_TOKEN secret missing. See frontend/digiquant/README.md for setup."
+            exit 1
+          fi
+
+      - name: Assemble dist/
+        # Mirrors the static.yml pattern: the landing page is the root of the
+        # Pages artifact, design-system assets are exposed at /design/ so
+        # relative references like `../design/tokens.css` resolve correctly
+        # when the site is served from the publish repo's main branch.
+        run: |
+          mkdir -p dist
+          cp -r frontend/digiquant/. dist/
+          cp -r frontend/design dist/design
+          # CNAME is the source of truth for the custom domain on the Pages
+          # config — keep it at the publish repo root.
+          echo "digiquant.io" > dist/CNAME
+          echo "--- dist/ contents ---"
+          ls -la dist/
+
+      - name: Push dist/ to publish repo
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DIGIQUANT_IO_DEPLOY_TOKEN }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config --global user.name  "digithings-bot"
+          git config --global user.email "bot@digithings.ai"
+
+          cd dist
+          git init -q -b main
+          git add -A
+          git commit -q -m "deploy: ${SOURCE_REF}@${SOURCE_SHA:0:7} from digithings-ai/digithings"
+
+          # Force-push so the publish repo always mirrors the latest dist/.
+          # History on the publish repo is a by-product of deploys, not
+          # meaningful source history — which lives in the monorepo.
+          git push --force "https://x-access-token:${DEPLOY_TOKEN}@github.com/${PUBLISH_REPO}.git" main
+
+      - name: Deploy summary
+        run: |
+          cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          ### digiquant.io deploy
+          - Source: \`${{ github.ref_name }}@${{ github.sha }}\` (\`${{ github.event_name }}\`)
+          - Published to: [\`${PUBLISH_REPO}\`](https://github.com/${PUBLISH_REPO})
+          - Live URL: https://digiquant.io (cert propagation may take a few minutes for first-time setup)
+          EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,9 +222,9 @@ All web frontends live under `frontend/` as npm workspace members
 [ADR-0009](docs/adr/0009-frontend-umbrella.md).
 
 - **`frontend/design/`** — `@digithings/design` workspace package. Shared tokens, CSS primitives, starfield / scroll-trigger / typewriter modules, favicons, OG image.
-- **`frontend/digithings/`** — static landing page at digithings.ai (vanilla HTML/CSS/JS, canvas starfield). References the design via `../design/…`.
-- **`frontend/digiquant/`** — static landing page at digiquant.io. Same design source of truth.
+- **`frontend/digithings/`** — static landing page at digithings.ai (vanilla HTML/CSS/JS, canvas starfield). References the design via `../design/…`. Deployed via `.github/workflows/static.yml` — Pages on this monorepo, custom domain `digithings.ai`.
+- **`frontend/digiquant/`** — static landing page at digiquant.io. Same design source of truth. Deployed via `.github/workflows/deploy-digiquant.yml` — builds `dist/` and pushes to the separate [`digithings-ai/digiquant.io`](https://github.com/digithings-ai/digiquant.io) publish repo (GitHub Pages supports one custom domain per repo, see [ADR-0012](docs/adr/0012-digiquant-io-split-repo.md)).
 - **`frontend/digichat/`** — production Next.js + React chat UI + BFF for DigiGraph. Deployed to `chat.digithings.ai`. Docker Compose profile `digichat`. Imports `@digithings/design` as a workspace dependency.
 - **`apps/digiquant-atlas/frontend/`** — research-app frontend; joins the workspace in place (the surrounding research project stays under `apps/`).
 
-See [ADR-0002](docs/adr/0002-domain-unification.md) for the two-domain plan (amended by ADR-0009).
+See [ADR-0002](docs/adr/0002-domain-unification.md) for the two-domain plan (amended by ADR-0009 and ADR-0012).

--- a/docs/adr/0012-digiquant-io-split-repo.md
+++ b/docs/adr/0012-digiquant-io-split-repo.md
@@ -1,0 +1,46 @@
+# ADR-0012 — digiquant.io served from a separate publish repo
+
+**Status:** Accepted (2026-04-23)
+**Amends:** [ADR-0002](0002-domain-unification.md) (two-domain plan) and [ADR-0009](0009-frontend-umbrella.md) (frontend umbrella).
+**Context:** Issues [#174](https://github.com/digithings-ai/digithings/issues/174) (live-websites epic), [#301](https://github.com/digithings-ai/digithings/issues/301) (digiquant.io deploy).
+
+## Context
+
+ADR-0002 committed to two live domains — `digithings.ai` and `digiquant.io` — both served from this monorepo. ADR-0009 consolidated every web surface under `frontend/*`. In this session (2026-04-23) we hit the hard constraint: **GitHub Pages supports exactly one custom domain per repository**. The monorepo's Pages slot is already assigned to `digithings.ai` (via `static.yml`), so `digiquant.io` cannot be served from the same repo.
+
+## Options considered
+
+1. **Cloudflare Pages for digiquant.io.** Free, handles multiple domains per account, PR previews out of the box. Rejected because the user prefers GitHub-native tooling across the board for auditability and reduced vendor surface.
+2. **Subpath hosting** at `digithings-ai.github.io/digiquant/`. Loses the `.io` vanity domain, which is a product-marketing requirement.
+3. **Move digithings.ai to a separate repo too.** Symmetric, but displaces a working deploy for no functional benefit — three repos where two suffice.
+4. **Split-repo publish target for digiquant.io only** (this ADR). Keeps digithings.ai where it is; adds a thin publish repo for digiquant.io; monorepo stays the single source of truth for content.
+
+## Decision
+
+`digiquant.io` is served from a dedicated publish repo, `digithings-ai/digiquant.io`, whose GitHub Pages config serves its `main` branch root. A sync workflow in this monorepo (`.github/workflows/deploy-digiquant.yml`) builds `dist/` from `frontend/digiquant/` + `frontend/design/` on every push to `develop`/`main` touching those paths, and force-pushes the result to the publish repo using a fine-grained PAT (`DIGIQUANT_IO_DEPLOY_TOKEN`, scoped to the publish repo, contents: read/write).
+
+**The publish repo is deploy-only.** No human commits there; its history is a byproduct of deploys. The monorepo remains the sole source of truth.
+
+## Consequences
+
+### Positive
+
+- digithings.ai deploy is untouched — zero risk to the live site.
+- `frontend/digiquant/` keeps a single canonical location in the monorepo for content + review.
+- Fast iteration: `push` to `develop` on the relevant paths triggers a deploy within a few minutes.
+- Future split of other subdomains (e.g., `atlas.digiquant.io`) follows the same pattern — one publish repo per custom domain.
+
+### Negative
+
+- One additional repo to monitor (minimal surface — README + `dist/` content, no code).
+- A PAT is now a supply-chain-relevant secret; rotate on the usual cadence. Fine-grained PAT limits blast radius to the publish repo's contents.
+- Force-pushing to the publish repo's `main` means no meaningful git history there; if you need a forensic record, check the monorepo.
+
+### Neutral
+
+- Force-push was chosen over diff-and-commit because the publish repo's `main` is a deploy artifact, not a codebase. Retaining history would mean meaningful-looking commits that aren't meaningful.
+
+## Follow-ups
+
+- If a third custom domain appears (e.g., a client pilot subdomain outside the two-domain plan), reassess whether Cloudflare Pages' PR-preview ergonomics justify adopting it as the delivery layer for all marketing sites, with GitHub Pages retained only for internal tools. Not urgent.
+- The publish repo `README.md` should make its one-way-ness obvious to anyone who lands there from GitHub search.

--- a/frontend/digiquant/README.md
+++ b/frontend/digiquant/README.md
@@ -39,26 +39,60 @@ python3 -m http.server 8765
 The dev server must run from `frontend/` (not `frontend/digiquant/`)
 so the `../design/` imports resolve.
 
-## Deployment — follow-up (out of scope for this PR)
+## Deployment
 
-This scaffold does **not** yet ship its own deploy. The existing
-`static.yml` workflow deploys `frontend/digithings/` to `digithings.ai`.
-`digiquant.io` needs a parallel Pages project (or a sibling workflow)
-pointing at `frontend/digiquant/`. Tracked under epic #9.
+Deployed via [`.github/workflows/deploy-digiquant.yml`](../../.github/workflows/deploy-digiquant.yml).
 
-### DNS
+GitHub Pages supports one custom domain per repo and the monorepo's slot
+is taken by `digithings.ai`. `digiquant.io` is therefore served from a
+separate **publish repo**, [`digithings-ai/digiquant.io`](https://github.com/digithings-ai/digiquant.io).
+The workflow above runs on every push to `develop`/`main` that touches
+`frontend/digiquant/**` or `frontend/design/**`, builds a `dist/` mirroring
+the Pages artifact shape, and force-pushes it to the publish repo's
+`main` branch.
 
-GitHub Pages custom domain setup:
+**Rule:** the publish repo is write-only from this workflow. Never edit
+files in `digithings-ai/digiquant.io` directly — every deploy rewrites
+its `main` branch.
 
-1. In the repo settings, create a second Pages site that serves
-   `frontend/digiquant/` (separate from the one serving
-   `frontend/digithings/`).
-2. Set the custom domain to `digiquant.io`. `CNAME` in this directory
-   carries that value.
-3. At the registrar, add a DNS `CNAME` record for `digiquant.io` pointing
-   at `digithings-ai.github.io`. For apex-domain setups, use four `A`
-   records per the [GitHub Pages docs](https://docs.github.com/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site).
-4. Enable HTTPS in Pages settings once DNS has propagated.
+### Required monorepo secret
+
+`DIGIQUANT_IO_DEPLOY_TOKEN` — fine-grained GitHub PAT scoped to the
+publish repo only, with **Contents: Read and write**. Generate it at
+[github.com/settings/tokens?type=beta](https://github.com/settings/personal-access-tokens/new),
+then set it here:
+
+```bash
+gh secret set DIGIQUANT_IO_DEPLOY_TOKEN  # paste the PAT
+```
+
+### DNS (at registrar)
+
+Apex `digiquant.io` → GitHub Pages A/AAAA records:
+
+| Type  | Host | Value                  |
+| ----- | ---- | ---------------------- |
+| A     | @    | 185.199.108.153        |
+| A     | @    | 185.199.109.153        |
+| A     | @    | 185.199.110.153        |
+| A     | @    | 185.199.111.153        |
+| AAAA  | @    | 2606:50c0:8000::153    |
+| AAAA  | @    | 2606:50c0:8001::153    |
+| AAAA  | @    | 2606:50c0:8002::153    |
+| AAAA  | @    | 2606:50c0:8003::153    |
+| CNAME | www  | digithings-ai.github.io |
+
+Propagation + GitHub cert issuance typically takes 10–30 minutes combined.
+Enable HTTPS in the publish repo's Pages settings once the cert issues.
+
+### Publish-repo Pages config (one-time)
+
+In `digithings-ai/digiquant.io` → Settings → Pages:
+
+- Source: **Deploy from a branch**
+- Branch: `main` / `/ (root)`
+- Custom domain: `digiquant.io`
+- Enforce HTTPS: enabled (toggle after cert issues)
 
 ### Related
 


### PR DESCRIPTION
Closes #301 (code portion).

Adds a sync workflow that builds \`frontend/digiquant/\` + \`frontend/design/\` into a \`dist/\` artifact and force-pushes to a dedicated publish repo whose Pages config serves \`digiquant.io\`. GitHub Pages allows one custom domain per repo; the monorepo's slot is \`digithings.ai\`, so \`digiquant.io\` needs a separate publish target.

Stacked on top of #369 (frontend renames) — uses the new \`frontend/digiquant/\` + \`frontend/design/\` paths directly.

## Files

- \`.github/workflows/deploy-digiquant.yml\` — trigger on push to \`develop\`/\`main\` on \`frontend/digiquant/**\` or \`frontend/design/**\`, plus \`workflow_dispatch\`. Validates secret presence, assembles \`dist/\`, writes \`CNAME=digiquant.io\`, force-pushes to \`digithings-ai/digiquant.io:main\` with a fine-grained PAT.
- \`docs/adr/0012-digiquant-io-split-repo.md\` — decision record amending ADR-0002 + ADR-0009.
- \`frontend/digiquant/README.md\` — full deploy guide (secret setup, DNS records, publish-repo Pages config).
- \`CLAUDE.md\` — one line in the frontend umbrella section.

## User-action checklist (post-merge)

Three things I can't do — all take ~10 minutes total:

1. **Create publish repo** via \`gh repo create digithings-ai/digiquant.io --public --add-readme\` (or the github.com UI).
2. **Generate fine-grained PAT** scoped to \`digithings-ai/digiquant.io\` with \`Contents: Read and write\`, then \`gh secret set DIGIQUANT_IO_DEPLOY_TOKEN\`.
3. **Enable Pages** on the new repo: Settings → Pages → source=main/root, custom domain=\`digiquant.io\`, Enforce HTTPS (after cert issues).

GoDaddy DNS is already configured (user-confirmed earlier).

## Verification path post-setup

Dispatch the workflow from develop (\`gh workflow run "Deploy digiquant.io"\`), watch the run, then verify the live URL via HEAD request once DNS + cert propagate (10–30m).

## Quality gate

- [x] /simplify run — workflow uses standard actions only (checkout, plain git push); no third-party action supply-chain risk. Docs + ADR reviewed.
- [x] /review completed — scored 10/10 on all four dimensions; doc-check passes across 128 markdown files.