### PR TITLE
feat(atlas): frontend reads live daily snapshot from Supabase (#303)

### DIFF
--- a/apps/digiquant-atlas/frontend/README.md
+++ b/apps/digiquant-atlas/frontend/README.md
@@ -59,9 +59,38 @@ cd apps/digiquant-atlas/frontend
 npm run dev                  # http://localhost:3000/digiquant-atlas/
 npm run build                # static export (output: 'export')
 npm run lint
+npm run test                 # Vitest (lib/**/*.test.ts + components/**/*.test.tsx)
 ```
 
-No `test` script is configured for this workspace yet.
+## Environment variables
+
+Copy `.env.local.example` to `.env.local` and fill in your Supabase credentials:
+
+| Variable                          | Purpose                                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`        | Supabase project URL. Used by every client-side reader, including `lib/snapshot-fetch.ts`.               |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY`   | Supabase anon key. The frontend reads `daily_snapshots` under the `anon_read` RLS policy (migration 011). |
+| `NEXT_PUBLIC_ATLAS_VERSION`       | Optional. Shown in the page-chrome version label (defaults to `v0.1 · dev`).                              |
+
+When the URL or anon key is unset the daily-snapshot panel renders an empty
+banner pointing back to this section instead of throwing.
+
+## Daily snapshot envelope
+
+The Overview page renders a typed `SnapshotEnvelope` panel above the KPI strip
+(`components/overview/daily-snapshot-panel.tsx`). The envelope shape mirrors
+`digiquant.atlas.snapshot.SnapshotEnvelope` from
+[`atlas_snapshot.v1.json`](../../../digiquant/docs/schemas/atlas_snapshot.v1.json):
+
+- `lib/snapshot-types.ts` — TypeScript mirror of the Pydantic model.
+- `lib/snapshot-fetch.ts` — `fetchLatestSnapshot()` reads the freshest
+  `daily_snapshots` row and only surfaces it when the row is from today or
+  yesterday (UTC). Older rows resolve to `kind: 'empty'`.
+- `lib/snapshot-staleness.ts` — `isStale(publishedAt, hours)` decides whether
+  to show the "stale" banner above the panel; default threshold is 48h.
+- `components/overview/daily-snapshot-panel.tsx` — render component with
+  loading skeleton, error banner (with Retry button), stale banner, and empty
+  state.
 
 ## Token collision notes
 

--- a/apps/digiquant-atlas/frontend/app/page.tsx
+++ b/apps/digiquant-atlas/frontend/app/page.tsx
@@ -27,6 +27,7 @@ import {
   YAxis,
 } from 'recharts';
 import TopAssetsPulse from '@/components/overview/top-assets-pulse';
+import { DailySnapshotPanel } from '@/components/overview/daily-snapshot-panel';
 import AtlasLoader from '@/components/AtlasLoader';
 import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
 
@@ -365,6 +366,9 @@ export default function OverviewPage() {
           )}
         </div>
       </div>
+
+      {/* ── Daily snapshot envelope (live read from daily_snapshots) ───────── */}
+      <DailySnapshotPanel />
 
       {/* ── KPI Stat Strip ─────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">

--- a/apps/digiquant-atlas/frontend/components/overview/daily-snapshot-panel.test.tsx
+++ b/apps/digiquant-atlas/frontend/components/overview/daily-snapshot-panel.test.tsx
@@ -1,0 +1,162 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { DailySnapshotPanel } from './daily-snapshot-panel';
+import {
+  fixtureDigest,
+  fixtureEnvelope,
+} from '@/lib/__fixtures__/snapshot-fixture';
+import type { SnapshotFetchResult } from '@/lib/snapshot-types';
+
+const FIXED_NOW = new Date('2026-04-27T12:00:00Z');
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+/**
+ * `renderToStaticMarkup` HTML-encodes `&`, `<`, `>`, `"`. Tests assert
+ * against text content, so apply the same transform before checking.
+ */
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+describe('DailySnapshotPanel — present envelope', () => {
+  const result: SnapshotFetchResult = { kind: 'present', envelope: fixtureEnvelope() };
+
+  it('renders the headline, segment, run_date, and run_type from the envelope', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    const env = fixtureEnvelope();
+    expect(html).toContain(htmlEscape(env.digest.headline));
+    expect(html).toContain(htmlEscape(env.digest.segment));
+    expect(html).toContain(env.run_date);
+    expect(html).toContain(env.run_type);
+  });
+
+  it('every visible narrative section traces to a digest field', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    const digest = fixtureDigest();
+    const narrativeFields = [
+      digest.market_regime_snapshot,
+      digest.alt_data_dashboard,
+      digest.institutional_summary,
+      digest.asset_classes_summary,
+      digest.us_equities_summary,
+      digest.thesis_tracker,
+      digest.portfolio_recommendations,
+    ];
+    for (const slot of narrativeFields) {
+      expect(html).toContain(htmlEscape(slot));
+    }
+  });
+
+  it('renders every actionable summary entry from the envelope', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    for (const item of fixtureDigest().actionable_summary) {
+      expect(html).toContain(htmlEscape(item.label));
+      expect(html).toContain(htmlEscape(item.rationale));
+      expect(html).toContain(`P${item.priority}`);
+    }
+  });
+
+  it('renders every risk-radar entry from the envelope', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    for (const item of fixtureDigest().risk_radar) {
+      expect(html).toContain(htmlEscape(item.label));
+      expect(html).toContain(htmlEscape(item.trigger));
+      expect(html).toContain(`${item.horizon_hours}h`);
+    }
+  });
+
+  it('renders the bias label transformed for display', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    // bias 'bullish' renders verbatim; multi-word ones replace underscores.
+    expect(html).toContain('bullish');
+  });
+
+  it('does not show the stale banner when published_at is fresh', () => {
+    const fresh: SnapshotFetchResult = {
+      kind: 'present',
+      envelope: { ...fixtureEnvelope(), published_at: FIXED_NOW.toISOString() },
+    };
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: fresh, now: FIXED_NOW }),
+    );
+    expect(html).not.toContain('snapshot-stale-banner');
+    expect(html).not.toContain('Stale snapshot');
+  });
+
+  it('shows the stale banner when published_at is older than 48h', () => {
+    const stalePublished = new Date(FIXED_NOW.getTime() - 72 * 60 * 60 * 1000).toISOString();
+    const stale: SnapshotFetchResult = {
+      kind: 'present',
+      envelope: { ...fixtureEnvelope(), published_at: stalePublished },
+    };
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: stale, now: FIXED_NOW }),
+    );
+    expect(html).toContain('snapshot-stale-banner');
+    expect(html).toContain('Stale snapshot');
+  });
+
+  it('asserts no leftover mock/stub strings appear in the rendered output', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, { fetchResult: result, now: FIXED_NOW }),
+    );
+    // If anyone accidentally hardcodes these in the panel, fail loud.
+    expect(html.toLowerCase()).not.toContain('lorem ipsum');
+    expect(html.toLowerCase()).not.toContain('todo');
+    expect(html.toLowerCase()).not.toContain('placeholder');
+  });
+});
+
+describe('DailySnapshotPanel — empty / error states', () => {
+  it('shows the empty banner with the no_recent_row reason', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, {
+        fetchResult: { kind: 'empty', reason: 'no_recent_row' },
+        now: FIXED_NOW,
+      }),
+    );
+    expect(html).toContain('snapshot-empty');
+    expect(html).toContain('No snapshot');
+  });
+
+  it('shows the empty banner with the unconfigured reason', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, {
+        fetchResult: { kind: 'empty', reason: 'unconfigured' },
+        now: FIXED_NOW,
+      }),
+    );
+    expect(html).toContain('snapshot-empty');
+    expect(html).toContain('NEXT_PUBLIC_SUPABASE_URL');
+  });
+
+  it('shows the error banner with the message', () => {
+    const html = render(
+      createElement(DailySnapshotPanel, {
+        fetchResult: { kind: 'error', message: 'connection refused' },
+        now: FIXED_NOW,
+      }),
+    );
+    expect(html).toContain('snapshot-error');
+    expect(html).toContain('connection refused');
+    expect(html).toContain('Retry');
+  });
+});

--- a/apps/digiquant-atlas/frontend/components/overview/daily-snapshot-panel.tsx
+++ b/apps/digiquant-atlas/frontend/components/overview/daily-snapshot-panel.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Badge, SectionTitle } from '@/components/ui';
+import { fetchLatestSnapshot } from '@/lib/snapshot-fetch';
+import type {
+  ActionableItem,
+  DigestPayload,
+  RiskItem,
+  SnapshotBias,
+  SnapshotEnvelope,
+  SnapshotFetchResult,
+} from '@/lib/snapshot-types';
+import {
+  DEFAULT_SNAPSHOT_STALENESS_HOURS,
+  formatAge,
+  isStale,
+} from '@/lib/snapshot-staleness';
+
+const BIAS_VARIANT: Record<SnapshotBias, 'green' | 'red' | 'amber' | 'blue' | 'default'> = {
+  strong_bullish: 'green',
+  bullish: 'green',
+  neutral: 'blue',
+  bearish: 'red',
+  strong_bearish: 'red',
+  mixed: 'amber',
+};
+
+function biasLabel(bias: SnapshotBias): string {
+  return bias.replace(/_/g, ' ');
+}
+
+export interface DailySnapshotPanelProps {
+  /** Inject a fetch result for tests (skips network). */
+  fetchResult?: SnapshotFetchResult;
+  /** Override "now" for staleness checks (tests). */
+  now?: Date;
+}
+
+export function DailySnapshotPanel({ fetchResult, now }: DailySnapshotPanelProps) {
+  // Tests inject `fetchResult` directly — render synchronously without an
+  // effect. Production renders defer to `<DailySnapshotPanelLive />`, which
+  // owns the network fetch in an effect.
+  if (fetchResult) {
+    return <RenderResult result={fetchResult} now={now} />;
+  }
+  return <DailySnapshotPanelLive now={now} />;
+}
+
+function DailySnapshotPanelLive({ now }: { now?: Date }) {
+  const [reloadTick, setReloadTick] = useState(0);
+  const [result, setResult] = useState<SnapshotFetchResult | null>(null);
+
+  const refetch = useCallback(() => {
+    setResult(null);
+    setReloadTick((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchLatestSnapshot()
+      .then((next) => {
+        if (!cancelled) setResult(next);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setResult({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadTick]);
+
+  if (result === null) return <SnapshotSkeleton />;
+  return <RenderResult result={result} now={now} onRetry={refetch} />;
+}
+
+function RenderResult({
+  result,
+  now,
+  onRetry,
+}: {
+  result: SnapshotFetchResult;
+  now?: Date;
+  onRetry?: () => void;
+}) {
+  if (result.kind === 'error') {
+    return (
+      <SnapshotErrorBanner
+        message={result.message}
+        onRetry={onRetry ?? (() => undefined)}
+      />
+    );
+  }
+  if (result.kind === 'empty') {
+    return <SnapshotEmptyBanner reason={result.reason} />;
+  }
+  return <SnapshotContent envelope={result.envelope} now={now} />;
+}
+
+function SnapshotSkeleton() {
+  return (
+    <section
+      data-testid="snapshot-loading"
+      aria-busy="true"
+      aria-label="Loading daily snapshot"
+      className="glass-card p-6 space-y-4 animate-pulse"
+    >
+      <div className="h-3 w-40 rounded bg-white/10" />
+      <div className="h-6 w-3/4 rounded bg-white/10" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="h-20 rounded bg-white/5" />
+        <div className="h-20 rounded bg-white/5" />
+      </div>
+    </section>
+  );
+}
+
+function SnapshotErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <section
+      data-testid="snapshot-error"
+      role="alert"
+      className="glass-card p-5 border-fin-red/30 bg-fin-red/5"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <SectionTitle className="text-fin-red">Snapshot unavailable</SectionTitle>
+          <p className="text-sm text-text-secondary break-words">{message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="shrink-0 rounded-md border border-fin-red/40 bg-fin-red/10 px-3 py-1.5 text-xs font-semibold text-fin-red hover:bg-fin-red/20"
+        >
+          Retry
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function SnapshotEmptyBanner({ reason }: { reason: 'no_recent_row' | 'unconfigured' }) {
+  const message =
+    reason === 'unconfigured'
+      ? 'Supabase credentials are not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+      : 'No snapshot has been published for today or yesterday yet. Check back after the next pipeline run.';
+  return (
+    <section
+      data-testid="snapshot-empty"
+      role="status"
+      className="glass-card p-5 border-border-subtle bg-bg-secondary/40"
+    >
+      <SectionTitle>No snapshot available</SectionTitle>
+      <p className="text-sm text-text-secondary">{message}</p>
+    </section>
+  );
+}
+
+function SnapshotContent({
+  envelope,
+  now,
+}: {
+  envelope: SnapshotEnvelope;
+  now?: Date;
+}) {
+  const stale = useMemo(
+    () => isStale(envelope.published_at, DEFAULT_SNAPSHOT_STALENESS_HOURS, now ?? new Date()),
+    [envelope.published_at, now],
+  );
+  const age = useMemo(
+    () => formatAge(envelope.published_at, now ?? new Date()),
+    [envelope.published_at, now],
+  );
+  const digest = envelope.digest;
+
+  return (
+    <section data-testid="snapshot-present" className="space-y-4">
+      {stale && (
+        <div
+          data-testid="snapshot-stale-banner"
+          role="status"
+          className="glass-card p-4 border-fin-amber/40 bg-fin-amber/5 flex items-center justify-between gap-3"
+        >
+          <div>
+            <p className="text-sm font-semibold text-fin-amber">Stale snapshot</p>
+            <p className="text-xs text-text-secondary">
+              Published {age ?? 'unknown'} (older than {DEFAULT_SNAPSHOT_STALENESS_HOURS}h).
+            </p>
+          </div>
+          <Badge variant="amber">stale</Badge>
+        </div>
+      )}
+
+      <article className="glass-card p-6 space-y-5">
+        <header className="flex flex-wrap items-baseline justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+              Daily snapshot
+            </p>
+            <h2
+              data-testid="snapshot-headline"
+              className="text-xl font-semibold leading-snug text-text-primary"
+            >
+              {digest.headline}
+            </h2>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+            <Badge variant={BIAS_VARIANT[digest.bias] ?? 'default'} data-testid="snapshot-bias">
+              {biasLabel(digest.bias)}
+            </Badge>
+            <span data-testid="snapshot-segment">{digest.segment}</span>
+            <span aria-hidden="true">·</span>
+            <span data-testid="snapshot-run-date">{envelope.run_date}</span>
+            <span aria-hidden="true">·</span>
+            <span data-testid="snapshot-run-type" className="uppercase tracking-wider">
+              {envelope.run_type}
+            </span>
+            {age && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span data-testid="snapshot-published-age">{age}</span>
+              </>
+            )}
+          </div>
+        </header>
+
+        <NarrativeSection title="Market regime" body={digest.market_regime_snapshot} testId="snapshot-section-regime" />
+        <NarrativeSection title="Alt data" body={digest.alt_data_dashboard} testId="snapshot-section-alt-data" />
+        <NarrativeSection title="Institutional flows" body={digest.institutional_summary} testId="snapshot-section-institutional" />
+        <NarrativeSection title="Asset classes" body={digest.asset_classes_summary} testId="snapshot-section-asset-classes" />
+        <NarrativeSection title="US equities" body={digest.us_equities_summary} testId="snapshot-section-us-equities" />
+
+        {digest.thesis_tracker.trim().length > 0 && (
+          <NarrativeSection title="Thesis tracker" body={digest.thesis_tracker} testId="snapshot-section-thesis" />
+        )}
+        {digest.portfolio_recommendations.trim().length > 0 && (
+          <NarrativeSection
+            title="Portfolio recommendations"
+            body={digest.portfolio_recommendations}
+            testId="snapshot-section-portfolio-recs"
+          />
+        )}
+
+        <ActionableList items={digest.actionable_summary} />
+        <RiskList items={digest.risk_radar} />
+      </article>
+    </section>
+  );
+}
+
+function NarrativeSection({ title, body, testId }: { title: string; body: string; testId: string }) {
+  return (
+    <div data-testid={testId} className="space-y-1.5">
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+        {title}
+      </h3>
+      <p className="text-sm leading-relaxed text-text-secondary whitespace-pre-line">{body}</p>
+    </div>
+  );
+}
+
+function ActionableList({ items }: { items: ActionableItem[] }) {
+  if (!items.length) return null;
+  return (
+    <div data-testid="snapshot-actionable" className="space-y-2">
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+        Actionable summary
+      </h3>
+      <ul className="space-y-2">
+        {items.map((item, i) => (
+          <li
+            key={`${item.priority}-${i}`}
+            data-testid="snapshot-actionable-item"
+            className="rounded-md border border-border-subtle bg-bg-secondary/30 p-3 text-sm"
+          >
+            <div className="flex items-center gap-2 text-xs text-text-muted">
+              <span className="font-mono">P{item.priority}</span>
+              <span aria-hidden="true">·</span>
+              <span className="font-semibold text-text-primary">{item.label}</span>
+            </div>
+            <p className="mt-1 text-text-secondary">{item.rationale}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RiskList({ items }: { items: RiskItem[] }) {
+  if (!items.length) return null;
+  return (
+    <div data-testid="snapshot-risk-radar" className="space-y-2">
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+        Risk radar
+      </h3>
+      <ul className="space-y-2">
+        {items.map((item, i) => (
+          <li
+            key={`${item.label}-${i}`}
+            data-testid="snapshot-risk-item"
+            className="rounded-md border border-border-subtle bg-bg-secondary/30 p-3 text-sm"
+          >
+            <div className="flex items-center gap-2 text-xs text-text-muted">
+              <span className="font-mono">{item.horizon_hours}h</span>
+              <span aria-hidden="true">·</span>
+              <span className="font-semibold text-text-primary">{item.label}</span>
+            </div>
+            <p className="mt-1 text-text-secondary">{item.trigger}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** Re-export for tests that want to assert against the digest field set. */
+export type { DigestPayload, SnapshotEnvelope };

--- a/apps/digiquant-atlas/frontend/lib/__fixtures__/snapshot-fixture.ts
+++ b/apps/digiquant-atlas/frontend/lib/__fixtures__/snapshot-fixture.ts
@@ -1,0 +1,94 @@
+/**
+ * Test-only fixture for a `daily_snapshots` row + the parsed
+ * {@link SnapshotEnvelope} digest payload. Mirrors the shape Pydantic emits
+ * (`digiquant.atlas.snapshot.SnapshotEnvelope.model_dump()`).
+ *
+ * Kept under `__fixtures__/` so the production bundle never imports it.
+ */
+import type { DigestPayload, SnapshotEnvelope } from '../snapshot-types';
+
+export type SnapshotRowFixture = {
+  date: string;
+  run_type: string | null;
+  baseline_date: string | null;
+  snapshot: unknown;
+  created_at: string | null;
+};
+
+/** Mutable copy of a DigestPayload — useful when tests want to tweak fields. */
+export function fixtureDigest(): DigestPayload {
+  return {
+    segment: 'master',
+    date: '2026-04-27',
+    bias: 'bullish',
+    headline: 'Tech rally extends as macro stress eases',
+    material_findings: [
+      {
+        label: 'NVDA breaks resistance',
+        summary: 'Closes above 1,200 on heavy volume.',
+        source_ids: ['src-1'],
+      },
+    ],
+    sources: [
+      { id: 'src-1', title: 'Bloomberg market wrap', url: 'https://example.com/src-1' },
+    ],
+    notes: 'Watch sentiment shifts at the open.',
+    market_regime_snapshot:
+      'Risk-on regime confirmed; VIX down 4% week-over-week, breadth healthy across cyclicals.',
+    alt_data_dashboard:
+      'Aggregate credit-card spending data turning higher; cargo throughput stable WoW.',
+    institutional_summary:
+      'Hedge funds increased net long exposure to mega-cap tech for the third consecutive week.',
+    asset_classes_summary:
+      'Treasuries flat; commodities mixed (gold +0.6%, WTI -1.2%); FX shows dollar weakness.',
+    us_equities_summary:
+      'S&P 500 +0.8%, NDX +1.4%, RUT +0.3%. Semis lead, energy lags.',
+    thesis_tracker:
+      'AI-Compute thesis remains intact; semis breadth confirms.',
+    portfolio_recommendations:
+      'Hold positioning; consider tactical add to NVDA on intraday weakness.',
+    actionable_summary: [
+      {
+        priority: 1,
+        label: 'Trim energy underweight',
+        rationale: 'Crude inventories suggest mean reversion risk.',
+      },
+      {
+        priority: 2,
+        label: 'Monitor 10Y yields',
+        rationale: 'A break above 4.6% would invalidate duration overweight.',
+      },
+    ],
+    risk_radar: [
+      {
+        horizon_hours: 24,
+        label: 'CPI release Tuesday',
+        trigger: 'Hotter-than-expected core CPI > 0.4% MoM.',
+      },
+    ],
+    segment_freshness: {
+      master: { source: 'today', as_of: '2026-04-27' },
+    },
+  };
+}
+
+export function fixtureEnvelope(): SnapshotEnvelope {
+  return {
+    schema_version: 1,
+    run_date: '2026-04-27',
+    run_type: 'delta',
+    baseline_date: '2026-04-26',
+    published_at: '2026-04-27T11:30:00Z',
+    digest: fixtureDigest(),
+  };
+}
+
+export function fixtureSnapshotRow(): SnapshotRowFixture {
+  return {
+    date: '2026-04-27',
+    run_type: 'delta',
+    baseline_date: '2026-04-26',
+    snapshot: fixtureDigest(),
+    created_at: '2026-04-27T11:30:00Z',
+  };
+}

--- a/apps/digiquant-atlas/frontend/lib/snapshot-fetch.test.ts
+++ b/apps/digiquant-atlas/frontend/lib/snapshot-fetch.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { envelopeFromRow, fetchLatestSnapshot } from './snapshot-fetch';
+import { fixtureDigest, fixtureSnapshotRow } from './__fixtures__/snapshot-fixture';
+import type { Database } from './database.types';
+
+const NOW = new Date('2026-04-27T12:00:00Z');
+
+/** Build a fake Supabase client whose `from()...maybeSingle()` returns a fixed shape. */
+function fakeClient<T>(payload: { data: T | null; error: { message: string } | null }) {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(payload),
+  };
+  const from = vi.fn().mockReturnValue(builder);
+  // Cast through unknown — the test only exercises the chain we use in
+  // snapshot-fetch.ts, not the full SupabaseClient surface.
+  return { from } as unknown as SupabaseClient<Database>;
+}
+
+describe('envelopeFromRow', () => {
+  it('builds an envelope from a row with a valid digest payload', () => {
+    const env = envelopeFromRow(fixtureSnapshotRow(), NOW);
+    expect(env).not.toBeNull();
+    expect(env?.run_date).toBe('2026-04-27');
+    expect(env?.run_type).toBe('delta');
+    expect(env?.baseline_date).toBe('2026-04-26');
+    expect(env?.digest.headline).toBe(fixtureDigest().headline);
+  });
+
+  it('returns null when run_type is not baseline/delta', () => {
+    const row = fixtureSnapshotRow();
+    row.run_type = 'invalid';
+    expect(envelopeFromRow(row, NOW)).toBeNull();
+  });
+
+  it('returns null when the snapshot payload is missing required fields', () => {
+    const row = fixtureSnapshotRow();
+    row.snapshot = { headline: 'only this one' };
+    expect(envelopeFromRow(row, NOW)).toBeNull();
+  });
+
+  it('falls back to "now" when created_at is missing', () => {
+    const row = fixtureSnapshotRow();
+    row.created_at = null;
+    const env = envelopeFromRow(row, NOW);
+    expect(env?.published_at).toBe(NOW.toISOString());
+  });
+});
+
+describe('fetchLatestSnapshot', () => {
+  it('returns kind=present when the latest row is for today', async () => {
+    const today = NOW.toISOString().slice(0, 10);
+    const row = fixtureSnapshotRow();
+    row.date = today;
+    const client = fakeClient({ data: row, error: null });
+
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.envelope.run_date).toBe(today);
+    }
+  });
+
+  it('returns kind=present when the latest row is for yesterday', async () => {
+    const row = fixtureSnapshotRow();
+    row.date = '2026-04-26'; // yesterday vs NOW
+    const client = fakeClient({ data: row, error: null });
+
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('present');
+  });
+
+  it('returns kind=empty/no_recent_row when the latest row is older than yesterday', async () => {
+    const row = fixtureSnapshotRow();
+    row.date = '2026-04-20'; // 7 days old
+    const client = fakeClient({ data: row, error: null });
+
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('empty');
+    if (result.kind === 'empty') {
+      expect(result.reason).toBe('no_recent_row');
+    }
+  });
+
+  it('returns kind=empty/no_recent_row when no row exists', async () => {
+    const client = fakeClient({ data: null, error: null });
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('empty');
+    if (result.kind === 'empty') {
+      expect(result.reason).toBe('no_recent_row');
+    }
+  });
+
+  it('returns kind=empty/unconfigured when no Supabase client is available', async () => {
+    const result = await fetchLatestSnapshot({ now: NOW, client: null });
+    expect(result.kind).toBe('empty');
+    if (result.kind === 'empty') {
+      expect(result.reason).toBe('unconfigured');
+    }
+  });
+
+  it('returns kind=error when Supabase returns an error', async () => {
+    const client = fakeClient({ data: null, error: { message: 'RLS denied' } });
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('error');
+    if (result.kind === 'error') {
+      expect(result.message).toContain('RLS denied');
+    }
+  });
+
+  it('returns kind=error when the payload fails validation', async () => {
+    const today = NOW.toISOString().slice(0, 10);
+    const row = fixtureSnapshotRow();
+    row.date = today;
+    row.snapshot = { headline: 'incomplete' };
+    const client = fakeClient({ data: row, error: null });
+
+    const result = await fetchLatestSnapshot({ now: NOW, client });
+    expect(result.kind).toBe('error');
+  });
+});

--- a/apps/digiquant-atlas/frontend/lib/snapshot-fetch.ts
+++ b/apps/digiquant-atlas/frontend/lib/snapshot-fetch.ts
@@ -1,0 +1,198 @@
+/**
+ * Live read of the latest Atlas daily snapshot from Supabase.
+ *
+ * Reads the freshest `daily_snapshots` row, validates the `snapshot` jsonb
+ * payload conforms to the {@link DigestPayload} shape, and assembles a typed
+ * {@link SnapshotEnvelope} that mirrors the Pydantic model exported by the
+ * Atlas pipeline (see `digiquant/src/digiquant/atlas/snapshot.py`).
+ *
+ * Empty-state rule: returns `{ kind: 'empty' }` when the freshest row is older
+ * than yesterday (today's UTC date or yesterday's UTC date). A 5-day-old row
+ * is **not** treated as "present but stale" — that combination would surface
+ * stale-banner ambiguity. Only rows from {today, yesterday} are surfaced.
+ *
+ * Anonymous read works under migration 011's `anon_read` SELECT RLS policy
+ * (`apps/digiquant-atlas/supabase/migrations/011_anon_read_daily_snapshots.sql`).
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { isSupabaseConfigured, supabase } from './supabase';
+import type { Database } from './database.types';
+import type {
+  DigestPayload,
+  SnapshotEnvelope,
+  SnapshotFetchResult,
+} from './snapshot-types';
+
+type SB = SupabaseClient<Database>;
+
+/** Narrow `daily_snapshots` row pick — only what we need to assemble the envelope. */
+type SnapshotRowPick = {
+  date: string;
+  run_type: string | null;
+  baseline_date: string | null;
+  snapshot: unknown;
+  created_at: string | null;
+};
+
+/** Format a UTC date as `YYYY-MM-DD`. Stable independent of host TZ. */
+function isoUtcDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Returns `[todayUtc, yesterdayUtc]` as ISO date strings. */
+function todayAndYesterday(now: Date = new Date()): [string, string] {
+  const today = isoUtcDate(now);
+  const y = new Date(now);
+  y.setUTCDate(y.getUTCDate() - 1);
+  return [today, isoUtcDate(y)];
+}
+
+function isObjectRecord(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/** Validate the jsonb payload looks like {@link DigestPayload}. Defensive — does not deep-validate. */
+function asDigestPayload(raw: unknown): DigestPayload | null {
+  if (!isObjectRecord(raw)) return null;
+  const requiredStringKeys: Array<keyof DigestPayload> = [
+    'segment',
+    'date',
+    'bias',
+    'headline',
+    'market_regime_snapshot',
+    'alt_data_dashboard',
+    'institutional_summary',
+    'asset_classes_summary',
+    'us_equities_summary',
+  ];
+  for (const k of requiredStringKeys) {
+    if (typeof raw[k as string] !== 'string') return null;
+  }
+
+  // Provide defaults for optional list / map fields so the renderer can rely
+  // on iterating without null-checks. The pipeline always emits these, but
+  // historical / hand-edited rows may not.
+  const safe: DigestPayload = {
+    segment: raw.segment as string,
+    date: raw.date as string,
+    bias: raw.bias as DigestPayload['bias'],
+    headline: raw.headline as string,
+    material_findings: Array.isArray(raw.material_findings)
+      ? (raw.material_findings as DigestPayload['material_findings'])
+      : [],
+    sources: Array.isArray(raw.sources) ? (raw.sources as DigestPayload['sources']) : [],
+    notes: typeof raw.notes === 'string' ? raw.notes : '',
+    market_regime_snapshot: raw.market_regime_snapshot as string,
+    alt_data_dashboard: raw.alt_data_dashboard as string,
+    institutional_summary: raw.institutional_summary as string,
+    asset_classes_summary: raw.asset_classes_summary as string,
+    us_equities_summary: raw.us_equities_summary as string,
+    thesis_tracker: typeof raw.thesis_tracker === 'string' ? raw.thesis_tracker : '',
+    portfolio_recommendations:
+      typeof raw.portfolio_recommendations === 'string' ? raw.portfolio_recommendations : '',
+    actionable_summary: Array.isArray(raw.actionable_summary)
+      ? (raw.actionable_summary as DigestPayload['actionable_summary'])
+      : [],
+    risk_radar: Array.isArray(raw.risk_radar) ? (raw.risk_radar as DigestPayload['risk_radar']) : [],
+    segment_freshness: isObjectRecord(raw.segment_freshness)
+      ? (raw.segment_freshness as DigestPayload['segment_freshness'])
+      : {},
+  };
+  return safe;
+}
+
+/**
+ * Build a {@link SnapshotEnvelope} from a raw `daily_snapshots` row pick.
+ *
+ * Mirrors `SnapshotEnvelope.from_supabase_row` in the Pydantic source. The
+ * `published_at` timestamp resolves from `created_at` (the only timestamp
+ * column the table currently exposes) → "now" as a last resort.
+ */
+export function envelopeFromRow(
+  row: SnapshotRowPick,
+  now: Date = new Date(),
+): SnapshotEnvelope | null {
+  const digest = asDigestPayload(row.snapshot);
+  if (!digest) return null;
+  const runType = row.run_type === 'baseline' || row.run_type === 'delta' ? row.run_type : null;
+  if (!runType) return null;
+  return {
+    schema_version: 1,
+    run_date: row.date,
+    run_type: runType,
+    baseline_date: row.baseline_date ?? null,
+    published_at: row.created_at ?? now.toISOString(),
+    digest,
+  };
+}
+
+interface FetchOpts {
+  /** Override "now" for tests. */
+  now?: Date;
+  /**
+   * Inject a Supabase client for tests. Defaults to the module-level
+   * singleton from `lib/supabase.ts`. When the caller passes an explicit
+   * client (even if `null`), the env-var configuration check is skipped —
+   * the explicit value is treated as the source of truth.
+   */
+  client?: SB | null;
+}
+
+/**
+ * Fetch the latest snapshot row, returning a discriminated result.
+ *
+ * - `present`: row exists for today or yesterday and the payload validates.
+ * - `empty.no_recent_row`: no row, or the latest row is older than yesterday.
+ * - `empty.unconfigured`: Supabase URL / anon key not set in env.
+ * - `error`: Supabase returned an error or the payload failed validation.
+ */
+export async function fetchLatestSnapshot(
+  opts: FetchOpts = {},
+): Promise<SnapshotFetchResult> {
+  const now = opts.now ?? new Date();
+  // When the caller injected a client (even `null`), trust it. Otherwise
+  // fall back to the module singleton, which itself is `null` when the
+  // public env vars are missing.
+  const explicitClient = 'client' in opts;
+  const client = explicitClient ? opts.client ?? null : supabase;
+  if (!client) {
+    // No production client and no env-configured singleton → ask the user
+    // to set the public env vars. (Tests inject `null` directly to exercise
+    // this branch.)
+    if (!explicitClient && isSupabaseConfigured()) {
+      // Defensive — should never happen since the singleton is null when
+      // unconfigured, but keep an explicit error rather than silent miss.
+      return { kind: 'error', message: 'Supabase singleton missing despite configured env.' };
+    }
+    return { kind: 'empty', reason: 'unconfigured' };
+  }
+  try {
+    const { data, error } = await client
+      .from('daily_snapshots')
+      .select('date, run_type, baseline_date, snapshot, created_at')
+      .order('date', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      return { kind: 'error', message: error.message ?? String(error) };
+    }
+    if (!data) return { kind: 'empty', reason: 'no_recent_row' };
+
+    const row = data as SnapshotRowPick;
+    const [today, yesterday] = todayAndYesterday(now);
+    if (row.date !== today && row.date !== yesterday) {
+      return { kind: 'empty', reason: 'no_recent_row' };
+    }
+
+    const envelope = envelopeFromRow(row, now);
+    if (!envelope) {
+      return {
+        kind: 'error',
+        message: `Latest daily_snapshots row for ${row.date} has an invalid 'snapshot' payload.`,
+      };
+    }
+    return { kind: 'present', envelope };
+  } catch (err) {
+    return { kind: 'error', message: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/apps/digiquant-atlas/frontend/lib/snapshot-staleness.test.ts
+++ b/apps/digiquant-atlas/frontend/lib/snapshot-staleness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SNAPSHOT_STALENESS_HOURS,
+  formatAge,
+  isStale,
+} from './snapshot-staleness';
+
+const NOW = new Date('2026-04-27T12:00:00Z');
+
+function hoursAgo(h: number): string {
+  return new Date(NOW.getTime() - h * 60 * 60 * 1000).toISOString();
+}
+
+describe('isStale', () => {
+  it('treats a 1-hour-old timestamp as fresh at the 48h threshold', () => {
+    expect(isStale(hoursAgo(1), 48, NOW)).toBe(false);
+  });
+
+  it('treats a 47-hour-old timestamp as fresh at the 48h threshold', () => {
+    expect(isStale(hoursAgo(47), 48, NOW)).toBe(false);
+  });
+
+  it('treats a 49-hour-old timestamp as stale at the 48h threshold', () => {
+    expect(isStale(hoursAgo(49), 48, NOW)).toBe(true);
+  });
+
+  it('treats an empty string as stale (fail-loud)', () => {
+    expect(isStale('', 48, NOW)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as stale (fail-loud)', () => {
+    expect(isStale('not-a-date', 48, NOW)).toBe(true);
+  });
+
+  it('treats a future timestamp as fresh', () => {
+    const future = new Date(NOW.getTime() + 60 * 60 * 1000).toISOString();
+    expect(isStale(future, 48, NOW)).toBe(false);
+  });
+
+  it('exposes the 48h default threshold', () => {
+    expect(DEFAULT_SNAPSHOT_STALENESS_HOURS).toBe(48);
+  });
+});
+
+describe('formatAge', () => {
+  it('formats minute-level ages', () => {
+    expect(formatAge(hoursAgo(0.25), NOW)).toBe('15m ago');
+  });
+
+  it('formats hour-level ages', () => {
+    expect(formatAge(hoursAgo(3), NOW)).toBe('3h ago');
+  });
+
+  it('switches to days at 48h+', () => {
+    expect(formatAge(hoursAgo(72), NOW)).toBe('3d ago');
+  });
+
+  it('returns null for unparseable timestamps', () => {
+    expect(formatAge('not-a-date', NOW)).toBeNull();
+    expect(formatAge('', NOW)).toBeNull();
+  });
+});

--- a/apps/digiquant-atlas/frontend/lib/snapshot-staleness.ts
+++ b/apps/digiquant-atlas/frontend/lib/snapshot-staleness.ts
@@ -1,0 +1,49 @@
+/**
+ * Snapshot staleness checks.
+ *
+ * The published-at timestamp on a `SnapshotEnvelope` is UTC. The frontend
+ * shows a "stale" banner when the freshest envelope was assembled more than
+ * `hours` ago. The default of 48h matches the Atlas weekly-baseline +
+ * weekday-delta cadence: a missing weekday delta should still be shown,
+ * but anything older than two days warrants a visible warning.
+ */
+
+/** ISO date / datetime string accepted by `Date.parse`. */
+export type IsoTimestamp = string;
+
+/**
+ * Returns true when `publishedAt` was more than `hours` ago vs `now`.
+ * Returns true (treated as "definitely stale") when the input cannot be parsed —
+ * the UI fails loud rather than silently rendering stale content.
+ */
+export function isStale(
+  publishedAt: IsoTimestamp,
+  hours: number,
+  now: Date = new Date(),
+): boolean {
+  if (!publishedAt) return true;
+  const ts = Date.parse(publishedAt);
+  if (Number.isNaN(ts)) return true;
+  const ageMs = now.getTime() - ts;
+  if (ageMs < 0) return false;
+  return ageMs > hours * 60 * 60 * 1000;
+}
+
+/** Default staleness threshold (hours) for the Atlas daily snapshot UI. */
+export const DEFAULT_SNAPSHOT_STALENESS_HOURS = 48;
+
+/**
+ * Human-readable age in the form "Xh ago" / "Xd ago" suitable for the
+ * stale banner subtitle. Returns `null` when `publishedAt` cannot be parsed.
+ */
+export function formatAge(publishedAt: IsoTimestamp, now: Date = new Date()): string | null {
+  if (!publishedAt) return null;
+  const ts = Date.parse(publishedAt);
+  if (Number.isNaN(ts)) return null;
+  const minutes = Math.max(0, Math.floor((now.getTime() - ts) / 60_000));
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/apps/digiquant-atlas/frontend/lib/snapshot-types.ts
+++ b/apps/digiquant-atlas/frontend/lib/snapshot-types.ts
@@ -1,0 +1,111 @@
+/**
+ * Hand-written TypeScript mirror of `SnapshotEnvelope` in
+ * `digiquant/src/digiquant/atlas/snapshot.py` (schema v1).
+ *
+ * Source of truth: `digiquant/docs/schemas/atlas_snapshot.v1.json`. When the
+ * Pydantic model bumps `SCHEMA_VERSION`, regenerate the JSON schema and
+ * update this file in lockstep — the Atlas pipeline writes the envelope
+ * shape into `daily_snapshots.snapshot` and the frontend reads it back.
+ *
+ * Why hand-written vs json-schema-to-typescript? The field set is small
+ * (six top-level keys, eleven nested narrative slots) and adding a code
+ * generator just for this one schema introduces a build-time dependency we
+ * would otherwise not need.
+ */
+export const SNAPSHOT_SCHEMA_VERSION = 1 as const;
+
+/** Bias vocabulary mirrored from `digiquant_atlas.segments.Bias`. */
+export type SnapshotBias =
+  | 'strong_bullish'
+  | 'bullish'
+  | 'neutral'
+  | 'bearish'
+  | 'strong_bearish'
+  | 'mixed';
+
+/** Per-segment provenance marker. Mirrors phase7_synthesis.SegmentFreshness. */
+export interface SegmentFreshness {
+  source: 'today' | 'baseline';
+  /** ISO date string ('' if unknown). */
+  as_of: string;
+}
+
+/** One actionable summary entry. Mirrors phase7_synthesis.ActionableItem. */
+export interface ActionableItem {
+  /** 1 (highest) … 5 (lowest). */
+  priority: number;
+  label: string;
+  rationale: string;
+}
+
+/** One risk-radar entry. Mirrors phase7_synthesis.RiskItem. */
+export interface RiskItem {
+  /** 1 … 168 hours. */
+  horizon_hours: number;
+  label: string;
+  trigger: string;
+}
+
+/** One material finding. Mirrors digiquant_atlas.segments.Finding. */
+export interface SnapshotFinding {
+  label: string;
+  summary: string;
+  source_ids?: string[];
+}
+
+/** One cited source. Mirrors digiquant_atlas.segments.Source. */
+export interface SnapshotSource {
+  id: string;
+  title?: string | null;
+  url?: string | null;
+}
+
+/**
+ * Frontend-facing copy of the Phase 7 master synthesis payload.
+ * Mirrors `digiquant.atlas.snapshot.DigestPayload`.
+ */
+export interface DigestPayload {
+  /* SegmentReport core */
+  segment: string;
+  /** ISO date `YYYY-MM-DD`. */
+  date: string;
+  bias: SnapshotBias;
+  headline: string;
+  material_findings: SnapshotFinding[];
+  sources: SnapshotSource[];
+  notes: string;
+
+  /* Digest-specific narrative sections */
+  market_regime_snapshot: string;
+  alt_data_dashboard: string;
+  institutional_summary: string;
+  asset_classes_summary: string;
+  us_equities_summary: string;
+  thesis_tracker: string;
+  portfolio_recommendations: string;
+  actionable_summary: ActionableItem[];
+  risk_radar: RiskItem[];
+  segment_freshness: Record<string, SegmentFreshness>;
+}
+
+/**
+ * Frontend-consumable wrapper around a `daily_snapshots` row.
+ * Mirrors `digiquant.atlas.snapshot.SnapshotEnvelope`.
+ */
+export interface SnapshotEnvelope {
+  schema_version: number;
+  /** ISO date `YYYY-MM-DD`. */
+  run_date: string;
+  run_type: 'baseline' | 'delta';
+  /** ISO date `YYYY-MM-DD` — the most recent baseline a delta builds on; `null` on a baseline run. */
+  baseline_date: string | null;
+  /** ISO 8601 UTC timestamp the envelope was assembled. */
+  published_at: string;
+  digest: DigestPayload;
+}
+
+/** Outcome of `fetchLatestSnapshot()`. Discriminated union to make rendering states explicit. */
+export type SnapshotFetchResult =
+  | { kind: 'present'; envelope: SnapshotEnvelope }
+  | { kind: 'empty'; reason: 'no_recent_row' | 'unconfigured' }
+  | { kind: 'error'; message: string };

--- a/apps/digiquant-atlas/frontend/package.json
+++ b/apps/digiquant-atlas/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@digithings/design": "*",
@@ -31,6 +32,7 @@
     "eslint-config-next": "16.2.2",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.7",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.0"
   }
 }

--- a/apps/digiquant-atlas/frontend/vitest.config.ts
+++ b/apps/digiquant-atlas/frontend/vitest.config.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Atlas frontend Vitest config — node-environment, mirrors the digichat setup
+ * (`frontend/digichat/vitest.config.ts`). Tests live next to the code under
+ * `lib/` and `components/`.
+ *
+ * `tsconfig.json` declares `jsx: "preserve"` for Next.js, which Vitest cannot
+ * consume directly. We override the OXC transformer (Vitest 4's default) to
+ * compile JSX automatically so `.tsx` files import cleanly under the test
+ * runner.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['lib/**/*.test.ts', 'lib/**/*.test.tsx', 'components/**/*.test.tsx'],
+    // OXC transformer config — mirrors Vitest's default but pins JSX runtime.
+    // See https://vitest.dev/config/#oxc
+  },
+  oxc: {
+    jsx: {
+      runtime: 'automatic',
+      importSource: 'react',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "eslint-config-next": "16.2.2",
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.7",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.0"
       }
     },
     "frontend/design": {


### PR DESCRIPTION
## Summary

- Wires the Atlas Next.js Overview page to a typed `SnapshotEnvelope` read off `daily_snapshots`. New `lib/snapshot-{types,fetch,staleness}.ts` mirror the Pydantic contract from `digiquant.atlas.snapshot` (PRs #441 + #445) and feed a new `<DailySnapshotPanel />` mounted above the KPI strip.
- Loading skeleton, retry-able error banner, stale-snapshot banner (>48h via `isStale`), and empty-state banner (no row for today or yesterday UTC) are all wired in. Pre-existing `getFullDashboardData()` stays untouched — this is additive.
- Adds Vitest (devDep) + a 33-test suite covering fetch state machine, staleness thresholds, and a smoke render of the panel against a fixture envelope. Smoke test asserts every visible element traces to a digest field (headline, bias, segment, all 7 narrative slots, actionable summary, risk radar) — no mock leftovers.

## Files

- New: `apps/digiquant-atlas/frontend/lib/snapshot-types.ts`, `lib/snapshot-fetch.ts`, `lib/snapshot-staleness.ts`, `lib/__fixtures__/snapshot-fixture.ts`, `components/overview/daily-snapshot-panel.tsx`, `vitest.config.ts`, plus three `*.test.ts` files.
- Modified: `app/page.tsx` (mount the panel), `package.json` (`test` script + Vitest devDep, `lint` script switched from removed-in-Next-16 `next lint` to `eslint .`), `README.md` (env vars + envelope docs).

## Verification (locally)

| Check | Result |
| ----- | ------ |
| `npm run test` | 33 / 33 passing (3 test files) |
| `npm run build` | Static pages generated successfully (Next 16 + Turbopack) |
| `npm run lint` | Script now runs `eslint .` correctly. **Fails on 6 pre-existing errors** in `components/library/DigestDocumentView.tsx` (React 19 hook rules) — out of scope for #303. New files (`components/overview/daily-snapshot-panel*.tsx`, `lib/snapshot-*.ts`) are lint-clean. |
| `python3 scripts/score.py --staged` | Security 10, Quality 10, Optimization 10, Accuracy 10 |

## Deviations / punts

- **Pre-existing eslint failures.** `next lint` was removed in Next 16, so the workspace `lint` script was broken before this PR. Switching to `eslint .` surfaces 6 pre-existing errors in `DigestDocumentView.tsx` (React 19 `react-hooks/set-state-in-effect` + `react-hooks/immutability`). Suggest a follow-up issue; not in scope here.
- **No `@testing-library/react`.** Per the "don't add a heavy dep" constraint, the smoke render uses `react-dom/server`'s `renderToStaticMarkup` (already a transitive dep) and asserts against the HTML string. This matches digichat's precedent of pure-function tests.
- **Hand-written types vs json-schema-to-typescript.** Field set is small (six top-level keys, 11 narrative slots). A code generator would have added a build-time dependency for marginal benefit; drift is caught by the existing parity test on the Python side (`test_payload_matches_pipeline_digest`).
- **Existing `getFullDashboardData()` untouched.** That path consumes the legacy `DigestSnapshot` shape from `render-digest-from-snapshot.ts` (`regime`, `portfolio`, `narrative`, `sector_scorecard`). Replacing it with the new envelope shape is wider-scope work and would require migrating downstream readers; left for a follow-up. The new typed path is wired alongside as a sibling, not a replacement.
- **`tsconfig.json` + `next-env.d.ts` Next-16 churn.** `next build` rewrites both files on every invocation (forces `jsx: 'react-jsx'` plus reformatting). I reverted those auto-edits — they're pre-existing maintenance debt unrelated to #303.

## Test plan

- [ ] `cd apps/digiquant-atlas/frontend && npm run test` → 33 passing
- [ ] `npm run build` → all static pages generated
- [ ] Inspect the Overview page locally with `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` set — panel renders the freshest digest from `daily_snapshots`.
- [ ] Unset the env vars → empty banner appears with the configuration hint.
- [ ] Aim a stale `published_at` at the panel (manual fixture or DB row) → stale banner appears above the panel body.

Fixes #303
Refs #295