### PR TITLE
fix(ci): wrap cursor-dispatch if-expression in ${{ }}

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run cursor-agent
         id: run_agent
         continue-on-error: true
-        if: steps.quota.outputs.exhausted != 'true' && secrets.CURSOR_API_KEY != ''
+        if: ${{ steps.quota.outputs.exhausted != 'true' && secrets.CURSOR_API_KEY != '' }}
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GITHUB_TOKEN:   ${{ github.token }}


### PR DESCRIPTION
## Diagnosis

- \`cursor-agent-dispatch.yml\` hasn't fired on any \`issues.labeled\` event since #389 merged (previously fired OK).
- Push events generate "failure" runs with zero jobs — workflow is parsing but GitHub can't register the event handler.
- Claude Code dispatch on the same event schema fires fine — the issue is local to the Cursor workflow.

Hypothesis: the bare \`if: steps.quota.outputs.exhausted != 'true' && secrets.CURSOR_API_KEY != ''\` (unwrapped) trips GitHub's parser. The \`secrets\` context may require \`\${{ }}\` wrapping.

## Fix

Wrap the step-level \`if:\` in \`\${{ }}\` to match the original working pattern.

## Verification plan

After merge, apply \`exec:cursor\` to a test issue and confirm the workflow fires.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)