### PR TITLE
feat(atlas): custom research trigger — backend wiring (#313)

### DIFF
--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -62,6 +62,9 @@ class AtlasInput:
     baseline_date: date | None = None
     watchlist: tuple[str, ...] = ()
     digi_bearer: str | None = None
+    # Optional user-supplied prompt for a one-off custom research run (#313).
+    # Empty string is treated as None at CLI parse time.
+    custom_prompt: str | None = None
 
 
 @dataclass(frozen=True)
@@ -186,6 +189,7 @@ def initial_state(
         run_date=atlas_input.run_date,
         baseline_date=atlas_input.baseline_date,
         config=config or AtlasConfigBundle(watchlist=list(atlas_input.watchlist)),
+        custom_prompt=atlas_input.custom_prompt or None,
         **extra,
     )
 
@@ -345,6 +349,15 @@ def build_cli_parser():
         action="store_true",
         help="Resolve inputs + compile graph, print JSON summary, exit 0 (no LLM calls).",
     )
+    parser.add_argument(
+        "--custom-prompt",
+        default="",
+        help=(
+            "Optional one-off research prompt (#313). When set, Phase 7 synthesis "
+            "includes the prompt as additional context and the publish phase routes "
+            "the digest under doc_type='Custom Research'. Empty string means none."
+        ),
+    )
     return parser
 
 
@@ -405,11 +418,13 @@ def resolve_cli_inputs(args) -> dict:
             )
         baseline_date = resolved
 
+    custom_prompt_raw = (getattr(args, "custom_prompt", "") or "").strip()
     return {
         "run_type": args.run_type,
         "run_date": args.run_date,
         "baseline_date": baseline_date,
         "watchlist": watchlist,
+        "custom_prompt": custom_prompt_raw or None,
     }
 
 

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7_synthesis.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7_synthesis.py
@@ -102,6 +102,11 @@ def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
         "phase4": _bodies(state.phase4_outputs),
         "phase5": _bodies(state.phase5_outputs),
     }
+    # Custom research prompt threading (#313). Surfaced as an explicit
+    # ``custom_prompt`` field rather than mixed into ``bias_row`` so the
+    # digest skill can detect and prioritize it. Absent on routine runs.
+    if state.custom_prompt:
+        phase_inputs["custom_prompt"] = state.custom_prompt
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=phase_inputs,

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/publish_phase.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/publish_phase.py
@@ -129,8 +129,23 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
             )
 
         if state.phase7_digest is not None:
-            digest_key = _DIGEST_KEY.get(run_type, "digest")
-            digest_doc_type = _DIGEST_DOC_TYPE.get(run_type)
+            # Custom research routing (#313). When the user supplied a
+            # one-off prompt at run start, stamp the digest as
+            # ``Custom Research`` and key it under
+            # ``custom-research/<run_id>`` so it doesn't collide with
+            # the day's standard ``digest`` row. We also skip
+            # ``daily_snapshots`` for custom runs — that table holds
+            # the canonical baseline / delta cadence and a one-off
+            # custom run shouldn't pollute the time series.
+            if state.custom_prompt:
+                digest_key = f"custom-research/{state.run_id}"
+                digest_doc_type: str | None = "Custom Research"
+                title = f"Atlas Custom Research {date_str}"
+            else:
+                digest_key = _DIGEST_KEY.get(run_type, "digest")
+                digest_doc_type = _DIGEST_DOC_TYPE.get(run_type)
+                title = f"Atlas {digest_doc_type or 'Digest'} {date_str}"
+
             artifacts.append(
                 publish_document(
                     client=deps.client,
@@ -138,20 +153,21 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     payload=dict(state.phase7_digest),
                     doc_type=digest_doc_type,
                     run_type=run_type,
-                    title=f"Atlas {digest_doc_type or 'Digest'} {date_str}",
+                    title=title,
                     date_str=date_str,
                 )
             )
-            baseline_iso = state.baseline_date.isoformat() if state.baseline_date else None
-            artifacts.append(
-                publish_daily_snapshot(
-                    client=deps.client,
-                    date_str=date_str,
-                    snapshot=dict(state.phase7_digest),
-                    run_type=run_type,
-                    baseline_date=baseline_iso,
+            if not state.custom_prompt:
+                baseline_iso = state.baseline_date.isoformat() if state.baseline_date else None
+                artifacts.append(
+                    publish_daily_snapshot(
+                        client=deps.client,
+                        date_str=date_str,
+                        snapshot=dict(state.phase7_digest),
+                        run_type=run_type,
+                        baseline_date=baseline_iso,
+                    )
                 )
-            )
 
         for ticker, payload in state.phase7c_analysts.items():
             artifacts.append(

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -284,6 +284,14 @@ class AtlasResearchState(BaseModel):
     phase7d_rebalance: dict[str, Any] | None = None
     phase9_evolution: dict[str, Any] | None = None
 
+    # Optional user-supplied prompt for a one-off custom research run (#313).
+    # When set, Phase 7 synthesis includes the prompt as additional context
+    # and the publish phase routes the digest to
+    # ``doc_type='Custom Research'`` / ``document_key='custom-research/<run_id>'``
+    # instead of the standard ``Daily Digest`` / ``digest`` keys. Empty
+    # string is treated as None at the CLI boundary.
+    custom_prompt: str | None = None
+
     triage: DeltaTriageResult | None = None
     # Per-ticker fractional pct_change between the two most-recent trading
     # days strictly before run_date. Populated by the triage phase on delta

--- a/apps/digiquant-atlas/supabase/migrations/027_custom_research_doc_type.sql
+++ b/apps/digiquant-atlas/supabase/migrations/027_custom_research_doc_type.sql
@@ -1,0 +1,41 @@
+-- 027_custom_research_doc_type.sql — extend documents.doc_type CHECK constraint
+-- to allow 'Custom Research' for user-triggered one-off runs (#313).
+--
+-- Run with:  supabase db push  (from apps/digiquant-atlas/supabase/)
+--
+-- Custom Research rows live alongside the standard Daily Digest / Daily Delta
+-- output but with document_key = 'custom-research/<run_id>' so they don't
+-- collide with the day's canonical digest row. They are never written to
+-- ``daily_snapshots`` — that table is reserved for the regular cadence.
+
+ALTER TABLE documents DROP CONSTRAINT IF EXISTS chk_documents_doc_type;
+
+ALTER TABLE documents ADD CONSTRAINT chk_documents_doc_type CHECK (
+  doc_type IS NULL OR doc_type IN (
+    'Daily Digest',
+    'Daily Delta',
+    'Weekly Rollup',
+    'Monthly Summary',
+    'Deep Dive',
+    'Research Delta',
+    'Research Baseline Manifest',
+    'Document Delta',
+    'Research Changelog',
+    'Rebalance Decision',
+    'Asset Recommendation',
+    'Deliberation Transcript',
+    'Deliberation Session Index',
+    'Market Thesis Exploration',
+    'Thesis Vehicle Map',
+    'PM Allocation Memo',
+    'Sector Report',
+    'Evolution Sources',
+    'Evolution Quality Log',
+    'Evolution Proposals',
+    'Pipeline Review',
+    'Custom Research'
+  )
+);
+
+COMMENT ON CONSTRAINT chk_documents_doc_type ON documents IS
+  'Track A/B output + #313 user-triggered Custom Research doc type.';

--- a/apps/digiquant-atlas/tests/test_custom_research.py
+++ b/apps/digiquant-atlas/tests/test_custom_research.py
@@ -1,0 +1,298 @@
+"""Custom research trigger tests (#313).
+
+Covers:
+- ``AtlasInput`` carries ``custom_prompt``.
+- CLI parses ``--custom-prompt`` and threads it into ``AtlasInput``.
+- ``AtlasResearchState.custom_prompt`` is populated by ``initial_state``.
+- Phase 7 synthesis adds ``custom_prompt`` to ``phase_inputs`` when set,
+  and omits it on routine runs.
+- Publish phase routes the digest under ``doc_type='Custom Research'``
+  + ``document_key='custom-research/<run_id>'`` for custom runs.
+- Publish phase skips ``daily_snapshots`` for custom runs.
+- Routine runs (custom_prompt=None) keep the standard
+  ``Daily Digest`` / ``digest`` keys untouched.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-payload dict shape
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from digiquant_atlas.graph import (
+    AtlasInput,
+    build_cli_parser,
+    initial_state,
+    resolve_cli_inputs,
+)
+from digiquant_atlas.phases.publish_phase import PublishDeps, build_publish_node
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    Carried,  # noqa: F401 — re-export check
+    SegmentPayload,
+    SegmentSlot,
+)
+
+from tests.test_supabase_io import FakeSupabaseClient
+
+
+# ─── AtlasInput + CLI parser ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestAtlasInputCustomPrompt:
+    def test_default_is_none(self) -> None:
+        inp = AtlasInput(run_type="baseline", run_date=date(2026, 4, 26))
+        assert inp.custom_prompt is None
+
+    def test_explicit_prompt_propagates(self) -> None:
+        inp = AtlasInput(
+            run_type="baseline",
+            run_date=date(2026, 4, 26),
+            custom_prompt="Drill into NVDA earnings risk.",
+        )
+        assert inp.custom_prompt == "Drill into NVDA earnings risk."
+
+
+@pytest.mark.unit
+class TestCustomPromptCli:
+    def test_cli_flag_default_yields_none(self) -> None:
+        parser = build_cli_parser()
+        args = parser.parse_args(["--run-type", "baseline", "--run-date", "2026-04-26"])
+        kwargs = resolve_cli_inputs(args)
+        assert kwargs["custom_prompt"] is None
+
+    def test_cli_flag_set_threads_through(self) -> None:
+        parser = build_cli_parser()
+        args = parser.parse_args(
+            [
+                "--run-type",
+                "baseline",
+                "--run-date",
+                "2026-04-26",
+                "--custom-prompt",
+                "Why is XLE underperforming?",
+            ]
+        )
+        kwargs = resolve_cli_inputs(args)
+        assert kwargs["custom_prompt"] == "Why is XLE underperforming?"
+
+    def test_empty_prompt_normalized_to_none(self) -> None:
+        """``--custom-prompt ""`` and stray whitespace must collapse to ``None``."""
+        parser = build_cli_parser()
+        args = parser.parse_args(
+            [
+                "--run-type",
+                "baseline",
+                "--run-date",
+                "2026-04-26",
+                "--custom-prompt",
+                "   ",
+            ]
+        )
+        kwargs = resolve_cli_inputs(args)
+        assert kwargs["custom_prompt"] is None
+
+
+# ─── initial_state ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestInitialStateCustomPrompt:
+    def test_state_carries_custom_prompt(self) -> None:
+        inp = AtlasInput(
+            run_type="baseline",
+            run_date=date(2026, 4, 26),
+            custom_prompt="Hot take on small caps?",
+        )
+        state = initial_state(inp)
+        assert state.custom_prompt == "Hot take on small caps?"
+
+    def test_state_default_custom_prompt_is_none(self) -> None:
+        inp = AtlasInput(run_type="baseline", run_date=date(2026, 4, 26))
+        state = initial_state(inp)
+        assert state.custom_prompt is None
+
+
+# ─── Phase 7 synthesis input threading ──────────────────────────────────────
+
+
+def _seed_state_minimal(custom_prompt: str | None = None) -> AtlasResearchState:
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=AtlasConfigBundle(watchlist=["AAPL"]),
+    )
+    if custom_prompt is not None:
+        state.custom_prompt = custom_prompt
+
+    def _slot(slug: str) -> SegmentSlot:
+        return SegmentSlot(
+            payload=SegmentPayload(
+                segment=slug,
+                body={"segment": slug, "bias": "neutral"},
+                as_of=date(2026, 4, 26),
+            )
+        )
+
+    state.phase1_outputs = {"alt-sentiment-news": _slot("alt-sentiment-news")}
+    state.phase3_output = _slot("macro")
+    state.phase5_outputs = {"equity": _slot("equity")}
+    state.phase6_bias_row = {"date": "2026-04-26"}
+    return state
+
+
+@pytest.mark.unit
+class TestPhase7SynthesisCustomPrompt:
+    def test_custom_prompt_added_to_phase_inputs_when_set(self) -> None:
+        from digiquant_atlas.phases.phase7_synthesis import _synthesis_node
+
+        captured: dict[str, str] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            captured["text"] = inputs_part["text"]
+            # Return a minimal valid DigestSnapshot.
+            import json
+
+            return json.dumps(
+                {
+                    "segment": "master-digest",
+                    "date": "2026-04-26",
+                    "bias": "neutral",
+                    "headline": "test",
+                    "material_findings": [],
+                    "sources": [],
+                    "notes": "",
+                    "market_regime_snapshot": "x",
+                    "alt_data_dashboard": "x",
+                    "institutional_summary": "x",
+                    "asset_classes_summary": "x",
+                    "us_equities_summary": "x",
+                    "thesis_tracker": "",
+                    "portfolio_recommendations": "",
+                    "actionable_summary": [],
+                    "risk_radar": [],
+                    "segment_freshness": {},
+                }
+            )
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            _synthesis_node(_seed_state_minimal("Why is XLE underperforming?"))
+
+        assert "custom_prompt" in captured["text"]
+        assert "XLE" in captured["text"]
+
+    def test_custom_prompt_omitted_on_routine_run(self) -> None:
+        from digiquant_atlas.phases.phase7_synthesis import _synthesis_node
+
+        captured: dict[str, str] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            captured["text"] = inputs_part["text"]
+            import json
+
+            return json.dumps(
+                {
+                    "segment": "master-digest",
+                    "date": "2026-04-26",
+                    "bias": "neutral",
+                    "headline": "test",
+                    "material_findings": [],
+                    "sources": [],
+                    "notes": "",
+                    "market_regime_snapshot": "x",
+                    "alt_data_dashboard": "x",
+                    "institutional_summary": "x",
+                    "asset_classes_summary": "x",
+                    "us_equities_summary": "x",
+                    "thesis_tracker": "",
+                    "portfolio_recommendations": "",
+                    "actionable_summary": [],
+                    "risk_radar": [],
+                    "segment_freshness": {},
+                }
+            )
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            _synthesis_node(_seed_state_minimal())
+
+        assert "custom_prompt" not in captured["text"]
+
+
+# ─── Publish phase routing ──────────────────────────────────────────────────
+
+
+def _state_with_digest(custom_prompt: str | None = None) -> AtlasResearchState:
+    state = _seed_state_minimal(custom_prompt)
+    state.run_id = UUID("00000000-0000-0000-0000-000000000abc")
+    state.phase7_digest = {"market_regime_snapshot": "x", "us_equities_summary": "y"}
+    return state
+
+
+@pytest.mark.unit
+class TestPublishCustomResearch:
+    def test_custom_run_uses_custom_research_doc_type(self) -> None:
+        client = FakeSupabaseClient()
+        state = _state_with_digest("Drill into NVDA earnings.")
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        digest_rows = [r for r in client.store["documents"] if r["doc_type"] == "Custom Research"]
+        assert len(digest_rows) == 1
+        assert digest_rows[0]["document_key"].startswith("custom-research/")
+        assert "00000000" in digest_rows[0]["document_key"]
+        assert digest_rows[0]["title"].startswith("Atlas Custom Research")
+
+    def test_custom_run_skips_daily_snapshots(self) -> None:
+        """One-off custom runs must not pollute the cadence time series."""
+        client = FakeSupabaseClient()
+        state = _state_with_digest("anything")
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        assert "daily_snapshots" not in client.store
+
+    def test_routine_run_uses_daily_digest_doc_type(self) -> None:
+        """Backward-compat: when ``custom_prompt`` is None, behavior is unchanged."""
+        client = FakeSupabaseClient()
+        state = _state_with_digest()  # None custom_prompt
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        digest_rows = [r for r in client.store["documents"] if r["doc_type"] == "Daily Digest"]
+        assert len(digest_rows) == 1
+        assert digest_rows[0]["document_key"] == "digest"
+        # Routine baseline run still writes daily_snapshots.
+        assert len(client.store["daily_snapshots"]) == 1
+
+    def test_no_custom_research_row_when_digest_missing(self) -> None:
+        """Defensive: if Phase 7 was skipped, no Custom Research row gets written."""
+        client = FakeSupabaseClient()
+        state = _state_with_digest("query")
+        state.phase7_digest = None
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        for row in client.store.get("documents", []):
+            assert row["doc_type"] != "Custom Research"
+        assert "daily_snapshots" not in client.store


### PR DESCRIPTION
## Summary

Threads an optional user-supplied prompt through the Atlas LangGraph pipeline and routes the resulting digest to a separate `Custom Research` document so one-off runs don't collide with the day's canonical `Daily Digest`.

## What changed

- **`AtlasInput.custom_prompt`** + **`AtlasResearchState.custom_prompt`** — optional plumbing.
- **CLI `--custom-prompt "<text>"`** — empty / whitespace collapses to None.
- **Phase 7 synthesis** adds `custom_prompt` to `phase_inputs` only when set.
- **Publish phase** stamps the digest as `doc_type='Custom Research'` keyed under `custom-research/<run_id>` and **skips `daily_snapshots`** so cadence time series stays clean. Routine runs (custom_prompt=None) keep the standard `Daily Digest` / `digest` path unchanged.
- **Migration `027_custom_research_doc_type.sql`** extends the doc_type CHECK constraint.

## Test plan

- [x] 244 / 244 atlas unit tests pass (was 231; +13 new in `test_custom_research.py`).
- [x] `make score` passes 10 / 10 / 10 / 10.
- [x] Backward-compat regression: routine runs with `custom_prompt=None` produce `Daily Digest` + a `daily_snapshots` row exactly as before (asserted in `test_routine_run_uses_daily_digest_doc_type`).

## ⚠️ User action required

Apply migration: `supabase db push` from `apps/digiquant-atlas/supabase/`.

## Punted to follow-up issue

The frontend "Run custom research" button + Next.js API route + queue table + per-user rate limit. The backend now accepts custom prompts via CLI, which is the load-bearing piece — UI can wire to that surface in a follow-up. (Could also be invoked manually via `gh workflow run atlas-baseline.yml -f custom_prompt="..."` once the workflow input is added — micro-PR.)

Fixes #313