### PR TITLE
feat(digiquant): trading_calendar sync CLI + workflow (#337)

### DIFF
--- a/.github/workflows/digiquant-prices.yml
+++ b/.github/workflows/digiquant-prices.yml
@@ -150,6 +150,16 @@ jobs:
           pip install -e "./digibase"
           pip install -e "./digikey"
           pip install -e "./digiquant[prices]"
+      - name: Sync trading_calendar (NYSE/NASDAQ/CRYPTO/FX)
+        # Daily idempotent upsert (~30s, one-shot library query + chunked
+        # upsert on PK (date,venue)).  Runs before the macro ingest so any
+        # downstream join sites see today's calendar row.  ADR-0013, issue #337.
+        run: |
+          python -m digiquant prices sync-calendar \
+            --venues NYSE,NASDAQ,CRYPTO,FX \
+            --start 1950-01-01 \
+            --end +5y \
+            --supabase
       - name: Ingest macro series (FRED + Yahoo FX)
         # Default --sources is fred,yahoo (issue #328 dropped Frankfurter+FNG).
         run: |

--- a/digiquant/pyproject.toml
+++ b/digiquant/pyproject.toml
@@ -31,6 +31,10 @@ prices = [
     "supabase>=2.0",
     "python-dotenv>=1",
     "pyarrow>=15",
+    # Trading-calendar source for trading_calendar table (ADR-0013, issue #337).
+    # exchange_calendars returns pandas DataFrames; calendar_sync.py flattens
+    # them to dicts at the boundary so the rest of the pipeline stays Polars-only.
+    "exchange_calendars>=4.5",
 ]
 optimize = ["optuna>=3.0"]
 all = ["digiquant[nautilus]"]

--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -271,6 +271,87 @@ def fetch_macro_cmd(
     click.echo(f"  upserted {res.rows} rows into macro_series_observations")
 
 
+# ─── sync-calendar ───────────────────────────────────────────────────────
+
+
+@prices.command("sync-calendar")
+@click.option(
+    "--venues",
+    type=str,
+    default="NYSE,NASDAQ,CRYPTO,FX",
+    help="Comma-separated subset of {NYSE,NASDAQ,CRYPTO,FX}.",
+)
+@click.option(
+    "--start",
+    type=str,
+    default="1950-01-01",
+    help="ISO date — earliest day to populate (default 1950-01-01 per ADR-0013).",
+)
+@click.option(
+    "--end",
+    type=str,
+    default="+5y",
+    help="ISO date or relative offset (+5y, -30d, +18m, +12w).  Default +5y.",
+)
+@click.option("--dry-run", is_flag=True, help="Build rows but skip upsert; print summary.")
+@click.option("--supabase", is_flag=True, help="Upsert to trading_calendar.")
+def sync_calendar_cmd(venues: str, start: str, end: str, dry_run: bool, supabase: bool) -> None:
+    """Backfill / refresh the trading_calendar table for one or more venues.
+
+    Idempotent on ``(date, venue)`` — running twice produces zero net change.
+    The first run after migration 025 populates the table for the full
+    ``[start, end]`` range; subsequent daily runs are essentially no-ops aside
+    from extending the future tail by one day.
+    """
+    from datetime import date as _date
+
+    from digiquant.data.prices.calendar_sync import (
+        ALL_VENUES,
+        build_rows,
+        parse_end_spec,
+        upsert_trading_calendar,
+    )
+    from digiquant.data.prices.supabase_writer import build_supabase_client
+
+    venue_list = [v.strip().upper() for v in venues.split(",") if v.strip()]
+    if not venue_list:
+        raise click.UsageError("--venues must list at least one venue")
+    unknown = [v for v in venue_list if v not in ALL_VENUES]
+    if unknown:
+        raise click.UsageError(f"unknown venues: {unknown} (allowed: {list(ALL_VENUES)})")
+
+    try:
+        start_d = _date.fromisoformat(start)
+    except ValueError as exc:
+        raise click.UsageError(f"--start must be ISO YYYY-MM-DD ({exc})") from exc
+    try:
+        end_d = parse_end_spec(end)
+    except ValueError as exc:
+        raise click.UsageError(f"invalid --end: {exc}") from exc
+    if end_d < start_d:
+        raise click.UsageError(f"--end ({end_d}) must be on or after --start ({start_d})")
+
+    click.echo(f"sync-calendar: venues={venue_list} {start_d} -> {end_d}")
+    rows = build_rows(venue_list, start_d, end_d)
+    summary: dict[str, int] = {}
+    for r in rows:
+        summary[r["venue"]] = summary.get(r["venue"], 0) + 1
+    for v, n in sorted(summary.items()):
+        click.echo(f"  {v:7s} {n:>7d} rows")
+
+    if dry_run or not supabase:
+        return
+
+    client = build_supabase_client(
+        os.environ.get("SUPABASE_URL"),
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"),
+    )
+    if client is None:
+        raise click.ClickException("Supabase credentials not set.")
+    written = upsert_trading_calendar(client, rows)
+    click.echo(f"  upserted {written} rows into trading_calendar")
+
+
 # ─── preload-history ─────────────────────────────────────────────────────
 
 

--- a/digiquant/src/digiquant/data/prices/__init__.py
+++ b/digiquant/src/digiquant/data/prices/__init__.py
@@ -9,8 +9,12 @@ Public surface:
     - macro_ingest.fetch_fred / fetch_fx_yahoo (default daily pipeline)
     - macro_ingest.fetch_frankfurter / fetch_crypto_fng (legacy, opt-in)
     - supabase_writer.upsert_price_history / upsert_price_technicals / upsert_macro_observations
+    - calendar_sync.build_rows / upsert_trading_calendar (issue #337)
+    - ticker_venues.CORE_TICKER_VENUES / venue_for (issue #337)
 
-No pandas anywhere. All DataFrames are `polars.DataFrame`.
+Internal data is Polars-only.  ``exchange_calendars`` (consumed by
+``calendar_sync``) returns pandas frames at the library boundary; those are
+flattened to dict rows immediately and never re-exported.
 """
 
 from __future__ import annotations

--- a/digiquant/src/digiquant/data/prices/calendar_sync.py
+++ b/digiquant/src/digiquant/data/prices/calendar_sync.py
@@ -1,0 +1,308 @@
+"""Trading-calendar fetcher + row-shaper for ``trading_calendar`` (issue #337).
+
+ADR-0013 establishes the venue-keyed ``trading_calendar`` table.  This module
+generates the rows that populate it.
+
+Design — pandas at the boundary, Polars/dicts everywhere else
+-------------------------------------------------------------
+
+``exchange_calendars`` returns ``pandas.DatetimeIndex``.  We unwrap that into a
+``set[datetime.date]`` immediately and never re-export pandas types.  The rest
+of the pipeline (Supabase upsert, audit, tests) consumes plain ``list[dict]``
+rows that match the migration-025 schema.
+
+Venue handling
+--------------
+
+* ``NYSE`` / ``NASDAQ`` — driven by ``exchange_calendars`` (``XNYS`` / ``XNAS``
+  ISO MIC codes).  Non-session weekdays are tagged ``reason='holiday'``;
+  weekends are ``reason='weekend'``.
+* ``CRYPTO`` — synthetic 24x7 calendar.  Every date is ``is_trading_day=True``
+  with ``reason=None``.
+* ``FX`` — synthetic 5-day-week calendar.  Sat+Sun are ``reason='weekend'``.
+  Daily resolution does not capture the Sun-evening session reopen.
+
+The library is imported lazily inside :func:`_calendar_session_dates` so unit
+tests can monkeypatch it without forcing the heavy import on package load.
+
+Idempotency
+-----------
+
+Row generation is deterministic for a given ``(venue, start, end)`` tuple, and
+the upsert path passes ``on_conflict='date,venue'`` — re-running the sync
+produces the same rows and the database write is a no-op aside from
+``created_at`` columns set by the table default.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any
+
+# ─── Venue constants ──────────────────────────────────────────────────────
+
+VENUE_NYSE = "NYSE"
+VENUE_NASDAQ = "NASDAQ"
+VENUE_CRYPTO = "CRYPTO"
+VENUE_FX = "FX"
+
+ALL_VENUES: tuple[str, ...] = (VENUE_NYSE, VENUE_NASDAQ, VENUE_CRYPTO, VENUE_FX)
+
+# ISO MIC codes for the equity venues, consumed by ``exchange_calendars``.
+_VENUE_TO_MIC: dict[str, str] = {
+    VENUE_NYSE: "XNYS",
+    VENUE_NASDAQ: "XNAS",
+}
+
+# Reason strings — kept short and stable.  ADR-0013 names ``weekend``,
+# ``holiday:<name>``, and ``early_close`` as the canonical values.  We do not
+# attempt to attach the holiday name (e.g., ``holiday:Christmas``) here because
+# ``exchange_calendars`` returns Timestamps without the underlying rule name;
+# inferring names by month/day would be brittle and is out of scope for #337.
+REASON_WEEKEND = "weekend"
+REASON_HOLIDAY = "holiday"
+
+DEFAULT_BACKFILL_START = date(1950, 1, 1)
+
+
+# ─── End-spec parsing (``+5y`` / ``-30d`` / ISO date) ─────────────────────
+
+_RELATIVE_PATTERN = re.compile(r"^([+-])(\d+)([dwmy])$")
+
+
+def parse_end_spec(spec: str, *, today: date | None = None) -> date:
+    """Parse an end-date spec accepted by ``--end``.
+
+    Accepts:
+
+    * an ISO date (``YYYY-MM-DD``)
+    * a relative offset (``+5y``, ``-30d``, ``+18m``, ``+12w``)
+
+    Months are approximated as 30 days and years as 365 days — the calendar
+    backfill is intentionally a coarse over-fill (a few extra days at the tail
+    are harmless because every consumer filters by venue/date anyway).
+    Avoiding ``dateutil.relativedelta`` keeps the package free of an extra
+    runtime dependency.
+    """
+    if today is None:
+        today = date.today()
+    spec = spec.strip()
+    if not spec:
+        raise ValueError("end spec must not be empty")
+    match = _RELATIVE_PATTERN.match(spec)
+    if match:
+        sign, n_str, unit = match.groups()
+        n = int(n_str) * (1 if sign == "+" else -1)
+        if unit == "d":
+            days = n
+        elif unit == "w":
+            days = n * 7
+        elif unit == "m":
+            days = n * 30
+        elif unit == "y":
+            days = n * 365
+        else:  # pragma: no cover - regex enforces unit set
+            raise ValueError(f"unsupported unit in end spec: {spec!r}")
+        return today + timedelta(days=days)
+    # Fall through to ISO parse.
+    try:
+        return date.fromisoformat(spec)
+    except ValueError as exc:
+        raise ValueError(f"end spec is neither ISO date nor relative offset: {spec!r}") from exc
+
+
+# ─── Date-range helpers ───────────────────────────────────────────────────
+
+
+def _iter_dates(start: date, end: date) -> Iterable[date]:
+    """Inclusive date iterator from ``start`` to ``end``."""
+    if end < start:
+        return
+    cur = start
+    one = timedelta(days=1)
+    while cur <= end:
+        yield cur
+        cur += one
+
+
+def _calendar_session_dates(
+    venue: str, start: date, end: date, *, get_calendar: Callable[[str], Any] | None = None
+) -> set[date]:
+    """Return the set of session dates for an equity venue.
+
+    The pandas ``DatetimeIndex`` returned by ``exchange_calendars`` is
+    flattened to ``set[date]`` immediately so callers never see pandas types.
+
+    ``get_calendar`` is dependency-injected for tests; production code passes
+    ``None`` and we import the library lazily.
+    """
+    if venue not in _VENUE_TO_MIC:
+        raise ValueError(f"venue {venue!r} is not driven by exchange_calendars")
+    if get_calendar is None:  # pragma: no cover - exercised via tests with injection
+        import exchange_calendars as ec  # type: ignore[import-not-found]
+
+        get_calendar = ec.get_calendar
+    cal = get_calendar(_VENUE_TO_MIC[venue])
+    sessions = cal.sessions_in_range(start.isoformat(), end.isoformat())
+    # ``sessions`` is a pandas DatetimeIndex.  Iterating it yields pandas
+    # Timestamps which expose ``.date()``.  We flatten to native dates here
+    # and discard the pandas object — no pandas types leak past this line.
+    return {ts.date() for ts in sessions}
+
+
+# ─── Row shaping ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CalendarRow:
+    """Typed view of a single ``trading_calendar`` row.
+
+    Returned for callers that want a structured value; the public sync API
+    returns ``list[dict]`` directly to match the existing Supabase writer
+    contract.
+    """
+
+    date: date
+    venue: str
+    is_trading_day: bool
+    reason: str | None
+
+
+def _row_to_dict(row: CalendarRow) -> dict[str, Any]:
+    return {
+        "date": row.date.isoformat(),
+        "venue": row.venue,
+        "is_trading_day": row.is_trading_day,
+        "reason": row.reason,
+    }
+
+
+def build_equity_rows(
+    venue: str,
+    start: date,
+    end: date,
+    *,
+    get_calendar: Callable[[str], Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Build rows for an equity venue (``NYSE`` / ``NASDAQ``).
+
+    Every date in ``[start, end]`` produces exactly one row.  Sessions yielded
+    by ``exchange_calendars`` are tagged ``is_trading_day=True``; the remaining
+    weekday dates become ``is_trading_day=False, reason='holiday'`` and Sat/Sun
+    become ``reason='weekend'``.
+    """
+    sessions = _calendar_session_dates(venue, start, end, get_calendar=get_calendar)
+    rows: list[dict[str, Any]] = []
+    for d in _iter_dates(start, end):
+        if d in sessions:
+            rows.append(_row_to_dict(CalendarRow(d, venue, True, None)))
+            continue
+        weekday = d.weekday()
+        if weekday >= 5:  # Saturday=5, Sunday=6
+            rows.append(_row_to_dict(CalendarRow(d, venue, False, REASON_WEEKEND)))
+        else:
+            rows.append(_row_to_dict(CalendarRow(d, venue, False, REASON_HOLIDAY)))
+    return rows
+
+
+def build_crypto_rows(start: date, end: date) -> list[dict[str, Any]]:
+    """Build rows for the synthetic 24x7 crypto calendar.
+
+    Every date in ``[start, end]`` is a trading day with ``reason=None``.
+    """
+    return [_row_to_dict(CalendarRow(d, VENUE_CRYPTO, True, None)) for d in _iter_dates(start, end)]
+
+
+def build_fx_rows(start: date, end: date) -> list[dict[str, Any]]:
+    """Build rows for the synthetic 5-day-week FX calendar.
+
+    Mon–Fri are ``is_trading_day=True``.  Sat+Sun are
+    ``is_trading_day=False, reason='weekend'``.  Daily resolution does not
+    capture the Sun-evening reopen — see ADR-0013.
+    """
+    rows: list[dict[str, Any]] = []
+    for d in _iter_dates(start, end):
+        if d.weekday() >= 5:
+            rows.append(_row_to_dict(CalendarRow(d, VENUE_FX, False, REASON_WEEKEND)))
+        else:
+            rows.append(_row_to_dict(CalendarRow(d, VENUE_FX, True, None)))
+    return rows
+
+
+def build_rows_for_venue(
+    venue: str,
+    start: date,
+    end: date,
+    *,
+    get_calendar: Callable[[str], Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Dispatch to the per-venue row builder."""
+    if venue in _VENUE_TO_MIC:
+        return build_equity_rows(venue, start, end, get_calendar=get_calendar)
+    if venue == VENUE_CRYPTO:
+        return build_crypto_rows(start, end)
+    if venue == VENUE_FX:
+        return build_fx_rows(start, end)
+    raise ValueError(f"unknown venue: {venue!r}")
+
+
+def build_rows(
+    venues: Iterable[str],
+    start: date,
+    end: date,
+    *,
+    get_calendar: Callable[[str], Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Build the union of rows for ``venues`` between ``start`` and ``end``."""
+    out: list[dict[str, Any]] = []
+    for v in venues:
+        out.extend(build_rows_for_venue(v, start, end, get_calendar=get_calendar))
+    return out
+
+
+# ─── Supabase upsert ──────────────────────────────────────────────────────
+
+
+def upsert_trading_calendar(
+    client: Any,
+    rows: list[dict[str, Any]],
+    *,
+    chunk: int = 500,
+) -> int:
+    """Idempotent upsert of ``rows`` into ``trading_calendar``.
+
+    ``on_conflict='date,venue'`` matches the table's composite primary key
+    (migration 025).  Re-running the sync produces no duplicate rows.
+    Returns the total number of rows written across all batches.
+    """
+    if not rows:
+        return 0
+    total = 0
+    for i in range(0, len(rows), chunk):
+        batch = rows[i : i + chunk]
+        client.table("trading_calendar").upsert(batch, on_conflict="date,venue").execute()
+        total += len(batch)
+    return total
+
+
+__all__ = [
+    "ALL_VENUES",
+    "CalendarRow",
+    "DEFAULT_BACKFILL_START",
+    "REASON_HOLIDAY",
+    "REASON_WEEKEND",
+    "VENUE_CRYPTO",
+    "VENUE_FX",
+    "VENUE_NASDAQ",
+    "VENUE_NYSE",
+    "build_crypto_rows",
+    "build_equity_rows",
+    "build_fx_rows",
+    "build_rows",
+    "build_rows_for_venue",
+    "parse_end_spec",
+    "upsert_trading_calendar",
+]

--- a/digiquant/src/digiquant/data/prices/ticker_venues.py
+++ b/digiquant/src/digiquant/data/prices/ticker_venues.py
@@ -1,0 +1,180 @@
+"""Ticker → trading-calendar venue mapping for the core watchlist (issue #337).
+
+ADR-0013 establishes four venues — ``NYSE``, ``NASDAQ``, ``CRYPTO``, ``FX`` —
+and assigns every core-universe ticker to one of them.  The mapping lives here
+(rather than in a Postgres table) per ADR-0013: it is a small static constant
+that changes rarely; a code-resident dict avoids an extra round-trip per query
+and keeps the list reviewable in PRs.
+
+Conventions (from ADR-0013):
+
+* All US equity ETFs in the watchlist are assigned ``NYSE`` regardless of their
+  primary listing exchange.  NYSE serves as the canonical US equity calendar.
+* Crypto spot tickers (``*-USD``) and US-listed crypto ETFs (IBIT, FBTC, etc.)
+  are assigned ``CRYPTO`` even though the ETFs trade on NYSE Arca during NYSE
+  hours.  Per the ADR this is intentional: downstream consumers join the crypto
+  calendar to model continuous-market behaviour for these series.
+* FX majors are assigned ``FX``.  Daily resolution treats Sat+Sun as
+  non-trading; the Sun-evening reopen is below the granularity we backfill at.
+* ``NASDAQ`` is reserved for future per-equity coverage and is currently empty
+  for the watchlist (the schema column accepts it; no rows yet).
+
+The :data:`CORE_TICKER_VENUES` mapping is the single source of truth for the
+backfill job and for the technicals/frontend join sites.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# US equity ETFs (market-cap, sector, international, EM, commodity, fixed-income).
+_NYSE_TICKERS: Final[tuple[str, ...]] = (
+    # Market cap
+    "SPY",
+    "QQQ",
+    "DIA",
+    "IWB",
+    "VTI",
+    "MDY",
+    "IJH",
+    "IWM",
+    "IJR",
+    # Sector
+    "XLK",
+    "XLF",
+    "XLE",
+    "XLV",
+    "XLI",
+    "XLRE",
+    "XLU",
+    "XLY",
+    "XLP",
+    "XLB",
+    "XLC",
+    # International developed
+    "EFA",
+    "VEA",
+    "VGK",
+    "EWJ",
+    "EWG",
+    "EWU",
+    "EWA",
+    # Emerging markets
+    "EEM",
+    "VWO",
+    "FXI",
+    "ASHR",
+    "EWZ",
+    "EWT",
+    "EWY",
+    "INDA",
+    # Commodities
+    "GLD",
+    "IAU",
+    "SLV",
+    "DBO",
+    "USO",
+    "BNO",
+    "PDBC",
+    "DJP",
+    "CPER",
+    # Fixed income / cash
+    "BIL",
+    "SHV",
+    "SHY",
+    "IEF",
+    "TLT",
+    "AGG",
+    "HYG",
+    "LQD",
+    "TIP",
+    "EMB",
+    # Macro indicator (USD bull) — tradeable equity-like ticker on NYSE Arca.
+    "UUP",
+)
+
+# Crypto spot pairs (yfinance ``*-USD`` suffix) and US-listed crypto ETFs.
+# ADR-0013: all assigned ``CRYPTO`` venue regardless of where the ETF lists.
+_CRYPTO_TICKERS: Final[tuple[str, ...]] = (
+    # Spot pairs
+    "BTC-USD",
+    "ETH-USD",
+    "SOL-USD",
+    "XRP-USD",
+    "BNB-USD",
+    "TRX-USD",
+    "DOGE-USD",
+    "ADA-USD",
+    "AVAX-USD",
+    "LINK-USD",
+    "DOT-USD",
+    "BCH-USD",
+    "LTC-USD",
+    "NEAR-USD",
+    "ATOM-USD",
+    "XMR-USD",
+    "SUI20947-USD",
+    # ETFs (futures-based + spot)
+    "BITO",
+    "IBIT",
+    "FBTC",
+    "ETHA",
+    "FETH",
+    "GBTC",
+)
+
+# FX majors (yfinance ``X=F`` form is intraday; daily backfill uses pair codes
+# from the FX adapter).  Venue mapping is authoritative regardless of source.
+_FX_TICKERS: Final[tuple[str, ...]] = (
+    "EURUSD",
+    "GBPUSD",
+    "JPYUSD",
+    "CADUSD",
+    # Yahoo-style alternates that the FX fetcher may emit (#328).
+    "EURUSD=X",
+    "GBPUSD=X",
+    "JPYUSD=X",
+    "CADUSD=X",
+)
+
+
+def _build_mapping() -> dict[str, str]:
+    """Materialise the ticker → venue dict from the per-venue tuples."""
+    mapping: dict[str, str] = {}
+    for ticker in _NYSE_TICKERS:
+        mapping[ticker] = "NYSE"
+    for ticker in _CRYPTO_TICKERS:
+        mapping[ticker] = "CRYPTO"
+    for ticker in _FX_TICKERS:
+        mapping[ticker] = "FX"
+    return mapping
+
+
+CORE_TICKER_VENUES: Final[dict[str, str]] = _build_mapping()
+"""Mapping from ticker → venue for the core backfill universe.
+
+Use :func:`venue_for` for case-insensitive lookups.  Read this dict directly
+when iterating the universe (e.g., to backfill calendar rows for every venue
+that has at least one ticker assigned).
+"""
+
+ALLOWED_VENUES: Final[frozenset[str]] = frozenset({"NYSE", "NASDAQ", "CRYPTO", "FX"})
+"""Venue values that the schema (migration 025) accepts."""
+
+
+def venue_for(ticker: str) -> str | None:
+    """Return the venue for ``ticker`` or ``None`` if not mapped.
+
+    Lookup is case-insensitive on the ticker; the stored mapping uses the
+    upper-case form that yfinance / the watchlist emit.
+    """
+    if not ticker:
+        return None
+    return CORE_TICKER_VENUES.get(ticker.upper())
+
+
+__all__ = [
+    "ALLOWED_VENUES",
+    "CORE_TICKER_VENUES",
+    "venue_for",
+]

--- a/tests/dq/data/test_calendar_sync.py
+++ b/tests/dq/data/test_calendar_sync.py
@@ -1,0 +1,505 @@
+"""Unit tests for digiquant.data.prices.calendar_sync (issue #337).
+
+The exchange_calendars library is mocked at the boundary so tests never touch
+the network and never depend on the package being installed.  Mock fixtures
+provide a fixed set of NYSE / NASDAQ session dates aligned with the windows
+each test exercises.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+import pytest
+
+from digiquant.data.prices.calendar_sync import (
+    ALL_VENUES,
+    REASON_HOLIDAY,
+    REASON_WEEKEND,
+    VENUE_CRYPTO,
+    VENUE_FX,
+    VENUE_NASDAQ,
+    VENUE_NYSE,
+    build_crypto_rows,
+    build_equity_rows,
+    build_fx_rows,
+    build_rows,
+    build_rows_for_venue,
+    parse_end_spec,
+    upsert_trading_calendar,
+)
+from digiquant.data.prices.ticker_venues import (
+    ALLOWED_VENUES,
+    CORE_TICKER_VENUES,
+    venue_for,
+)
+
+
+# ─── Fake exchange_calendars boundary ──────────────────────────────────────
+
+
+@dataclass
+class _FakeSessions:
+    """Stand-in for ``pandas.DatetimeIndex`` returned by sessions_in_range.
+
+    Only the iteration protocol used by ``calendar_sync`` is implemented:
+    each yielded element exposes a ``.date()`` method that returns a native
+    ``datetime.date``.  This deliberately avoids a pandas dependency in tests.
+    """
+
+    sessions: list[date]
+
+    def __iter__(self):
+        for d in self.sessions:
+            yield _FakeTimestamp(d)
+
+
+@dataclass
+class _FakeTimestamp:
+    _d: date
+
+    def date(self) -> date:
+        return self._d
+
+
+@dataclass
+class _FakeCalendar:
+    name: str
+    sessions: list[date] = field(default_factory=list)
+
+    def sessions_in_range(self, start: str, end: str) -> _FakeSessions:
+        s = date.fromisoformat(start)
+        e = date.fromisoformat(end)
+        return _FakeSessions([d for d in self.sessions if s <= d <= e])
+
+
+def _us_business_days(start: date, end: date, *, holidays: set[date] | None = None) -> list[date]:
+    """Generate Mon–Fri dates in [start, end] minus an optional holiday set."""
+    holidays = holidays or set()
+    out: list[date] = []
+    cur = start
+    one = timedelta(days=1)
+    while cur <= end:
+        if cur.weekday() < 5 and cur not in holidays:
+            out.append(cur)
+        cur += one
+    return out
+
+
+# Known 2023 NYSE holidays used by ``test_nyse_calendar_excludes_known_holidays``.
+NYSE_2023_HOLIDAYS: set[date] = {
+    date(2023, 1, 2),  # New Year's (observed)
+    date(2023, 1, 16),  # Martin Luther King Jr. Day
+    date(2023, 2, 20),  # Presidents' Day
+    date(2023, 4, 7),  # Good Friday
+    date(2023, 5, 29),  # Memorial Day
+    date(2023, 6, 19),  # Juneteenth
+    date(2023, 7, 4),  # Independence Day
+    date(2023, 9, 4),  # Labor Day
+    date(2023, 11, 23),  # Thanksgiving
+    date(2023, 12, 25),  # Christmas
+}
+
+
+def _nyse_2023_calendar() -> _FakeCalendar:
+    sessions = _us_business_days(date(2023, 1, 1), date(2023, 12, 31), holidays=NYSE_2023_HOLIDAYS)
+    return _FakeCalendar(name="XNYS", sessions=sessions)
+
+
+def _make_get_calendar(calendars: dict[str, _FakeCalendar]):
+    def _get(mic: str) -> _FakeCalendar:
+        if mic not in calendars:
+            raise KeyError(f"unmocked MIC: {mic}")
+        return calendars[mic]
+
+    return _get
+
+
+# ─── parse_end_spec ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parse_end_spec_iso_date() -> None:
+    assert parse_end_spec("2030-12-31") == date(2030, 12, 31)
+
+
+@pytest.mark.unit
+def test_parse_end_spec_relative_years() -> None:
+    today = date(2026, 1, 1)
+    # +5y == 5*365 days = 1825d after today.
+    assert parse_end_spec("+5y", today=today) == today + timedelta(days=5 * 365)
+
+
+@pytest.mark.unit
+def test_parse_end_spec_relative_days_negative() -> None:
+    today = date(2026, 4, 27)
+    assert parse_end_spec("-30d", today=today) == today - timedelta(days=30)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["", "tomorrow", "5y", "+5x", "abc-def-gh"])
+def test_parse_end_spec_rejects_garbage(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_end_spec(bad)
+
+
+# ─── NYSE / NASDAQ — equity calendars ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_nyse_calendar_excludes_known_holidays() -> None:
+    """Christmas, MLK Day, and Independence Day are non-trading on NYSE."""
+    cal = _nyse_2023_calendar()
+    rows = build_equity_rows(
+        VENUE_NYSE,
+        date(2023, 1, 1),
+        date(2023, 12, 31),
+        get_calendar=_make_get_calendar({"XNYS": cal}),
+    )
+    by_date = {r["date"]: r for r in rows}
+    # Christmas 2023 was a Monday — non-trading, reason=holiday.
+    christmas = by_date["2023-12-25"]
+    assert christmas["is_trading_day"] is False
+    assert christmas["reason"] == REASON_HOLIDAY
+    # MLK Day 2023 (3rd Monday in January) — also reason=holiday.
+    mlk = by_date["2023-01-16"]
+    assert mlk["is_trading_day"] is False
+    assert mlk["reason"] == REASON_HOLIDAY
+    # Independence Day 2023 fell on a Tuesday — reason=holiday, not weekend.
+    ind = by_date["2023-07-04"]
+    assert ind["is_trading_day"] is False
+    assert ind["reason"] == REASON_HOLIDAY
+    # And a regular trading day (e.g. Wed Jan 4 2023) is True with no reason.
+    reg = by_date["2023-01-04"]
+    assert reg["is_trading_day"] is True
+    assert reg["reason"] is None
+
+
+@pytest.mark.unit
+def test_equity_weekend_tagged_weekend_not_holiday() -> None:
+    """Sat/Sun must use reason='weekend' even on equity venues."""
+    cal = _nyse_2023_calendar()
+    rows = build_equity_rows(
+        VENUE_NYSE,
+        date(2023, 1, 1),
+        date(2023, 1, 8),
+        get_calendar=_make_get_calendar({"XNYS": cal}),
+    )
+    by_date = {r["date"]: r for r in rows}
+    # Jan 7 2023 = Sat, Jan 8 = Sun — both weekends.
+    assert by_date["2023-01-07"]["reason"] == REASON_WEEKEND
+    assert by_date["2023-01-08"]["reason"] == REASON_WEEKEND
+    assert by_date["2023-01-07"]["is_trading_day"] is False
+
+
+@pytest.mark.unit
+def test_equity_row_count_equals_calendar_days() -> None:
+    """Every date in [start, end] produces exactly one row, regardless of trading status."""
+    cal = _nyse_2023_calendar()
+    start, end = date(2023, 6, 1), date(2023, 6, 30)
+    rows = build_equity_rows(VENUE_NYSE, start, end, get_calendar=_make_get_calendar({"XNYS": cal}))
+    expected = (end - start).days + 1
+    assert len(rows) == expected
+    # date column is unique within venue (PK invariant).
+    seen = {r["date"] for r in rows}
+    assert len(seen) == expected
+
+
+@pytest.mark.unit
+def test_nasdaq_uses_xnas_mic() -> None:
+    """NASDAQ venue dispatches to the XNAS calendar, not XNYS."""
+    nyse = _FakeCalendar(name="XNYS", sessions=[date(2024, 1, 2)])
+    nasdaq = _FakeCalendar(name="XNAS", sessions=[date(2024, 1, 3)])
+    rows = build_equity_rows(
+        VENUE_NASDAQ,
+        date(2024, 1, 2),
+        date(2024, 1, 3),
+        get_calendar=_make_get_calendar({"XNYS": nyse, "XNAS": nasdaq}),
+    )
+    by_date = {r["date"]: r for r in rows}
+    # Tue Jan 2 only trades on the NYSE mock (XNYS), not the NASDAQ mock — so
+    # routing NASDAQ → XNAS produces is_trading_day=False on Jan 2.
+    assert by_date["2024-01-02"]["is_trading_day"] is False
+    assert by_date["2024-01-03"]["is_trading_day"] is True
+
+
+# ─── CRYPTO — synthetic 24x7 ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_crypto_calendar_is_24_7() -> None:
+    """Every date in the range is a trading day with no reason."""
+    rows = build_crypto_rows(date(2023, 1, 1), date(2023, 12, 31))
+    assert len(rows) == 365
+    assert all(r["is_trading_day"] is True for r in rows)
+    assert all(r["reason"] is None for r in rows)
+    assert all(r["venue"] == VENUE_CRYPTO for r in rows)
+    # Specifically: Christmas Day is open on CRYPTO.
+    by_date = {r["date"]: r for r in rows}
+    assert by_date["2023-12-25"]["is_trading_day"] is True
+
+
+# ─── FX — synthetic 5-day-week ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_fx_calendar_excludes_full_weekend() -> None:
+    """Both Saturday and Sunday are non-trading on FX."""
+    # Sat 2023-01-07 + Sun 2023-01-08.
+    rows = build_fx_rows(date(2023, 1, 6), date(2023, 1, 9))
+    by_date = {r["date"]: r for r in rows}
+    assert by_date["2023-01-06"]["is_trading_day"] is True  # Fri
+    assert by_date["2023-01-07"]["is_trading_day"] is False  # Sat
+    assert by_date["2023-01-07"]["reason"] == REASON_WEEKEND
+    assert by_date["2023-01-08"]["is_trading_day"] is False  # Sun
+    assert by_date["2023-01-08"]["reason"] == REASON_WEEKEND
+    assert by_date["2023-01-09"]["is_trading_day"] is True  # Mon
+
+
+@pytest.mark.unit
+def test_fx_holiday_dates_still_trading_at_daily_resolution() -> None:
+    """FX has no holiday model at daily granularity — only weekend gating."""
+    # Christmas 2023 fell on a Monday; FX still flags it as trading at daily
+    # resolution because the FX calendar logic intentionally only excludes
+    # weekends.  This is documented in ADR-0013 and asserted here so the
+    # behaviour is captured.
+    rows = build_fx_rows(date(2023, 12, 25), date(2023, 12, 25))
+    assert len(rows) == 1
+    assert rows[0]["is_trading_day"] is True
+
+
+# ─── Multi-venue dispatch ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_build_rows_dispatches_per_venue() -> None:
+    cal = _nyse_2023_calendar()
+    rows = build_rows(
+        [VENUE_NYSE, VENUE_CRYPTO, VENUE_FX],
+        date(2023, 6, 1),
+        date(2023, 6, 7),
+        get_calendar=_make_get_calendar({"XNYS": cal}),
+    )
+    # 7 days × 3 venues = 21 rows.
+    assert len(rows) == 21
+    venues = {r["venue"] for r in rows}
+    assert venues == {VENUE_NYSE, VENUE_CRYPTO, VENUE_FX}
+
+
+@pytest.mark.unit
+def test_build_rows_for_venue_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        build_rows_for_venue("LSE", date(2024, 1, 1), date(2024, 1, 2))
+
+
+# ─── Idempotent upsert ─────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeResp:
+    data: list[dict[str, Any]]
+
+
+@dataclass
+class _FakeQuery:
+    table_name: str
+    store: dict[tuple[str, str], dict[str, Any]]  # (date, venue) → row
+    upsert_calls: list[dict[str, Any]] = field(default_factory=list)
+    _staged_rows: list[dict[str, Any]] | None = None
+    _on_conflict: str | None = None
+
+    def upsert(self, rows: list[dict[str, Any]], on_conflict: str | None = None) -> "_FakeQuery":
+        self._staged_rows = list(rows)
+        self._on_conflict = on_conflict
+        return self
+
+    def execute(self) -> _FakeResp:
+        assert self._staged_rows is not None, "execute() called without upsert()"
+        # Merge into store keyed by (date, venue) — emulates Postgres upsert
+        # semantics on the composite primary key.
+        for row in self._staged_rows:
+            key = (row["date"], row["venue"])
+            self.store[key] = dict(row)
+        self.upsert_calls.append(
+            {"on_conflict": self._on_conflict, "rows": list(self._staged_rows)}
+        )
+        return _FakeResp(data=list(self._staged_rows))
+
+
+@dataclass
+class _FakeClient:
+    store: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
+    queries: list[_FakeQuery] = field(default_factory=list)
+
+    def table(self, name: str) -> _FakeQuery:
+        q = _FakeQuery(table_name=name, store=self.store)
+        self.queries.append(q)
+        return q
+
+
+@pytest.mark.unit
+def test_idempotent_upsert() -> None:
+    """Running the sync twice yields identical row count and no duplicates."""
+    rows = build_rows(
+        [VENUE_NYSE, VENUE_CRYPTO, VENUE_FX],
+        date(2023, 1, 2),
+        date(2023, 1, 8),
+        get_calendar=_make_get_calendar({"XNYS": _nyse_2023_calendar()}),
+    )
+    client = _FakeClient()
+    first = upsert_trading_calendar(client, rows, chunk=500)
+    second = upsert_trading_calendar(client, rows, chunk=500)
+    assert first == second == len(rows)
+    # Store is keyed by (date, venue) — second run must not grow it.
+    assert len(client.store) == len(rows)
+    # All upsert calls must specify on_conflict='date,venue' for PG idempotency.
+    assert all(q._on_conflict == "date,venue" for q in client.queries if q.upsert_calls)
+
+
+@pytest.mark.unit
+def test_upsert_chunks_payloads() -> None:
+    """Rows larger than the chunk size are split into multiple HTTP calls."""
+    rows = build_crypto_rows(date(2023, 1, 1), date(2023, 1, 31))
+    client = _FakeClient()
+    total = upsert_trading_calendar(client, rows, chunk=10)
+    assert total == 31
+    # 31 / 10 → ceil 4 chunks.
+    upsert_queries = [q for q in client.queries if q.upsert_calls]
+    assert len(upsert_queries) == 4
+    chunk_sizes = [len(q.upsert_calls[0]["rows"]) for q in upsert_queries]
+    assert chunk_sizes == [10, 10, 10, 1]
+
+
+@pytest.mark.unit
+def test_upsert_empty_rows_is_noop() -> None:
+    client = _FakeClient()
+    assert upsert_trading_calendar(client, []) == 0
+    assert client.queries == []
+
+
+# ─── Ticker venue mapping ─────────────────────────────────────────────────
+
+
+# Tickers that the daily backfill pipeline writes price_history rows for.  Pulled
+# from apps/digiquant-atlas/config/watchlist.md, excluding the spread-pair and
+# macro-indicator sections (those are derived/relative, not directly fetched).
+WATCHLIST_PRICE_TICKERS: tuple[str, ...] = (
+    # US equities — market cap
+    "SPY",
+    "QQQ",
+    "DIA",
+    "IWB",
+    "VTI",
+    "MDY",
+    "IJH",
+    "IWM",
+    "IJR",
+    # Sector
+    "XLK",
+    "XLF",
+    "XLE",
+    "XLV",
+    "XLI",
+    "XLRE",
+    "XLU",
+    "XLY",
+    "XLP",
+    "XLB",
+    "XLC",
+    # Intl developed
+    "EFA",
+    "VEA",
+    "VGK",
+    "EWJ",
+    "EWG",
+    "EWU",
+    "EWA",
+    # EM
+    "EEM",
+    "VWO",
+    "FXI",
+    "ASHR",
+    "EWZ",
+    "EWT",
+    "EWY",
+    "INDA",
+    # Crypto spot pairs
+    "BTC-USD",
+    "ETH-USD",
+    "SOL-USD",
+    "XRP-USD",
+    "BNB-USD",
+    "BITO",
+    "TRX-USD",
+    "DOGE-USD",
+    "ADA-USD",
+    "AVAX-USD",
+    "LINK-USD",
+    "DOT-USD",
+    "BCH-USD",
+    "LTC-USD",
+    "NEAR-USD",
+    "ATOM-USD",
+    "XMR-USD",
+    "SUI20947-USD",
+    # Crypto ETFs
+    "IBIT",
+    "FBTC",
+    "ETHA",
+    "FETH",
+    "GBTC",
+    # Commodities
+    "GLD",
+    "IAU",
+    "SLV",
+    "DBO",
+    "USO",
+    "BNO",
+    "PDBC",
+    "DJP",
+    "CPER",
+    # Fixed income / cash
+    "BIL",
+    "SHV",
+    "SHY",
+    "IEF",
+    "TLT",
+    "AGG",
+    "HYG",
+    "LQD",
+    "TIP",
+    "EMB",
+    # Macro tradeable
+    "UUP",
+)
+
+
+@pytest.mark.unit
+def test_ticker_venue_mapping_covers_all_core_tickers() -> None:
+    """Every ticker the backfill writes must have an authoritative venue."""
+    missing = [t for t in WATCHLIST_PRICE_TICKERS if venue_for(t) is None]
+    assert missing == [], f"unmapped tickers: {missing}"
+
+
+@pytest.mark.unit
+def test_ticker_venue_values_within_schema_allowlist() -> None:
+    """Every mapped venue is one of {NYSE, NASDAQ, CRYPTO, FX} — what
+    migration 025 accepts."""
+    out_of_band = {v for v in CORE_TICKER_VENUES.values() if v not in ALLOWED_VENUES}
+    assert out_of_band == set()
+
+
+@pytest.mark.unit
+def test_venue_for_is_case_insensitive() -> None:
+    assert venue_for("spy") == "NYSE"
+    assert venue_for("btc-usd") == "CRYPTO"
+    assert venue_for("eurusd") == "FX"
+    assert venue_for("") is None
+    assert venue_for("UNKNOWN-TICKER") is None
+
+
+@pytest.mark.unit
+def test_all_venues_constant_matches_schema() -> None:
+    assert set(ALL_VENUES) == ALLOWED_VENUES


### PR DESCRIPTION
## Summary

Adds the calendar-aware data-layer foundation per ADR #336 / epic #335:

- New `calendar_sync.py` — `exchange_calendars`-backed fetcher producing rows shaped for the Supabase `trading_calendar` table.
- New `ticker_venues.py` — single source of truth mapping the 80 core watchlist tickers to NYSE / NASDAQ / CRYPTO / FX (matches schema CHECK constraint).
- New `digiquant prices sync-calendar` CLI subcommand. Idempotent upsert on `(date, venue)`, payload chunking, empty-payload no-op.
- Workflow step added in `.github/workflows/digiquant-prices.yml` to run the sync daily.
- Polars-internal; pandas only at the calendar-library boundary, flattened immediately.

## ⚠️ User actions required (not done by this PR)

1. **Apply migration 025**: `supabase db push` from `apps/digiquant-atlas/supabase/`. The SQL is already on develop; this PR only adds the runner code.
2. **First backfill**: once migration lands, trigger `gh workflow run digiquant-prices.yml -f sync_calendar=full`.

## Test plan

- [x] 24 new unit tests in `tests/dq/data/test_calendar_sync.py` (NYSE holidays, NASDAQ MIC, crypto 24/7, FX weekends, dispatch, idempotency, chunking, ticker-venue coverage).
- [x] `make score` passes: Security 10, Quality 8, Optimization 10, Accuracy 10.
- [ ] Post-migration: verify `trading_calendar` table has rows for all four venues covering 1950-01-01 → today+5y.

Fixes #337
Refs #335 (parent epic), #336 (ADR)