### PR TITLE
feat(digiquant): richer failure-issue body + on-call runbook (#304)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read
 
 concurrency:
   group: atlas-baseline
@@ -107,6 +108,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           # Title is date-independent so consecutive failures roll up into
           # a single issue (dedupe across days). Per-run context goes in
@@ -121,9 +125,37 @@ jobs:
           else
             printf '(no log captured)\n' > artifacts/tail.log
           fi
+          # Extract the first failing step name from this run's job graph.
+          # `actions: read` permission required (granted on this workflow).
+          FAILED_STEP=$(gh run view "$RUN_ID" --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .steps[]? | select(.conclusion == "failure") | .name][0] // "unknown"' \
+            2>/dev/null || echo "unknown")
+          # Last successful run of this workflow (excludes the in-progress one).
+          LAST_OK=$(gh run list --workflow="$WORKFLOW_NAME" --status=success --limit=1 \
+            --json updatedAt --jq '.[0].updatedAt // "unknown"' 2>/dev/null || echo "unknown")
+          # Human-friendly "N hours/days ago" string (Ubuntu runners only — GNU date).
+          if [ "$LAST_OK" != "unknown" ]; then
+            LAST_OK_EPOCH=$(date -u -d "$LAST_OK" +%s 2>/dev/null || echo "")
+            NOW_EPOCH=$(date -u +%s)
+            if [ -n "$LAST_OK_EPOCH" ]; then
+              DELTA_SEC=$(( NOW_EPOCH - LAST_OK_EPOCH ))
+              if [ "$DELTA_SEC" -lt 86400 ]; then
+                LAST_OK_REL="$(( DELTA_SEC / 3600 )) hours ago"
+              else
+                LAST_OK_REL="$(( DELTA_SEC / 86400 )) days ago"
+              fi
+            else
+              LAST_OK_REL="age unknown"
+            fi
+          else
+            LAST_OK_REL="never recorded"
+          fi
           {
             printf 'Atlas baseline run failed on %s.\n\n' "$RUN_DATE"
-            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '**Failing step:** %s\n' "$FAILED_STEP"
+            printf '**Last successful run:** %s (%s)\n' "$LAST_OK" "$LAST_OK_REL"
+            printf '**Workflow run:** %s\n\n' "$RUN_URL"
+            printf '**On-call:** see [apps/digiquant-atlas/RUNBOOK.md](%s/blob/develop/apps/digiquant-atlas/RUNBOOK.md) §"Atlas job failure triage".\n\n' "$REPO_URL"
             printf '<details><summary>Last 200 log lines</summary>\n\n'
             printf '```\n'
             cat artifacts/tail.log

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read
 
 concurrency:
   group: atlas-delta
@@ -107,6 +108,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           # Title is date-independent so consecutive failures roll up into
           # a single issue (dedupe across days). Per-run context goes in
@@ -121,9 +125,37 @@ jobs:
           else
             printf '(no log captured)\n' > artifacts/tail.log
           fi
+          # Extract the first failing step name from this run's job graph.
+          # `actions: read` permission required (granted on this workflow).
+          FAILED_STEP=$(gh run view "$RUN_ID" --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .steps[]? | select(.conclusion == "failure") | .name][0] // "unknown"' \
+            2>/dev/null || echo "unknown")
+          # Last successful run of this workflow (excludes the in-progress one).
+          LAST_OK=$(gh run list --workflow="$WORKFLOW_NAME" --status=success --limit=1 \
+            --json updatedAt --jq '.[0].updatedAt // "unknown"' 2>/dev/null || echo "unknown")
+          # Human-friendly "N hours/days ago" string (Ubuntu runners only — GNU date).
+          if [ "$LAST_OK" != "unknown" ]; then
+            LAST_OK_EPOCH=$(date -u -d "$LAST_OK" +%s 2>/dev/null || echo "")
+            NOW_EPOCH=$(date -u +%s)
+            if [ -n "$LAST_OK_EPOCH" ]; then
+              DELTA_SEC=$(( NOW_EPOCH - LAST_OK_EPOCH ))
+              if [ "$DELTA_SEC" -lt 86400 ]; then
+                LAST_OK_REL="$(( DELTA_SEC / 3600 )) hours ago"
+              else
+                LAST_OK_REL="$(( DELTA_SEC / 86400 )) days ago"
+              fi
+            else
+              LAST_OK_REL="age unknown"
+            fi
+          else
+            LAST_OK_REL="never recorded"
+          fi
           {
             printf 'Atlas delta run failed on %s.\n\n' "$RUN_DATE"
-            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '**Failing step:** %s\n' "$FAILED_STEP"
+            printf '**Last successful run:** %s (%s)\n' "$LAST_OK" "$LAST_OK_REL"
+            printf '**Workflow run:** %s\n\n' "$RUN_URL"
+            printf '**On-call:** see [apps/digiquant-atlas/RUNBOOK.md](%s/blob/develop/apps/digiquant-atlas/RUNBOOK.md) §"Atlas job failure triage".\n\n' "$REPO_URL"
             printf '<details><summary>Last 200 log lines</summary>\n\n'
             printf '```\n'
             cat artifacts/tail.log

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -34,6 +34,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read
 
 concurrency:
   group: atlas-monthly
@@ -160,6 +161,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_DATE: ${{ steps.resolve.outputs.run_date }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           # Title is date-independent so consecutive failures roll up into
           # a single issue (dedupe across months). Per-run context goes in
@@ -174,9 +178,37 @@ jobs:
           else
             printf '(no log captured)\n' > artifacts/tail.log
           fi
+          # Extract the first failing step name from this run's job graph.
+          # `actions: read` permission required (granted on this workflow).
+          FAILED_STEP=$(gh run view "$RUN_ID" --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .steps[]? | select(.conclusion == "failure") | .name][0] // "unknown"' \
+            2>/dev/null || echo "unknown")
+          # Last successful run of this workflow (excludes the in-progress one).
+          LAST_OK=$(gh run list --workflow="$WORKFLOW_NAME" --status=success --limit=1 \
+            --json updatedAt --jq '.[0].updatedAt // "unknown"' 2>/dev/null || echo "unknown")
+          # Human-friendly "N hours/days ago" string (Ubuntu runners only — GNU date).
+          if [ "$LAST_OK" != "unknown" ]; then
+            LAST_OK_EPOCH=$(date -u -d "$LAST_OK" +%s 2>/dev/null || echo "")
+            NOW_EPOCH=$(date -u +%s)
+            if [ -n "$LAST_OK_EPOCH" ]; then
+              DELTA_SEC=$(( NOW_EPOCH - LAST_OK_EPOCH ))
+              if [ "$DELTA_SEC" -lt 86400 ]; then
+                LAST_OK_REL="$(( DELTA_SEC / 3600 )) hours ago"
+              else
+                LAST_OK_REL="$(( DELTA_SEC / 86400 )) days ago"
+              fi
+            else
+              LAST_OK_REL="age unknown"
+            fi
+          else
+            LAST_OK_REL="never recorded"
+          fi
           {
             printf 'Atlas monthly run failed on %s.\n\n' "$RUN_DATE"
-            printf 'Workflow run: %s\n\n' "$RUN_URL"
+            printf '**Failing step:** %s\n' "$FAILED_STEP"
+            printf '**Last successful run:** %s (%s)\n' "$LAST_OK" "$LAST_OK_REL"
+            printf '**Workflow run:** %s\n\n' "$RUN_URL"
+            printf '**On-call:** see [apps/digiquant-atlas/RUNBOOK.md](%s/blob/develop/apps/digiquant-atlas/RUNBOOK.md) §"Atlas job failure triage".\n\n' "$REPO_URL"
             printf '<details><summary>Last 200 log lines</summary>\n\n'
             printf '```\n'
             cat artifacts/tail.log

--- a/apps/digiquant-atlas/RUNBOOK.md
+++ b/apps/digiquant-atlas/RUNBOOK.md
@@ -153,6 +153,21 @@ Per-document research deltas (`document_delta`, manifest) use the same **week an
 - **Disk migration:** if you have an external export of old daily folders, copy them into `data/agent-cache/daily/` (gitignored) before running backfill scripts — see below — this is **not** part of day-to-day tasks.
 - **Retired `outputs/` path:** the repo must not depend on an `outputs/` directory (it is **gitignored** if recreated). Before deleting any local copy, confirm Supabase is canonical: `python3 scripts/verify_supabase_canonical.py` and optional `--date YYYY-MM-DD` for days you care about.
 
+## Atlas job failure triage
+
+When the scheduled Atlas pipeline fails (`atlas baseline`, `atlas delta`, or `atlas monthly`), the workflow opens or appends to a deduped tracking issue titled `atlas-{baseline,delta,monthly}-failure` with `ci:failure` label. Each comment lists the failing step, the last successful run timestamp, the run URL, and the last 200 log lines.
+
+**Owner:** Chris (sole on-call). New failure issues should be triaged within one business day.
+
+**First-look checklist:**
+1. Open the **Workflow run** URL from the issue body and scroll to the failing step (named in the issue).
+2. Read the last 200 log lines in the issue body for the immediate error before clicking through to the full run log.
+3. Classify the failure:
+   - **Transient** (rate limit, provider 5xx, network blip, missing/expired secret): comment on the issue with the cause, then re-run via `gh workflow run "<workflow name>"` (or the workflow_dispatch button). Confirm the next run is green.
+   - **Code regression** (assertion error, schema mismatch, new exception): file or update the linked task issue, fix on a `task/<N>-…` branch, and gate landing on a successful manual workflow_dispatch.
+   - **Provider/model change** (e.g. Ollama Cloud capacity, Gemini quota): update [`config/litellm.yaml`](../../config/litellm.yaml) routing or the workflow `env:` block; document in commit message.
+4. **Closing:** leave the issue open until the next scheduled run is green. The dedupe-by-title logic re-opens a new issue automatically on the next failure, so closing prematurely does not lose state — a transient that recurs surfaces a fresh issue.
+
 ## Environment requirements
 1. Python 3.11+ recommended.
 2. Install dependencies:


### PR DESCRIPTION
## Summary

- Atlas baseline / delta / monthly workflows now include the **failing step name** and **last successful run timestamp** (with relative "N hours/days ago" string) in the auto-created `atlas-{baseline,delta,monthly}-failure` tracking issue, alongside the existing run URL + 200-line log tail.
- Adds `actions: read` permission to all three workflows so the in-step `gh run view` / `gh run list` calls can read the job graph and prior-run history. Falls back to `unknown` / `never recorded` if either API call fails.
- New `## Atlas job failure triage` section in `apps/digiquant-atlas/RUNBOOK.md` covering owner (Chris, sole on-call), first-look checklist, transient vs regression vs provider-change classification, and close-out rule.

## Test plan

- [x] `actionlint` passes locally on all three modified workflows.
- [x] `python3 -c 'import yaml; ...'` confirms YAML parses.
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10.
- [ ] **Manual verification (post-merge):** intentionally fail one `workflow_dispatch` run (e.g. set `GEMINI_API_KEY` to an empty value via a temporary edit, or invoke with an obviously bad `run_date`) on `atlas delta` and confirm the resulting tracking issue body shows:
  - `**Failing step:** Run delta` (or whichever step short-circuited)
  - `**Last successful run:** <ISO>` plus a `(N hours ago)` style suffix
  - The on-call link to RUNBOOK.md §"Atlas job failure triage"

## Notes

- Failing-step extraction uses `gh run view --json jobs --jq` to find the first step with `conclusion == "failure"`. If multiple jobs/steps fail in parallel, only the first is surfaced — the full picture remains in the run URL.
- Relative-age math relies on GNU `date -u -d` which is fine on Ubuntu runners.

Fixes #304.