### PR TITLE
chore(ci): bump Cursor agent model to Sonnet 4.6

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -202,7 +202,7 @@ jobs:
           - PR body must contain: Closes #$ISSUE_NUMBER
           - Scope too large? Relabel exec:claude, comment why, stop.
           Full protocol: docs/agents/CURSOR_AGENT_ONBOARDING.md" \
-            --model claude-sonnet-4-5
+            --model claude-sonnet-4-6
 
       - name: Post dispatch comment
         if: always() && steps.quota.outputs.exhausted != 'true'


### PR DESCRIPTION
## Summary

One-line bump of Cursor's Background Agent from \`claude-sonnet-4-5\` → \`claude-sonnet-4-6\`. Brings Cursor in line with the code-review pin shipped in #385.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)