### PR TITLE
feat(digiquant): personalize_snapshot — apply profile + preferences (#312)

### DIFF
--- a/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
+++ b/apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md
@@ -387,6 +387,26 @@ The envelope is `extra="forbid"` end-to-end, so a frontend validator catches dri
 
 Bump `digiquant.atlas.snapshot.SCHEMA_VERSION` and ship a sibling `atlas_snapshot.v{N}.json` whenever fields are added/removed/renamed or semantics change. Frontend consumers branch on `envelope.schema_version`. The previous version's schema file stays committed for grace-period rollouts.
 
+### Personalization (read-time, additive)
+
+The pipeline writes one canonical `daily_snapshots` row per day — *not* a per-user view. Per-user filtering and ranking happens at read time via [`digiquant.atlas.personalize_snapshot`](../../../../digiquant/src/digiquant/atlas/personalization.py). Issue [#312](https://github.com/digithings-ai/digithings/issues/312).
+
+```
+SnapshotEnvelope ──┐
+                   ├──> personalize_snapshot ──> PersonalizedSnapshot { envelope, excluded_count, rank_changes }
+InvestmentProfile ─┤
+AssetPreferences ──┘
+```
+
+Behavior:
+- **Anonymous** (both args `None`): pass-through — same envelope instance, no diagnostics.
+- **`AssetPreferences.excluded_tickers`**: drops items in `actionable_summary`, `risk_radar`, `material_findings` whose label/rationale/trigger/summary mention an excluded ticker (word-boundary uppercase regex; coarse but documented — "USA"/"UK" can collide).
+- **`AssetPreferences.custom_universe`**: stable-partitions `actionable_summary` so items mentioning a custom-universe ticker move to the front; positional moves are reported in `rank_changes`.
+- **`InvestmentProfile.risk_tolerance`**: `conservative` drops `actionable_summary` items with `priority < 3`; `moderate` / `aggressive` keep all.
+- **`InvestmentProfile.esg_preference == "strict"`**: drops items whose label/rationale/trigger/summary contain any `excluded_sectors` substring (lower-cased contains-match). `tilt` / `none` are pass-through here — `tilt` drives weighting downstream in Hermes/Kairos, not visibility in Atlas.
+
+`schema_version` does **not** bump — personalization is additive and consumed via the sibling `PersonalizedSnapshot` dataclass, keeping the wire envelope contract immutable. Performance budget: < 100 ms per snapshot (issue req); CI assertion at 200 ms for runner variance.
+
 ---
 
 ## Research Continuity Architecture

--- a/digiquant/src/digiquant/atlas/__init__.py
+++ b/digiquant/src/digiquant/atlas/__init__.py
@@ -13,6 +13,10 @@ read path") for the data flow and consumption pattern.
 
 from __future__ import annotations
 
+from digiquant.atlas.personalization import (
+    PersonalizedSnapshot,
+    personalize_snapshot,
+)
 from digiquant.atlas.snapshot import (
     SCHEMA_VERSION,
     DigestPayload,
@@ -22,5 +26,7 @@ from digiquant.atlas.snapshot import (
 __all__ = [
     "SCHEMA_VERSION",
     "DigestPayload",
+    "PersonalizedSnapshot",
     "SnapshotEnvelope",
+    "personalize_snapshot",
 ]

--- a/digiquant/src/digiquant/atlas/personalization.py
+++ b/digiquant/src/digiquant/atlas/personalization.py
@@ -1,0 +1,361 @@
+"""Personalize a SnapshotEnvelope for a logged-in user.
+
+This module turns the global Atlas digest into a per-user view by applying
+:class:`digiquant.profiles.investment_profile.InvestmentProfile` and
+:class:`digiquant.profiles.asset_preferences.AssetPreferences` to a
+:class:`digiquant.atlas.snapshot.SnapshotEnvelope`. It is the read-time helper
+the Atlas BFF / dashboard calls before rendering — the upstream pipeline still
+writes one canonical row per day to ``daily_snapshots`` (Phase 7), and this
+function adapts that row for the calling user.
+
+Issue: `#312 <https://github.com/digithings-ai/digithings/issues/312>`_.
+
+Return shape — a sibling dataclass, not a v2 envelope
+-----------------------------------------------------
+The task brief offered two designs. We pick the **sibling dataclass**:
+
+    >>> result: PersonalizedSnapshot = personalize_snapshot(env, profile=p)
+    >>> result.envelope          # SnapshotEnvelope, schema_version unchanged
+    >>> result.excluded_count    # int — items dropped by exclusion rules
+    >>> result.rank_changes      # list[(label, old_index, new_index)]
+
+Why not stick a ``personalized_for`` block on the envelope?
+:class:`SnapshotEnvelope`, :class:`DigestPayload`, :class:`ActionableItem`,
+:class:`RiskItem` are all ``model_config = ConfigDict(extra="forbid")`` and
+the project convention is to **not** bump ``SCHEMA_VERSION`` for additive
+read-time decoration. The dataclass keeps the wire contract immutable
+(important: the same envelope JSON is reused for caching, audit, and the
+schema-export drift test) while still surfacing diagnostics for QA + UI.
+
+Filtering + ranking semantics
+-----------------------------
+Anonymous (both ``profile`` and ``preferences`` are ``None``)
+    Pass-through: returns ``PersonalizedSnapshot(envelope=envelope,
+    excluded_count=0, rank_changes=[])`` — the envelope object is the same
+    instance the caller passed in.
+
+``preferences.excluded_tickers``
+    Drop list-shaped items (``actionable_summary``, ``risk_radar``,
+    ``material_findings``) whose ``label`` / ``rationale`` / ``trigger`` /
+    ``summary`` mention any excluded ticker. Ticker matching is a
+    word-boundary uppercase regex (``\\b[A-Z]{1,5}\\b``) — coarse but
+    documented: "USA", "UK", "API" can collide with real tickers. The
+    upside is determinism and zero-dependency.
+
+    Prose blocks (``headline``, ``market_regime_snapshot``, etc.) are
+    **not** rewritten — string surgery on narrative summaries is brittle
+    and the personalization is consumed by a UI that renders structured
+    items as the primary affordance anyway.
+
+``preferences.custom_universe``
+    Reorder ``actionable_summary`` so items mentioning a custom-universe
+    ticker move to the front while preserving relative order within the
+    "matched" and "unmatched" partitions. Each move is reported in
+    ``rank_changes`` so the UI can render a "boosted by your watchlist"
+    badge if it wants to.
+
+``profile.risk_tolerance``
+    ``conservative`` drops actionable items with ``priority < 3`` (low
+    priority = aggressive trade ideas in the upstream schema, see
+    ``ActionableItem`` field rationale).  ``moderate`` is a pass-through.
+    ``aggressive`` is a pass-through (everything stays).
+
+``profile.esg_preference`` + (``profile.excluded_sectors`` or
+``preferences.excluded_sectors``)
+    ``strict`` drops items whose ``label`` or ``rationale`` (lower-cased)
+    contains an excluded sector substring. ``tilt`` and ``none`` are
+    pass-through here — ``tilt`` is intended to drive *weighting* in
+    Hermes / Kairos, not visibility in Atlas.
+
+Performance
+-----------
+Issue requirement: < 100 ms for a typical snapshot.  The implementation is
+O(N · (T + S)) where N = number of items, T = number of excluded tickers,
+S = number of excluded sectors — all small constants in practice. We
+mutate a single dict copy of the envelope (``model_dump`` once,
+``model_validate`` once), avoiding per-item ``model_copy(deep=True)``. The
+unit test budgets 200 ms for a 100-item snapshot to stay quiet on noisy
+CI runners while still catching catastrophic regressions.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from digiquant.atlas.snapshot import SnapshotEnvelope
+from digiquant.profiles.asset_preferences import AssetPreferences
+from digiquant.profiles.investment_profile import InvestmentProfile
+
+# Word-boundary upper-case 1..5 chars — captures "AAPL", "XOM", "TSLA",
+# also "USA", "UK". Trade-off documented in the module docstring.
+_TICKER_RE: re.Pattern[str] = re.compile(r"\b[A-Z]{1,5}\b")
+
+
+# ─── Public return type ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PersonalizedSnapshot:
+    """Result of :func:`personalize_snapshot`.
+
+    Attributes
+    ----------
+    envelope
+        The personalized :class:`SnapshotEnvelope`. ``schema_version`` is
+        identical to the input envelope's. For an anonymous call (both
+        ``profile`` and ``preferences`` are ``None``) this is the *same*
+        instance the caller passed in.
+    excluded_count
+        Total number of list-shaped items dropped by exclusion rules across
+        ``actionable_summary``, ``risk_radar``, and ``material_findings``.
+        Useful as a diagnostic ("we filtered N items for you") and for
+        observability.
+    rank_changes
+        For each item moved by the custom-universe boost, a tuple
+        ``(label, old_index, new_index)`` — ``label`` is the
+        ``ActionableItem.label`` that moved.  Items that were not moved
+        do not appear here. Empty list when no boost applied.
+    """
+
+    envelope: SnapshotEnvelope
+    excluded_count: int = 0
+    rank_changes: list[tuple[str, int, int]] = field(default_factory=list)
+
+
+# ─── Public entry point ─────────────────────────────────────────────────────
+
+
+def personalize_snapshot(
+    envelope: SnapshotEnvelope,
+    *,
+    profile: InvestmentProfile | None = None,
+    preferences: AssetPreferences | None = None,
+) -> PersonalizedSnapshot:
+    """Return a copy of ``envelope`` filtered + ranked for the given user.
+
+    See the module docstring for the full filtering and ranking semantics.
+
+    Parameters
+    ----------
+    envelope
+        The Atlas snapshot envelope, typically loaded from
+        ``daily_snapshots`` via :meth:`SnapshotEnvelope.from_supabase_row`.
+    profile
+        Optional investment profile. ``None`` = anonymous user.
+    preferences
+        Optional asset preferences. ``None`` = anonymous user.
+
+    Returns
+    -------
+    PersonalizedSnapshot
+        Wraps the personalized envelope plus diagnostics. The envelope's
+        ``schema_version`` is identical to the input's.
+    """
+    # Fast path: anonymous user — return the envelope unchanged. We return
+    # the same instance (no clone) because Pydantic v2 BaseModel is
+    # effectively immutable in our config (frozen=False but extra=forbid
+    # and no setters in the surrounding code).
+    if profile is None and preferences is None:
+        return PersonalizedSnapshot(envelope=envelope)
+
+    # Collect the rule sets once. Lookups inside the hot loop are sets.
+    excluded_tickers: frozenset[str] = (
+        frozenset(preferences.excluded_tickers) if preferences is not None else frozenset()
+    )
+    custom_universe: tuple[str, ...] = (
+        tuple(preferences.custom_universe) if preferences is not None else ()
+    )
+
+    # Sector exclusions union both sources. Profile + preferences are
+    # already lower-cased + de-duplicated by their validators.
+    excluded_sectors: list[str] = []
+    seen_sectors: set[str] = set()
+    if profile is not None and profile.esg_preference == "strict":
+        for sector in profile.excluded_sectors:
+            if sector not in seen_sectors:
+                seen_sectors.add(sector)
+                excluded_sectors.append(sector)
+    if preferences is not None:
+        for sector in preferences.excluded_sectors:
+            if sector not in seen_sectors:
+                seen_sectors.add(sector)
+                excluded_sectors.append(sector)
+
+    drop_low_priority: bool = profile is not None and profile.risk_tolerance == "conservative"
+    apply_strict_esg: bool = (
+        profile is not None and profile.esg_preference == "strict" and bool(excluded_sectors)
+    )
+
+    # Dump once — mutating the dict in place is dramatically faster than
+    # ``model_copy(deep=True)`` + per-list rebuilds, especially with 100+
+    # items.  ``model_dump(mode="python")`` keeps date / datetime objects
+    # as Python instances so re-validation is cheap.
+    payload: dict[str, Any] = envelope.model_dump(mode="python")
+    digest: dict[str, Any] = payload["digest"]
+
+    excluded_count: int = 0
+
+    # ── actionable_summary: exclusion + ESG drop + low-priority drop ───
+    actionable_in: list[dict[str, Any]] = digest.get("actionable_summary", [])
+    actionable_kept: list[dict[str, Any]] = []
+    for item in actionable_in:
+        if _item_mentions_excluded_ticker(item, excluded_tickers, ("label", "rationale")):
+            excluded_count += 1
+            continue
+        if apply_strict_esg and _item_mentions_excluded_sector(
+            item, excluded_sectors, ("label", "rationale")
+        ):
+            excluded_count += 1
+            continue
+        if drop_low_priority and int(item.get("priority", 0)) < 3:
+            excluded_count += 1
+            continue
+        actionable_kept.append(item)
+
+    # ── custom-universe boost: stable partition (matched first) ────────
+    rank_changes: list[tuple[str, int, int]] = []
+    if custom_universe:
+        actionable_kept, rank_changes = _boost_by_custom_universe(actionable_kept, custom_universe)
+
+    digest["actionable_summary"] = actionable_kept
+
+    # ── risk_radar: exclusion + ESG drop ───────────────────────────────
+    risk_in: list[dict[str, Any]] = digest.get("risk_radar", [])
+    risk_kept: list[dict[str, Any]] = []
+    for item in risk_in:
+        if _item_mentions_excluded_ticker(item, excluded_tickers, ("label", "trigger")):
+            excluded_count += 1
+            continue
+        if apply_strict_esg and _item_mentions_excluded_sector(
+            item, excluded_sectors, ("label", "trigger")
+        ):
+            excluded_count += 1
+            continue
+        risk_kept.append(item)
+    digest["risk_radar"] = risk_kept
+
+    # ── material_findings: exclusion + ESG drop ────────────────────────
+    findings_in: list[dict[str, Any]] = digest.get("material_findings", [])
+    findings_kept: list[dict[str, Any]] = []
+    for item in findings_in:
+        if _item_mentions_excluded_ticker(item, excluded_tickers, ("label", "summary")):
+            excluded_count += 1
+            continue
+        if apply_strict_esg and _item_mentions_excluded_sector(
+            item, excluded_sectors, ("label", "summary")
+        ):
+            excluded_count += 1
+            continue
+        findings_kept.append(item)
+    digest["material_findings"] = findings_kept
+
+    # Re-validate so callers get a typed envelope back. If we have built up
+    # a structurally invalid digest (we shouldn't — exclusion only drops
+    # whole items, never reshapes one), pydantic raises with a clear path.
+    new_envelope = SnapshotEnvelope.model_validate(payload)
+
+    return PersonalizedSnapshot(
+        envelope=new_envelope,
+        excluded_count=excluded_count,
+        rank_changes=rank_changes,
+    )
+
+
+# ─── Internals ──────────────────────────────────────────────────────────────
+
+
+def _extract_tickers(text: str) -> set[str]:
+    """Pull candidate tickers out of free text. Coarse, documented above."""
+    if not text:
+        return set()
+    return set(_TICKER_RE.findall(text))
+
+
+def _item_mentions_excluded_ticker(
+    item: dict[str, Any],
+    excluded: frozenset[str],
+    fields: tuple[str, ...],
+) -> bool:
+    if not excluded:
+        return False
+    for field_name in fields:
+        value = item.get(field_name) or ""
+        if not isinstance(value, str):
+            continue
+        candidates = _extract_tickers(value)
+        if candidates & excluded:
+            return True
+    return False
+
+
+def _item_mentions_excluded_sector(
+    item: dict[str, Any],
+    sectors: list[str],
+    fields: tuple[str, ...],
+) -> bool:
+    if not sectors:
+        return False
+    for field_name in fields:
+        value = item.get(field_name) or ""
+        if not isinstance(value, str):
+            continue
+        haystack = value.lower()
+        for sector in sectors:
+            if sector and sector in haystack:
+                return True
+    return False
+
+
+def _boost_by_custom_universe(
+    items: list[dict[str, Any]],
+    universe: tuple[str, ...],
+) -> tuple[list[dict[str, Any]], list[tuple[str, int, int]]]:
+    """Stable partition: items mentioning a universe ticker move to the front.
+
+    Within each partition (matched / unmatched) the original relative order
+    is preserved — a stable reorder, not a sort.
+
+    Returns
+    -------
+    (reordered_items, rank_changes)
+        ``rank_changes`` lists tuples ``(label, old_idx, new_idx)`` for any
+        item whose position changed. Items that did not move are omitted
+        for compactness.
+    """
+    if not items or not universe:
+        return items, []
+
+    universe_set = frozenset(universe)
+    matched: list[tuple[int, dict[str, Any]]] = []
+    unmatched: list[tuple[int, dict[str, Any]]] = []
+    for idx, item in enumerate(items):
+        text = " ".join(
+            str(item.get(name, "")) for name in ("label", "rationale") if item.get(name)
+        )
+        if _extract_tickers(text) & universe_set:
+            matched.append((idx, item))
+        else:
+            unmatched.append((idx, item))
+
+    if not matched:
+        # Nothing to boost — preserve original order verbatim.
+        return items, []
+
+    reordered: list[dict[str, Any]] = [item for _, item in matched] + [
+        item for _, item in unmatched
+    ]
+    rank_changes: list[tuple[str, int, int]] = []
+    for new_idx, (old_idx, item) in enumerate(matched + unmatched):
+        if new_idx != old_idx:
+            label = str(item.get("label", ""))
+            rank_changes.append((label, old_idx, new_idx))
+
+    return reordered, rank_changes
+
+
+__all__ = [
+    "PersonalizedSnapshot",
+    "personalize_snapshot",
+]

--- a/tests/dq/atlas/test_personalization.py
+++ b/tests/dq/atlas/test_personalization.py
@@ -1,0 +1,340 @@
+"""Unit tests for digiquant.atlas.personalization.
+
+Covers anonymous pass-through, ticker exclusion, custom-universe boosting,
+risk-tolerance filtering, ESG sector exclusion, the return-shape contract,
+and the < 100 ms (relaxed to < 200 ms in CI) performance budget.
+
+Issue #312.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import date, datetime, timezone
+from typing import Any
+
+import pytest
+
+from digiquant.atlas import (
+    PersonalizedSnapshot,
+    SnapshotEnvelope,
+    personalize_snapshot,
+)
+from digiquant.atlas.snapshot import DigestPayload
+from digiquant.profiles import AssetPreferences, InvestmentProfile
+
+
+# ─── Helpers (mirror tests/dq/atlas/test_snapshot.py style) ────────────────
+
+
+def _digest_payload_kwargs() -> dict[str, Any]:
+    """Hand-built digest, mirrors the snapshot-test helper."""
+    return {
+        "segment": "master-digest",
+        "date": date(2026, 4, 20),
+        "bias": "neutral",
+        "headline": "Markets digest mixed Fed signals; risk-on intact in tech",
+        "material_findings": [
+            {
+                "label": "Tech leadership widens",
+                "summary": "QQQ +1.8%, NVDA +3.1% on AI capex commentary.",
+                "source_ids": ["src-1"],
+            }
+        ],
+        "sources": [
+            {"id": "src-1", "title": "WSJ Markets Live", "url": "https://wsj.com/x"},
+        ],
+        "notes": "Volume light into Fed week.",
+        "market_regime_snapshot": "Risk-on; growth leadership reasserting.",
+        "alt_data_dashboard": "Card-spend trends accelerating in services.",
+        "institutional_summary": "Net inflows into US equity ETFs.",
+        "asset_classes_summary": "Equities up; bonds flat; commodities mixed.",
+        "us_equities_summary": "Tech +1.8%, energy -0.4%; breadth fair.",
+        "thesis_tracker": "Long-tech thesis intact.",
+        "portfolio_recommendations": "Hold growth; trim defensives 2pp.",
+        "actionable_summary": [
+            {
+                "priority": 1,
+                "label": "Trim staples",
+                "rationale": "Defensives losing relative momentum.",
+            },
+            {
+                "priority": 4,
+                "label": "Add NVDA on dip",
+                "rationale": "AI capex commentary supportive.",
+            },
+        ],
+        "risk_radar": [
+            {
+                "horizon_hours": 24,
+                "label": "Hawkish FOMC minutes",
+                "trigger": "5y5y reprices >10bps wider.",
+            }
+        ],
+        "segment_freshness": {
+            "macro": {"source": "today", "as_of": "2026-04-20"},
+        },
+    }
+
+
+def _envelope_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "run_date": date(2026, 4, 20),
+        "run_type": "baseline",
+        "baseline_date": None,
+        "published_at": datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+        "digest": _digest_payload_kwargs(),
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_envelope(**overrides: Any) -> SnapshotEnvelope:
+    return SnapshotEnvelope(**_envelope_kwargs(**overrides))
+
+
+def _moderate_profile(**overrides: Any) -> InvestmentProfile:
+    """A 'neutral' profile that disables ESG drops and keeps all priorities."""
+    base: dict[str, Any] = {
+        "risk_tolerance": "moderate",
+        "horizon_years": 10,
+        "liquidity_needs": "medium",
+        "base_currency": "USD",
+        "tax_jurisdiction": "US",
+        "esg_preference": "none",
+        "excluded_sectors": [],
+        "experience_level": "intermediate",
+    }
+    base.update(overrides)
+    return InvestmentProfile(**base)
+
+
+# ─── 1. Anonymous pass-through ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_anonymous_returns_unchanged() -> None:
+    env = _make_envelope()
+    result = personalize_snapshot(env, profile=None, preferences=None)
+    # Same instance — anonymous path is a no-op.
+    assert result.envelope is env
+    assert result.excluded_count == 0
+    assert result.rank_changes == []
+
+
+# ─── 2. Excluded ticker dropped from actionable ────────────────────────────
+
+
+@pytest.mark.unit
+def test_excluded_ticker_dropped_from_actionable() -> None:
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {
+            "priority": 4,
+            "label": "Trim XOM exposure",
+            "rationale": "Oil rolling over.",
+        },
+        {
+            "priority": 4,
+            "label": "Add NVDA on dip",
+            "rationale": "AI capex commentary supportive.",
+        },
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    prefs = AssetPreferences(excluded_tickers=["XOM"])
+    result = personalize_snapshot(env, preferences=prefs)
+
+    labels = [item.label for item in result.envelope.digest.actionable_summary]
+    assert "Trim XOM exposure" not in labels
+    assert "Add NVDA on dip" in labels
+    assert result.excluded_count == 1
+
+
+# ─── 3. Custom-universe boosts rank ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_custom_universe_boosts_rank_or_tags() -> None:
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {
+            "priority": 3,
+            "label": "Trim staples",
+            "rationale": "Defensives losing relative momentum.",
+        },
+        {
+            "priority": 3,
+            "label": "Energy hedge",
+            "rationale": "OPEC supply uncertainty.",
+        },
+        {
+            "priority": 3,
+            "label": "Long NVDA",
+            "rationale": "AI capex tailwind.",
+        },
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    prefs = AssetPreferences(custom_universe=["NVDA"])
+    result = personalize_snapshot(env, preferences=prefs)
+
+    labels = [item.label for item in result.envelope.digest.actionable_summary]
+    # NVDA mention moved to position 0.
+    assert labels[0] == "Long NVDA"
+    # Other items kept relative order.
+    assert labels[1:] == ["Trim staples", "Energy hedge"]
+    # rank_changes records what moved (only the items whose index changed).
+    assert ("Long NVDA", 2, 0) in result.rank_changes
+    assert ("Trim staples", 0, 1) in result.rank_changes
+    assert ("Energy hedge", 1, 2) in result.rank_changes
+
+
+# ─── 4. Conservative drops low priority ─────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_conservative_drops_low_priority_items() -> None:
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {"priority": 1, "label": "Speculative call", "rationale": "Tactical."},
+        {"priority": 2, "label": "Edge trade", "rationale": "Small size."},
+        {"priority": 3, "label": "Core hold", "rationale": "Long-term."},
+        {"priority": 5, "label": "Defensive bond", "rationale": "Treasury ladder."},
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    profile = _moderate_profile(risk_tolerance="conservative")
+    result = personalize_snapshot(env, profile=profile)
+
+    labels = [item.label for item in result.envelope.digest.actionable_summary]
+    assert labels == ["Core hold", "Defensive bond"]
+    assert result.excluded_count == 2  # priority 1 + priority 2 dropped
+
+
+# ─── 5. Aggressive keeps all items ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_aggressive_keeps_all_items() -> None:
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {"priority": 1, "label": "Speculative call", "rationale": "Tactical."},
+        {"priority": 2, "label": "Edge trade", "rationale": "Small size."},
+        {"priority": 3, "label": "Core hold", "rationale": "Long-term."},
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    profile = _moderate_profile(risk_tolerance="aggressive")
+    result = personalize_snapshot(env, profile=profile)
+
+    labels = [item.label for item in result.envelope.digest.actionable_summary]
+    assert labels == ["Speculative call", "Edge trade", "Core hold"]
+    assert result.excluded_count == 0
+
+
+# ─── 6. Strict ESG drops excluded-sector mentions ───────────────────────────
+
+
+@pytest.mark.unit
+def test_strict_esg_drops_excluded_sector_mentions() -> None:
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {
+            "priority": 4,
+            "label": "Long Tobacco basket",
+            "rationale": "Defensive cash flows.",
+        },
+        {
+            "priority": 4,
+            "label": "Add NVDA on dip",
+            "rationale": "AI capex commentary.",
+        },
+    ]
+    digest["risk_radar"] = [
+        {
+            "horizon_hours": 48,
+            "label": "Tobacco regulation headlines",
+            "trigger": "FDA menthol ban revival.",
+        },
+        {
+            "horizon_hours": 24,
+            "label": "Hawkish FOMC minutes",
+            "trigger": "5y5y reprices wider.",
+        },
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    profile = _moderate_profile(esg_preference="strict", excluded_sectors=["tobacco"])
+    result = personalize_snapshot(env, profile=profile)
+
+    actionable_labels = [item.label for item in result.envelope.digest.actionable_summary]
+    risk_labels = [item.label for item in result.envelope.digest.risk_radar]
+    assert "Long Tobacco basket" not in actionable_labels
+    assert "Add NVDA on dip" in actionable_labels
+    assert "Tobacco regulation headlines" not in risk_labels
+    assert "Hawkish FOMC minutes" in risk_labels
+    assert result.excluded_count == 2
+
+
+# ─── 7. Return-shape contract ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_returns_envelope_subclass_or_envelope() -> None:
+    """Asserts the return type contract: PersonalizedSnapshot wrapping a SnapshotEnvelope.
+
+    See module docstring of digiquant.atlas.personalization for the rationale —
+    we picked the sibling-dataclass form over a v2 envelope bump because
+    SnapshotEnvelope/DigestPayload are extra="forbid" end-to-end.
+    """
+    env = _make_envelope()
+    result = personalize_snapshot(
+        env,
+        profile=_moderate_profile(),
+        preferences=AssetPreferences(),
+    )
+    assert isinstance(result, PersonalizedSnapshot)
+    assert isinstance(result.envelope, SnapshotEnvelope)
+    assert isinstance(result.envelope.digest, DigestPayload)
+    # Schema version preserved (no v2 bump).
+    assert result.envelope.schema_version == env.schema_version
+
+
+# ─── 8. Performance budget ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_performance_budget_under_200ms_for_100_items() -> None:
+    """Issue req: < 100 ms; CI-safe assert at 200 ms to absorb runner variance."""
+    digest = _digest_payload_kwargs()
+    digest["actionable_summary"] = [
+        {
+            "priority": (i % 5) + 1,
+            "label": f"Idea {i} on AAPL" if i % 3 == 0 else f"Idea {i} on tobacco basket",
+            "rationale": f"Rationale {i} mentioning XOM and TSLA.",
+        }
+        for i in range(100)
+    ]
+    env = SnapshotEnvelope(**_envelope_kwargs(digest=digest))
+
+    profile = _moderate_profile(
+        risk_tolerance="conservative",
+        esg_preference="strict",
+        excluded_sectors=["tobacco"],
+    )
+    prefs = AssetPreferences(
+        excluded_tickers=["XOM"],
+        custom_universe=["AAPL"],
+    )
+
+    start = time.perf_counter()
+    result = personalize_snapshot(env, profile=profile, preferences=prefs)
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    assert elapsed_ms < 200.0, (
+        f"personalize_snapshot took {elapsed_ms:.2f} ms; budget is < 100 ms (CI assert < 200 ms)"
+    )
+    # Sanity: exclusion + boost actually happened.
+    assert isinstance(result, PersonalizedSnapshot)
+    assert result.excluded_count > 0


### PR DESCRIPTION
## Summary

- Adds `digiquant.atlas.personalize_snapshot(envelope, *, profile, preferences)` — read-time helper that filters and ranks an Atlas `SnapshotEnvelope` per the user's `InvestmentProfile` (PR #444) and `AssetPreferences` (PR #448).
- Returns a sibling `PersonalizedSnapshot` dataclass (`envelope`, `excluded_count`, `rank_changes`) — the wire `SnapshotEnvelope` shape and `schema_version` are unchanged. `extra=\"forbid\"` on the envelope models forced the sibling-wrapper choice over an in-envelope metadata block.
- 8 unit tests covering anonymous pass-through, ticker exclusion, custom-universe boosting, risk-tolerance filtering, ESG sector exclusion, the return-shape contract, and the < 100 ms performance budget (CI assert at 200 ms for runner variance).
- Architecture section added under `apps/digiquant-atlas/docs/agentic/ARCHITECTURE.md` next to the existing snapshot read-path docs.

## Behavior

- **Anonymous** (both args `None`): pass-through — same envelope instance, no diagnostics.
- **`AssetPreferences.excluded_tickers`**: drop items in `actionable_summary`, `risk_radar`, `material_findings` whose label/rationale/trigger/summary mention an excluded ticker (word-boundary uppercase regex; coarse but documented — \"USA\"/\"UK\" can collide with real tickers).
- **`AssetPreferences.custom_universe`**: stable-partition `actionable_summary` so items mentioning a universe ticker move to the front; positional moves recorded in `rank_changes`.
- **`InvestmentProfile.risk_tolerance`**: `conservative` drops `actionable_summary` items with `priority < 3`; `moderate` / `aggressive` keep all.
- **`InvestmentProfile.esg_preference == \"strict\"`**: drop items whose label/rationale/trigger/summary contain any `excluded_sectors` substring (lower-cased contains-match). `tilt` / `none` are pass-through here — `tilt` drives weighting downstream in Hermes/Kairos, not visibility in Atlas.

## Judgment calls

- **Return shape**: chose the sibling `PersonalizedSnapshot` dataclass instead of bumping `SCHEMA_VERSION` for an in-envelope metadata block. `SnapshotEnvelope`, `DigestPayload`, `ActionableItem`, `RiskItem` are all `extra=\"forbid\"`, and the task explicitly said \"don't bump SnapshotEnvelope schema_version\" — the dataclass keeps the wire contract immutable while still surfacing diagnostics.
- **Mutate-and-revalidate over deep copy**: implementation does one `model_dump(mode=\"python\")` → mutate dict → `model_validate(...)` instead of per-item `model_copy(deep=True)`. Faster on 100+ items and cleaner since exclusion only drops whole items, never reshapes one.
- **Sector-exclusion gating** (worth a reviewer second look): `AssetPreferences.excluded_sectors` is unioned with `InvestmentProfile.excluded_sectors` but the whole sector-filter pass is gated on `profile.esg_preference == \"strict\"`. So `preferences.excluded_sectors=[\"tobacco\"]` + `profile=None` will **not** filter tobacco items today. This matches the task brief (\"Apply profile: ESG: strict drops anything whose label/rationale contains an excluded sector\"), but a future change could make `preferences.excluded_sectors` always-on independent of the profile's ESG flag — happy to follow up if reviewers prefer.
- **Ticker matcher**: word-boundary uppercase `\\b[A-Z]{1,5}\\b` — coarse, documented in the module docstring. Picked determinism + zero deps over a curated ticker set.
- **Prose blocks not rewritten**: `headline`, `market_regime_snapshot`, etc. are not rewritten on exclusion — string surgery on narrative summaries is brittle and the dashboard renders structured items as the primary affordance.

## Test plan

- [x] `pytest tests/dq/atlas/test_personalization.py -v` — 8/8 pass in 0.03 s
- [x] `pytest tests/dq/atlas/ -v` — no regressions; 19 pass, 3 skip (pre-existing parity tests, `digiquant_atlas` not installed in this env)
- [x] `ruff format` + `ruff check` — clean
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 8, Optimization 10, Accuracy 10 (all thresholds met)
- [x] `make doc-check` — 117 markdown files OK
- [x] `digiquant/docs/schemas/atlas_snapshot.v1.json` unchanged — confirms no envelope shape drift

Fixes #312
Part of #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)