### PR TITLE
feat(ci): agent quota management — state, escalation, monthly reset

### DIFF
--- a/.github/workflows/agent-quota-reset.yml
+++ b/.github/workflows/agent-quota-reset.yml
@@ -1,0 +1,72 @@
+name: Agent quota reset
+
+# Runs on the 1st of each month at 09:00 UTC (09:00 to clear after most
+# quota resets, which typically happen at 00:00 UTC). Clears the
+# quota:* flags on the singleton state issue and re-dispatches issues
+# parked with pending:quota.
+#
+# Can also be triggered manually via workflow_dispatch when a human
+# confirms quotas have reset mid-month (rare).
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  QUOTA_STATE_ISSUE: 387
+
+jobs:
+  reset:
+    name: Clear quota flags + re-dispatch parked tasks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear quota flags on state issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+        run: |
+          for LABEL in "quota:cursor-exhausted" "quota:copilot-exhausted"; do
+            gh issue edit "$QUOTA_STATE_ISSUE" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+          done
+          gh issue comment "$QUOTA_STATE_ISSUE" --repo "$REPO" --body "\
+          **Monthly quota reset — $(date -u +%Y-%m-%d)** — cleared \`quota:*\` flags.
+          If either service is still exhausted, re-apply the flag manually."
+
+      - name: Re-dispatch parked cursor tasks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+        run: |
+          # Find issues with pending:quota + exec:cursor, bounce the exec:cursor
+          # label to re-fire the dispatch workflow.
+          ISSUES=$(gh issue list --repo "$REPO" --state open --label "pending:quota" --label "exec:cursor" --json number --jq '.[].number')
+          for N in $ISSUES; do
+            echo "Re-dispatching cursor task #$N"
+            gh issue edit "$N" --repo "$REPO" --remove-label "pending:quota"
+            gh issue edit "$N" --repo "$REPO" --remove-label "exec:cursor"
+            gh issue edit "$N" --repo "$REPO" --add-label "exec:cursor"
+          done
+
+      - name: Re-dispatch parked copilot tasks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+        run: |
+          # Copilot requires re-assignment rather than label bounce. We post
+          # a reminder comment; human re-assigns @Copilot. (v1 — full
+          # automation of Copilot assignment deferred to v2 once we've
+          # confirmed the bot's stable login.)
+          ISSUES=$(gh issue list --repo "$REPO" --state open --label "pending:quota" --label "exec:copilot" --json number --jq '.[].number')
+          for N in $ISSUES; do
+            echo "Posting reset reminder for copilot task #$N"
+            gh issue edit "$N" --repo "$REPO" --remove-label "pending:quota"
+            gh issue comment "$N" --repo "$REPO" --body "\
+            **Monthly quota reset — ready for @Copilot re-assignment**
+
+            Copilot quota has reset. Please re-assign @Copilot to kick dispatch."
+          done

--- a/.github/workflows/copilot-quota-gate.yml
+++ b/.github/workflows/copilot-quota-gate.yml
@@ -1,0 +1,120 @@
+name: Copilot quota gate
+
+# Intercepts issue assignments to @Copilot when the singleton quota-state
+# issue (#387) has quota:copilot-exhausted set. Copilot has no dispatch
+# workflow we own — it's invoked by assignment — so this is the cleanest
+# intercept point. Unassigns @Copilot and either escalates (priority:high|
+# critical) to local Tier 3 or parks the task with pending:quota.
+#
+# The Copilot bot appears under several logins in different contexts; we
+# match a known-variants list. Add to it if GitHub introduces a new one.
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  QUOTA_STATE_ISSUE: 387
+
+jobs:
+  gate:
+    name: Gate @Copilot on quota state
+    runs-on: ubuntu-latest
+    if: |
+      github.event.assignee.login == 'Copilot' ||
+      github.event.assignee.login == 'copilot' ||
+      github.event.assignee.login == 'github-copilot[bot]' ||
+      github.event.assignee.login == 'copilot-swe-agent' ||
+      github.event.assignee.login == 'copilot-swe-agent[bot]'
+
+    steps:
+      - name: Check quota state
+        id: quota
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+        run: |
+          STATE_LABELS=$(gh issue view "$QUOTA_STATE_ISSUE" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          ISSUE_LABELS='${{ toJson(github.event.issue.labels) }}'
+
+          EXHAUSTED=$(echo "$STATE_LABELS" | python3 -c "
+          import json, sys
+          labels = json.load(sys.stdin)
+          print('true' if 'quota:copilot-exhausted' in labels else 'false')
+          ")
+
+          PRIORITY=$(echo "$ISSUE_LABELS" | python3 -c "
+          import json, sys, re
+          labels = json.load(sys.stdin)
+          tier = 'none'
+          for l in labels:
+              m = re.match(r'^priority:(critical|high|medium|low)$', l['name'])
+              if m:
+                  tier = m.group(1)
+                  break
+          print(tier)
+          ")
+
+          echo "exhausted=$EXHAUSTED" >> "$GITHUB_OUTPUT"
+          echo "priority=$PRIORITY"   >> "$GITHUB_OUTPUT"
+
+      - name: Unassign @Copilot
+        if: steps.quota.outputs.exhausted == 'true'
+        env:
+          GH_TOKEN:       ${{ github.token }}
+          REPO:           ${{ github.repository }}
+          ISSUE_NUMBER:   ${{ github.event.issue.number }}
+          ASSIGNEE_LOGIN: ${{ github.event.assignee.login }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-assignee "$ASSIGNEE_LOGIN"
+
+      - name: Escalate to Tier 3 (priority high|critical)
+        if: steps.quota.outputs.exhausted == 'true' && (steps.quota.outputs.priority == 'high' || steps.quota.outputs.priority == 'critical')
+        env:
+          GH_TOKEN:     ${{ github.token }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PRIORITY:     ${{ steps.quota.outputs.priority }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "exec:copilot" --add-label "exec:claude" || \
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "exec:claude"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "\
+          **Copilot quota exhausted — escalating to Tier 3 (Claude Code, local)**
+
+          Priority: \`${PRIORITY}\`. Executing locally on the human's workstation:
+
+          \`\`\`
+          make task ISSUE=${ISSUE_NUMBER}
+          \`\`\`
+
+          State: [quota state issue #${{ env.QUOTA_STATE_ISSUE }}](../issues/${{ env.QUOTA_STATE_ISSUE }})"
+
+      - name: Park task until quota reset (priority medium|low|none)
+        if: steps.quota.outputs.exhausted == 'true' && steps.quota.outputs.priority != 'high' && steps.quota.outputs.priority != 'critical'
+        env:
+          GH_TOKEN:     ${{ github.token }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Predicted reset: 1st of next month 00:00 UTC (hardcoded — monthly
+          # cron will clean up if the date is wrong).
+          RESET=$(python3 -c "
+          import datetime
+          d = datetime.datetime.utcnow().replace(day=1) + datetime.timedelta(days=32)
+          print(d.replace(day=1).strftime('%Y-%m-%d'))
+          ")
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "pending:quota"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "\
+          **Copilot quota exhausted — task parked**
+
+          Waiting for quota reset, estimated **~${RESET}**. The monthly reset cron will
+          post a reminder for @Copilot re-assignment. If this is actually urgent, add
+          \`priority:high\` and re-assign @Copilot — the re-check will find quota still
+          exhausted + priority now high, and escalate to Tier 3 (Claude Code, local).
+
+          State: [quota state issue #${{ env.QUOTA_STATE_ISSUE }}](../issues/${{ env.QUOTA_STATE_ISSUE }})"

--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -10,6 +10,10 @@ name: Cursor agent dispatch
 #
 # Note: the @cursor comment trigger only responds to human-posted comments,
 # not GitHub Actions bot comments. The Cursor CLI is the correct automated path.
+#
+# Pre-flight: checks the singleton quota-state issue (#387) for
+# quota:cursor-exhausted. If set, escalates priority:high|critical tasks
+# to exec:claude (local Tier 3) and parks the rest with pending:quota.
 
 on:
   issues:
@@ -19,6 +23,9 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+
+env:
+  QUOTA_STATE_ISSUE: 387
 
 jobs:
   dispatch:
@@ -31,7 +38,85 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check quota state
+        id: quota
+        env:
+          GH_TOKEN:     ${{ github.token }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          STATE_LABELS=$(gh issue view "$QUOTA_STATE_ISSUE" --repo "$REPO" --json labels --jq '[.labels[].name]')
+          ISSUE_LABELS='${{ toJson(github.event.issue.labels) }}'
+
+          EXHAUSTED=$(echo "$STATE_LABELS" | python3 -c "
+          import json, sys
+          labels = json.load(sys.stdin)
+          print('true' if 'quota:cursor-exhausted' in labels else 'false')
+          ")
+
+          PRIORITY=$(echo "$ISSUE_LABELS" | python3 -c "
+          import json, sys, re
+          labels = json.load(sys.stdin)
+          tier = 'none'
+          for l in labels:
+              m = re.match(r'^priority:(critical|high|medium|low)$', l['name'])
+              if m:
+                  tier = m.group(1)
+                  break
+          print(tier)
+          ")
+
+          echo "exhausted=$EXHAUSTED" >> "$GITHUB_OUTPUT"
+          echo "priority=$PRIORITY"   >> "$GITHUB_OUTPUT"
+
+      - name: Escalate to Tier 3 (priority high|critical)
+        if: steps.quota.outputs.exhausted == 'true' && (steps.quota.outputs.priority == 'high' || steps.quota.outputs.priority == 'critical')
+        env:
+          GH_TOKEN:     ${{ github.token }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PRIORITY:     ${{ steps.quota.outputs.priority }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+            --remove-label "exec:cursor" --add-label "exec:claude"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "\
+          **Cursor quota exhausted — escalating to Tier 3 (Claude Code, local)**
+
+          Priority: \`${PRIORITY}\`. Executing locally on the human's workstation:
+
+          \`\`\`
+          make task ISSUE=${ISSUE_NUMBER}
+          \`\`\`
+
+          State: [quota state issue #${{ env.QUOTA_STATE_ISSUE }}](../issues/${{ env.QUOTA_STATE_ISSUE }})"
+
+      - name: Park task until quota reset (priority medium|low|none)
+        if: steps.quota.outputs.exhausted == 'true' && steps.quota.outputs.priority != 'high' && steps.quota.outputs.priority != 'critical'
+        env:
+          GH_TOKEN:     ${{ github.token }}
+          REPO:         ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Predicted reset: 1st of next month 00:00 UTC (hardcoded — neither
+          # Cursor nor Copilot exposes a reset API; monthly cron will clean up).
+          RESET=$(python3 -c "
+          import datetime
+          d = datetime.datetime.utcnow().replace(day=1) + datetime.timedelta(days=32)
+          print(d.replace(day=1).strftime('%Y-%m-%d'))
+          ")
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "pending:quota"
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "\
+          **Cursor quota exhausted — task parked**
+
+          Waiting for quota reset, estimated **~${RESET}**. The monthly reset cron will
+          re-dispatch automatically. If this is actually urgent, add \`priority:high\` and
+          re-apply \`exec:cursor\` — the re-check will find quota still exhausted + priority
+          now high, and escalate to Tier 3 (Claude Code, local).
+
+          State: [quota state issue #${{ env.QUOTA_STATE_ISSUE }}](../issues/${{ env.QUOTA_STATE_ISSUE }})"
+
       - name: Resolve component metadata
+        if: steps.quota.outputs.exhausted != 'true'
         id: meta
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -79,6 +164,7 @@ jobs:
 
       - name: Install Cursor CLI
         id: install_cli
+        if: steps.quota.outputs.exhausted != 'true'
         continue-on-error: true
         run: |
           curl -fsSL "https://cursor.com/install" | bash
@@ -87,7 +173,7 @@ jobs:
       - name: Run cursor-agent
         id: run_agent
         continue-on-error: true
-        if: ${{ secrets.CURSOR_API_KEY != '' }}
+        if: steps.quota.outputs.exhausted != 'true' && secrets.CURSOR_API_KEY != ''
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GITHUB_TOKEN:   ${{ github.token }}
@@ -119,7 +205,7 @@ jobs:
             --model claude-sonnet-4-5
 
       - name: Post dispatch comment
-        if: always()
+        if: always() && steps.quota.outputs.exhausted != 'true'
         env:
           GH_TOKEN:        ${{ github.token }}
           REPO:            ${{ github.repository }}

--- a/docs/agents/EXECUTION_TIERS.md
+++ b/docs/agents/EXECUTION_TIERS.md
@@ -108,6 +108,52 @@ Epics appear on multiple boards; the workflow updates every project that contain
 Requires `DIGITHINGS_PROJECT_TOKEN` (PAT with `project` + `repo` scopes); workflow exits silently
 if the token is missing.
 
+## Quota exhaustion — state, escalation, reset
+
+Copilot (premium requests) and Cursor (Background Agent tokens) both have monthly-reset subscription quotas. When a tier is out of quota, dispatching to it wastes cycles and leaves tasks silently stalled. The quota-management system below makes this visible and handles escalation.
+
+### State
+
+The singleton issue [#387 `[meta] Agent quota state — DO NOT CLOSE`](../../../issues/387) carries the live state as labels:
+
+- `quota:cursor-exhausted` — set when the Cursor Background Agent is out of tokens
+- `quota:copilot-exhausted` — set when Copilot premium requests are exhausted
+
+v1 is **human-flippable**: when you notice either service hitting quota, add the label. Example:
+
+```bash
+gh issue edit 387 --add-label "quota:cursor-exhausted"
+```
+
+Auto-detection is v2 — deferred until we've captured real error text from each service. Building a sweeper on a guessed error string trips on the wrong text.
+
+### Dispatch-time behavior
+
+- **Cursor** (`cursor-agent-dispatch.yml`) reads state before calling the CLI:
+  - If `quota:cursor-exhausted` + task is `priority:high|critical` → swap `exec:cursor` for `exec:claude` (local Tier 3 dispatch).
+  - If exhausted + lower priority → add `pending:quota`, post a park notice with the predicted reset date (~1st of next month).
+  - Otherwise → dispatch normally.
+- **Copilot** (`copilot-quota-gate.yml`) intercepts on `issues.assigned` for Copilot-variant logins:
+  - If `quota:copilot-exhausted` → unassign @Copilot, then escalate (priority high|critical) or park (lower priority) using the same logic.
+
+### Monthly reset
+
+`agent-quota-reset.yml` runs 1st of the month at 09:00 UTC:
+1. Removes both `quota:*` labels from the state issue.
+2. For parked issues with `exec:cursor`: bounces the label to re-fire dispatch.
+3. For parked issues with `exec:copilot`: posts a reminder comment for manual @Copilot re-assignment (v2 will fully automate once we confirm the stable bot login).
+
+Reset date is **hardcoded** to "1st of next month, 00:00 UTC" because neither Cursor nor Copilot exposes a quota-reset API. If the actual reset is a few days off, the monthly cron cleans up anyway.
+
+### Quick reference
+
+| Situation | Action |
+|---|---|
+| Notice Cursor failing — out of tokens | `gh issue edit 387 --add-label "quota:cursor-exhausted"` |
+| Notice Copilot failing — out of requests | `gh issue edit 387 --add-label "quota:copilot-exhausted"` |
+| Parked task is actually urgent | Add `priority:high` + re-fire the tier label |
+| Quota reset mid-month (rare) | Run `gh workflow run agent-quota-reset.yml` |
+
 ## Cost note
 
 - Copilot: flat subscription — use freely.


### PR DESCRIPTION
## Summary

V1 of the agent-quota-management system spec'd in #386. Stops us from dispatching tasks to exhausted tiers and routes urgent work around the quota cliff.

- **State**: singleton issue #387 (pinned) carries \`quota:cursor-exhausted\` / \`quota:copilot-exhausted\` labels. v1 is human-flippable; auto-detect is v2.
- **Cursor**: \`cursor-agent-dispatch.yml\` pre-flight check → escalates \`priority:high|critical\` to \`exec:claude\` (local), parks the rest with \`pending:quota\`.
- **Copilot**: new \`copilot-quota-gate.yml\` on \`issues.assigned\` for @Copilot variant logins. Unassigns + escalate-or-park.
- **Reset**: new \`agent-quota-reset.yml\`, 1st of month 09:00 UTC. Clears flags, bounces \`exec:cursor\` for parked cursor tasks, posts @Copilot re-assignment reminder for parked copilot tasks (full auto-reassign is v2 once the bot login is observed stable).
- **Docs**: \`EXECUTION_TIERS.md\` → new "Quota exhaustion" section with operator quick reference.

## Why

Today we keep firing \`cursor-agent\` and assigning @Copilot until the external service hard-fails. The user asked for intelligent delegation: high-priority work escalates to Claude locally when quota is gone, low-priority parks until reset. This lands that.

## Validation

- [x] YAML parses (all three files)
- [x] \`scripts/agents_init.py --check\` clean
- [x] \`make doc-check\` clean
- [ ] **Smoke test after merge** (events fire from the default branch, so can't test on PR branch):
  1. \`gh issue edit 387 --add-label "quota:cursor-exhausted"\`
  2. Create test issue, label \`exec:cursor\` + \`priority:medium\` → expect park comment + \`pending:quota\`
  3. Add \`priority:high\`, re-apply \`exec:cursor\` → expect escalate comment + swap to \`exec:claude\`
  4. \`gh issue edit 387 --remove-label "quota:cursor-exhausted"\` → re-apply \`exec:cursor\` → expect normal dispatch
  5. \`gh workflow run agent-quota-reset.yml\` on a test issue with \`pending:quota\` → expect label cleanup + re-dispatch
  6. Close test issue

## Known limitations (v2 backlog)

- **Auto-detection**: currently human-flippable. Need to capture real Cursor-CLI / Copilot-silent-fail signatures first to avoid building sweepers on guessed strings.
- **Copilot re-assignment on reset**: v1 posts a reminder; v2 will auto-re-assign @Copilot once we've confirmed the stable bot login (GitHub has rotated these before).
- **Copilot bot login variants**: \`copilot-quota-gate.yml\` matches \`Copilot\`, \`copilot\`, \`github-copilot[bot]\`, \`copilot-swe-agent\`, \`copilot-swe-agent[bot]\`. Once we see one real assignment event in production, prune to what's actually used.

## Test plan

See Validation → smoke test block above. After merge, run that sequence against a throwaway issue and update this PR with the results.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)