### PR TITLE
fix(atlas): drop Groq — route all extraction phases to Gemini Flash

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -61,7 +61,6 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           python apps/digiquant-atlas/scripts/validate-providers.py --skip-dry-run
@@ -71,16 +70,14 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # Gemini is the default tier for phases 3, 4, 5 (medium/best in model_modes.yaml).
-          # Ollama Cloud kept for test-mode local dev fallback only.
+          # Gemini Flash handles all phases (extraction + research). Groq free
+          # tier TPM reduced to 6k in 2026 — unusable for 41k tokens/run.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Ollama Cloud for reasoning tier (phases 7, 7D) — 2 calls/day.
           OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_API_BASE: https://ollama.com/v1
           DIGI_LLM_MODE: best
-          # Groq (extraction tier — phases 1, 2, 7C)
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # Gemini (synthesis tier — phases 7, 7D, 9)
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Cap Phase 7C fan-out to 25 tickers in CI (Groq free-tier concurrency)
+          # Cap Phase 7C fan-out to 25 tickers in CI (Gemini 10 RPM ≈ 3 min)
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}
         run: |

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -61,7 +61,6 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           python apps/digiquant-atlas/scripts/validate-providers.py --skip-dry-run
@@ -70,16 +69,14 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # Gemini is the default tier for phases 3, 4, 5 (medium/best in model_modes.yaml).
-          # Ollama Cloud kept for test-mode local dev fallback only.
+          # Gemini Flash handles all phases (extraction + research). Groq free
+          # tier TPM reduced to 6k in 2026 — unusable for 41k tokens/run.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Ollama Cloud for reasoning tier (phases 7, 7D) — 2 calls/day.
           OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_API_BASE: https://ollama.com/v1
           DIGI_LLM_MODE: medium
-          # Groq (extraction tier — phases 1, 2, 7C)
-          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # Gemini (synthesis tier — phases 7, 7D, 9)
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Cap Phase 7C fan-out to 25 tickers in CI (Groq free-tier concurrency)
+          # Cap Phase 7C fan-out to 25 tickers in CI (Gemini 10 RPM ≈ 3 min)
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}
         run: |

--- a/apps/digiquant-atlas/scripts/validate-providers.py
+++ b/apps/digiquant-atlas/scripts/validate-providers.py
@@ -4,10 +4,10 @@ Atlas provider validation — run before triggering a real pipeline run.
 
 Checks (in order):
   1. Required env vars are present
-  2. Groq API key is valid (1-token ping to llama-3.1-8b-instant)
-  3. Gemini API key is valid (1-token ping to gemini-2.5-flash)
-     Note: gemini-2.5-pro is NOT checked — it requires a paid key (moved
-     behind paywall Dec 2025). Reasoning phases use Ollama Cloud instead.
+  2. Gemini API key is valid (1-token ping to gemini-2.5-flash)
+     Note: Groq removed — free tier TPM reduced to 6k in 2026, too low for
+     41k tokens/run. All phases now route through Gemini Flash or Ollama Cloud.
+     Note: gemini-2.5-pro is NOT checked — paid key required (Dec 2025).
   4. Supabase is reachable and daily_snapshots has a prior baseline row
      (required for --auto-baseline on delta runs)
   5. Graph compiles cleanly — dry-run for both baseline and delta
@@ -95,8 +95,7 @@ def check_env_vars() -> bool:
     required = {
         "SUPABASE_URL": "Supabase project URL",
         "SUPABASE_SERVICE_KEY": "Supabase service-role key",
-        "GROQ_API_KEY": "Groq API key (extraction tier — phases 1, 2, 7C)",
-        "GEMINI_API_KEY": "Gemini API key (research tier — phases 3, 4, 5, 9; Flash only)",
+        "GEMINI_API_KEY": "Gemini API key (all phases except reasoning — Flash for extraction + research)",
     }
     all_ok = True
     for var, desc in required.items():
@@ -108,37 +107,8 @@ def check_env_vars() -> bool:
     return all_ok
 
 
-def check_groq(model: str = "llama-3.1-8b-instant") -> bool:
-    print(_bold("\n2. Groq connectivity"))
-    api_key = os.environ.get("GROQ_API_KEY", "").strip()
-    if not api_key:
-        check("Groq ping", False, "GROQ_API_KEY not set — skipping")
-        return False
-    try:
-        from openai import OpenAI
-
-        t0 = time.monotonic()
-        client = OpenAI(api_key=api_key, base_url="https://api.groq.com/openai/v1")
-        resp = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": "Reply with the single word: ok"}],
-            max_tokens=5,
-            temperature=0,
-        )
-        elapsed = time.monotonic() - t0
-        content = resp.choices[0].message.content or ""
-        ok = bool(content.strip())
-        return check(
-            f"Groq {model}",
-            ok,
-            f"{elapsed:.1f}s — response: {content.strip()!r}" if ok else "empty response",
-        )
-    except Exception as exc:
-        return check("Groq ping", False, str(exc))
-
-
 def check_gemini(model: str = "gemini-2.5-flash") -> bool:
-    print(_bold("\n3. Gemini connectivity"))
+    print(_bold("\n2. Gemini connectivity"))
     api_key = os.environ.get("GEMINI_API_KEY", "").strip()
     if not api_key:
         check("Gemini ping", False, "GEMINI_API_KEY not set — skipping")
@@ -256,10 +226,10 @@ def main() -> int:
         epilog=textwrap.dedent("""\
             Tip: load your local env before running:
               export $(grep -v '^#' apps/digiquant-atlas/config/supabase.env | xargs)
-              export GROQ_API_KEY=... GEMINI_API_KEY=...
+              export GEMINI_API_KEY=...
         """),
     )
-    parser.add_argument("--skip-llm", action="store_true", help="Skip Groq + Gemini pings")
+    parser.add_argument("--skip-llm", action="store_true", help="Skip Gemini ping")
     parser.add_argument("--skip-db", action="store_true", help="Skip Supabase check")
     parser.add_argument("--skip-dry-run", action="store_true", help="Skip graph dry-run")
     args = parser.parse_args()
@@ -270,7 +240,6 @@ def main() -> int:
     check_env_vars()
 
     if not args.skip_llm:
-        check_groq()
         check_gemini("gemini-2.5-flash")
 
     if not args.skip_db:

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -10,8 +10,9 @@
 #   Task:    Structured JSON parsing from short, well-defined inputs. Pulls
 #            specific fields (scores, tickers, numeric signals) from pre-fetched
 #            market text. No multi-step inference required.
-#   Needs:   Schema compliance, speed, high concurrency tolerance.
-#   Free:    Groq llama-3.1-8b-instant (20k TPM, handles 25 parallel calls).
+#   Needs:   Schema compliance, speed, concurrency tolerance.
+#   Free:    Gemini 2.5 Flash (250k TPM, 10 RPM; 41k tokens/run fits easily).
+#            Note: Groq free tier TPM reduced to 6k in 2026 — too low for 41k.
 #   Paid:    Claude Haiku 4.5, GPT-4o-mini, Gemma 2 9B, any fast/cheap model.
 #
 # research
@@ -53,20 +54,22 @@
 phase_models:
   # Phase 1 — alt-data extraction (4 parallel segments, ~500 tokens each)
   # [tier: extraction] — sentiment scores, CTA signals, options flow numbers
-  alt-sentiment-news: "groq/llama-3.1-8b-instant"
-  alt-cta-positioning: "groq/llama-3.1-8b-instant"
-  alt-options-derivatives: "groq/llama-3.1-8b-instant"
-  alt-politician-signals: "groq/llama-3.1-8b-instant"
+  # Groq free tier reduced to 6k TPM in 2026 — too low for 41k tokens/run.
+  # Gemini Flash (250k TPM, 10 RPM) handles extraction at slightly lower throughput.
+  alt-sentiment-news: "gemini/gemini-2.5-flash"
+  alt-cta-positioning: "gemini/gemini-2.5-flash"
+  alt-options-derivatives: "gemini/gemini-2.5-flash"
+  alt-politician-signals: "gemini/gemini-2.5-flash"
 
   # Phase 2 — institutional flow extraction (2 segments, ~800 tokens each)
   # [tier: extraction] — 13F signals, institutional order-flow tables
-  inst-institutional-flows: "groq/llama-3.1-8b-instant"
-  inst-hedge-fund-intel: "groq/llama-3.1-8b-instant"
+  inst-institutional-flows: "gemini/gemini-2.5-flash"
+  inst-hedge-fund-intel: "gemini/gemini-2.5-flash"
 
   # Phase 7C — per-ticker analyst fan-out (prefix match: analyst-AAPL, …)
-  # [tier: extraction — throughput-constrained; see note above]
-  # ATLAS_MAX_ANALYSTS=25 in CI; ~35k tokens total across 25 parallel calls.
-  "analyst-": "groq/llama-3.1-8b-instant"
+  # [tier: extraction — throughput-constrained]
+  # ATLAS_MAX_ANALYSTS=25 in CI; ~35k tokens at 10 RPM ≈ 3 min (with backoff).
+  "analyst-": "gemini/gemini-2.5-flash"
 
   # Phase 7 — master digest synthesis (~8k tokens in, reads all phase 1–6 outputs)
   # [tier: reasoning] — THE highest-stakes call; reconciles 20+ signals into

--- a/docs/atlas/token-budget.md
+++ b/docs/atlas/token-budget.md
@@ -10,7 +10,7 @@ Every phase in the pipeline is assigned a **capability tier** that defines the c
 
 | Tier | What the phase does | Key model attributes | Free default | Paid upgrade |
 |------|--------------------|-----------------------|--------------|--------------|
-| **extraction** | Structured JSON parsing from short, constrained inputs. Pulls scores, tickers, and numeric signals from pre-fetched text. No multi-step inference. | Schema compliance, speed, concurrency tolerance | Groq `llama-3.1-8b-instant` | Claude Haiku 4.5, GPT-4o-mini, Gemma 2 9B |
+| **extraction** | Structured JSON parsing from short, constrained inputs. Pulls scores, tickers, and numeric signals from pre-fetched text. No multi-step inference. | Schema compliance, speed, concurrency tolerance | Gemini `gemini-2.5-flash` (same as research; Groq free TPM 6k — too low) | Claude Haiku 4.5, GPT-4o-mini, Gemma 2 9B |
 | **research** | Multi-factor financial analysis over moderate context. Macro regime reads, sector deep-dives, asset-class conviction calls. Coherent analytical prose required. | Financial domain knowledge, analytical depth, 32k+ context | Gemini `gemini-2.5-flash` | Claude Sonnet 4.6, GPT-4o, Gemini 2.5 Pro |
 | **reasoning** | High-stakes synthesis and portfolio decision-making. Reconciles 20+ upstream signals, resolves contradictions, ranks priorities, and produces output that drives real investment decisions. | Cross-domain synthesis, internal consistency, financial judgment; extended thinking / chain-of-thought beneficial | Ollama Cloud `deepseek-v4-flash:cloud` (284B MoE, 1M ctx) | Claude Opus 4.7 (extended thinking), GPT-o1/o3, Gemini 2.5 Pro (paid) |
 
@@ -20,10 +20,10 @@ Every phase in the pipeline is assigned a **capability tier** that defines the c
 
 ### Phase 1 — Alt-data extraction `[tier: extraction]`
 
-**Model:** `groq/llama-3.1-8b-instant`  
+**Model:** `gemini/gemini-2.5-flash`  
 **Segments:** 4 parallel (sentiment-news, cta-positioning, options-derivatives, politician-signals)
 
-Task is structured extraction from pre-fetched text: classify sentiment, extract CTA positioning signals, read options flow numbers. No multi-step reasoning required. 4 parallel calls; Groq's 20k TPM free tier handles the fan-out without throttling.
+Task is structured extraction from pre-fetched text: classify sentiment, extract CTA positioning signals, read options flow numbers. No multi-step reasoning required. 4 parallel calls. Gemini Flash (250k TPM, 10 RPM) handles extraction — Groq free tier reduced to 6k TPM in 2026, too low for 41k tokens/run.
 
 **Token budget per segment:** ~500 in + ~400 out = 900 × 4 = **~3,600 tokens**
 
@@ -31,7 +31,7 @@ Task is structured extraction from pre-fetched text: classify sentiment, extract
 
 ### Phase 2 — Institutional flow extraction `[tier: extraction]`
 
-**Model:** `groq/llama-3.1-8b-instant`  
+**Model:** `gemini/gemini-2.5-flash`  
 **Segments:** 2 parallel (institutional-flows, hedge-fund-intel)
 
 Extraction of hedge fund 13F signals and institutional order-flow tables. Short context, structured output, same rationale as Phase 1.
@@ -79,12 +79,12 @@ Each segment reads upstream macro and asset-class context, requiring coherent mu
 
 ### Phase 7C — Per-ticker analyst fan-out `[tier: extraction — throughput-constrained]`
 
-**Model:** `groq/llama-3.1-8b-instant`  
+**Model:** `gemini/gemini-2.5-flash`  
 **Segments:** up to 25 tickers in CI (`ATLAS_MAX_ANALYSTS=25`)
 
-> **Why not research tier?** Writing a 1,200-char investment thesis and conviction score (−5 to +5) ideally belongs in the research tier. However, 25 parallel calls × ~1.4k tokens ≈ 35k tokens exceeds Groq's 70B model free limit (12k TPM) but fits within the 8B model (20k TPM). The 8B assignment is a concurrency tradeoff.
+> **Why Gemini Flash for extraction?** Groq's free tier TPM was reduced to 6,000 in 2026. Phase 7C alone needs ~35k tokens; combined with phases 1 and 2, a single run requires ~41k tokens — exceeding the per-minute cap by 7×. Gemini Flash (250k TPM, 10 RPM) handles the volume; the 10 RPM limit means 25 calls serialise over ~3 minutes with backoff.
 >
-> **To upgrade:** Reduce `ATLAS_MAX_ANALYSTS` (fewer tickers → fewer tokens per minute), switch to a paid Groq plan and use `llama-3.3-70b-versatile`, or route Phase 7C to Gemini and accept rate-limiting with backoff.
+> **To upgrade:** Switch to a paid Groq plan and set `analyst-: "groq/llama-3.3-70b-versatile"`, or reduce `ATLAS_MAX_ANALYSTS` to stay within 6k TPM on the free tier.
 
 **Token budget per ticker:** ~1,000 in + ~400 out = 1,400 × 25 = **~35,000 tokens (CI)**  
 *Full watchlist (98 tickers): ~137k tokens — serialised across 7+ minutes at 20k TPM.*
@@ -129,21 +129,20 @@ Reads the digest and evaluates prediction quality across prior snapshots. Genera
 
 | Phase | Tier | Provider | Model | Tokens |
 |-------|------|----------|-------|--------|
-| 1 — Alt-data (4 segments) | extraction | Groq | llama-3.1-8b-instant | 3,600 |
-| 2 — Institutional (2 segments) | extraction | Groq | llama-3.1-8b-instant | 2,600 |
-| 7C — Analyst fan-out (25 tickers) | extraction* | Groq | llama-3.1-8b-instant | 35,000 |
-| **Groq subtotal** | | | | **41,200** |
+| 1 — Alt-data (4 segments) | extraction | Gemini | gemini-2.5-flash | 3,600 |
+| 2 — Institutional (2 segments) | extraction | Gemini | gemini-2.5-flash | 2,600 |
 | 3 — Macro | research | Gemini | gemini-2.5-flash | 2,800 |
 | 4 — Asset classes (5 segments) | research | Gemini | gemini-2.5-flash | 10,500 |
 | 5 — Equities + sectors (12 segments) | research | Gemini | gemini-2.5-flash | 30,700 |
+| 7C — Analyst fan-out (25 tickers) | extraction† | Gemini | gemini-2.5-flash | 35,000 |
 | 9 — Evolution | research | Gemini | gemini-2.5-flash | 4,800 |
-| **Gemini Flash subtotal** | | | | **48,800** |
+| **Gemini Flash subtotal** | | | | **90,000** |
 | 7 — Master digest | reasoning | Ollama Cloud | deepseek-v4-flash:cloud | 10,000 |
 | 7D — PM rebalance | reasoning | Ollama Cloud | deepseek-v4-flash:cloud | 13,500 |
 | **Ollama Cloud subtotal** | | | | **23,500** |
 | **Grand total** | | | | **~113,500 tokens** |
 
-*Phase 7C is throughput-constrained to extraction tier; see note above.*
+†Phase 7C is throughput-constrained to extraction tier; see note above.
 
 ---
 
@@ -151,8 +150,7 @@ Reads the digest and evaluates prediction quality across prior snapshots. Genera
 
 | Provider | Model | Per-run estimate | Free limit | Notes |
 |----------|-------|-----------------|------------|-------|
-| Groq | llama-3.1-8b-instant | ~41k tokens | ~20k TPM | Phase 7C (25 calls) is tightest; backoff retry serialises across ~2 min |
-| Gemini Flash | gemini-2.5-flash | ~49k tokens | 1M TPM, 1500 RPD | Negligible usage — 35× TPM headroom |
+| Gemini Flash | gemini-2.5-flash | ~90k tokens | 250k TPM, 250 RPD, 10 RPM | Phase 7C (25 calls) serialises over ~3 min at 10 RPM; TPM headroom is 2.7× |
 | Ollama Cloud | deepseek-v4-flash:cloud | ~24k tokens | Session-based (resets every 5h) | 2 calls/day — negligible vs. free quota |
 
 ---
@@ -162,8 +160,8 @@ Reads the digest and evaluates prediction quality across prior snapshots. Genera
 To substitute paid models, replace values in `config/model_modes.yaml` → `phase_models`:
 
 ```yaml
-# extraction tier upgrades (phases 1, 2, 7C)
-alt-sentiment-news: "groq/llama-3.3-70b-versatile"   # paid Groq plan
+# extraction tier upgrades (phases 1, 2, 7C) — currently Gemini Flash
+alt-sentiment-news: "groq/llama-3.3-70b-versatile"   # paid Groq plan (>6k TPM)
 analyst-: "anthropic/claude-haiku-4-5"                # or any fast model
 
 # research tier upgrades (phases 3, 4, 5, 9 via defaults)


### PR DESCRIPTION
Fixes #436

## Component
- [x] config / infra

## Change Type
- [x] fix — bug fix

## Summary

Groq free tier TPM dropped to 6,000 in 2026. Atlas sends ~41k tokens/run for phases 1, 2, and 7C combined — hitting the limit immediately with a 413 error on the first backfill attempt. Route all extraction phases to Gemini Flash (250k TPM, 10 RPM). The 10 RPM limit means 25 analyst calls serialise over ~3 minutes with backoff, well within the 45-minute CI timeout.

**Provider stack after this change (fully free):**
| Tier | Phases | Provider | Model |
|---|---|---|---|
| extraction + research | 1, 2, 3, 4, 5, 7C, 9 | Gemini | gemini-2.5-flash |
| reasoning | 7, 7D | Ollama Cloud | deepseek-v4-flash:cloud |

`GROQ_API_KEY` no longer required in CI.

## Self-Score
**Security: 9/10** — no secrets in code, removed an unused secret reference  
**Quality: 9/10** — ruff clean, 172 tests pass  
**Optimization: 8/10** — Gemini Flash 250k TPM > 6k Groq limit  
**Accuracy: 9/10** — single provider for extraction+research simplifies routing

## Testing Evidence
```
172 passed in 1.96s
ruff: All checks passed!
```

**Is human review required?** No

🤖 Generated with [Claude Code](https://claude.com/claude-code)