### PR TITLE
chore(ci): retire GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,15 +1,14 @@
-# Deploy digithings.ai static landing page to GitHub Pages.
-#
-# The site lives at frontend/digithings/ and references shared tokens / JS /
-# assets at frontend/design/ via ../design/… paths. The job
-# below stages a dist/ directory that mirrors that layout so Pages can
-# serve both trees from a single artifact.
-name: Deploy static content to Pages
+# RETIRED — digithings.ai is now served by Cloudflare Pages (project: digithings-ai).
+# Cloudflare watches `develop` and runs `bash scripts/build-digithings.sh`.
+# Kept for history; push trigger removed so it no longer fires automatically.
+name: Deploy static content to Pages (retired)
 
 on:
-  push:
-    branches: ["main", "develop"]
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type RETIRED to confirm you intend to run this legacy workflow"
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Removes the push trigger from `static.yml` so GitHub Pages no longer deploys on every push to `develop`
- `digithings.ai` is now served by Cloudflare Pages (`digithings-ai` project), which watches `develop` and runs `bash scripts/build-digithings.sh`
- Workflow retained (as manual-only) for historical reference

## Context
Cloudflare Pages projects set up during the website audit session:
- `digithings-ai` → `digithings.ai` (custom domain initializing)
- `digiquant-io` → `digiquant.io` (custom domain initializing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)