### PR TITLE
feat(digiquant): InvestmentProfile schema (#305)

### DIFF
--- a/digiquant/docs/profiles/README.md
+++ b/digiquant/docs/profiles/README.md
@@ -1,0 +1,23 @@
+# Investment profiles
+
+`digiquant.profiles.InvestmentProfile` is the canonical user-facing description of an investor's posture: risk tolerance, horizon, liquidity needs, base currency, coarse tax jurisdiction, ESG stance, excluded sectors, and self-reported experience. Atlas, Hermes, and Kairos consult it to filter idea generation, constrain deliberation, and shape portfolio construction.
+
+The schema is intentionally coarse. Per-portfolio limits (CVaR, factor caps, position-size rules) live on a policy object, not here. Tax detail (state, ISA, RRSP, PEA, etc.) is deferred to a future `TaxProfile`.
+
+## Why versioned
+
+Every profile carries `schema_version: int = 1`. Storage layers (Supabase, Atlas runner state) persist profiles long-term, so adding or reshaping fields without a version field would silently corrupt older rows. The version field gives migrations a hook: on read, dispatch on `schema_version` and upgrade in place.
+
+## How to extend
+
+1. **Additive, non-breaking** — new field with a sensible default. Keep `schema_version=1`. Existing fixtures still validate.
+2. **Breaking** — field removed, retyped, or semantics changed. Bump `schema_version` (e.g. to `2`), keep the v1 model behind it, and add a migration in `digiquant.profiles` that upgrades v1 payloads to v2 on read. Update `examples` and the exported JSON schema (`schemas/investment_profile.v{N}.json`).
+
+Field validators live alongside the model in `digiquant/src/digiquant/profiles/investment_profile.py`. `excluded_sectors` is lower-cased, de-duplicated (insertion-order preserving), and stripped of empties. `base_currency` is upper-cased before pattern validation. `extra="forbid"` catches typos at load time rather than silently dropping them.
+
+## Pointers
+
+- Model: [`digiquant/src/digiquant/profiles/investment_profile.py`](../../src/digiquant/profiles/investment_profile.py)
+- JSON schema: [`schemas/investment_profile.v1.json`](../schemas/investment_profile.v1.json) — regenerate via `python3 scripts/export_profile_schema.py`
+- Example fixture: [`tests/dq/profiles/fixtures/example_profile.json`](../../../tests/dq/profiles/fixtures/example_profile.json)
+- Tests: [`tests/dq/profiles/test_investment_profile.py`](../../../tests/dq/profiles/test_investment_profile.py)

--- a/digiquant/docs/schemas/investment_profile.v1.json
+++ b/digiquant/docs/schemas/investment_profile.v1.json
@@ -1,0 +1,98 @@
+{
+  "additionalProperties": false,
+  "description": "User investment profile (schema v1).\n\nAttributes\n----------\nschema_version\n    Monotonic schema version. Increment only on breaking changes.\n    Additive fields with defaults do not require a bump.\nrisk_tolerance\n    Coarse risk bucket. Refined risk metrics (e.g. CVaR limits) belong\n    on a per-portfolio policy object, not here.\nhorizon_years\n    Investment horizon in whole years. Bounded ``1..50`` to cover a\n    single tactical year through a multi-decade plan.\nliquidity_needs\n    How much of the portfolio may be locked up in illiquid positions:\n    ``low`` tolerates lockups, ``high`` requires daily liquidity.\nbase_currency\n    ISO 4217 alphabetic currency code (e.g. ``USD``). Normalized to\n    upper case before validation.\ntax_jurisdiction\n    Coarse tax bucket \u2014 finer detail (state, ISA, RRSP, PEA, etc.) is\n    deferred to a future ``TaxProfile`` companion model.\nesg_preference\n    ``none`` ignores ESG, ``tilt`` overweights leaders, ``strict``\n    excludes laggards entirely.\nexcluded_sectors\n    Free-form sector exclusion list (e.g. ``tobacco``, ``defense``).\n    Normalized to lower case and de-duplicated while preserving\n    insertion order.\nexperience_level\n    Self-reported sophistication. Used to gate complex order types\n    and structured products in the UI.",
+  "properties": {
+    "base_currency": {
+      "description": "ISO 4217 alphabetic currency code (3 upper-case letters).",
+      "pattern": "^[A-Z]{3}$",
+      "title": "Base Currency",
+      "type": "string"
+    },
+    "esg_preference": {
+      "description": "ESG posture: ignore, overweight leaders, or hard-exclude laggards.",
+      "enum": [
+        "none",
+        "tilt",
+        "strict"
+      ],
+      "title": "Esg Preference",
+      "type": "string"
+    },
+    "excluded_sectors": {
+      "description": "Sectors to exclude (lower-cased, de-duplicated).",
+      "items": {
+        "type": "string"
+      },
+      "title": "Excluded Sectors",
+      "type": "array"
+    },
+    "experience_level": {
+      "description": "Self-reported investing experience.",
+      "enum": [
+        "novice",
+        "intermediate",
+        "expert"
+      ],
+      "title": "Experience Level",
+      "type": "string"
+    },
+    "horizon_years": {
+      "description": "Investment horizon in whole years.",
+      "maximum": 50,
+      "minimum": 1,
+      "title": "Horizon Years",
+      "type": "integer"
+    },
+    "liquidity_needs": {
+      "description": "Tolerance for capital lockup; high = needs daily liquidity.",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ],
+      "title": "Liquidity Needs",
+      "type": "string"
+    },
+    "risk_tolerance": {
+      "description": "Coarse risk bucket.",
+      "enum": [
+        "conservative",
+        "moderate",
+        "aggressive"
+      ],
+      "title": "Risk Tolerance",
+      "type": "string"
+    },
+    "schema_version": {
+      "default": 1,
+      "description": "Schema version; bump on breaking changes.",
+      "minimum": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    },
+    "tax_jurisdiction": {
+      "description": "Coarse tax jurisdiction; refine via a future TaxProfile.",
+      "enum": [
+        "US",
+        "EU",
+        "UK",
+        "CA",
+        "AU",
+        "OTHER"
+      ],
+      "title": "Tax Jurisdiction",
+      "type": "string"
+    }
+  },
+  "required": [
+    "risk_tolerance",
+    "horizon_years",
+    "liquidity_needs",
+    "base_currency",
+    "tax_jurisdiction",
+    "esg_preference",
+    "experience_level"
+  ],
+  "title": "InvestmentProfile",
+  "type": "object"
+}

--- a/digiquant/src/digiquant/profiles/__init__.py
+++ b/digiquant/src/digiquant/profiles/__init__.py
@@ -1,0 +1,15 @@
+"""User investment profile schemas.
+
+Versioned Pydantic v2 models describing a user's investment posture:
+risk tolerance, horizon, liquidity needs, base currency, tax jurisdiction,
+ESG preferences, excluded sectors, experience level. Consumed by Atlas /
+Hermes / Kairos to constrain idea generation and portfolio construction.
+
+See ``digiquant/docs/profiles/README.md`` for the migration story.
+"""
+
+from __future__ import annotations
+
+from digiquant.profiles.investment_profile import InvestmentProfile
+
+__all__ = ["InvestmentProfile"]

--- a/digiquant/src/digiquant/profiles/investment_profile.py
+++ b/digiquant/src/digiquant/profiles/investment_profile.py
@@ -1,0 +1,120 @@
+"""Versioned Pydantic v2 schema for a user's investment profile.
+
+The ``InvestmentProfile`` is a coarse-grained input that downstream services
+(Atlas idea generation, Hermes deliberation, Kairos portfolio construction)
+consult to filter strategies and constrain allocation. It is intentionally
+small: refinements are captured by bumping ``schema_version`` and shipping a
+migration, not by inflating this model.
+
+See ``digiquant/docs/profiles/README.md`` for the migration story and field
+rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class InvestmentProfile(BaseModel):
+    """User investment profile (schema v1).
+
+    Attributes
+    ----------
+    schema_version
+        Monotonic schema version. Increment only on breaking changes.
+        Additive fields with defaults do not require a bump.
+    risk_tolerance
+        Coarse risk bucket. Refined risk metrics (e.g. CVaR limits) belong
+        on a per-portfolio policy object, not here.
+    horizon_years
+        Investment horizon in whole years. Bounded ``1..50`` to cover a
+        single tactical year through a multi-decade plan.
+    liquidity_needs
+        How much of the portfolio may be locked up in illiquid positions:
+        ``low`` tolerates lockups, ``high`` requires daily liquidity.
+    base_currency
+        ISO 4217 alphabetic currency code (e.g. ``USD``). Normalized to
+        upper case before validation.
+    tax_jurisdiction
+        Coarse tax bucket — finer detail (state, ISA, RRSP, PEA, etc.) is
+        deferred to a future ``TaxProfile`` companion model.
+    esg_preference
+        ``none`` ignores ESG, ``tilt`` overweights leaders, ``strict``
+        excludes laggards entirely.
+    excluded_sectors
+        Free-form sector exclusion list (e.g. ``tobacco``, ``defense``).
+        Normalized to lower case and de-duplicated while preserving
+        insertion order.
+    experience_level
+        Self-reported sophistication. Used to gate complex order types
+        and structured products in the UI.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    schema_version: int = Field(
+        default=1,
+        ge=1,
+        description="Schema version; bump on breaking changes.",
+    )
+    risk_tolerance: Literal["conservative", "moderate", "aggressive"] = Field(
+        ...,
+        description="Coarse risk bucket.",
+    )
+    horizon_years: int = Field(
+        ...,
+        ge=1,
+        le=50,
+        description="Investment horizon in whole years.",
+    )
+    liquidity_needs: Literal["low", "medium", "high"] = Field(
+        ...,
+        description="Tolerance for capital lockup; high = needs daily liquidity.",
+    )
+    base_currency: str = Field(
+        ...,
+        pattern=r"^[A-Z]{3}$",
+        description="ISO 4217 alphabetic currency code (3 upper-case letters).",
+    )
+    tax_jurisdiction: Literal["US", "EU", "UK", "CA", "AU", "OTHER"] = Field(
+        ...,
+        description="Coarse tax jurisdiction; refine via a future TaxProfile.",
+    )
+    esg_preference: Literal["none", "tilt", "strict"] = Field(
+        ...,
+        description="ESG posture: ignore, overweight leaders, or hard-exclude laggards.",
+    )
+    excluded_sectors: list[str] = Field(
+        default_factory=list,
+        description="Sectors to exclude (lower-cased, de-duplicated).",
+    )
+    experience_level: Literal["novice", "intermediate", "expert"] = Field(
+        ...,
+        description="Self-reported investing experience.",
+    )
+
+    @field_validator("base_currency", mode="before")
+    @classmethod
+    def _upper_currency(cls, value: object) -> object:
+        """Upper-case currency before pattern validation rejects mixed case."""
+        if isinstance(value, str):
+            return value.strip().upper()
+        return value
+
+    @field_validator("excluded_sectors", mode="after")
+    @classmethod
+    def _normalize_sectors(cls, value: list[str]) -> list[str]:
+        """Lower-case, strip, drop empties, and de-duplicate while keeping order."""
+        seen: dict[str, None] = {}
+        for raw in value:
+            if not isinstance(raw, str):
+                # Pydantic's list[str] coercion will already reject non-strings,
+                # but guard explicitly to keep the validator total.
+                raise TypeError(f"excluded_sectors entries must be str, got {type(raw)!r}")
+            normalized = raw.strip().lower()
+            if not normalized:
+                continue
+            seen.setdefault(normalized, None)
+        return list(seen)

--- a/scripts/export_profile_schema.py
+++ b/scripts/export_profile_schema.py
@@ -1,0 +1,33 @@
+"""Export the ``InvestmentProfile`` JSON schema to ``digiquant/docs/schemas/``.
+
+Regenerate after any change to ``digiquant.profiles.investment_profile`` and
+commit the result alongside the model change. Run from the repo root::
+
+    python3 scripts/export_profile_schema.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Make the digiquant package importable when invoked outside an editable install.
+sys.path.insert(0, str(REPO_ROOT / "digiquant" / "src"))
+
+from digiquant.profiles.investment_profile import InvestmentProfile  # noqa: E402
+
+
+def main() -> int:
+    out = REPO_ROOT / "digiquant" / "docs" / "schemas" / "investment_profile.v1.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    schema = InvestmentProfile.model_json_schema()
+    out.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dq/profiles/fixtures/example_profile.json
+++ b/tests/dq/profiles/fixtures/example_profile.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "risk_tolerance": "moderate",
+  "horizon_years": 10,
+  "liquidity_needs": "medium",
+  "base_currency": "USD",
+  "tax_jurisdiction": "US",
+  "esg_preference": "tilt",
+  "excluded_sectors": ["tobacco", "defense"],
+  "experience_level": "intermediate"
+}

--- a/tests/dq/profiles/test_investment_profile.py
+++ b/tests/dq/profiles/test_investment_profile.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``InvestmentProfile``.
+
+Covers schema-version defaulting, JSON round-trip, field validators, and the
+checked-in example fixture. These tests are the contract — bumping the schema
+must keep them green (or migrate them deliberately and bump
+``schema_version``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from digiquant.profiles import InvestmentProfile
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "example_profile.json"
+
+
+def _valid_payload(**overrides: Any) -> dict[str, Any]:
+    """Return a valid profile payload, optionally overriding individual fields."""
+    payload: dict[str, Any] = {
+        "risk_tolerance": "moderate",
+        "horizon_years": 10,
+        "liquidity_needs": "medium",
+        "base_currency": "USD",
+        "tax_jurisdiction": "US",
+        "esg_preference": "tilt",
+        "excluded_sectors": [],
+        "experience_level": "intermediate",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.unit
+class TestInvestmentProfile:
+    """Schema-level guarantees for ``InvestmentProfile``."""
+
+    def test_valid_profile_round_trips_json(self) -> None:
+        original = InvestmentProfile(**_valid_payload(excluded_sectors=["tobacco"]))
+        as_json = original.model_dump_json()
+        restored = InvestmentProfile.model_validate_json(as_json)
+        assert restored == original
+        assert restored.model_dump() == original.model_dump()
+
+    def test_invalid_risk_tolerance_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(risk_tolerance="extreme"))
+        assert any(err["loc"] == ("risk_tolerance",) for err in exc_info.value.errors())
+
+    def test_horizon_below_minimum_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(horizon_years=0))
+        assert any(err["loc"] == ("horizon_years",) for err in exc_info.value.errors())
+
+    def test_horizon_above_maximum_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(horizon_years=51))
+        assert any(err["loc"] == ("horizon_years",) for err in exc_info.value.errors())
+
+    @pytest.mark.parametrize("bad_currency", ["us", "USD123", "1USD", ""])
+    def test_invalid_currency_format_raises(self, bad_currency: str) -> None:
+        # ``us`` normalizes to ``US`` (still 2 chars → fails pattern). The
+        # remaining cases are length / charset failures. ``"usd"`` is *valid*
+        # because the validator upper-cases input first — see the dedicated
+        # test below.
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(base_currency=bad_currency))
+        assert any(err["loc"] == ("base_currency",) for err in exc_info.value.errors())
+
+    def test_currency_lowercase_normalized_to_uppercase(self) -> None:
+        profile = InvestmentProfile(**_valid_payload(base_currency="eur"))
+        assert profile.base_currency == "EUR"
+
+    def test_excluded_sectors_normalized(self) -> None:
+        profile = InvestmentProfile(
+            **_valid_payload(excluded_sectors=["Tobacco", "tobacco", "Defense"])
+        )
+        # Lower-cased, de-duplicated, and insertion-order preserved.
+        assert profile.excluded_sectors == ["tobacco", "defense"]
+
+    def test_excluded_sectors_strips_whitespace_and_drops_empties(self) -> None:
+        profile = InvestmentProfile(
+            **_valid_payload(excluded_sectors=["  Tobacco ", "", "  ", "DEFENSE"])
+        )
+        assert profile.excluded_sectors == ["tobacco", "defense"]
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(foo="bar"))  # type: ignore[arg-type]
+        assert any("foo" in str(err["loc"]) for err in exc_info.value.errors())
+
+    def test_schema_version_default_is_one(self) -> None:
+        profile = InvestmentProfile(**_valid_payload())
+        assert profile.schema_version == 1
+
+    def test_schema_version_below_one_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            InvestmentProfile(**_valid_payload(schema_version=0))
+        assert any(err["loc"] == ("schema_version",) for err in exc_info.value.errors())
+
+    def test_example_fixture_loads(self) -> None:
+        assert FIXTURE_PATH.exists(), f"missing fixture at {FIXTURE_PATH}"
+        raw = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        profile = InvestmentProfile.model_validate(raw)
+        assert profile.schema_version == 1
+        assert profile.base_currency == "USD"
+        # Round-trip the fixture too — it must be byte-stable under ``model_dump``.
+        assert profile.model_dump() == raw


### PR DESCRIPTION
## Linked issue

Fixes #305
Refs #296 (parent epic)

---

## Component

- [x] digiquant

## Change Type

- [x] feat — new capability

## Agent Quality Gates

- [x] /simplify run — code reviewed for reuse, quality, and efficiency; issues addressed (see notes below)
- [x] /review completed — PR reviewed against scoring rubric; findings addressed (see notes below)

### Simplify pass — findings

- **Reuse**: Standalone new package; no shared abstractions to fold into. Pydantic-v2 conventions follow existing `digiquant/src/digiquant/models.py`.
- **Quality**: `setdefault(...)` chosen for insertion-order-preserving dedupe combined with single-pass strip/empty-filter. `dict.fromkeys(...)` rejected because it would require a second pass for normalization.
- **Efficiency**: One pass per validator, no redundant copies, no LLM/HTTP/DB I/O. Schema export is a single `model_json_schema()` write.
- **No issues to fix** — code is minimal and the test suite is precise.

### Review pass — rubric findings

- **Security 10/10** — no secrets, no PII surface, input validation at boundary, no injection vectors, no auth/live-trading paths.
- **Quality 9/10** — `from typing import Any` used in test-helper kwargs payload (intentional; helper is generic). All other criteria green.
- **Optimization 10/10** — no LLM/HTTP/N+1/async-blocking surface; nothing to optimize beyond what's there.
- **Accuracy 10/10** — matches spec field-for-field, validators behave as documented, fixture round-trips byte-stable.

## Summary

Versioned Pydantic v2 model describing a user's investment posture: risk tolerance, horizon, liquidity needs, base currency, coarse tax jurisdiction, ESG preference, excluded sectors, experience level. Atlas / Hermes / Kairos will consult it to filter idea generation and constrain portfolio construction. `schema_version: int = 1` is the migration hook — additive fields stay on v1, breaking changes bump the version. Validators normalize `base_currency` to upper case and `excluded_sectors` to insertion-ordered, de-duplicated lower case. `extra="forbid"` catches typos at load time.

Ships:
- `digiquant.profiles.InvestmentProfile` model + package init
- Exported JSON schema at `digiquant/docs/schemas/investment_profile.v1.json` (regenerable via `scripts/export_profile_schema.py`)
- README at `digiquant/docs/profiles/README.md` documenting the migration story
- Example fixture at `tests/dq/profiles/fixtures/example_profile.json`
- 15 unit tests covering round-trip, all field validators, bounds, normalization, and the fixture

---

## Self-Score Checklist

### Security (10/10)
- [x] 1. No secrets in code
- [x] 2. No PII in spans or audit logs
- [x] 3. Input validation at system boundaries (Pydantic models with `extra="forbid"`)
- [x] 4. No injection vectors
- [x] 5. Scope-checked auth — N/A (no new routes)
- [x] 6. Fail-closed on missing auth config — N/A
- [x] 7. No new loopback exceptions
- [x] 8. No live-trading path touched
- [x] 9. Least-privilege secret access — N/A
- [x] 10. No debug back-doors

**Security score: 10 / 10**

### Quality (9/10)
- [x] 1. Pydantic v2 (`field_validator`, `ConfigDict`)
- [x] 2. Polars only — N/A (no data flow)
- [ ] 3. Strict typing — `Any` used in `_valid_payload` kwargs (intentional, helper is generic)
- [x] 4. Ruff clean
- [x] 5. Tests added (15 unit tests)
- [x] 6. No orphaned code
- [x] 7. Files focused (max ~120 lines)
- [x] 8. Errors structured (`pydantic.ValidationError`)
- [x] 9. ARCHITECTURE.md updated — N/A (new docs added in `digiquant/docs/profiles/`)
- [x] 10. No backward-compat hacks

**Quality score: 9 / 10**

### Optimization (10/10)
- [x] All criteria — no LLM/HTTP/Polars/async surface to optimize

**Optimization score: 10 / 10**

### Accuracy (10/10)
- [x] 1. Matches spec
- [x] 2. State transitions — N/A
- [x] 3. Audit events — N/A (pure data model)
- [x] 4. DigiSmith spans — N/A
- [x] 5. Error paths handled (Pydantic raises `ValidationError`)
- [x] 6. API contracts — first version
- [x] 7. Strategy invariants — N/A
- [x] 8. JWT scope contract — N/A
- [x] 9. Test assertions are specific (`("risk_tolerance",)`, `["tobacco", "defense"]`, etc.)
- [x] 10. No regression (all existing tests still pass)

**Accuracy score: 10 / 10**

---

## Testing Evidence

```
$ pytest tests/dq/profiles/ -v -m unit
============================== 15 passed in 0.02s ==============================

$ ruff check digiquant/src/digiquant/profiles/ tests/dq/profiles/ scripts/export_profile_schema.py
All checks passed!

$ ruff format --check digiquant/src/digiquant/profiles/ tests/dq/profiles/ scripts/export_profile_schema.py
5 files already formatted

$ python3 scripts/score.py --staged
  PASS  Security      10/10  (threshold >=8)
  PASS  Quality        9/10  (threshold >=8)
  PASS  Optimization  10/10  (threshold >=7)
  PASS  Accuracy      10/10  (threshold >=9)
```

---

## Documentation Updated

- [x] New module docs added: `digiquant/docs/profiles/README.md` and `digiquant/docs/schemas/investment_profile.v1.json`
- [ ] `{component}/ARCHITECTURE.md` updated — N/A; new package, no architectural surface change
- [ ] Root `AGENTS.md` / `CLAUDE.md` — N/A

---

## Human Gate

No live-trading, auth/crypto, JWT scope, network exposure, or security policy changes. Pure schema addition.

**Is human review required?** No
