### PR TITLE
fix(ci): cursor-dispatch — secrets check belongs in run: not if:

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Run cursor-agent
         id: run_agent
         continue-on-error: true
-        if: ${{ steps.quota.outputs.exhausted != 'true' && secrets.CURSOR_API_KEY != '' }}
+        if: steps.quota.outputs.exhausted != 'true'
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           GITHUB_TOKEN:   ${{ github.token }}
@@ -186,6 +186,10 @@ jobs:
           BRANCH:         ${{ steps.meta.outputs.branch }}
           REPO:           ${{ github.repository }}
         run: |
+          if [ -z "${CURSOR_API_KEY:-}" ]; then
+            echo "::notice::CURSOR_API_KEY not set — skipping CLI dispatch (label still marks tier)"
+            exit 0
+          fi
           cursor-agent --force \
             -p "You are working on the DigiThings repository ($REPO).
           Task: $ISSUE_TITLE


### PR DESCRIPTION
## Root cause (actionlint)

\`\`\`
cursor-agent-dispatch.yml:176:60: context "secrets" is not allowed here.
available contexts are "env", "github", "inputs", "job", "matrix", "needs",
"runner", "steps", "strategy", "vars". [expression]
\`\`\`

The \`secrets\` context is not valid in step-level \`if:\` conditions. GitHub silently rejects the workflow file — \`cursor-agent-dispatch\` has not fired on any \`issues.labeled\` event since this syntax was introduced (predates PR #389; the previous one-line fix in #407 wrapped the same invalid expression in \`\${{ }}\` which didn't help because the invalid context was already wrapped).

## Fix

Keep the step-level \`if:\` gated to quota-state only (\`exhausted != 'true'\`). Move the \`CURSOR_API_KEY\` presence check into the \`run:\` block where secrets flowing in via \`env:\` are allowed. Emits \`::notice::\` and clean-exits when the secret is missing.

## Why this went undetected so long

- \`python3 -c "import yaml; yaml.safe_load(...)"\` only catches YAML-level syntax. Expression-level semantics need actionlint.
- Event-trigger failures are invisible in CI — the workflow just doesn't run, no red check.
- GitHub's UI shows zero-job "failure" runs on pushes for workflows in this state, which look like normal noise.

## Side effect

While cursor-dispatch was dark, the \`quota:cursor-exhausted\` flag had no effect — park/escalate logic never ran. After this merge, flag becomes functional again.

## Verification plan

1. Merge.
2. Bounce \`exec:cursor\` on test issue #394 (currently priority:medium, quota:cursor-exhausted is set on #387).
3. Expect: \`Cursor agent dispatch\` run fires on issues event → park-path comment + \`pending:quota\` label.
4. Add \`priority:high\`, bounce label.
5. Expect: escalate-path → swap to \`exec:claude\`, post local-dispatch comment.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)