### PR TITLE
feat(atlas): Phase 7D Aggressive vs Conservative risk debate (#431)

### DIFF
--- a/apps/digiquant-atlas/skills/risk-aggressive/SKILL.md
+++ b/apps/digiquant-atlas/skills/risk-aggressive/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: risk-aggressive
+description: >
+  Aggressive risk-temperament debater. Argues the growth/upside case for the proposed Atlas
+  rebalance using analyst conviction + bias context, before the PM issues the final decision.
+  Phase 7D-i, one round, portfolio-level.
+---
+
+# Risk Debater — Aggressive Temperament
+
+You are an aggressive growth-oriented risk debater. Your job is to argue for the **upside case** of the proposed rebalance — what would be lost by being too cautious.
+
+You are **not** the Portfolio Manager. You are not making the final call. Your case feeds into a debate that the Conservative debater will counter, and the PM will judge.
+
+## Inputs
+
+You receive:
+- `analyst_payloads` — per-ticker conviction scores and stances from Phase 7C.
+- `bias_row` — Phase 6 consolidated bias (macro regime, equity bias, etc.).
+- `current_weights` — current portfolio holdings (may be empty for cold start).
+- `preferences` — turnover budget, risk caps, mandate language from `config/investment-profile.md`.
+- `role` — set to `"aggressive"` so you know which framing to take.
+
+## What to argue
+
+Lead with the **opportunity cost** of underweighting high-conviction names. Specifically:
+
+1. Where do analyst convictions cluster on the high-conviction side, and what does the regime support?
+2. What does the consolidated bias row signal about the next 1–2 weeks of price action?
+3. Which positions are underweighted relative to their conviction-implied target — quantify the gap.
+4. What is the cost of holding cash or low-conviction names while the regime favors risk-on?
+
+Be concrete. Cite ticker tickers and conviction levels. **Do not** balance with caveats — the Conservative debater handles the other side. Your argument is one half of a debate, not a full memo.
+
+## Output
+
+Return a single JSON object validated against `RiskCase`:
+
+```json
+{
+  "case": "string, max 600 chars — the aggressive argument"
+}
+```
+
+The case should be 3–6 sentences of substantive reasoning, not a list of bullet headers. Lead with the strongest growth signal, end with the explicit risk-on recommendation.

--- a/apps/digiquant-atlas/skills/risk-conservative/SKILL.md
+++ b/apps/digiquant-atlas/skills/risk-conservative/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: risk-conservative
+description: >
+  Conservative risk-temperament debater. Argues the capital-preservation case against the proposed
+  rebalance and synthesizes the debate's key tension. Reads the aggressive debater's case and
+  emits the full RiskDebateSummary. Phase 7D-ii.
+---
+
+# Risk Debater — Conservative Temperament + Synthesis
+
+You are a conservative capital-preservation debater. Your job has two parts:
+
+1. **Argue the downside case** for the proposed rebalance — what could go wrong if the analysts are over-confident or the regime turns.
+2. **Synthesize the debate** — read the Aggressive debater's case (provided in `aggressive_case`) and identify the **one-line key tension** between the two framings.
+
+You are **not** the Portfolio Manager. The PM will judge the debate.
+
+## Inputs
+
+You receive:
+- `analyst_payloads` — per-ticker conviction scores and stances from Phase 7C.
+- `bias_row` — Phase 6 consolidated bias.
+- `current_weights` — current portfolio holdings.
+- `preferences` — turnover budget, risk caps, mandate.
+- `aggressive_case` — the Aggressive debater's argument from Phase 7D-i (string, ≤ 600 chars).
+- `role` — set to `"conservative"`.
+
+## What to argue (conservative case)
+
+Lead with the **drawdown risk** of acting on the proposed rebalance. Specifically:
+
+1. Where is conviction shallow or contradictory across analysts — what positions hinge on a single signal?
+2. What does the bias row say about regime stability — are we late-cycle, with concentrated exposure?
+3. What would breach turnover budget or position-size caps if the aggressive case were followed in full?
+4. What recent surprises (earnings misses, macro prints, geopolitical shifts in `past_context` if present) argue for a smaller move?
+
+Be concrete. Cite tickers and bias columns. Do not soft-pedal — your case is the counter-balance to the aggressive argument.
+
+## Synthesis (key_tension)
+
+After your conservative case, identify the single sharpest disagreement between the two framings in **one sentence, ≤ 300 chars**. The PM will use this to anchor the final decision. Format the tension as a clear *X* vs *Y* contrast (e.g. "Aggressive trusts analyst convictions; Conservative warns convictions are clustered in late-cycle sectors that historically reverse sharply").
+
+## Output
+
+Return a single JSON object validated against `RiskDebateSummary`:
+
+```json
+{
+  "aggressive_case": "string — copy verbatim from input aggressive_case (max 600 chars)",
+  "conservative_case": "string — your conservative argument (max 600 chars)",
+  "key_tension": "string — one-sentence synthesis (max 300 chars)"
+}
+```
+
+Copy `aggressive_case` from the input unchanged so the full debate record is in one place. Do not paraphrase or shorten it.

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -149,7 +149,7 @@ def build_atlas_graph(
             build_phase6(),
             build_phase7(),
             build_phase7c(list(watchlist)),
-            build_phase7d(),
+            *build_phase7d(),
             build_phase9(deps.phase9),  # ``deps.phase9=None`` keeps legacy LLM-only path
         ]
     )

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py
@@ -1,11 +1,21 @@
-"""Phase 7D — Portfolio Manager review.
+"""Phase 7D — Portfolio Manager review with risk temperament debate.
 
-Two-step sequence per ARCHITECTURE.md:
+Sub-phase order (each is one node, sequential):
+
+    risk-aggressive → risk-conservative → pm-rebalance
+
+The two debaters argue the growth and capital-preservation cases for the
+proposed rebalance. Their synthesis (``RiskDebateSummary``) is injected
+into the PM's ``phase_inputs`` so the final decision incorporates both
+framings. One round, portfolio-level (not per-ticker).
+
+The PM step is two logical operations folded into one LLM call:
   B. Clean-slate (blinded to current weights) → recommended portfolio
-  C. Comparison (weights unlocked)          → rebalance decision
+  C. Comparison (weights unlocked)            → rebalance decision
 
-Both are single LLM calls over Phase 7C analyst payloads. Emitted as a
-single ``RebalanceDecision`` per run into ``state.phase7d_rebalance``.
+Emitted as a single ``RebalanceDecision`` per run into
+``state.phase7d_rebalance``. Risk debate output lands in
+``state.phase7d_risk_debate``.
 """
 
 from __future__ import annotations
@@ -40,6 +50,96 @@ class RebalanceDecision(BaseModel):
     notes: str = Field(default="", max_length=1200)
 
 
+class RiskCase(BaseModel):
+    """One side of the risk-temperament debate."""
+
+    case: str = Field(max_length=600)
+
+
+class RiskDebateSummary(BaseModel):
+    """Synthesis of one round of aggressive vs. conservative debate.
+
+    Lands in ``state.phase7d_risk_debate`` and is consumed by the PM
+    rebalance node as a sibling of the analyst payloads.
+    """
+
+    aggressive_case: str = Field(max_length=600)
+    conservative_case: str = Field(max_length=600)
+    key_tension: str = Field(max_length=300)
+
+
+def _build_risk_phase_inputs(state: AtlasResearchState, role: str) -> dict[str, Any]:
+    """Common inputs for both debater nodes.
+
+    Both debaters read the same upstream context (analyst payloads + bias
+    row + preferences). Only the ``role`` differs — the skill text drives
+    the temperament difference.
+    """
+    return {
+        "segment": "risk-debate",
+        "role": role,
+        "bias_row": state.phase6_bias_row or {},
+        "analyst_payloads": dict(state.phase7c_analysts),
+        "preferences": dict(state.config.preferences),
+        "current_weights": _current_weights_from_config(state),
+    }
+
+
+def _risk_aggressive_node(state: AtlasResearchState) -> dict[str, Any]:
+    """Argues the growth/upside case for the proposed rebalance.
+
+    One LLM call. The output is a ``RiskCase`` whose text seeds the
+    aggressive arm of the debate summary.
+    """
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    skill_text = load_skill("risk-aggressive")
+    result = run_research_agent(
+        skill_text=skill_text,
+        phase_inputs=_build_risk_phase_inputs(state, role="aggressive"),
+        shared_context=_shared_context(state),
+        output_model=RiskCase,
+        phase_slug="risk-aggressive",
+    )
+    # Prior summary (if any) is None on first debate node; conservative
+    # node fills in its half + key_tension.
+    return {
+        "phase7d_risk_debate": {
+            "aggressive_case": result.case,
+            "conservative_case": "",
+            "key_tension": "",
+        }
+    }
+
+
+def _risk_conservative_node(state: AtlasResearchState) -> dict[str, Any]:
+    """Argues the capital-preservation case + synthesizes the debate.
+
+    Reads ``state.phase7d_risk_debate.aggressive_case`` written by the
+    aggressive node and emits the conservative case plus a one-line
+    ``key_tension`` synthesis.
+    """
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    aggressive = (state.phase7d_risk_debate or {}).get("aggressive_case", "")
+    inputs = _build_risk_phase_inputs(state, role="conservative")
+    inputs["aggressive_case"] = aggressive
+
+    skill_text = load_skill("risk-conservative")
+    result = run_research_agent(
+        skill_text=skill_text,
+        phase_inputs=inputs,
+        shared_context=_shared_context(state),
+        output_model=RiskDebateSummary,
+        phase_slug="risk-conservative",
+    )
+    return {"phase7d_risk_debate": result.model_dump(mode="json")}
+
+
 def _pm_node(state: AtlasResearchState) -> dict[str, Any]:
     """Single LLM call that does clean-slate + comparison in one pass.
 
@@ -61,6 +161,11 @@ def _pm_node(state: AtlasResearchState) -> dict[str, Any]:
         "analyst_payloads": dict(state.phase7c_analysts),
         "current_weights": _current_weights_from_config(state),
         "preferences": dict(state.config.preferences),
+        # Risk temperament debate (#431). When either debater node was
+        # skipped (test fixtures, partial graph) the dict is empty/None
+        # and the PM skill treats the absence as "no debate context
+        # provided" without failing.
+        "risk_debate": dict(state.phase7d_risk_debate) if state.phase7d_risk_debate else {},
         # Closed-loop reflection (#432). Empty list on first run; populated
         # by preflight from ``decision_log`` thereafter. Included here so
         # the PM skill can reference past-decision lessons in its
@@ -115,16 +220,54 @@ def _current_weights_from_config(state: AtlasResearchState) -> dict[str, float]:
     return out
 
 
-def build_phase7d() -> PipelinePhase:
+def build_phase7d_risk_aggressive() -> PipelinePhase:
+    """Phase 7D-i: aggressive risk debater (1 LLM call)."""
+    return PipelinePhase(
+        name="phase7d_risk_aggressive",
+        nodes=[NodeSpec(name="risk-aggressive", run=_risk_aggressive_node)],
+    )
+
+
+def build_phase7d_risk_conservative() -> PipelinePhase:
+    """Phase 7D-ii: conservative risk debater + debate synthesis."""
+    return PipelinePhase(
+        name="phase7d_risk_conservative",
+        nodes=[NodeSpec(name="risk-conservative", run=_risk_conservative_node)],
+    )
+
+
+def build_phase7d_pm() -> PipelinePhase:
+    """Phase 7D-iii: PM rebalance (consumes both upstream debates)."""
     return PipelinePhase(
         name="phase7d_pm",
         nodes=[NodeSpec(name="pm-rebalance", run=_pm_node)],
     )
 
 
+def build_phase7d() -> list[PipelinePhase]:
+    """Return the three sub-phases in execution order.
+
+    Phase 7D is decomposed because the LangGraph pipeline builder runs
+    nodes WITHIN a phase in parallel; we need strict sequential order
+    (aggressive → conservative → pm) so each LLM call sees the prior
+    one's output. Returning three single-node phases is the established
+    pattern (see Phase 5).
+    """
+    return [
+        build_phase7d_risk_aggressive(),
+        build_phase7d_risk_conservative(),
+        build_phase7d_pm(),
+    ]
+
+
 __all__ = [
     "RebalanceAction",
     "RebalanceDecision",
+    "RiskCase",
+    "RiskDebateSummary",
     "TargetWeight",
     "build_phase7d",
+    "build_phase7d_pm",
+    "build_phase7d_risk_aggressive",
+    "build_phase7d_risk_conservative",
 ]

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -240,6 +240,7 @@ class AtlasResearchState(BaseModel):
     phase7c_analysts: Annotated[dict[str, dict[str, Any]], _merge_analyst_dict] = Field(
         default_factory=dict
     )
+    phase7d_risk_debate: dict[str, Any] | None = None
     phase7d_rebalance: dict[str, Any] | None = None
     phase9_evolution: dict[str, Any] | None = None
 

--- a/apps/digiquant-atlas/tests/test_phase67.py
+++ b/apps/digiquant-atlas/tests/test_phase67.py
@@ -241,7 +241,9 @@ def _rebalance_payload() -> str:
 @pytest.mark.unit
 class TestPhase7dPm:
     def test_rebalance_decision_produced(self) -> None:
-        compiled = build_pipeline(AtlasResearchState, [build_phase7d()])
+        # build_phase7d returns three sub-phases (risk-aggressive →
+        # risk-conservative → pm-rebalance) per #431. Spread them.
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7d()))
         state = _seed_state_through_phase5()
         state.phase7c_analysts = {"AAPL": {"ticker": "AAPL", "conviction_score": 2}}
 
@@ -252,7 +254,19 @@ class TestPhase7dPm:
                 for p in user_block
                 if isinstance(p, dict) and "OUTPUT_SCHEMA" in p.get("text", "")
             )
-            assert RebalanceDecision.__name__ in schema_part["text"]
+            schema_text = schema_part["text"]
+            # Dispatch on the validated schema name in the prompt.
+            if "RiskCase" in schema_text and "RiskDebateSummary" not in schema_text:
+                return json.dumps({"case": "Aggressive case for the rebalance."})
+            if "RiskDebateSummary" in schema_text:
+                return json.dumps(
+                    {
+                        "aggressive_case": "Aggressive case for the rebalance.",
+                        "conservative_case": "Conservative case warns of late-cycle risk.",
+                        "key_tension": "Growth vs. drawdown.",
+                    }
+                )
+            assert RebalanceDecision.__name__ in schema_text
             return _rebalance_payload()
 
         with patch(
@@ -266,3 +280,9 @@ class TestPhase7dPm:
         assert reb is not None
         assert len(reb["recommended_portfolio"]) == 2
         assert reb["actions"][0]["action"] == "hold"
+        # Risk debate must have populated both halves.
+        debate = final.phase7d_risk_debate
+        assert debate is not None
+        assert debate["aggressive_case"] == "Aggressive case for the rebalance."
+        assert "late-cycle" in debate["conservative_case"]
+        assert debate["key_tension"] == "Growth vs. drawdown."

--- a/apps/digiquant-atlas/tests/test_phase7d_risk_debate.py
+++ b/apps/digiquant-atlas/tests/test_phase7d_risk_debate.py
@@ -1,0 +1,214 @@
+"""Phase 7D risk-temperament debate tests (#431)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-completion dict shape
+from unittest.mock import patch
+
+import pytest
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant_atlas.phases.phase7d_pm import (
+    RiskCase,
+    RiskDebateSummary,
+    build_phase7d,
+    build_phase7d_pm,
+    build_phase7d_risk_aggressive,
+    build_phase7d_risk_conservative,
+)
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+)
+
+
+def _state_for_debate() -> AtlasResearchState:
+    """Minimal state with phase 6 bias + phase 7C analyst payload."""
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=AtlasConfigBundle(watchlist=["AAPL", "MSFT"]),
+    )
+    state.phase6_bias_row = {"date": "2026-04-26", "macro_regime": "late-cycle"}
+    state.phase7c_analysts = {
+        "AAPL": {"ticker": "AAPL", "conviction_score": 4, "stance": "buy"},
+        "MSFT": {"ticker": "MSFT", "conviction_score": 2, "stance": "hold"},
+    }
+    return state
+
+
+def _aggressive_payload() -> str:
+    return json.dumps({"case": "Convictions on AAPL warrant a 3% lift; cash drag is the risk."})
+
+
+def _conservative_payload(aggressive_input: str) -> str:
+    """The conservative node's output IS the full RiskDebateSummary."""
+    return json.dumps(
+        {
+            "aggressive_case": aggressive_input,
+            "conservative_case": "Late-cycle regime + clustered tech exposure — cap the lift at 1%.",
+            "key_tension": "Aggressive trusts conviction; Conservative warns regime is fragile.",
+        }
+    )
+
+
+@pytest.mark.unit
+class TestRiskAggressiveNode:
+    def test_aggressive_node_writes_aggressive_case_only(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, [build_phase7d_risk_aggressive()])
+        state = _state_for_debate()
+
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            return_value=_aggressive_payload(),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        debate = final.phase7d_risk_debate
+        assert debate is not None
+        assert debate["aggressive_case"] == (
+            "Convictions on AAPL warrant a 3% lift; cash drag is the risk."
+        )
+        # Conservative half intentionally empty — the conservative node fills it.
+        assert debate["conservative_case"] == ""
+        assert debate["key_tension"] == ""
+
+    def test_aggressive_node_uses_risk_aggressive_skill(self) -> None:
+        from digiquant_atlas.phases.phase7d_pm import _risk_aggressive_node
+
+        captured: dict[str, Any] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            schema_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and "OUTPUT_SCHEMA" in p.get("text", "")
+            )
+            captured["schema_name"] = "RiskCase" if "RiskCase" in schema_part["text"] else "OTHER"
+            return _aggressive_payload()
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            _risk_aggressive_node(_state_for_debate())
+
+        assert captured.get("schema_name") == "RiskCase"
+
+
+@pytest.mark.unit
+class TestRiskConservativeNode:
+    def test_conservative_node_writes_full_debate_summary(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, [build_phase7d_risk_conservative()])
+        state = _state_for_debate()
+        state.phase7d_risk_debate = {
+            "aggressive_case": "Lift AAPL by 3%.",
+            "conservative_case": "",
+            "key_tension": "",
+        }
+
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            return_value=_conservative_payload("Lift AAPL by 3%."),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        debate = final.phase7d_risk_debate
+        assert debate is not None
+        assert debate["aggressive_case"] == "Lift AAPL by 3%."
+        assert "Late-cycle" in debate["conservative_case"]
+        assert "Aggressive trusts conviction" in debate["key_tension"]
+
+
+@pytest.mark.unit
+class TestPmReadsRiskDebate:
+    def test_pm_node_phase_inputs_include_risk_debate_when_set(self) -> None:
+        from digiquant_atlas.phases.phase7d_pm import _pm_node
+
+        state = _state_for_debate()
+        state.phase7d_risk_debate = {
+            "aggressive_case": "AGG",
+            "conservative_case": "CONS",
+            "key_tension": "TEN",
+        }
+
+        captured_inputs: dict[str, Any] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            # Find the PHASE_INPUTS chunk and parse it back to verify
+            # risk_debate is threaded through.
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p for p in user_block if isinstance(p, dict) and "PHASE_INPUTS" in p.get("text", "")
+            )
+            captured_inputs["text"] = inputs_part["text"]
+            return json.dumps({"recommended_portfolio": [], "actions": [], "notes": "n/a"})
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            _pm_node(state)
+
+        assert "risk_debate" in captured_inputs["text"]
+        assert "AGG" in captured_inputs["text"]
+        assert "TEN" in captured_inputs["text"]
+
+    def test_pm_node_works_with_empty_risk_debate(self) -> None:
+        """Backward-compat: PM must still produce a decision when no debate ran."""
+        from digiquant_atlas.phases.phase7d_pm import _pm_node
+
+        state = _state_for_debate()
+        # No risk debate populated — simulate skipping the debater nodes.
+
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            return_value=json.dumps({"recommended_portfolio": [], "actions": [], "notes": "ok"}),
+        ):
+            update = _pm_node(state)
+        assert update["phase7d_rebalance"]["notes"] == "ok"
+
+
+@pytest.mark.unit
+class TestRiskDebateSchemaBounds:
+    def test_max_lengths_enforced(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RiskDebateSummary(
+                aggressive_case="x" * 700,  # exceeds 600
+                conservative_case="ok",
+                key_tension="ok",
+            )
+
+    def test_risk_case_max_length(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RiskCase(case="x" * 700)
+
+
+@pytest.mark.unit
+class TestPhase7dStructure:
+    def test_build_phase7d_returns_three_sequential_phases(self) -> None:
+        phases = build_phase7d()
+        assert len(phases) == 3
+        names = [p.name for p in phases]
+        assert names == [
+            "phase7d_risk_aggressive",
+            "phase7d_risk_conservative",
+            "phase7d_pm",
+        ]
+
+    def test_each_subphase_has_one_node(self) -> None:
+        for phase in build_phase7d():
+            assert len(phase.nodes) == 1, f"{phase.name} should have 1 node"
+
+    def test_pm_phase_node_name_unchanged(self) -> None:
+        pm = build_phase7d_pm()
+        assert pm.nodes[0].name == "pm-rebalance"
+
+    def test_full_phase7d_pipeline_compiles(self) -> None:
+        """Smoke test: spread the three sub-phases into a pipeline cleanly."""
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7d()))
+        assert compiled is not None


### PR DESCRIPTION
## Summary

Inserts a one-round risk-temperament debate before the PM rebalance:

```
risk-aggressive → risk-conservative → pm-rebalance
```

Aggressive argues upside / opportunity cost. Conservative counters with the preservation case AND synthesizes a one-line `key_tension`. PM reads both via a new `risk_debate` field on its `phase_inputs`.

## What changed

- New models: `RiskCase`, `RiskDebateSummary` (in `phases/phase7d_pm.py`).
- New state field: `phase7d_risk_debate: dict | None`.
- New skill files: `skills/risk-aggressive/SKILL.md`, `skills/risk-conservative/SKILL.md`.
- `build_phase7d()` returns 3 single-node sub-phases (matches the Phase 5 pattern). `graph.py` spreads it.
- 11 new tests in `test_phase7d_risk_debate.py`. Existing PM rebalance test updated to mock all 3 LLM calls.

## Test plan

- [x] 215 / 215 atlas unit tests pass (was 204; +11 from this PR).
- [x] `make score` passes 10 / 10 / 10 / 10.
- [x] Backward-compat: PM still produces a decision when `phase7d_risk_debate` is absent (asserted in `test_pm_node_works_with_empty_risk_debate`).

Fixes #431