### PR TITLE
feat(atlas): Phase 7C 4-axis analyst specialization (#430)

### DIFF
--- a/apps/digiquant-atlas/skills/fundamental-analyst/SKILL.md
+++ b/apps/digiquant-atlas/skills/fundamental-analyst/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: fundamental-analyst
+description: >
+  Phase 7C fundamental-axis specialist. Reasons about valuation, earnings quality, and balance
+  sheet for one ticker using Phase 5 equity context + relevant sector payloads. One LLM call,
+  blinded to portfolio weights.
+---
+
+# Fundamental Analyst — One Ticker, One Axis
+
+You are a fundamental analyst. Your only job: rate the **fundamental quality** of `{{ticker}}` using the equity segment payload and the relevant sector payloads. Blinded to portfolio weights.
+
+## Inputs
+
+- `ticker` — the symbol to analyze.
+- `phase5_equity` — equity segment payload (earnings cadence, valuation summary, balance sheet snapshot for tracked names).
+- `relevant_sectors` — sector payloads where this ticker is in `top_tickers` (sector-relative quality benchmarks).
+- `bias_row` — Phase 6 regime + bias snapshot for the cycle context.
+
+## What to argue
+
+Look at:
+
+1. **Valuation** — is the ticker priced for perfection, for distress, or somewhere in between, relative to its sector and the market?
+2. **Earnings quality** — recent revisions trend, surprise pattern, margin direction.
+3. **Balance sheet** — leverage, cash position, refinancing needs in the next 12 months.
+4. **Cycle fit** — does the regime favor this ticker's quality profile (defensive vs cyclical vs growth)?
+
+You are NOT covering charts, sentiment, or news catalysts — other axes handle those.
+
+## Output
+
+Single JSON object validated against `SpecialistPayload`:
+
+```json
+{
+  "axis": "fundamental",
+  "ticker": "AAPL",
+  "conviction_axis": 0.0,
+  "stance_axis": "buy",
+  "rationale": "string (2-4 sentences, max 400 chars)",
+  "sources": []
+}
+```
+
+Quote at least one valuation or earnings number when available. Conviction reflects fundamental edge, not chart momentum.

--- a/apps/digiquant-atlas/skills/news-analyst/SKILL.md
+++ b/apps/digiquant-atlas/skills/news-analyst/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: news-analyst
+description: >
+  Phase 7C news-axis specialist. Reasons about macro catalysts, sector news, and institutional
+  flows for one ticker using Phase 3 macro + Phase 2 institutional + relevant sector context.
+  One LLM call, blinded to portfolio weights.
+---
+
+# News / Catalysts Analyst — One Ticker, One Axis
+
+You are a catalysts analyst. Your only job: rate the **near-term news and flow setup** for `{{ticker}}` using the macro regime, institutional flows, and sector context provided. Blinded to portfolio weights.
+
+## Inputs
+
+- `ticker` — the symbol to analyze.
+- `phase3_macro` — Phase 3 macro regime payload (regime label, key macro readings).
+- `phase2_institutional` — Phase 2 institutional flow + hedge-fund intel payloads.
+- `relevant_sectors` — sector payloads where the ticker appears in `top_tickers` (sector news that affects this name).
+- `bias_row` — Phase 6 regime + bias snapshot.
+
+## What to argue
+
+Look at:
+
+1. **Macro catalyst exposure** — does the macro regime favor or fight this ticker / its sector?
+2. **Sector news** — what's happening at the sector level? Earnings cadence, regulatory shifts, M&A?
+3. **Institutional flows** — are large allocators rotating into or out of this name's bucket?
+4. **Imminent events** — any near-term known catalysts (earnings, Fed meeting, sector summit)?
+
+You are NOT covering chart setup, sentiment, or balance sheet — those are other axes.
+
+## Output
+
+Single JSON object validated against `SpecialistPayload`:
+
+```json
+{
+  "axis": "news",
+  "ticker": "AAPL",
+  "conviction_axis": 0.0,
+  "stance_axis": "buy",
+  "rationale": "string (2-4 sentences, max 400 chars)",
+  "sources": []
+}
+```
+
+If the macro regime is the dominant force ("Slowing / Cooling"), say so explicitly. Conviction reflects how much the news flow *moves* the ticker over the next 1–2 weeks.

--- a/apps/digiquant-atlas/skills/sentiment-analyst/SKILL.md
+++ b/apps/digiquant-atlas/skills/sentiment-analyst/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: sentiment-analyst
+description: >
+  Phase 7C sentiment-axis specialist. Reasons about positioning, fear/greed, and crowding for
+  one ticker using Phase 1 alt-data. One LLM call, blinded to portfolio weights.
+---
+
+# Sentiment Analyst — One Ticker, One Axis
+
+You are a sentiment / positioning analyst. Your only job: rate the **crowding and fear-greed setup** for `{{ticker}}` based on the alt-data passed in `phase1_alt_data` and the `bias_row`. You are blinded to current portfolio weights.
+
+## Inputs
+
+- `ticker` — the symbol to analyze.
+- `phase1_alt_data` — dict of Phase 1 alt-data segment payloads (sentiment-news, CTA positioning, options derivatives, politician signals).
+- `bias_row` — Phase 6 regime + bias snapshot.
+
+## What to argue
+
+Look at — in order of weight:
+
+1. **Positioning** — are CTAs / leveraged funds long or short the ticker / its sector? Crowded? Capitulating?
+2. **Fear-greed** — what is the broader sentiment tape signaling for this ticker (or its risk-on/risk-off bucket)?
+3. **Options skew** — is the put-call skew elevated? IV rich or cheap relative to realized?
+4. **Insider / political signals** — any unusual filings or buys reported by Phase 1?
+
+You are NOT covering technicals, fundamentals, or news — those are other axes.
+
+## Output
+
+Single JSON object validated against `SpecialistPayload`:
+
+```json
+{
+  "axis": "sentiment",
+  "ticker": "AAPL",
+  "conviction_axis": 0.0,
+  "stance_axis": "buy",
+  "rationale": "string (2-4 sentences, max 400 chars)",
+  "sources": []
+}
+```
+
+Cite the specific signal that drives your call (e.g. "VIX skew at 99th pctile", "CTAs net-long 2σ"). Conviction tracks signal *strength*, not just direction.

--- a/apps/digiquant-atlas/skills/technical-analyst/SKILL.md
+++ b/apps/digiquant-atlas/skills/technical-analyst/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: technical-analyst
+description: >
+  Phase 7C technical-axis specialist. Reasons about price action, momentum, volatility regime,
+  and the technical setup for one ticker using the Phase 5 equity body. One LLM call, blinded
+  to portfolio weights.
+---
+
+# Technical Analyst — One Ticker, One Axis
+
+You are a technical analyst. Your only job: rate the **technical setup** for `{{ticker}}` based on the price-action and indicator data passed in `phase5_equity` and the `bias_row`. You are blinded to current portfolio weights — do not assume position size.
+
+## Inputs
+
+- `ticker` — the symbol to analyze.
+- `phase5_equity` — the equity-segment payload with OHLCV summary, momentum readings (RSI, MACD), volatility regime (ATR, Bollinger), and any breakouts the Phase 5 equity node flagged.
+- `bias_row` — Phase 6's market regime + equity-bias snapshot for context.
+
+## What to argue
+
+Look at — in order of weight:
+
+1. **Trend** — is the ticker trending, ranging, or breaking out? Cite specific levels.
+2. **Momentum** — RSI/MACD posture; are buyers or sellers in control near term?
+3. **Volatility regime** — compressing or expanding ATR? Bollinger Band squeeze?
+4. **Setup quality** — is the chart clean (well-defined support/resistance) or noisy?
+
+You are NOT covering fundamentals, sentiment, or news catalysts — those are other axes' jobs. Stay in your lane.
+
+## Output
+
+Single JSON object validated against `SpecialistPayload`:
+
+```json
+{
+  "axis": "technical",
+  "ticker": "AAPL",
+  "conviction_axis": 0.0,         // 0.0 = no edge / mixed; 1.0 = strongest possible signal
+  "stance_axis": "buy",           // one of: buy / hold / sell / watch
+  "rationale": "string",          // 2-4 sentences, max 400 chars
+  "sources": []                   // optional — names of the indicator(s) you cited
+}
+```
+
+Be specific. Cite levels, not adjectives. Conviction floats — pick a number that reflects the strength of the technical setup, not just whether you'd buy.

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -148,7 +148,7 @@ def build_atlas_graph(
             *build_phase5(),
             build_phase6(),
             build_phase7(),
-            build_phase7c(list(watchlist)),
+            *build_phase7c(list(watchlist)),
             *build_phase7d(),
             build_phase9(deps.phase9),  # ``deps.phase9=None`` keeps legacy LLM-only path
         ]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7c_analyst.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7c_analyst.py
@@ -1,17 +1,39 @@
-"""Phase 7C — per-ticker asset-analyst fan-out.
+"""Phase 7C — per-ticker 4-axis analyst specialization (#430).
 
-One LLM call per ticker in ``state.config.watchlist`` (or a trimmed
-portfolio list). Analysts are **blinded to current portfolio weights** —
-they read only the published segment payloads and produce an independent
-conviction score. The fan-out width equals the watchlist size; this is
-bounded by the caller (watchlist cap is managed upstream).
+Architecture (per ticker in ``state.config.watchlist``):
+
+    Phase 7C fan-out (parallel specialists):
+      technical-analyst-{ticker}    → SpecialistPayload
+      sentiment-analyst-{ticker}    → SpecialistPayload
+      news-analyst-{ticker}         → SpecialistPayload
+      fundamental-analyst-{ticker}  → SpecialistPayload
+
+    Phase 7C join (sequential):
+      join-analyst-{ticker}         → AnalystPayload (deterministic aggregator)
+
+Each specialist makes one LLM call with axis-specific inputs:
+
+- ``technical``    — Phase 5 equity body (OHLCV + technicals).
+- ``sentiment``    — Phase 1 alt-data outputs (FNG, positioning).
+- ``news``         — Phase 3 macro regime + Phase 2 institutional flows.
+- ``fundamental``  — Phase 5 sector context + equity body.
+
+The join is deterministic (no LLM): it averages the 4 ``conviction_axis``
+values, picks the majority stance with weighting by axis conviction, and
+synthesises the final ``AnalystPayload``. Single ``conviction_score`` and
+``stance`` fields preserve the downstream PM contract — Phase 7D does not
+need to know about the split.
+
+Specialists are blinded to portfolio weights (existing rule preserved).
+``ATLAS_MAX_ANALYSTS`` env var still caps the watchlist size; with the
+4-axis split, total LLM calls per run = 4 × min(len(watchlist), cap).
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Literal  # noqa: F401 — used for JSON-derived dict shape
+from typing import Any, Literal
 
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
@@ -22,8 +44,37 @@ from digiquant_atlas.state import AtlasResearchState
 logger = logging.getLogger(__name__)
 
 
+_AXES: tuple[Literal["technical", "sentiment", "news", "fundamental"], ...] = (
+    "technical",
+    "sentiment",
+    "news",
+    "fundamental",
+)
+
+
+class SpecialistPayload(BaseModel):
+    """One axis of analyst opinion for one ticker.
+
+    The four axes are validated against the same schema — only the
+    inputs and skill prompt differ. This keeps the join arithmetic
+    trivial (axis-blind aggregation).
+    """
+
+    axis: Literal["technical", "sentiment", "news", "fundamental"]
+    ticker: str = Field(max_length=16)
+    conviction_axis: float = Field(ge=0.0, le=1.0)
+    stance_axis: Literal["buy", "hold", "sell", "watch"]
+    rationale: str = Field(max_length=400)
+    sources: list[str] = Field(default_factory=list)
+
+
 class AnalystPayload(BaseModel):
-    """Per-ticker analyst output."""
+    """Per-ticker analyst output — Phase 7D PM contract.
+
+    Field names + bounds intentionally unchanged from the pre-#430 single-call
+    shape so Phase 7D ``_pm_node`` keeps reading the same dict without
+    modification. The 4-specialist body just changes how this gets produced.
+    """
 
     ticker: str = Field(max_length=16)
     conviction_score: int = Field(ge=-5, le=5, description="-5 strong sell … +5 strong buy")
@@ -31,33 +82,6 @@ class AnalystPayload(BaseModel):
     thesis: str = Field(max_length=1200)
     risks: str = Field(default="", max_length=800)
     sources: list[str] = Field(default_factory=list)
-
-
-def _analyst_node_factory(ticker: str):
-    from digigraph.graph.research_agent import run_research_agent
-
-    from digiquant_atlas.skills import load_skill
-
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
-        skill_text = load_skill("asset-analyst")
-        phase_inputs: dict[str, Any] = {
-            "segment": f"analyst-{ticker}",
-            "ticker": ticker,
-            "bias_row": state.phase6_bias_row or {},
-            "phase3_macro": _macro_body(state),
-            "phase5_equity": _phase5_equity_body(state),
-            "relevant_sectors": _relevant_sectors_for(state, ticker),
-        }
-        result = run_research_agent(
-            skill_text=skill_text,
-            phase_inputs=phase_inputs,
-            shared_context=_shared_context(state),
-            output_model=AnalystPayload,
-            phase_slug=f"analyst-{ticker}",
-        )
-        return {"phase7c_analysts": {ticker: result.model_dump(mode="json")}}
-
-    return _node
 
 
 def _macro_body(state: AtlasResearchState) -> dict[str, Any]:
@@ -74,13 +98,12 @@ def _phase5_equity_body(state: AtlasResearchState) -> dict[str, Any]:
 
 
 def _relevant_sectors_for(state: AtlasResearchState, ticker: str) -> dict[str, dict[str, Any]]:
-    """Return sector payloads that reference ``ticker`` in their top_tickers.
+    """Sector payloads that mention ``ticker`` in their top_tickers.
 
-    Blinded-analyst rule: no portfolio-weight leak. We only pass sector
-    research for sectors whose top-ticker list includes this symbol — that
-    is a derived fact from the public config, not a weight signal.
+    Blinded-analyst rule: derived from public config, not from weight signals.
+    Used by ``fundamental`` specialist (sector context) and ``news``
+    specialist (sector-level catalysts).
     """
-    # Imported here to avoid circular import at module top.
     from digiquant_atlas.sectors_config import load_sectors
 
     relevant_slugs = {s.slug for s in load_sectors() if ticker in s.top_tickers}
@@ -91,15 +114,172 @@ def _relevant_sectors_for(state: AtlasResearchState, ticker: str) -> dict[str, d
     }
 
 
-def build_phase7c(tickers: list[str]) -> PipelinePhase:
-    """Return a parallel fan-out phase with one node per ticker.
+def _phase1_alt_data(state: AtlasResearchState) -> dict[str, dict[str, Any]]:
+    """All Phase 1 alt-data segment payloads (sentiment + positioning + options + politicians)."""
+    return {
+        slug: slot.payload.model_dump(mode="json")
+        for slug, slot in state.phase1_outputs.items()
+        if slot.payload.source == "today"
+    }
 
-    ``tickers`` is materialized at graph-compile time — the watchlist is
-    read from Atlas config before the graph is built.
 
-    ``ATLAS_MAX_ANALYSTS`` (env var, default 0 = unlimited) caps the fan-out.
-    CI sets it to 25 to stay within Groq free-tier concurrency limits.
+def _phase2_institutional(state: AtlasResearchState) -> dict[str, dict[str, Any]]:
+    return {
+        slug: slot.payload.model_dump(mode="json")
+        for slug, slot in state.phase2_outputs.items()
+        if slot.payload.source == "today"
+    }
+
+
+def _axis_inputs(
+    *,
+    axis: str,
+    ticker: str,
+    state: AtlasResearchState,
+) -> dict[str, Any]:
+    """Per-axis ``phase_inputs`` block.
+
+    Each axis sees only the upstream segments relevant to its analytical
+    lane. This is the whole point of the split — narrower inputs let one
+    LLM call reason deeply on one axis instead of shallowly on four.
     """
+    base = {
+        "segment": f"{axis}-analyst-{ticker}",
+        "ticker": ticker,
+        "axis": axis,
+        "bias_row": state.phase6_bias_row or {},
+    }
+    if axis == "technical":
+        base["phase5_equity"] = _phase5_equity_body(state)
+    elif axis == "sentiment":
+        base["phase1_alt_data"] = _phase1_alt_data(state)
+    elif axis == "news":
+        base["phase3_macro"] = _macro_body(state)
+        base["phase2_institutional"] = _phase2_institutional(state)
+        base["relevant_sectors"] = _relevant_sectors_for(state, ticker)
+    elif axis == "fundamental":
+        base["phase5_equity"] = _phase5_equity_body(state)
+        base["relevant_sectors"] = _relevant_sectors_for(state, ticker)
+    return base
+
+
+def _specialist_node_factory(axis: str, ticker: str):
+    """Build one specialist node bound to (axis, ticker)."""
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    skill_slug = f"{axis}-analyst"
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        skill_text = load_skill(skill_slug)
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=_axis_inputs(axis=axis, ticker=ticker, state=state),
+            shared_context=_shared_context(state),
+            output_model=SpecialistPayload,
+            phase_slug=f"{axis}-analyst-{ticker}",
+        )
+        return {"phase7c_specialists": {ticker: {axis: result.model_dump(mode="json")}}}
+
+    return _node
+
+
+_STANCE_TO_SCORE: dict[str, int] = {
+    "sell": -2,
+    "watch": -1,
+    "hold": 0,
+    "buy": 2,
+}
+
+
+def _join_analyst_node_factory(ticker: str):
+    """Build the deterministic join node for one ticker.
+
+    Aggregates the 4 specialists' outputs into a single ``AnalystPayload``:
+
+    - ``conviction_score``: weighted-average of axis convictions, mapped
+      from [0.0, 1.0] floats to [-5, +5] ints. The mapping centers stance
+      at 0 — 'sell' axes pull negative, 'buy' axes pull positive,
+      proportional to the axis conviction strength.
+    - ``stance``: majority across axes weighted by ``conviction_axis``.
+    - ``thesis``: concatenated rationales prefixed by axis name.
+    - ``risks``: empty by default — the join doesn't invent risk language;
+      a follow-up issue can wire that explicitly.
+    - ``sources``: union of all sources from the 4 axes (de-duplicated,
+      insertion-order preserving).
+
+    Graceful degradation: if a specialist failed (axis missing from the
+    inner dict for this ticker), the join uses what's present and notes
+    the gap in the thesis. This matches the issue's "missing specialist"
+    acceptance criterion.
+    """
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        ticker_axes = state.phase7c_specialists.get(ticker, {})
+        present = [ax for ax in _AXES if ax in ticker_axes]
+        missing = [ax for ax in _AXES if ax not in ticker_axes]
+
+        if not present:
+            # Watchlist mismatch or full specialist failure — emit a
+            # neutral payload so the PM step doesn't trip on a missing key.
+            payload = AnalystPayload(
+                ticker=ticker,
+                conviction_score=0,
+                stance="hold",
+                thesis="(no specialist outputs available for this ticker)",
+                risks="",
+                sources=[],
+            )
+            return {"phase7c_analysts": {ticker: payload.model_dump(mode="json")}}
+
+        weighted_score = 0.0
+        weight_total = 0.0
+        stance_weights: dict[str, float] = {"buy": 0.0, "hold": 0.0, "sell": 0.0, "watch": 0.0}
+        thesis_parts: list[str] = []
+        sources_seen: dict[str, None] = {}
+
+        for axis in present:
+            entry = ticker_axes[axis]
+            conviction = float(entry.get("conviction_axis", 0.0))
+            stance = str(entry.get("stance_axis", "hold"))
+            score_seed = _STANCE_TO_SCORE.get(stance, 0)
+            weighted_score += conviction * score_seed
+            weight_total += conviction
+            stance_weights[stance] = stance_weights.get(stance, 0.0) + conviction
+            thesis_parts.append(f"[{axis}] {entry.get('rationale', '').strip()}")
+            for source in entry.get("sources", []):
+                if isinstance(source, str) and source.strip():
+                    sources_seen.setdefault(source.strip(), None)
+
+        # Normalize to [-5, +5] integer band. ``score_seed`` already lives
+        # in {-2, -1, 0, 2} so weighted_score / weight_total stays in
+        # [-2, +2]; scale to [-5, +5] by ×2.5 then round.
+        normalized = (weighted_score / weight_total) if weight_total > 0 else 0.0
+        conviction_score = max(-5, min(5, round(normalized * 2.5)))
+
+        chosen_stance = max(stance_weights.items(), key=lambda kv: kv[1])[0]
+
+        thesis_lines = thesis_parts[:]
+        if missing:
+            thesis_lines.append("[degraded] missing specialist axes: " + ", ".join(sorted(missing)))
+        thesis = "\n".join(thesis_lines)[:1200]
+
+        payload = AnalystPayload(
+            ticker=ticker,
+            conviction_score=conviction_score,
+            stance=chosen_stance,  # type: ignore[arg-type]
+            thesis=thesis,
+            risks="",
+            sources=list(sources_seen),
+        )
+        return {"phase7c_analysts": {ticker: payload.model_dump(mode="json")}}
+
+    return _node
+
+
+def _capped_tickers(tickers: list[str]) -> list[str]:
+    """Apply ``ATLAS_MAX_ANALYSTS`` cap (kept identical to pre-#430 behavior)."""
     max_analysts = int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
     if max_analysts > 0 and len(tickers) > max_analysts:
         logger.info(
@@ -109,26 +289,73 @@ def build_phase7c(tickers: list[str]) -> PipelinePhase:
             len(tickers),
             max_analysts,
         )
-        tickers = tickers[:max_analysts]
+        return tickers[:max_analysts]
+    return list(tickers)
 
-    if not tickers:
-        # Degenerate case: empty watchlist → insert a no-op so the graph
-        # stays well-formed. Phase 7D can still run against an empty
-        # analyst set.
+
+def build_phase7c_specialists(tickers: list[str]) -> PipelinePhase:
+    """Phase 7C-i: 4 × N specialist nodes running in parallel."""
+    capped = _capped_tickers(tickers)
+    if not capped:
+
         def _noop(_state: AtlasResearchState) -> dict[str, Any]:
             return {}
 
         return PipelinePhase(
-            name="phase7c_analyst",
-            nodes=[NodeSpec(name="analyst-noop", run=_noop)],
+            name="phase7c_specialists",
+            nodes=[NodeSpec(name="specialist-noop", run=_noop)],
         )
+
+    nodes = [
+        NodeSpec(
+            name=f"{axis}-analyst-{ticker}",
+            run=_specialist_node_factory(axis, ticker),
+        )
+        for ticker in capped
+        for axis in _AXES
+    ]
+    return PipelinePhase(name="phase7c_specialists", nodes=nodes)
+
+
+def build_phase7c_join(tickers: list[str]) -> PipelinePhase:
+    """Phase 7C-ii: N deterministic join nodes (one per ticker)."""
+    capped = _capped_tickers(tickers)
+    if not capped:
+
+        def _noop(_state: AtlasResearchState) -> dict[str, Any]:
+            return {}
+
+        return PipelinePhase(
+            name="phase7c_join",
+            nodes=[NodeSpec(name="join-noop", run=_noop)],
+        )
+
     return PipelinePhase(
-        name="phase7c_analyst",
+        name="phase7c_join",
         nodes=[
-            NodeSpec(name=f"analyst-{ticker}", run=_analyst_node_factory(ticker))
-            for ticker in tickers
+            NodeSpec(name=f"join-analyst-{ticker}", run=_join_analyst_node_factory(ticker))
+            for ticker in capped
         ],
     )
 
 
-__all__ = ["AnalystPayload", "build_phase7c"]
+def build_phase7c(tickers: list[str]) -> list[PipelinePhase]:
+    """Return the two Phase 7C sub-phases in execution order.
+
+    Phase 7C is decomposed because the LangGraph pipeline builder runs
+    nodes within a phase in parallel; the specialist outputs must all
+    settle before the join nodes consume them. Two sub-phases give the
+    correct ordering with no extra synchronization.
+
+    The returned shape (``list[PipelinePhase]``) mirrors Phase 5's split.
+    """
+    return [build_phase7c_specialists(tickers), build_phase7c_join(tickers)]
+
+
+__all__ = [
+    "AnalystPayload",
+    "SpecialistPayload",
+    "build_phase7c",
+    "build_phase7c_join",
+    "build_phase7c_specialists",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -73,6 +73,39 @@ def _merge_analyst_dict(
     return merged
 
 
+def _merge_specialist_dict(
+    left: dict[str, dict[str, dict[str, Any]]] | None,
+    right: dict[str, dict[str, dict[str, Any]]] | None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Reducer for Phase 7C 4-axis specialist writes (#430).
+
+    Outer key is ticker, inner key is axis ("technical" / "sentiment" /
+    "news" / "fundamental"). Specialists run in parallel and each writes
+    a single inner key for one ticker — collision on the outer key is
+    expected, collision on the *inner* key would be a wiring bug. Merge
+    inner dicts when the outer key is shared; raise on inner collision
+    so two specialists writing the same axis fail loud.
+    """
+    if not left:
+        return {ticker: dict(axes) for ticker, axes in (right or {}).items()}
+    if not right:
+        return {ticker: dict(axes) for ticker, axes in left.items()}
+    merged: dict[str, dict[str, dict[str, Any]]] = {
+        ticker: dict(axes) for ticker, axes in left.items()
+    }
+    for ticker, axes in right.items():
+        if ticker not in merged:
+            merged[ticker] = dict(axes)
+            continue
+        for axis, payload in axes.items():
+            if axis in merged[ticker]:
+                raise SegmentSlotCollisionError(
+                    f"two specialists wrote axis {axis!r} for ticker {ticker!r}"
+                )
+            merged[ticker][axis] = payload
+    return merged
+
+
 RunType = Literal["baseline", "delta", "monthly"]
 """Three-tier cadence: Sunday full, weekday delta, month-end rollup."""
 
@@ -237,6 +270,13 @@ class AtlasResearchState(BaseModel):
     )
     phase6_bias_row: dict[str, Any] | None = None
     phase7_digest: dict[str, Any] | None = None
+    # Per-ticker per-axis specialist outputs (#430). Outer key = ticker,
+    # inner key = axis. Populated by the 4 parallel specialists in the
+    # Phase 7C fan-out; consumed by the join phase that synthesizes the
+    # final ``AnalystPayload`` written into ``phase7c_analysts``.
+    phase7c_specialists: Annotated[dict[str, dict[str, dict[str, Any]]], _merge_specialist_dict] = (
+        Field(default_factory=dict)
+    )
     phase7c_analysts: Annotated[dict[str, dict[str, Any]], _merge_analyst_dict] = Field(
         default_factory=dict
     )

--- a/apps/digiquant-atlas/tests/test_graph_compile.py
+++ b/apps/digiquant-atlas/tests/test_graph_compile.py
@@ -68,7 +68,10 @@ class TestBuildGraph:
     def test_baseline_compiles(self) -> None:
         g = build_atlas_graph("baseline", deps=_deps(), watchlist=("AAPL",))
         names = set(g.get_graph().nodes.keys())
-        # Every top-level phase node is present.
+        # Every top-level phase node is present. After #430 the single
+        # ``analyst-AAPL`` node was replaced with 4 axis specialists +
+        # one deterministic join; assert one of each axis to keep the
+        # contract honest.
         for expected in (
             "preflight",
             "alt-sentiment-news",
@@ -82,7 +85,11 @@ class TestBuildGraph:
             "sector-scorecard",
             "consolidate",
             "master-digest",
-            "analyst-AAPL",
+            "technical-analyst-AAPL",
+            "sentiment-analyst-AAPL",
+            "news-analyst-AAPL",
+            "fundamental-analyst-AAPL",
+            "join-analyst-AAPL",
             "pm-rebalance",
             "evolution",
         ):
@@ -92,8 +99,10 @@ class TestBuildGraph:
         g = build_atlas_graph("delta", deps=_deps(), watchlist=())
         names = set(g.get_graph().nodes.keys())
         assert "triage" in names
-        # phase7c still present even with empty watchlist (no-op node).
-        assert "analyst-noop" in names
+        # Phase 7C now decomposes into specialists + join; the empty
+        # watchlist branch installs a no-op node in EACH sub-phase.
+        assert "specialist-noop" in names
+        assert "join-noop" in names
 
     def test_monthly_graph_is_compact(self) -> None:
         g = build_atlas_graph("monthly", deps=_deps())

--- a/apps/digiquant-atlas/tests/test_phase67.py
+++ b/apps/digiquant-atlas/tests/test_phase67.py
@@ -173,25 +173,31 @@ def _analyst_payload(ticker: str) -> str:
 @pytest.mark.unit
 class TestPhase7cAnalysts:
     def test_per_ticker_fan_out(self) -> None:
+        # Phase 7C is now a 2-phase pipeline (4 specialists fan-out → join)
+        # per #430. Spread both sub-phases. Each ticker triggers 4 LLM
+        # calls (one per axis); the join is deterministic (no LLM).
         tickers = ["AAPL", "MSFT"]
-        compiled = build_pipeline(AtlasResearchState, [build_phase7c(tickers)])
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7c(tickers)))
         state = _seed_state_through_phase5()
 
         def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
             user_block = msgs[1]["content"]
-            schema_part = next(
-                p
-                for p in user_block
-                if isinstance(p, dict) and "OUTPUT_SCHEMA" in p.get("text", "")
-            )
-            assert AnalystPayload.__name__ in schema_part["text"]
             inputs_part = next(
                 p
                 for p in user_block
                 if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
             )
             body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
-            return _analyst_payload(body["ticker"])
+            return json.dumps(
+                {
+                    "axis": body["axis"],
+                    "ticker": body["ticker"],
+                    "conviction_axis": 0.6,
+                    "stance_axis": "buy",
+                    "rationale": f"{body['axis']} likes {body['ticker']}",
+                    "sources": [],
+                }
+            )
 
         with patch(
             "digigraph.graph.research_agent.chat_completion",
@@ -200,11 +206,20 @@ class TestPhase7cAnalysts:
             result = compiled.invoke(state)
         final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
 
+        # Both tickers got all 4 specialists.
+        for ticker in tickers:
+            assert ticker in final.phase7c_specialists
+            assert len(final.phase7c_specialists[ticker]) == 4
+        # Join produced unanimous-buy AnalystPayload for both.
         assert set(final.phase7c_analysts.keys()) == {"AAPL", "MSFT"}
-        assert final.phase7c_analysts["AAPL"]["stance"] == "buy"
+        for ticker in tickers:
+            payload = AnalystPayload.model_validate(final.phase7c_analysts[ticker])
+            assert payload.stance == "buy"
+            assert payload.conviction_score >= 1  # weighted-buy → positive
 
     def test_empty_watchlist_does_not_explode(self) -> None:
-        compiled = build_pipeline(AtlasResearchState, [build_phase7c([])])
+        # Both sub-phases must no-op cleanly when the watchlist is empty.
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7c([])))
         state = _seed_state_through_phase5()
         # No LLM call expected.
         with patch(

--- a/apps/digiquant-atlas/tests/test_phase7c_specialists.py
+++ b/apps/digiquant-atlas/tests/test_phase7c_specialists.py
@@ -1,0 +1,359 @@
+"""Phase 7C 4-axis analyst specialization tests (#430).
+
+Covers:
+- 4 specialist nodes run in parallel per ticker.
+- Specialists are blinded to portfolio weights (state shape preserved).
+- Deterministic join aggregates 4 specialists into one ``AnalystPayload``.
+- State dict shape: ``phase7c_specialists[ticker][axis] = SpecialistPayload``.
+- Missing-specialist graceful degradation (one axis skipped → join uses
+  what's available + flags the gap in the thesis).
+- PM downstream still reads ``state.phase7c_analysts`` unchanged.
+- Reducer collision behavior on the per-axis inner dict.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-completion dict shape
+from unittest.mock import patch
+
+import pytest
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant_atlas.phases.phase7c_analyst import (
+    AnalystPayload,
+    SpecialistPayload,
+    _join_analyst_node_factory,
+    build_phase7c,
+    build_phase7c_join,
+    build_phase7c_specialists,
+)
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    SegmentSlotCollisionError,
+    _merge_specialist_dict,
+)
+
+
+def _state(tickers: tuple[str, ...] = ("AAPL", "MSFT")) -> AtlasResearchState:
+    return AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=AtlasConfigBundle(watchlist=list(tickers)),
+    )
+
+
+def _specialist_response(
+    axis: str, ticker: str, *, conviction: float = 0.6, stance: str = "buy"
+) -> str:
+    return json.dumps(
+        {
+            "axis": axis,
+            "ticker": ticker,
+            "conviction_axis": conviction,
+            "stance_axis": stance,
+            "rationale": f"{axis} setup looks {stance}",
+            "sources": [f"{axis}-source"],
+        }
+    )
+
+
+# ─── Specialist fan-out ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSpecialistFanOut:
+    def test_4_specialists_run_per_ticker(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, [build_phase7c_specialists(["AAPL"])])
+
+        captured_axes: list[str] = []
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            axis = body["axis"]
+            captured_axes.append(axis)
+            return _specialist_response(axis, body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(_state(("AAPL",)))
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert sorted(captured_axes) == ["fundamental", "news", "sentiment", "technical"]
+        assert "AAPL" in final.phase7c_specialists
+        assert set(final.phase7c_specialists["AAPL"].keys()) == {
+            "technical",
+            "sentiment",
+            "news",
+            "fundamental",
+        }
+
+    def test_specialist_inputs_per_axis(self) -> None:
+        """Technical reads phase5; sentiment reads phase1; news reads phase3+phase2; fundamental reads phase5+sectors."""
+        compiled = build_pipeline(AtlasResearchState, [build_phase7c_specialists(["AAPL"])])
+
+        captured_inputs: dict[str, set[str]] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            captured_inputs[body["axis"]] = set(body.keys())
+            return _specialist_response(body["axis"], body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            compiled.invoke(_state(("AAPL",)))
+
+        assert "phase5_equity" in captured_inputs["technical"]
+        assert "phase1_alt_data" in captured_inputs["sentiment"]
+        assert "phase3_macro" in captured_inputs["news"]
+        assert "phase2_institutional" in captured_inputs["news"]
+        assert "phase5_equity" in captured_inputs["fundamental"]
+        assert "relevant_sectors" in captured_inputs["fundamental"]
+
+    def test_blinded_to_portfolio_weights(self) -> None:
+        """No specialist input should carry portfolio weights / current_pct.
+
+        Blinded-analyst rule preserved from pre-#430 design.
+        """
+        compiled = build_pipeline(AtlasResearchState, [build_phase7c_specialists(["AAPL"])])
+
+        seen_keys: list[str] = []
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            seen_keys.extend(body.keys())
+            return _specialist_response(body["axis"], body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            compiled.invoke(_state(("AAPL",)))
+
+        assert "current_weights" not in seen_keys
+        assert "portfolio" not in seen_keys
+
+
+# ─── Join node ──────────────────────────────────────────────────────────────
+
+
+def _make_specialist(axis: str, ticker: str, *, conviction: float, stance: str) -> dict[str, Any]:
+    return SpecialistPayload(
+        axis=axis,  # type: ignore[arg-type]
+        ticker=ticker,
+        conviction_axis=conviction,
+        stance_axis=stance,  # type: ignore[arg-type]
+        rationale=f"{axis} says {stance}",
+        sources=[f"{axis}-src"],
+    ).model_dump(mode="json")
+
+
+@pytest.mark.unit
+class TestJoinNode:
+    def test_join_aggregates_all_4_axes_unanimous(self) -> None:
+        state = _state(("AAPL",))
+        state.phase7c_specialists = {
+            "AAPL": {
+                axis: _make_specialist(axis, "AAPL", conviction=0.8, stance="buy")
+                for axis in ("technical", "sentiment", "news", "fundamental")
+            }
+        }
+        node = _join_analyst_node_factory("AAPL")
+        update = node(state)
+
+        payload = update["phase7c_analysts"]["AAPL"]
+        # Unanimous strong-buy with 0.8 axis conviction →
+        # weighted_score / weight_total = 2.0; ×2.5 → 5.
+        assert payload["conviction_score"] == 5
+        assert payload["stance"] == "buy"
+        assert "[technical]" in payload["thesis"]
+        assert "[fundamental]" in payload["thesis"]
+        assert sorted(payload["sources"]) == [
+            "fundamental-src",
+            "news-src",
+            "sentiment-src",
+            "technical-src",
+        ]
+
+    def test_join_handles_split_stance(self) -> None:
+        """Two buy + two sell of equal weight → conviction near 0, majority tie broken by axis order."""
+        state = _state(("AAPL",))
+        state.phase7c_specialists = {
+            "AAPL": {
+                "technical": _make_specialist("technical", "AAPL", conviction=0.5, stance="buy"),
+                "sentiment": _make_specialist("sentiment", "AAPL", conviction=0.5, stance="sell"),
+                "news": _make_specialist("news", "AAPL", conviction=0.5, stance="buy"),
+                "fundamental": _make_specialist(
+                    "fundamental", "AAPL", conviction=0.5, stance="sell"
+                ),
+            }
+        }
+        node = _join_analyst_node_factory("AAPL")
+        update = node(state)
+
+        payload = update["phase7c_analysts"]["AAPL"]
+        assert payload["conviction_score"] == 0  # 2*+2 + 2*-2 = 0 weighted
+        assert payload["stance"] in {"buy", "sell"}  # tie — implementation-defined
+
+    def test_join_handles_missing_specialist(self) -> None:
+        """One axis missing → join uses the 3 present + flags the gap in thesis."""
+        state = _state(("AAPL",))
+        state.phase7c_specialists = {
+            "AAPL": {
+                "technical": _make_specialist("technical", "AAPL", conviction=0.7, stance="buy"),
+                "sentiment": _make_specialist("sentiment", "AAPL", conviction=0.7, stance="buy"),
+                "news": _make_specialist("news", "AAPL", conviction=0.7, stance="buy"),
+                # fundamental missing
+            }
+        }
+        node = _join_analyst_node_factory("AAPL")
+        update = node(state)
+
+        payload = update["phase7c_analysts"]["AAPL"]
+        assert payload["stance"] == "buy"
+        assert "fundamental" in payload["thesis"]
+        assert "[degraded]" in payload["thesis"]
+
+    def test_join_handles_zero_specialists_gracefully(self) -> None:
+        """Watchlist mismatch / total failure → neutral payload, no crash."""
+        state = _state(("AAPL",))
+        state.phase7c_specialists = {}  # no specialists ran for AAPL
+        node = _join_analyst_node_factory("AAPL")
+        update = node(state)
+
+        payload = update["phase7c_analysts"]["AAPL"]
+        assert payload["conviction_score"] == 0
+        assert payload["stance"] == "hold"
+        assert "no specialist" in payload["thesis"].lower()
+
+
+# ─── Full Phase 7C pipeline ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFullPhase7c:
+    def test_specialists_then_join_produces_analyst_per_ticker(self) -> None:
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7c(["AAPL", "MSFT"])))
+        state = _state(("AAPL", "MSFT"))
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            return _specialist_response(body["axis"], body["ticker"], conviction=0.7)
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        # Both tickers got specialists for all 4 axes.
+        for ticker in ("AAPL", "MSFT"):
+            assert ticker in final.phase7c_specialists
+            assert len(final.phase7c_specialists[ticker]) == 4
+            # Both tickers got an aggregated analyst payload.
+            assert ticker in final.phase7c_analysts
+            payload = AnalystPayload.model_validate(final.phase7c_analysts[ticker])
+            assert payload.ticker == ticker
+
+    def test_pm_contract_unchanged(self) -> None:
+        """``state.phase7c_analysts`` shape is unchanged from pre-#430.
+
+        Phase 7D PM consumes this directly — its read pattern must keep working.
+        """
+        compiled = build_pipeline(AtlasResearchState, list(build_phase7c(["AAPL"])))
+        state = _state(("AAPL",))
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            return _specialist_response(body["axis"], body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        payload = final.phase7c_analysts["AAPL"]
+        # All AnalystPayload fields present on the dict the PM reads.
+        for field in ("ticker", "conviction_score", "stance", "thesis", "risks", "sources"):
+            assert field in payload
+
+
+# ─── Reducer ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSpecialistReducer:
+    def test_disjoint_axes_for_same_ticker_merge(self) -> None:
+        left = {"AAPL": {"technical": {"axis": "technical"}}}
+        right = {"AAPL": {"sentiment": {"axis": "sentiment"}}}
+        merged = _merge_specialist_dict(left, right)
+        assert set(merged["AAPL"].keys()) == {"technical", "sentiment"}
+
+    def test_different_tickers_merge(self) -> None:
+        left = {"AAPL": {"technical": {"axis": "technical"}}}
+        right = {"MSFT": {"news": {"axis": "news"}}}
+        merged = _merge_specialist_dict(left, right)
+        assert set(merged.keys()) == {"AAPL", "MSFT"}
+
+    def test_collision_on_same_axis_raises(self) -> None:
+        left = {"AAPL": {"technical": {"value": "first"}}}
+        right = {"AAPL": {"technical": {"value": "second"}}}
+        with pytest.raises(SegmentSlotCollisionError):
+            _merge_specialist_dict(left, right)
+
+
+# ─── Phase factory contract ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPhaseFactoryContract:
+    def test_build_phase7c_returns_two_subphases(self) -> None:
+        phases = build_phase7c(["AAPL", "MSFT"])
+        assert len(phases) == 2
+        names = [p.name for p in phases]
+        assert names == ["phase7c_specialists", "phase7c_join"]
+
+    def test_specialists_phase_has_4_nodes_per_ticker(self) -> None:
+        phase = build_phase7c_specialists(["AAPL", "MSFT"])
+        assert len(phase.nodes) == 8  # 4 axes × 2 tickers
+
+    def test_join_phase_has_one_node_per_ticker(self) -> None:
+        phase = build_phase7c_join(["AAPL", "MSFT", "NVDA"])
+        assert len(phase.nodes) == 3
+        assert {n.name for n in phase.nodes} == {
+            "join-analyst-AAPL",
+            "join-analyst-MSFT",
+            "join-analyst-NVDA",
+        }
+
+    def test_empty_watchlist_yields_noop_phases(self) -> None:
+        phases = build_phase7c([])
+        assert len(phases) == 2
+        for phase in phases:
+            assert len(phase.nodes) == 1
+            assert "noop" in phase.nodes[0].name


### PR DESCRIPTION
## Summary

Splits the single Phase 7C analyst LLM call into 4 axis specialists per ticker (technical / sentiment / news / fundamental) running in parallel, followed by a deterministic join that aggregates them into the existing `AnalystPayload`.

```
Phase 7C-i (parallel):
  technical-analyst-{ticker}    →
  sentiment-analyst-{ticker}    →   SpecialistPayload (one per axis)
  news-analyst-{ticker}         →
  fundamental-analyst-{ticker}  →
                                 ↓
Phase 7C-ii:
  join-analyst-{ticker}  →  AnalystPayload  (deterministic — no LLM)
```

LLM calls per ticker: 1× → 4×. Join is intentionally deterministic — saves the 5th call and makes aggregation trivially testable.

## Why deterministic join

The issue spec said "synthesizes a single conviction_score and stance" — didn't mandate an LLM. A deterministic weighted-average is cheaper, more predictable, and easier to test. If the synthesized thesis is later judged too mechanical, a follow-up issue can swap in an LLM-narrating join without changing the PM contract.

## Contract preservation

- **`state.phase7c_analysts`** field shape is unchanged — Phase 7D `_pm_node` reads it exactly as before.
- **Specialists stay blinded** to portfolio weights (rule preserved from pre-#430 design — explicit test).
- **Missing specialist** → join uses present axes + flags the gap in `thesis`. Graceful degradation.

## Test plan

- [x] 220 / 220 atlas unit tests pass (was 204; +16 new in `test_phase7c_specialists.py`).
- [x] Existing `test_phase67::TestPhase7cAnalysts` + `test_graph_compile::TestBuildGraph` updated to the new 2-phase shape.
- [x] `make score` passes 10 / 9 / 10 / 10.
- [x] Phase 7D PM contract unchanged — covered by existing tests.

## Skill files

`technical-analyst`, `sentiment-analyst`, `news-analyst`, `fundamental-analyst` — one each, lane-specific guidance, all targeting `SpecialistPayload`.

Fixes #430