### PR TITLE
ops(ci): disable Claude cloud auto-dispatch, pin review to Sonnet 4.6

### DIFF
--- a/.github/workflows/claude-code-dispatch.yml
+++ b/.github/workflows/claude-code-dispatch.yml
@@ -1,34 +1,31 @@
 name: Claude Code dispatch
 
 # Fires when exec:claude label is applied to an issue.
-# Uses the official anthropics/claude-code-action to dispatch a Claude Code
-# session that reads the issue, implements the change, and opens a PR.
-# Ref: https://github.com/anthropics/claude-code-action
 #
-# Feature-flagged: requires the ANTHROPIC_API_KEY secret. When absent
-# (default), the workflow exits silently — the exec:claude label still
-# serves as a tier marker for local human dispatch via `make task ISSUE=N`.
+# Policy: Tier 3 (Claude) is LOCAL ONLY. Cloud dispatch is intentionally
+# disabled — only Copilot (Tier 1) and Cursor (Tier 2) auto-execute issues.
+# When a task needs Tier 3, a human runs `make task ISSUE=N` locally.
 #
-# To enable cloud dispatch later:
-#   1. console.anthropic.com -> Settings -> API Keys -> Create Key
-#   2. GitHub repo Settings -> Secrets -> Actions -> ANTHROPIC_API_KEY
+# This workflow exists solely to:
+#   1. Confirm the label was applied (and surface the expected branch/gate)
+#   2. Resolve component metadata (branch name, test command) so the human
+#      has copy-paste-ready instructions in the issue comments
 #
-# Note: this dispatch targets the highest-judgment tier (architecture,
-# cross-module, security-sensitive). Issues tagged exec:claude typically
-# also carry risk:high or epic labels and warrant human review of the PR.
+# If cloud dispatch is ever re-enabled, restore the Run Claude Code steps
+# from git history (pre-issue #384) and gate behind ANTHROPIC_API_KEY /
+# CLAUDE_CODE_OAUTH_TOKEN again.
 
 on:
   issues:
     types: [labeled]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   dispatch:
-    name: Dispatch to Claude Code
+    name: Acknowledge exec:claude label
     runs-on: ubuntu-latest
     if: github.event.label.name == 'exec:claude'
 
@@ -55,13 +52,6 @@ jobs:
                   break
           " 2>/dev/null || echo "root")
 
-          declare -A AGENTS_MD=(
-            [digigraph]="digigraph/AGENTS.md"   [digiquant]="digiquant/AGENTS.md"
-            [digisearch]="digisearch/AGENTS.md" [digikey]="digikey/AGENTS.md"
-            [digismith]="digismith/AGENTS.md"   [digiclaw]="digiclaw/AGENTS.md"
-            [digibase]="digibase/AGENTS.md"     [digichat]="frontend/digichat/AGENTS.md"
-            [root]="AGENTS.md"
-          )
           declare -A TEST_CMD=(
             [digigraph]="pytest -m unit -k digigraph -v --tb=short"
             [digiquant]="pytest -m unit -k digiquant -v --tb=short"
@@ -74,149 +64,31 @@ jobs:
             [root]="pytest -m unit -v --tb=short"
           )
 
-          AGENTS_PATH="${AGENTS_MD[$COMPONENT]:-AGENTS.md}"
           TEST="${TEST_CMD[$COMPONENT]:-pytest -m unit -v --tb=short}"
           BRANCH_SLUG=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' |
                         sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
 
-          echo "component=$COMPONENT"                     >> "$GITHUB_OUTPUT"
-          echo "agents_path=$AGENTS_PATH"                 >> "$GITHUB_OUTPUT"
-          echo "test_cmd=$TEST"                           >> "$GITHUB_OUTPUT"
+          echo "component=$COMPONENT"                       >> "$GITHUB_OUTPUT"
+          echo "test_cmd=$TEST"                             >> "$GITHUB_OUTPUT"
           echo "branch=task/${ISSUE_NUMBER}-${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
 
-      # Prefer CLAUDE_CODE_OAUTH_TOKEN (Claude Code Max subscription — no API
-       # billing). Fall back to ANTHROPIC_API_KEY if only the API key is set.
-      - name: Check auth
-        id: keycheck
+      - name: Post local-dispatch instructions
         env:
-          OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN:     ${{ secrets.GITHUB_TOKEN }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BRANCH:       ${{ steps.meta.outputs.branch }}
+          TEST_CMD:     ${{ steps.meta.outputs.test_cmd }}
         run: |
-          if [ -n "${OAUTH:-}" ]; then
-            echo "auth=oauth" >> "$GITHUB_OUTPUT"
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          elif [ -n "${APIKEY:-}" ]; then
-            echo "auth=apikey" >> "$GITHUB_OUTPUT"
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "auth=" >> "$GITHUB_OUTPUT"
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is set — cloud dispatch disabled. Label still marks tier; run \`make task ISSUE=${{ github.event.issue.number }}\` locally."
-          fi
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "\
+          **Tier 3 — Claude Code (local, human-supervised)**
 
-      - name: Run Claude Code (OAuth / subscription)
-        id: run_claude_oauth
-        if: steps.keycheck.outputs.auth == 'oauth'
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token:            ${{ secrets.GITHUB_TOKEN }}
-          base_branch:             develop
-          claude_args:             "--max-turns 25 --model claude-opus-4-7"
-          prompt: |
-            You are working on the DigiThings repository (${{ github.repository }}) as Tier 3 (Claude Code).
+          Cloud dispatch is disabled by policy. To execute this task, run locally:
 
-            Task: ${{ github.event.issue.title }}
-            Issue: ${{ github.event.issue.html_url }}
-            Component: ${{ steps.meta.outputs.component }}
-            Branch to create: ${{ steps.meta.outputs.branch }}
+          \`\`\`
+          make task ISSUE=${ISSUE_NUMBER}
+          \`\`\`
 
-            Issue body:
-            ${{ github.event.issue.body }}
+          This will create branch \`${BRANCH}\` from the active module branch.
 
-            Pre-flight (non-negotiable):
-            - Read CLAUDE.md and ${{ steps.meta.outputs.agents_path }} before writing any code
-            - Read docs/agents/EXECUTION_TIERS.md — confirm this issue actually requires Tier 3
-            - If the task turns out to be cursor-sized, relabel exec:cursor and stop
-
-            Rules:
-            - Polars only (no pandas), Pydantic v2, ruff-clean
-            - No comments unless the WHY is non-obvious
-            - Never touch SECURITY.md, docs/scoring/, config/litellm.yaml, projects/ without human approval
-            - Live-trading paths (digiquant/live/, config/live*, execute_trade, place_order) require
-              a Human-Approved-By commit trailer — do not touch without it
-
-            Gate before PR:
-            - make score  (must pass: Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9)
-            - ${{ steps.meta.outputs.test_cmd }}
-            - ruff check .
-
-            PR format:
-            - Title: feat(${{ steps.meta.outputs.component }}): <description> (#${{ github.event.issue.number }})
-            - Body must contain: Closes #${{ github.event.issue.number }}
-            - Target branch: develop (or the active module/<component> branch if one is ahead)
-
-            Full protocol: docs/agents/CLAUDE_CODE_ONBOARDING.md
-
-      - name: Run Claude Code (API key)
-        id: run_claude_apikey
-        if: steps.keycheck.outputs.auth == 'apikey'
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token:      ${{ secrets.GITHUB_TOKEN }}
-          base_branch:       develop
-          claude_args:       "--max-turns 25 --model claude-opus-4-7"
-          prompt: |
-            You are working on the DigiThings repository (${{ github.repository }}) as Tier 3 (Claude Code).
-
-            Task: ${{ github.event.issue.title }}
-            Issue: ${{ github.event.issue.html_url }}
-            Component: ${{ steps.meta.outputs.component }}
-            Branch to create: ${{ steps.meta.outputs.branch }}
-
-            Issue body:
-            ${{ github.event.issue.body }}
-
-            Pre-flight (non-negotiable):
-            - Read CLAUDE.md and ${{ steps.meta.outputs.agents_path }} before writing any code
-            - Read docs/agents/EXECUTION_TIERS.md — confirm this issue actually requires Tier 3
-            - If the task turns out to be cursor-sized, relabel exec:cursor and stop
-
-            Rules:
-            - Polars only (no pandas), Pydantic v2, ruff-clean
-            - No comments unless the WHY is non-obvious
-            - Never touch SECURITY.md, docs/scoring/, config/litellm.yaml, projects/ without human approval
-            - Live-trading paths (digiquant/live/, config/live*, execute_trade, place_order) require
-              a Human-Approved-By commit trailer — do not touch without it
-
-            Gate before PR:
-            - make score  (must pass: Security ≥ 8, Quality ≥ 8, Optimization ≥ 7, Accuracy ≥ 9)
-            - ${{ steps.meta.outputs.test_cmd }}
-            - ruff check .
-
-            PR format:
-            - Title: feat(${{ steps.meta.outputs.component }}): <description> (#${{ github.event.issue.number }})
-            - Body must contain: Closes #${{ github.event.issue.number }}
-            - Target branch: develop (or the active module/<component> branch if one is ahead)
-
-            Full protocol: docs/agents/CLAUDE_CODE_ONBOARDING.md
-
-      # Only posts when an auth path is present. When disabled, the
-      # exec:claude label remains as a silent tier marker and
-      # `make task ISSUE=N` remains the local human path — no comment noise.
-      - name: Post dispatch comment
-        if: always() && steps.keycheck.outputs.present == 'true'
-        env:
-          GH_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
-          REPO:          ${{ github.repository }}
-          ISSUE_NUMBER:  ${{ github.event.issue.number }}
-          BRANCH:        ${{ steps.meta.outputs.branch }}
-          TEST_CMD:      ${{ steps.meta.outputs.test_cmd }}
-          RUN_URL:       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          AUTH:          ${{ steps.keycheck.outputs.auth }}
-          OAUTH_OUTCOME: ${{ steps.run_claude_oauth.outcome }}
-          APIKEY_OUTCOME: ${{ steps.run_claude_apikey.outcome }}
-        run: |
-          OUTCOME="${OAUTH_OUTCOME:-$APIKEY_OUTCOME}"
-          AUTH_LABEL="Claude Code Max subscription"
-          [ "$AUTH" = "apikey" ] && AUTH_LABEL="Anthropic API key"
-          if [ "$OUTCOME" = "success" ]; then
-            STATUS="Claude Code dispatched via ${AUTH_LABEL} — see run log"
-          else
-            STATUS="Dispatch failed — check Actions log"
-          fi
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-            --body "**Claude Code dispatch** | ${STATUS} | Branch: \`${BRANCH}\` | Gate: \`make score && ${TEST_CMD} && ruff check .\` | [Run log](${RUN_URL})"
+          Gate before PR: \`make score && ${TEST_CMD} && ruff check .\`"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,4 +70,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # Pin to Sonnet: review is pattern-matching + style, not judgment-heavy.
+          # Opus here burns subscription tokens 5× faster on work Sonnet handles.
+          claude_args: '--model claude-sonnet-4-6'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/agents.yml
+++ b/agents.yml
@@ -58,13 +58,19 @@ execution_tiers:
       - "Ambiguous success criteria"
       - "Architectural or novel design"
   - label: "exec:claude"
-    name: "Tier 3 — Claude Code Max (human-supervised)"
-    scope: "Interactive, cross-module, architectural, or human-gated work."
+    name: "Tier 3 — Claude Code Max (human-supervised, LOCAL only)"
+    scope: >
+      Interactive, cross-module, architectural, or human-gated work. LOCAL
+      ONLY — cloud auto-dispatch is disabled. The label is a tier marker;
+      execution happens via `make task ISSUE=N` on a human's workstation.
     examples:
       - "Architecture and new-module scaffolding"
       - "Complex debugging, optimization, security review"
       - "Strategy / iterative design work"
       - "Decomposing milestones into Tier 1/2 tasks; reviewing agent PRs"
+    dispatch: "local-only (make task ISSUE=N)"
+    never:
+      - "Auto-execution from a GitHub label — only Copilot and Cursor auto-execute"
 
 # Heuristics for default tier when a creator hasn't classified explicitly.
 # risk:high OR matches a human_gate → exec:claude.

--- a/docs/agents/EXECUTION_TIERS.md
+++ b/docs/agents/EXECUTION_TIERS.md
@@ -27,21 +27,24 @@ Autonomous, asynchronous. Describable in one paragraph with clear acceptance cri
 **Setup & operations:** see `docs/agents/CURSOR_AGENT_ONBOARDING.md`.  
 **Dispatch:** applying the `exec:cursor` label triggers `.github/workflows/cursor-agent-dispatch.yml`, which posts a preflight checklist and "Open in Cursor" deep-link on the issue. Set the `CURSOR_API_KEY` repo secret to enable fully-automated dispatch.
 
-### `exec:claude` — Tier 3 — Claude Code (human-supervised)
+### `exec:claude` — Tier 3 — Claude Code (human-supervised, LOCAL only)
 
-Interactive, local, human-in-the-loop. The top tier; takes everything above and adds judgment-heavy work.
+Interactive, local, human-in-the-loop. The top tier; takes everything above and adds judgment-heavy work. **Claude never auto-executes issues — only Copilot (Tier 1) and Cursor (Tier 2) do.** The label is a tier *marker*; execution is always a human on a workstation.
 
-**Fits:** architecture and new-module scaffolding; complex debugging; cross-module integration; security review; strategy/iterative design; milestone decomposition; **PR code review (auto)**; targeted `@claude` help.
+**Fits:** architecture and new-module scaffolding; complex debugging; cross-module integration; security review; strategy/iterative design; milestone decomposition; **PR code review (auto, Sonnet 4.6)**; targeted `@claude` help.
 
-**Auto PR review:** every PR that opens/syncs/reopens runs Claude's `/code-review` plugin via `.github/workflows/claude-code-review.yml`. Why Claude and not Copilot: Copilot premium quota resets monthly (a quota miss means weeks of degraded flow), Claude Pro quota rolls on an hours window (a quota miss means ~5h delay). Pick the tool with the shorter failure-recovery.
+**Auto PR review:** every PR that opens/syncs/reopens runs Claude's `/code-review` plugin via `.github/workflows/claude-code-review.yml`, pinned to **Sonnet 4.6** (review is pattern-matching, not judgment-heavy — Opus is wasteful). Why Claude and not Copilot: Copilot premium quota resets monthly (a quota miss means weeks of degraded flow), Claude Pro quota rolls on an hours window (a quota miss means ~5h delay). Pick the tool with the shorter failure-recovery.
 
 **Weekly continuous-improvement digest:** `.github/workflows/continuous-improvement.yml` runs every Sunday 22:00 UTC, synthesizes the past 7 days of PR/CI/review activity, and files a single tracker issue with 3–5 prioritized suggestions. See [HOUSEKEEPING.md](HOUSEKEEPING.md#continuous-improvement) — synthesis is judgment work, so it lives at Tier 3.
 
 **Setup & operations:** see `docs/agents/CLAUDE_CODE_ONBOARDING.md`.
-**Dispatch:** applying the `exec:claude` label triggers `.github/workflows/claude-code-dispatch.yml`.
-The workflow accepts either `CLAUDE_CODE_OAUTH_TOKEN` (preferred — uses your Claude Code Max
-subscription, no API billing) or `ANTHROPIC_API_KEY` (fallback). Without either, the workflow is
-silently disabled and the label serves as a tier marker for the local path: `make task ISSUE=N`.
+**Dispatch (local only):** applying the `exec:claude` label triggers `.github/workflows/claude-code-dispatch.yml`, which posts a comment pointing at the local command:
+
+```
+make task ISSUE=N
+```
+
+Cloud dispatch via the Claude Code Action is **intentionally disabled** (policy, issue #384). If a task is cursor-sized, relabel `exec:cursor` and stop. If it genuinely needs Tier 3, a human runs `make task` locally.
 
 ## Decision tree
 


### PR DESCRIPTION
## Summary

- Strip the two `Run Claude Code` steps from `claude-code-dispatch.yml`. Applying `exec:claude` now only posts a comment pointing at `make task ISSUE=N`. Tier 3 is LOCAL ONLY — only Copilot (Tier 1) and Cursor (Tier 2) auto-execute from labels.
- Pin `claude-code-review.yml` to `--model claude-sonnet-4-6`. Review is pattern-matching, not judgment-heavy; Opus here wastes subscription-token budget.
- Update `agents.yml` + `docs/agents/EXECUTION_TIERS.md` so the policy is visible to humans and agents. `make agents-init` regenerates `.claude/`, `.cursor/rules/`, `.github/copilot-instructions.md`.

## Why

User observed Claude Code Action firing on `exec:claude` labels (e.g. the Atlas-Supabase-write-path issue). Policy intent was always local-only Tier 3. Also, review workflow had no model pin — running on subscription default (possibly Opus) when Sonnet is sufficient.

## Validation

- [x] `scripts/agents_init.py --check` — clean
- [x] `make doc-check` — 132 markdown files scanned, OK
- [ ] After merge: confirm `claude-code-review.yml` run log shows Sonnet 4.6 (if not, pin needs to move inside the plugin prompt)

## Test plan

- [ ] Apply `exec:claude` to a test issue → confirm the new comment appears and no Claude Code Action run starts
- [ ] Open a dummy code-touching PR → confirm `Claude /code-review` runs and log shows `claude-sonnet-4-6`
- [ ] Re-run `make agents-init` → no drift

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)