### PR TITLE
feat(digiquant): AssetPreferences schema (#306)

### DIFF
--- a/digiquant/docs/profiles/README.md
+++ b/digiquant/docs/profiles/README.md
@@ -1,23 +1,37 @@
-# Investment profiles
+# Investment profiles + asset preferences
 
-`digiquant.profiles.InvestmentProfile` is the canonical user-facing description of an investor's posture: risk tolerance, horizon, liquidity needs, base currency, coarse tax jurisdiction, ESG stance, excluded sectors, and self-reported experience. Atlas, Hermes, and Kairos consult it to filter idea generation, constrain deliberation, and shape portfolio construction.
+Two companion schemas live in `digiquant.profiles`:
 
-The schema is intentionally coarse. Per-portfolio limits (CVaR, factor caps, position-size rules) live on a policy object, not here. Tax detail (state, ISA, RRSP, PEA, etc.) is deferred to a future `TaxProfile`.
+- **`InvestmentProfile`** — slow-moving posture: risk tolerance, horizon, liquidity needs, base currency, tax jurisdiction, ESG stance, sector exclusions, experience level.
+- **`AssetPreferences`** — faster-moving asset choices: named watchlists, custom universe, hard ticker exclusions, sector exclusions.
+
+They are deliberately split: posture changes rarely (months/years), asset choices change frequently (days/weeks). Splitting simplifies cache invalidation and audit trails. Atlas / Hermes / Kairos consult both to filter idea generation, constrain deliberation, and shape portfolio construction.
+
+The schemas are intentionally coarse. Per-portfolio limits (CVaR, factor caps, position-size rules) live on a policy object, not here. Tax detail (state, ISA, RRSP, PEA, etc.) is deferred to a future `TaxProfile`.
 
 ## Why versioned
 
-Every profile carries `schema_version: int = 1`. Storage layers (Supabase, Atlas runner state) persist profiles long-term, so adding or reshaping fields without a version field would silently corrupt older rows. The version field gives migrations a hook: on read, dispatch on `schema_version` and upgrade in place.
+Every model carries `schema_version: int = 1` independently. Storage layers (Supabase, Atlas runner state) persist these long-term, so adding or reshaping fields without a version field would silently corrupt older rows. The version field gives migrations a hook: on read, dispatch on `schema_version` and upgrade in place. The two models version independently — bumping `InvestmentProfile` to v2 does not require bumping `AssetPreferences`.
 
 ## How to extend
 
 1. **Additive, non-breaking** — new field with a sensible default. Keep `schema_version=1`. Existing fixtures still validate.
 2. **Breaking** — field removed, retyped, or semantics changed. Bump `schema_version` (e.g. to `2`), keep the v1 model behind it, and add a migration in `digiquant.profiles` that upgrades v1 payloads to v2 on read. Update `examples` and the exported JSON schema (`schemas/investment_profile.v{N}.json`).
 
-Field validators live alongside the model in `digiquant/src/digiquant/profiles/investment_profile.py`. `excluded_sectors` is lower-cased, de-duplicated (insertion-order preserving), and stripped of empties. `base_currency` is upper-cased before pattern validation. `extra="forbid"` catches typos at load time rather than silently dropping them.
+Field validators live alongside the models. Both use `extra="forbid"` to catch typos at load time and shared normalization helpers (insertion-order-preserving de-duplication; tickers upper-cased; sectors lower-cased; whitespace stripped; empties dropped).
+
+`AssetPreferences` runs one extra rule after field validation: **exclusion wins over inclusion**. Tickers in `excluded_tickers` are silently dropped from every watchlist and from `custom_universe`, even if the user lists them in both places. The drop is silent rather than a hard error because users edit lists incrementally and intermittent overlaps are expected.
 
 ## Pointers
 
+### InvestmentProfile
 - Model: [`digiquant/src/digiquant/profiles/investment_profile.py`](../../src/digiquant/profiles/investment_profile.py)
 - JSON schema: [`schemas/investment_profile.v1.json`](../schemas/investment_profile.v1.json) — regenerate via `python3 scripts/export_profile_schema.py`
 - Example fixture: [`tests/dq/profiles/fixtures/example_profile.json`](../../../tests/dq/profiles/fixtures/example_profile.json)
 - Tests: [`tests/dq/profiles/test_investment_profile.py`](../../../tests/dq/profiles/test_investment_profile.py)
+
+### AssetPreferences
+- Model: [`digiquant/src/digiquant/profiles/asset_preferences.py`](../../src/digiquant/profiles/asset_preferences.py)
+- JSON schema: [`schemas/asset_preferences.v1.json`](../schemas/asset_preferences.v1.json) — same export script
+- Example fixture: [`tests/dq/profiles/fixtures/example_asset_preferences.json`](../../../tests/dq/profiles/fixtures/example_asset_preferences.json)
+- Tests: [`tests/dq/profiles/test_asset_preferences.py`](../../../tests/dq/profiles/test_asset_preferences.py)

--- a/digiquant/docs/schemas/asset_preferences.v1.json
+++ b/digiquant/docs/schemas/asset_preferences.v1.json
@@ -1,0 +1,50 @@
+{
+  "additionalProperties": false,
+  "description": "User asset preferences (schema v1).\n\nAttributes\n----------\nschema_version\n    Monotonic schema version. Increment only on breaking changes.\nwatchlists\n    Named ticker baskets (e.g. ``{\"core\": [\"SPY\", \"QQQ\"], \"thematic\": [\"NVDA\"]}``).\n    Each value is normalized to upper-case, de-duplicated, insertion-ordered.\ncustom_universe\n    Tickers the user wants Atlas to consider beyond the default watchlist.\n    Same normalization as ``watchlists``.\nexcluded_tickers\n    Hard exclusions. Wins over inclusion on conflict \u2014 a ticker that\n    appears in both a watchlist and ``excluded_tickers`` is dropped from\n    the watchlist by the post-validation hook.\nexcluded_sectors\n    Sector-level exclusions (lower-cased, de-duplicated). Overlap with\n    :attr:`InvestmentProfile.excluded_sectors` is allowed and intentional \u2014\n    the two have different update cadences.",
+  "properties": {
+    "custom_universe": {
+      "description": "Additional tickers Atlas should consider.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Custom Universe",
+      "type": "array"
+    },
+    "excluded_sectors": {
+      "description": "Sector exclusions (lower-cased, de-duplicated).",
+      "items": {
+        "type": "string"
+      },
+      "title": "Excluded Sectors",
+      "type": "array"
+    },
+    "excluded_tickers": {
+      "description": "Hard ticker exclusions; wins over inclusion on conflict.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Excluded Tickers",
+      "type": "array"
+    },
+    "schema_version": {
+      "default": 1,
+      "description": "Schema version; bump on breaking changes.",
+      "minimum": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    },
+    "watchlists": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "description": "Named ticker baskets, e.g. {'core': ['SPY', 'QQQ']}.",
+      "title": "Watchlists",
+      "type": "object"
+    }
+  },
+  "title": "AssetPreferences",
+  "type": "object"
+}

--- a/digiquant/src/digiquant/profiles/__init__.py
+++ b/digiquant/src/digiquant/profiles/__init__.py
@@ -1,15 +1,17 @@
-"""User investment profile schemas.
+"""User investment profile + asset preferences schemas.
 
-Versioned Pydantic v2 models describing a user's investment posture:
-risk tolerance, horizon, liquidity needs, base currency, tax jurisdiction,
-ESG preferences, excluded sectors, experience level. Consumed by Atlas /
-Hermes / Kairos to constrain idea generation and portfolio construction.
+Versioned Pydantic v2 models describing a user's investment posture
+(risk tolerance, horizon, currency, jurisdiction, ESG, sector exclusions,
+experience level) and per-user asset preferences (watchlists, custom
+universe, ticker / sector exclusions). Consumed by Atlas / Hermes /
+Kairos to constrain idea generation and portfolio construction.
 
 See ``digiquant/docs/profiles/README.md`` for the migration story.
 """
 
 from __future__ import annotations
 
+from digiquant.profiles.asset_preferences import AssetPreferences
 from digiquant.profiles.investment_profile import InvestmentProfile
 
-__all__ = ["InvestmentProfile"]
+__all__ = ["AssetPreferences", "InvestmentProfile"]

--- a/digiquant/src/digiquant/profiles/asset_preferences.py
+++ b/digiquant/src/digiquant/profiles/asset_preferences.py
@@ -1,0 +1,131 @@
+"""Versioned Pydantic v2 schema for a user's asset preferences.
+
+Companion to :class:`digiquant.profiles.investment_profile.InvestmentProfile`.
+Split into a separate model because asset preferences (watchlists, exclusions)
+mutate frequently while the underlying risk posture is stable — keeping them
+apart simplifies cache invalidation and audit trails.
+
+See ``digiquant/docs/profiles/README.md`` for the migration story.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _normalize_tickers(value: list[str]) -> list[str]:
+    """Strip + upper-case + drop empties + de-duplicate (insertion-ordered)."""
+    seen: dict[str, None] = {}
+    for raw in value:
+        if not isinstance(raw, str):
+            raise TypeError(f"ticker entries must be str, got {type(raw)!r}")
+        normalized = raw.strip().upper()
+        if not normalized:
+            continue
+        seen.setdefault(normalized, None)
+    return list(seen)
+
+
+def _normalize_sectors(value: list[str]) -> list[str]:
+    """Strip + lower-case + drop empties + de-duplicate (insertion-ordered)."""
+    seen: dict[str, None] = {}
+    for raw in value:
+        if not isinstance(raw, str):
+            raise TypeError(f"sector entries must be str, got {type(raw)!r}")
+        normalized = raw.strip().lower()
+        if not normalized:
+            continue
+        seen.setdefault(normalized, None)
+    return list(seen)
+
+
+class AssetPreferences(BaseModel):
+    """User asset preferences (schema v1).
+
+    Attributes
+    ----------
+    schema_version
+        Monotonic schema version. Increment only on breaking changes.
+    watchlists
+        Named ticker baskets (e.g. ``{"core": ["SPY", "QQQ"], "thematic": ["NVDA"]}``).
+        Each value is normalized to upper-case, de-duplicated, insertion-ordered.
+    custom_universe
+        Tickers the user wants Atlas to consider beyond the default watchlist.
+        Same normalization as ``watchlists``.
+    excluded_tickers
+        Hard exclusions. Wins over inclusion on conflict — a ticker that
+        appears in both a watchlist and ``excluded_tickers`` is dropped from
+        the watchlist by the post-validation hook.
+    excluded_sectors
+        Sector-level exclusions (lower-cased, de-duplicated). Overlap with
+        :attr:`InvestmentProfile.excluded_sectors` is allowed and intentional —
+        the two have different update cadences.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    schema_version: int = Field(
+        default=1,
+        ge=1,
+        description="Schema version; bump on breaking changes.",
+    )
+    watchlists: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description="Named ticker baskets, e.g. {'core': ['SPY', 'QQQ']}.",
+    )
+    custom_universe: list[str] = Field(
+        default_factory=list,
+        description="Additional tickers Atlas should consider.",
+    )
+    excluded_tickers: list[str] = Field(
+        default_factory=list,
+        description="Hard ticker exclusions; wins over inclusion on conflict.",
+    )
+    excluded_sectors: list[str] = Field(
+        default_factory=list,
+        description="Sector exclusions (lower-cased, de-duplicated).",
+    )
+
+    @field_validator("watchlists", mode="after")
+    @classmethod
+    def _normalize_watchlists(cls, value: dict[str, list[str]]) -> dict[str, list[str]]:
+        out: dict[str, list[str]] = {}
+        for raw_name, tickers in value.items():
+            name = raw_name.strip()
+            if not name:
+                raise ValueError("watchlist name must be non-empty after stripping")
+            out[name] = _normalize_tickers(list(tickers))
+        return out
+
+    @field_validator("custom_universe", "excluded_tickers", mode="after")
+    @classmethod
+    def _normalize_ticker_list(cls, value: list[str]) -> list[str]:
+        return _normalize_tickers(value)
+
+    @field_validator("excluded_sectors", mode="after")
+    @classmethod
+    def _normalize_sector_list(cls, value: list[str]) -> list[str]:
+        return _normalize_sectors(value)
+
+    @model_validator(mode="after")
+    def _exclusion_wins_over_inclusion(self) -> "AssetPreferences":
+        """Drop excluded tickers from watchlists + custom_universe.
+
+        Conflict resolution is silent (drop) rather than raising — most users
+        edit lists incrementally and intermittent overlaps are expected. The
+        post-validation pass is what makes the contract observable.
+        """
+        excluded = set(self.excluded_tickers)
+        if not excluded:
+            return self
+
+        cleaned_watchlists = {
+            name: [t for t in tickers if t not in excluded]
+            for name, tickers in self.watchlists.items()
+        }
+        cleaned_universe = [t for t in self.custom_universe if t not in excluded]
+
+        if cleaned_watchlists != self.watchlists or cleaned_universe != self.custom_universe:
+            object.__setattr__(self, "watchlists", cleaned_watchlists)
+            object.__setattr__(self, "custom_universe", cleaned_universe)
+        return self

--- a/scripts/export_profile_schema.py
+++ b/scripts/export_profile_schema.py
@@ -1,7 +1,7 @@
-"""Export the ``InvestmentProfile`` JSON schema to ``digiquant/docs/schemas/``.
+"""Export profile JSON schemas to ``digiquant/docs/schemas/``.
 
-Regenerate after any change to ``digiquant.profiles.investment_profile`` and
-commit the result alongside the model change. Run from the repo root::
+Regenerate after any change to a model in ``digiquant.profiles`` and commit
+the result alongside the model change. Run from the repo root::
 
     python3 scripts/export_profile_schema.py
 """
@@ -17,15 +17,23 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # Make the digiquant package importable when invoked outside an editable install.
 sys.path.insert(0, str(REPO_ROOT / "digiquant" / "src"))
 
+from digiquant.profiles.asset_preferences import AssetPreferences  # noqa: E402
 from digiquant.profiles.investment_profile import InvestmentProfile  # noqa: E402
+
+_SCHEMAS = (
+    (InvestmentProfile, "investment_profile.v1.json"),
+    (AssetPreferences, "asset_preferences.v1.json"),
+)
 
 
 def main() -> int:
-    out = REPO_ROOT / "digiquant" / "docs" / "schemas" / "investment_profile.v1.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    schema = InvestmentProfile.model_json_schema()
-    out.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(f"Wrote {out}")
+    out_dir = REPO_ROOT / "digiquant" / "docs" / "schemas"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for model, filename in _SCHEMAS:
+        out = out_dir / filename
+        schema = model.model_json_schema()
+        out.write_text(json.dumps(schema, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"Wrote {out}")
     return 0
 
 

--- a/tests/dq/profiles/fixtures/example_asset_preferences.json
+++ b/tests/dq/profiles/fixtures/example_asset_preferences.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "watchlists": {
+    "core": ["SPY", "QQQ", "IWM"],
+    "thematic-ai": ["NVDA", "AMD", "TSM", "MSFT"]
+  },
+  "custom_universe": ["BRK.B", "BTC-USD"],
+  "excluded_tickers": ["XOM"],
+  "excluded_sectors": ["tobacco", "thermal coal"]
+}

--- a/tests/dq/profiles/test_asset_preferences.py
+++ b/tests/dq/profiles/test_asset_preferences.py
@@ -1,0 +1,95 @@
+"""Unit tests for digiquant.profiles.asset_preferences (#306)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from digiquant.profiles import AssetPreferences
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "example_asset_preferences.json"
+
+
+@pytest.mark.unit
+class TestAssetPreferences:
+    def test_minimal_construction_uses_defaults(self) -> None:
+        prefs = AssetPreferences()
+        assert prefs.schema_version == 1
+        assert prefs.watchlists == {}
+        assert prefs.custom_universe == []
+        assert prefs.excluded_tickers == []
+        assert prefs.excluded_sectors == []
+
+    def test_round_trips_json(self) -> None:
+        prefs = AssetPreferences(
+            watchlists={"core": ["spy", "QQQ", "spy"]},
+            custom_universe=["nvda"],
+            excluded_tickers=["XOM"],
+            excluded_sectors=["Tobacco"],
+        )
+        loaded = AssetPreferences.model_validate_json(prefs.model_dump_json())
+        assert loaded == prefs
+
+    def test_tickers_normalized_to_uppercase_and_deduped(self) -> None:
+        prefs = AssetPreferences(
+            watchlists={"core": ["spy", " SPY ", "qqq"]},
+            custom_universe=["nvda", "NVDA", "amd"],
+        )
+        assert prefs.watchlists["core"] == ["SPY", "QQQ"]
+        assert prefs.custom_universe == ["NVDA", "AMD"]
+
+    def test_sectors_normalized_to_lowercase_and_deduped(self) -> None:
+        prefs = AssetPreferences(excluded_sectors=["Tobacco", "tobacco", "Defense"])
+        assert prefs.excluded_sectors == ["tobacco", "defense"]
+
+    def test_excluded_ticker_dropped_from_watchlist(self) -> None:
+        """Exclusion wins over inclusion — even if user lists a ticker in both."""
+        prefs = AssetPreferences(
+            watchlists={"core": ["SPY", "XOM", "QQQ"], "energy": ["XOM"]},
+            custom_universe=["XOM", "NVDA"],
+            excluded_tickers=["XOM"],
+        )
+        assert "XOM" not in prefs.watchlists["core"]
+        assert prefs.watchlists["core"] == ["SPY", "QQQ"]
+        assert prefs.watchlists["energy"] == []  # all members excluded
+        assert "XOM" not in prefs.custom_universe
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssetPreferences.model_validate({"foo": "bar"})
+
+    def test_schema_version_below_one_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssetPreferences(schema_version=0)
+
+    def test_empty_watchlist_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssetPreferences(watchlists={"   ": ["SPY"]})
+
+    def test_non_string_ticker_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AssetPreferences.model_validate({"custom_universe": ["NVDA", 42]})
+
+    def test_empty_string_tickers_dropped(self) -> None:
+        prefs = AssetPreferences(custom_universe=["NVDA", "", "  ", "AMD"])
+        assert prefs.custom_universe == ["NVDA", "AMD"]
+
+    def test_example_fixture_loads(self) -> None:
+        data = json.loads(FIXTURE_PATH.read_text())
+        prefs = AssetPreferences.model_validate(data)
+        assert prefs.schema_version == 1
+        assert "core" in prefs.watchlists
+        assert "XOM" in prefs.excluded_tickers
+        # Fixture lists XOM only in excluded_tickers (not watchlists), so the
+        # cross-check should leave watchlists untouched.
+        assert prefs.watchlists["core"] == ["SPY", "QQQ", "IWM"]
+
+    def test_round_trip_via_fixture_path(self) -> None:
+        """Loading + dumping the fixture should round-trip unchanged."""
+        data = json.loads(FIXTURE_PATH.read_text())
+        prefs = AssetPreferences.model_validate(data)
+        reloaded = AssetPreferences.model_validate(json.loads(prefs.model_dump_json()))
+        assert reloaded == prefs


### PR DESCRIPTION
## Summary

Companion to #305 — `AssetPreferences` is the faster-moving slice of user preferences (watchlists, custom universe, ticker / sector exclusions). Split from `InvestmentProfile` because cadences differ; each model versions independently.

## What changed

- New `digiquant/src/digiquant/profiles/asset_preferences.py`.
- `digiquant.profiles.__init__` re-exports `AssetPreferences` alongside `InvestmentProfile`.
- `scripts/export_profile_schema.py` extended to emit `digiquant/docs/schemas/asset_preferences.v1.json`.
- README updated: covers both schemas + the splitting rationale.
- 12 new unit tests + example fixture (`profiles/` suite now 27 passing).

## Key design call

**Exclusion wins over inclusion** — tickers in `excluded_tickers` are silently dropped from every watchlist and from `custom_universe`. Silent (not raising) because users edit lists incrementally; intermittent overlap is normal. Test `test_excluded_ticker_dropped_from_watchlist` pins the contract.

## Test plan

- [x] 27 / 27 `tests/dq/profiles/` pass.
- [x] `make score` passes: Security 10, Quality 10, Optimization 10, Accuracy 10.

Fixes #306
Refs #296 (parent epic)