### PR TITLE
docs(digiquant): ADR-0013 + trading_calendar migration DDL (#336)

### DIFF
--- a/apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql
+++ b/apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql
@@ -1,0 +1,48 @@
+-- 025_trading_calendar.sql — Venue-aware trading calendar table (epic #335)
+--
+-- A separate trading_calendar table keyed by (date, venue) replaces the
+-- is_trading_day flag on price_history (migration 013).  Separating the
+-- calendar from price rows eliminates forward-filled weekend/holiday rows,
+-- prevents TA indicators from running on synthetic zero-volume data, and
+-- correctly handles multi-venue schedules (NYSE vs. CRYPTO vs. FX).
+--
+-- Populated by the backfill job (issue #337) using the exchange_calendars
+-- library.  Venue values: 'NYSE' | 'NASDAQ' | 'CRYPTO' | 'FX'.
+-- The is_trading_day column on price_history is deprecated; see ADR-0013.
+
+CREATE TABLE IF NOT EXISTS trading_calendar (
+  date           date          NOT NULL,
+  venue          text          NOT NULL,   -- 'NYSE' | 'NASDAQ' | 'CRYPTO' | 'FX'
+  is_trading_day boolean       NOT NULL,
+  reason         text          NULL,       -- 'weekend' | 'holiday:<name>' | 'early_close' | NULL
+  created_at     timestamptz   NOT NULL DEFAULT now(),
+  PRIMARY KEY (date, venue)
+);
+
+-- Partial: non-trading rows (weekends/holidays) are never join-filtered, so
+-- excluding them keeps the index small and the join fast.
+CREATE INDEX IF NOT EXISTS trading_calendar_venue_is_trading_day_idx
+  ON trading_calendar (venue, is_trading_day) WHERE is_trading_day = true;
+
+ALTER TABLE trading_calendar ENABLE ROW LEVEL SECURITY;
+
+-- Anon users can read; writes require service_role key.
+DROP POLICY IF EXISTS "trading_calendar_anon_select" ON trading_calendar;
+CREATE POLICY "trading_calendar_anon_select"
+  ON trading_calendar FOR SELECT
+  TO anon USING (true);
+
+COMMENT ON TABLE trading_calendar IS
+  'Venue-keyed trading calendar.  One row per (date, venue) covering NYSE, '
+  'NASDAQ, CRYPTO (always open), and FX sessions.  Populated by the backfill '
+  'job (issue #337) using the exchange_calendars library.  '
+  'Join to price_history on date + venue to filter real trading days without '
+  'forward-filled rows in the price table.  See ADR-0013.';
+
+COMMENT ON COLUMN trading_calendar.venue IS
+  'Exchange / session identifier.  Allowed values: NYSE, NASDAQ, CRYPTO, FX.  '
+  'All core-universe US equity ETFs use NYSE regardless of primary listing.';
+
+COMMENT ON COLUMN trading_calendar.reason IS
+  'Non-NULL when is_trading_day = false.  Allowed values: weekend, '
+  'holiday:<name> (e.g. holiday:Christmas), early_close.  NULL on open days.';

--- a/apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql
+++ b/apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql
@@ -19,10 +19,12 @@ CREATE TABLE IF NOT EXISTS trading_calendar (
   PRIMARY KEY (date, venue)
 );
 
--- Partial: non-trading rows (weekends/holidays) are never join-filtered, so
--- excluding them keeps the index small and the join fast.
-CREATE INDEX IF NOT EXISTS trading_calendar_venue_is_trading_day_idx
-  ON trading_calendar (venue, is_trading_day) WHERE is_trading_day = true;
+-- Partial on trading days only.  venue+date covers both the equality join
+-- (ON tc.date=ph.date AND tc.venue='NYSE') and the date-range backfill scan
+-- (WHERE venue='NYSE' AND date BETWEEN A AND B).  is_trading_day is redundant
+-- as a key column inside a WHERE is_trading_day=true partial index.
+CREATE INDEX IF NOT EXISTS trading_calendar_venue_date_idx
+  ON trading_calendar (venue, date) WHERE is_trading_day = true;
 
 ALTER TABLE trading_calendar ENABLE ROW LEVEL SECURITY;
 

--- a/docs/adr/0013-trading-calendar.md
+++ b/docs/adr/0013-trading-calendar.md
@@ -1,0 +1,169 @@
+# ADR 0013: Venue-Aware Trading Calendar Table
+
+**Status:** accepted
+**Date:** 2026-04-23
+
+## Context
+
+Epic #335 (point-in-time price history completeness) requires a reliable way to
+distinguish trading days from non-trading days across the three venue types in
+the core universe: US equity exchanges (NYSE/NASDAQ), continuous crypto markets,
+and FX sessions.
+
+Migration `013_calendar_fill.sql` addressed this by adding an `is_trading_day`
+boolean column directly to `price_history`. That approach has three problems:
+
+1. **Row bloat.** To mark non-trading days, the pipeline must insert
+   forward-filled rows for weekends and holidays — roughly 40% more rows in
+   `price_history` for NYSE-listed assets alone.
+2. **Indicator corruption.** Technical analysis computations run on the full
+   `price_history` series produce incorrect results for volume-weighted signals
+   (e.g., OBV, VWAP) because forward-filled rows carry `volume = 0` but a
+   non-zero close; filtering after the fact is error-prone and cannot be
+   enforced at the schema level.
+3. **Multi-venue ambiguity.** A Saturday is a non-trading day for NYSE but a
+   valid trading day for CRYPTO. Encoding this in a single boolean per row in a
+   table keyed by `(date, ticker)` requires knowing the venue per ticker at
+   every read site — information that is absent from the schema today.
+
+The `trading_calendar` table is the standard pattern used by
+`exchange_calendars` and `pandas_market_calendars`: a separate venue-keyed
+relation that any consumer can join, with no dependency on whether a price row
+exists for that date.
+
+## Decision
+
+Create a standalone `trading_calendar` table keyed by `(date, venue)`. The
+table is populated by the backfill job (issue #337) using the
+`exchange_calendars` library (PyPI: `exchange-calendars`), which provides
+authoritative open/close/holiday data for NYSE, NASDAQ, and a broad set of
+other exchanges.
+
+**Library choice — `exchange_calendars` over `pandas_market_calendars`:**
+Both libraries cover NYSE, NASDAQ, and the crypto/FX special cases. We choose
+`exchange_calendars` because it has broader venue coverage, a more active
+maintenance record (QuantConnect / Zipline lineage), and a clean API for bulk
+date-range generation. `pandas_market_calendars` remains usable but is
+considered secondary.
+
+**Venue mapping for the core universe (~80 tickers):**
+
+| Venue | Asset classes | Representative tickers |
+|-------|--------------|------------------------|
+| NYSE | US equity ETFs — market-cap, sector, international, commodity, fixed-income | SPY, QQQ, DIA, IWM, XLK, GLD, TLT, EFA, EEM |
+| CRYPTO | Crypto spot + ETFs (24x7, no closures) | BTC-USD, ETH-USD, SOL-USD, IBIT, FBTC, ETHA, GBTC, BITO |
+| FX | FX majors (5.5-day week, pending issue #328) | EUR/USD, GBP/USD, JPY/USD, CAD/USD |
+| NASDAQ | Reserved for future individual equity coverage | (none in core universe today) |
+
+Notes:
+- All US equity ETFs in the current watchlist are assigned `venue = 'NYSE'`
+  regardless of primary listing exchange. NYSE Arca is the dominant listing
+  venue; NYSE is used as the canonical US equity calendar for simplicity.
+- Crypto assets trade continuously; their `is_trading_day` is always `true` and
+  `reason` is always `NULL`.
+- FRED macro series stored in `macro_series_observations` are exempt — macro
+  observation cadence is independent of exchange calendars.
+- The `NASDAQ` venue is defined in the schema to support future expansion (e.g.,
+  individual equities in a broader universe) but is not populated for the
+  current watchlist.
+
+**`is_trading_day` column on `price_history` (migration 013):** The column is
+retained but deprecated. The backfill pipeline (issue #337) will stop writing
+forward-filled rows and will no longer set `is_trading_day = false` on
+`price_history`. All new consumers must join `trading_calendar` instead. A
+follow-up migration to drop the column will be tracked as a separate issue once
+all read paths are confirmed migrated.
+
+**`reason` column:** Allowed values are `'weekend'`, `'holiday:<name>'`,
+`'early_close'`, and `NULL` (normal trading day). These are enforced by
+convention and documented via column comment rather than a CHECK constraint, so
+new reason types can be added without a schema change.
+
+**Query patterns:**
+
+TA layer — join price history to calendar to filter real trading days:
+```sql
+SELECT ph.*
+FROM price_history ph
+JOIN trading_calendar tc
+  ON ph.date = tc.date
+ AND tc.venue = 'NYSE'   -- or the venue for ph.ticker
+WHERE tc.is_trading_day = true;
+```
+
+Frontend — show only real trading days for charting:
+```sql
+SELECT ph.*
+FROM price_history ph
+JOIN trading_calendar tc
+  ON ph.date = tc.date
+ AND tc.venue = 'NYSE'
+WHERE tc.is_trading_day = true
+ORDER BY ph.date DESC;
+```
+
+Backfill iteration — enumerate business days for a venue:
+```sql
+SELECT date
+FROM trading_calendar
+WHERE venue = 'NYSE'
+  AND is_trading_day = true
+  AND date BETWEEN '2020-01-01' AND CURRENT_DATE
+ORDER BY date;
+```
+
+## Consequences
+
+**Positive:**
+
+- `price_history` stores only real price observations — no forward-filled
+  weekend/holiday rows — reducing table size by approximately 40% for
+  NYSE-class assets.
+- TA indicators computed over the full `price_history` series are correct by
+  construction; no per-query `is_trading_day` filter is needed on the price
+  table.
+- Multi-venue logic is centralised in one table. Adding a new venue (e.g., LSE
+  for European ETFs) requires only a new batch of rows in `trading_calendar`,
+  not schema changes or pipeline refactors.
+- The partial index `(venue, is_trading_day) WHERE is_trading_day = true` keeps
+  join cost low for the common case of filtering to open days.
+- RLS anon-SELECT policy matches the rest of the schema: public read, service
+  role write.
+
+**Negative / tradeoffs:**
+
+- Every TA or backfill query now requires a join. In practice the join is cheap
+  (indexed primary key lookup), but it adds query complexity.
+- The `is_trading_day` column on `price_history` remains until a follow-up
+  migration removes it. During the transition period, the two sources of truth
+  can diverge if the old pipeline path is not fully shut down.
+- `exchange_calendars` is a new Python dependency for the backfill job. It must
+  be added to `apps/digiquant-atlas/pyproject.toml` (or equivalent) before
+  issue #337 can ship.
+
+## Alternatives considered
+
+**`pandas_market_calendars`:** Overlapping functionality; `exchange_calendars`
+is preferred for broader venue coverage and more active maintenance. Either
+could be used; the schema is library-agnostic.
+
+**Inline flag on `price_history` (migration 013 approach):** Rejected. See
+Context above — row bloat, indicator corruption, and multi-venue ambiguity are
+all structural problems that cannot be solved by adding more columns to a
+row-per-day table.
+
+**Synthetic forward-fill filtered at query time:** Rejected. Puts business logic
+in every query site with no schema-level guardrail; harder to audit and
+maintain.
+
+**Materialised view over `generate_series`:** Rejected. A materialised view
+cannot be partially refreshed when holidays change; a plain table with a managed
+population job is simpler to operate and backfill.
+
+## Links
+
+- Epic: [#335](https://github.com/digithings-ai/digithings/issues/335)
+- This issue: [#336](https://github.com/digithings-ai/digithings/issues/336)
+- Child issues: [#337](https://github.com/digithings-ai/digithings/issues/337) (backfill), [#338](https://github.com/digithings-ai/digithings/issues/338) (full-history workflow), [#340](https://github.com/digithings-ai/digithings/issues/340) (frontend view)
+- Migration introduced by this ADR: `apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql`
+- Supersedes (in part): migration 013 pattern (`013_calendar_fill.sql`)


### PR DESCRIPTION
## Summary

- Adds `docs/adr/0013-trading-calendar.md`: decision record for the venue-aware `trading_calendar` table, covering why a separate table beats the migration-013 inline-flag approach, library choice (`exchange_calendars`), venue mapping for the ~80-ticker core universe, query patterns, and deprecation path for the `is_trading_day` column on `price_history`.
- Adds `apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql`: DDL with `IF NOT EXISTS` guards, corrected partial index `(venue, date)` (covers equality join + date-range scan), RLS enabled, anon SELECT policy matching `005_price_history.sql` pattern, and `COMMENT ON TABLE/COLUMN` for allowed venue/reason values.

Closes #336. Part of epic #335 (price history completeness + trading calendar).

## Test plan

- [x] `ls docs/adr/0013-trading-calendar.md` — file exists
- [x] `ls apps/digiquant-atlas/supabase/migrations/025_trading_calendar.sql` — file exists
- [x] ADR has required sections: Context, Decision, Consequences, Links
- [x] Migration has: `CREATE TABLE`, `PRIMARY KEY`, `CREATE INDEX (venue, date)`, `ROW LEVEL SECURITY`
- [x] `make doc-check` passes

## Quality gates
- [x] /simplify run — code reviewed for reuse, quality, and efficiency; partial index corrected from `(venue, is_trading_day)` to `(venue, date)`
- [x] /review completed — PR reviewed against scoring rubric; index design fixed, ADR number confirmed as 0013 (first to claim it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)