### PR TITLE
feat(atlas): Phase 7C-D Bull/Bear adversarial debate per ticker (#429)

### DIFF
--- a/apps/digiquant-atlas/skills/research-debate/SKILL.md
+++ b/apps/digiquant-atlas/skills/research-debate/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: research-debate
+description: >
+  Phase 7C-D bull or bear researcher. Single round, single role. Argues the assigned side
+  for one ticker using the Phase 7C analyst payload + bias context + any prior rounds.
+  Forbidden moves: strawmanning, irrelevant data, hedging the assigned position.
+---
+
+# Research Debate — One Side, One Round
+
+You are a research debater. Your role is fixed at invocation time via `role` (`bull` or `bear`). Argue **only** that side. The opposing role and the research manager handle the rest.
+
+## Inputs
+
+- `ticker` — the symbol under debate.
+- `role` — `bull` or `bear`. Argue this side.
+- `round_number` — which round you are in (1-indexed).
+- `analyst_payload` — Phase 7C consolidated `AnalystPayload` for this ticker (conviction_score, stance, thesis, risks, sources).
+- `bias_row` — Phase 6 macro / bias snapshot.
+- `prior_rounds` — list of completed `DebateRound` objects from earlier rounds. Empty on round 1.
+- `bull_argument` *(bear role only, round 2+)* — the bull's argument from this round so you can directly counter it.
+
+## What to argue (bull)
+
+1. Lead with the strongest **upside thesis** — what's the path to outperformance?
+2. Cite concrete signals from the analyst payload (conviction_score, stance, thesis fragments).
+3. Note macro tailwinds from `bias_row`.
+4. **Counter** any prior bear argument explicitly — name what you disagree with and why.
+5. Acknowledge ONE genuine risk and explain why it's already priced in or mitigated. Don't claim there's no risk.
+
+## What to argue (bear)
+
+1. Lead with the strongest **downside risk** — what kills this trade?
+2. Cite concrete signals from the analyst payload (`risks` field, low conviction axes if present).
+3. Note macro headwinds from `bias_row`.
+4. **Counter** the bull argument explicitly — name what you disagree with and why.
+5. Acknowledge ONE genuine upside and explain why it's overstated. Don't claim there's no upside.
+
+## Forbidden moves
+
+- **Strawmanning** — never paraphrase the other side's argument inaccurately.
+- **Irrelevant data** — every claim must reference an input field or the bias context.
+- **Hedging your role** — bulls argue bullish, bears argue bearish. The research manager will balance.
+- **Ad hominem** — debate the case, not the analyst.
+
+## Output
+
+Single JSON object validated against `DebateRoundContribution`:
+
+```json
+{
+  "role": "bull",                    // or "bear" — match the input role exactly
+  "ticker": "AAPL",
+  "round_number": 1,                 // match input round_number
+  "argument": "string (max 600 chars)"
+}
+```
+
+Your `argument` should be 3–5 substantive sentences. No bullet headers. End with a one-sentence stance recap so the next round / research manager has a clean signal.

--- a/apps/digiquant-atlas/skills/research-manager/SKILL.md
+++ b/apps/digiquant-atlas/skills/research-manager/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: research-manager
+description: >
+  Phase 7C-D research manager. Reads completed bull/bear debate rounds for one ticker and emits
+  the structured DebateSummary: synthesized bull/bear theses, net stance, conviction delta.
+  One LLM call per ticker after debate rounds finish.
+---
+
+# Research Manager — Judge the Debate
+
+You are the research manager. The bull and bear researchers have completed `N` rounds of debate over `{{ticker}}`. Your job is to synthesise both sides into a structured `DebateSummary` and assign a quantitative adjustment to the Phase 7C conviction score.
+
+You are **not** taking a side — you are integrating both. The PM (next phase) reads your summary alongside the analyst payload and decides the rebalance.
+
+## Inputs
+
+- `ticker` — the symbol debated.
+- `rounds` — list of `DebateRound` objects (already populated; one per completed round).
+- `analyst_payload` — Phase 7C consolidated payload for cross-checking.
+- `bias_row` — Phase 6 bias context.
+
+## Synthesis rules
+
+1. **`bull_thesis`** (≤ 800 chars): the strongest, most defensible bull case across all rounds. Combine the bull's best arguments. Don't add new arguments — only synthesize what was said.
+2. **`bear_thesis`** (≤ 800 chars): same for the bear side.
+3. **`net_stance`** ∈ {`bullish`, `neutral`, `bearish`}:
+   - `bullish` — bull arguments substantially stronger, bear arguments weak / countered
+   - `bearish` — opposite
+   - `neutral` — close call, or both sides scored hits
+4. **`conviction_delta`** ∈ [−2, +2]: integer adjustment to the Phase 7C analyst's `conviction_score`:
+   - +2: bull case is overwhelming and the analyst's score under-rates the upside
+   - +1: bull case is solid; the analyst's score should nudge up
+   - 0: debate did not change the picture
+   - −1: bear case is solid; nudge down
+   - −2: bear case is overwhelming
+5. **`rounds`**: copy the input rounds verbatim. The audit trail relies on this. (The pipeline overwrites your output's `rounds` with the deterministic record from state regardless — this is a belt-and-braces measure.)
+
+## Forbidden moves
+
+- Don't introduce new evidence the debaters didn't cite.
+- Don't pick the side that "sounds nicer" — judge on argument quality.
+- Don't max out `conviction_delta` to ±2 unless one side genuinely demolished the other.
+
+## Output
+
+Single JSON object validated against `DebateSummary`:
+
+```json
+{
+  "ticker": "AAPL",
+  "rounds": [/* copy from input */],
+  "bull_thesis": "string (max 800 chars)",
+  "bear_thesis": "string (max 800 chars)",
+  "net_stance": "bullish",        // bullish | neutral | bearish
+  "conviction_delta": 1            // -2 .. +2
+}
+```

--- a/apps/digiquant-atlas/src/digiquant_atlas/graph.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/graph.py
@@ -33,6 +33,7 @@ from digiquant_atlas.phases.phase5_equities import build_phase5
 from digiquant_atlas.phases.phase6_consolidate import build_phase6
 from digiquant_atlas.phases.phase7_synthesis import build_phase7
 from digiquant_atlas.phases.phase7c_analyst import build_phase7c
+from digiquant_atlas.phases.phase7cd_debate import build_phase7cd
 from digiquant_atlas.phases.phase7d_pm import build_phase7d
 from digiquant_atlas.phases.phase9_evolution import Phase9Deps, build_phase9
 from digiquant_atlas.phases.phase_monthly import build_phase_monthly
@@ -152,6 +153,13 @@ def build_atlas_graph(
             build_phase6(),
             build_phase7(),
             *build_phase7c(list(watchlist)),
+            # Phase 7C-D Bull/Bear debate (#429). Compile-time upper bound
+            # of 1 round matches the default; ``state.config.preferences[
+            # "debate_rounds"]`` at runtime controls how many of the wired
+            # sub-phases actually call the LLM (1..5 supported). Each
+            # ticker gets one bull node + one bear node per round, then
+            # one research-manager node at the end.
+            *build_phase7cd(list(watchlist), rounds=1),
             *build_phase7d(),
             build_phase9(deps.phase9),  # ``deps.phase9=None`` keeps legacy LLM-only path
         ]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7cd_debate.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7cd_debate.py
@@ -1,0 +1,348 @@
+"""Phase 7C-D — Bull/Bear adversarial debate per ticker (#429).
+
+Inserts an adversarial debate phase between Phase 7C (analyst fan-out)
+and Phase 7D (PM rebalance). For each ticker the bull/bear researcher
+exchange arguments for ``N`` rounds (default 1, configurable via
+``state.config.preferences["debate_rounds"]``); the research manager
+then judges the round(s) and emits a structured ``DebateSummary``.
+
+Sub-phase structure (per ticker):
+
+    bull-researcher-{ticker}    → DebateRoundContribution
+    bear-researcher-{ticker}    → DebateRoundContribution (counter)
+    research-manager-{ticker}   → DebateSummary
+
+Sequential — each step reads the prior one's output. Implemented as
+three single-node sub-phases per ticker so LangGraph's "nodes within a
+phase run in parallel" rule keeps each LLM call ordered.
+
+The PM (`phase7d_pm._pm_node`) consumes the resulting
+``state.phase7cd_debates[ticker]`` as a sibling of the analyst payload.
+Graceful degradation: when debate summaries are empty (e.g. empty
+watchlist, or the phase wasn't wired for a given graph shape), the PM
+still produces a decision from analyst payloads alone.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Literal
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
+from pydantic import BaseModel, Field
+
+from digiquant_atlas.phases._node_factory import _shared_context
+from digiquant_atlas.state import AtlasResearchState
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_DEBATE_ROUNDS = 1
+"""Number of bull-then-bear cycles before the research manager judges."""
+
+
+class DebateRoundContribution(BaseModel):
+    """One side's argument for a single round.
+
+    Bull and bear researchers each emit one of these; the research
+    manager assembles them into ``DebateRound`` instances.
+    """
+
+    role: Literal["bull", "bear"]
+    ticker: str = Field(max_length=16)
+    round_number: int = Field(ge=1, le=5)
+    argument: str = Field(max_length=600)
+
+
+class DebateRound(BaseModel):
+    """One full bull-then-bear exchange."""
+
+    round_number: int = Field(ge=1, le=5)
+    bull_argument: str = Field(max_length=600)
+    bear_argument: str = Field(max_length=600)
+
+
+class DebateSummary(BaseModel):
+    """Research-manager output. Lands in ``state.phase7cd_debates[ticker]``."""
+
+    ticker: str = Field(max_length=16)
+    rounds: list[DebateRound] = Field(default_factory=list)
+    bull_thesis: str = Field(max_length=800)
+    bear_thesis: str = Field(max_length=800)
+    net_stance: Literal["bullish", "neutral", "bearish"]
+    conviction_delta: int = Field(
+        ge=-2,
+        le=2,
+        description="Adjustment to Phase 7C analyst conviction_score.",
+    )
+
+
+def _round_count(state: AtlasResearchState) -> int:
+    """Resolve the configured round count from preferences (default 1)."""
+    raw = state.config.preferences.get("debate_rounds", _DEFAULT_DEBATE_ROUNDS)
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_DEBATE_ROUNDS
+    # Bound at 1..5 — TradingAgents typically uses 1-2; leave headroom
+    # without letting a misconfig produce 100-round debates.
+    return max(1, min(5, n))
+
+
+def _analyst_for(state: AtlasResearchState, ticker: str) -> dict[str, Any]:
+    """Phase 7C analyst payload for this ticker (empty if missing)."""
+    return dict(state.phase7c_analysts.get(ticker, {}))
+
+
+def _prior_rounds(
+    state: AtlasResearchState, ticker: str, role: Literal["bull", "bear"]
+) -> list[dict[str, Any]]:
+    """Return prior debate rounds + the most recent contribution from the
+    other side, so each researcher can read what's already been argued."""
+    debate = state.phase7cd_debates.get(ticker, {}) or {}
+    rounds = list(debate.get("rounds") or [])
+    pending = debate.get("pending") or {}
+    if role == "bear":
+        if pending.get("bull_argument"):
+            rounds = rounds + [
+                {
+                    "round_number": pending.get("round_number", len(rounds) + 1),
+                    "bull_argument": pending["bull_argument"],
+                    "bear_argument": "",
+                }
+            ]
+    return rounds
+
+
+def _bull_node_factory(ticker: str):
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        rounds = _round_count(state)
+        debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
+        completed = list(debate.get("rounds") or [])
+        # Bull always opens the next round.
+        round_number = len(completed) + 1
+        if round_number > rounds:
+            return {}  # debate length cap reached
+
+        skill_text = load_skill("research-debate")
+        phase_inputs: dict[str, Any] = {
+            "segment": f"bull-researcher-{ticker}",
+            "ticker": ticker,
+            "role": "bull",
+            "round_number": round_number,
+            "analyst_payload": _analyst_for(state, ticker),
+            "prior_rounds": _prior_rounds(state, ticker, role="bull"),
+            "bias_row": state.phase6_bias_row or {},
+        }
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=phase_inputs,
+            shared_context=_shared_context(state),
+            output_model=DebateRoundContribution,
+            phase_slug=f"bull-researcher-{ticker}",
+        )
+        debate["pending"] = {
+            "round_number": result.round_number,
+            "bull_argument": result.argument,
+        }
+        return {"phase7cd_debates": {ticker: debate}}
+
+    return _node
+
+
+def _bear_node_factory(ticker: str):
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
+        pending = dict(debate.get("pending") or {})
+        if not pending.get("bull_argument"):
+            return {}  # bull node was skipped (e.g. round cap)
+
+        skill_text = load_skill("research-debate")
+        phase_inputs: dict[str, Any] = {
+            "segment": f"bear-researcher-{ticker}",
+            "ticker": ticker,
+            "role": "bear",
+            "round_number": pending.get("round_number", 1),
+            "analyst_payload": _analyst_for(state, ticker),
+            "bull_argument": pending["bull_argument"],
+            "prior_rounds": _prior_rounds(state, ticker, role="bear"),
+            "bias_row": state.phase6_bias_row or {},
+        }
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=phase_inputs,
+            shared_context=_shared_context(state),
+            output_model=DebateRoundContribution,
+            phase_slug=f"bear-researcher-{ticker}",
+        )
+        completed = list(debate.get("rounds") or [])
+        completed.append(
+            DebateRound(
+                round_number=pending.get("round_number", 1),
+                bull_argument=pending["bull_argument"],
+                bear_argument=result.argument,
+            ).model_dump(mode="json")
+        )
+        debate["rounds"] = completed
+        debate["pending"] = {}
+        return {"phase7cd_debates": {ticker: debate}}
+
+    return _node
+
+
+def _research_manager_node_factory(ticker: str):
+    from digigraph.graph.research_agent import run_research_agent
+
+    from digiquant_atlas.skills import load_skill
+
+    def _node(state: AtlasResearchState) -> dict[str, Any]:
+        debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
+        rounds = list(debate.get("rounds") or [])
+        if not rounds:
+            # No completed rounds — emit a neutral summary so the PM
+            # phase still has a stable shape to read.
+            summary = DebateSummary(
+                ticker=ticker,
+                rounds=[],
+                bull_thesis="(no debate rounds completed)",
+                bear_thesis="(no debate rounds completed)",
+                net_stance="neutral",
+                conviction_delta=0,
+            )
+            return {"phase7cd_debates": {ticker: summary.model_dump(mode="json")}}
+
+        skill_text = load_skill("research-manager")
+        phase_inputs: dict[str, Any] = {
+            "segment": f"research-manager-{ticker}",
+            "ticker": ticker,
+            "rounds": rounds,
+            "analyst_payload": _analyst_for(state, ticker),
+            "bias_row": state.phase6_bias_row or {},
+        }
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=phase_inputs,
+            shared_context=_shared_context(state),
+            output_model=DebateSummary,
+            phase_slug=f"research-manager-{ticker}",
+        )
+        # The skill is told to return rounds verbatim; if it doesn't, we
+        # overwrite with the deterministic record from state to keep
+        # the audit trail intact.
+        merged = result.model_copy(
+            update={"rounds": [DebateRound.model_validate(r) for r in rounds]}
+        )
+        return {"phase7cd_debates": {ticker: merged.model_dump(mode="json")}}
+
+    return _node
+
+
+def _capped_tickers(tickers: list[str]) -> list[str]:
+    """Apply the same ``ATLAS_MAX_ANALYSTS`` cap Phase 7C uses."""
+    max_analysts = int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
+    if max_analysts > 0 and len(tickers) > max_analysts:
+        logger.info(
+            "Phase 7C-D limited to %d/%d tickers (ATLAS_MAX_ANALYSTS=%d)",
+            max_analysts,
+            len(tickers),
+            max_analysts,
+        )
+        return tickers[:max_analysts]
+    return list(tickers)
+
+
+def _noop(_state: AtlasResearchState) -> dict[str, Any]:
+    return {}
+
+
+def build_phase7cd_round(round_number: int, tickers: list[str]) -> list[PipelinePhase]:
+    """Return one round = bull phase + bear phase (sequential)."""
+    capped = _capped_tickers(tickers)
+    if not capped:
+        return [
+            PipelinePhase(
+                name=f"phase7cd_bull_round{round_number}",
+                nodes=[NodeSpec(name=f"debate-bull-r{round_number}-noop", run=_noop)],
+            ),
+            PipelinePhase(
+                name=f"phase7cd_bear_round{round_number}",
+                nodes=[NodeSpec(name=f"debate-bear-r{round_number}-noop", run=_noop)],
+            ),
+        ]
+
+    bull = PipelinePhase(
+        name=f"phase7cd_bull_round{round_number}",
+        nodes=[
+            NodeSpec(
+                name=f"bull-researcher-{ticker}-r{round_number}", run=_bull_node_factory(ticker)
+            )
+            for ticker in capped
+        ],
+    )
+    bear = PipelinePhase(
+        name=f"phase7cd_bear_round{round_number}",
+        nodes=[
+            NodeSpec(
+                name=f"bear-researcher-{ticker}-r{round_number}", run=_bear_node_factory(ticker)
+            )
+            for ticker in capped
+        ],
+    )
+    return [bull, bear]
+
+
+def build_phase7cd_research_manager(tickers: list[str]) -> PipelinePhase:
+    """Final per-ticker judgment phase — emits the DebateSummary."""
+    capped = _capped_tickers(tickers)
+    if not capped:
+        return PipelinePhase(
+            name="phase7cd_research_manager",
+            nodes=[NodeSpec(name="research-manager-noop", run=_noop)],
+        )
+    return PipelinePhase(
+        name="phase7cd_research_manager",
+        nodes=[
+            NodeSpec(name=f"research-manager-{ticker}", run=_research_manager_node_factory(ticker))
+            for ticker in capped
+        ],
+    )
+
+
+def build_phase7cd(
+    tickers: list[str],
+    *,
+    rounds: int = _DEFAULT_DEBATE_ROUNDS,
+) -> list[PipelinePhase]:
+    """Build the full Phase 7C-D pipeline for one debate.
+
+    ``rounds`` is the *graph-compile-time* upper bound. The actual round
+    count is read from ``state.config.preferences["debate_rounds"]`` at
+    invocation time (defaults to 1, max 5). Compile time uses ``rounds``
+    to decide how many bull/bear sub-phases to wire; runtime uses the
+    state to decide how many of those sub-phases actually do work.
+    """
+    bound = max(1, min(5, rounds))
+    phases: list[PipelinePhase] = []
+    for r in range(1, bound + 1):
+        phases.extend(build_phase7cd_round(r, tickers))
+    phases.append(build_phase7cd_research_manager(tickers))
+    return phases
+
+
+__all__ = [
+    "DebateRound",
+    "DebateRoundContribution",
+    "DebateSummary",
+    "build_phase7cd",
+    "build_phase7cd_research_manager",
+    "build_phase7cd_round",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py
@@ -159,6 +159,13 @@ def _pm_node(state: AtlasResearchState) -> dict[str, Any]:
         "segment": "pm-rebalance",
         "bias_row": state.phase6_bias_row or {},
         "analyst_payloads": dict(state.phase7c_analysts),
+        # Per-ticker Bull/Bear debate summaries (#429). Empty dict on
+        # legacy graphs that skip the debate phase. The PM skill reads
+        # ``net_stance`` / ``conviction_delta`` per ticker when present
+        # to adjust the analyst conviction at decision time.
+        "debate_summaries": {
+            ticker: dict(summary) for ticker, summary in state.phase7cd_debates.items()
+        },
         "current_weights": _current_weights_from_config(state),
         "preferences": dict(state.config.preferences),
         # Risk temperament debate (#431). When either debater node was

--- a/apps/digiquant-atlas/src/digiquant_atlas/state.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/state.py
@@ -280,6 +280,13 @@ class AtlasResearchState(BaseModel):
     phase7c_analysts: Annotated[dict[str, dict[str, Any]], _merge_analyst_dict] = Field(
         default_factory=dict
     )
+    # Per-ticker Bull/Bear debate summaries (#429). Populated by the
+    # Phase 7C-D research-manager node; consumed by Phase 7D PM as
+    # ``phase_inputs["debate_summaries"]``. Empty dict on routine runs
+    # where debate is skipped (legacy graphs that don't wire the phase).
+    phase7cd_debates: Annotated[dict[str, dict[str, Any]], _merge_analyst_dict] = Field(
+        default_factory=dict
+    )
     phase7d_risk_debate: dict[str, Any] | None = None
     phase7d_rebalance: dict[str, Any] | None = None
     phase9_evolution: dict[str, Any] | None = None

--- a/apps/digiquant-atlas/tests/test_phase7cd_debate.py
+++ b/apps/digiquant-atlas/tests/test_phase7cd_debate.py
@@ -1,0 +1,375 @@
+"""Phase 7C-D Bull/Bear adversarial debate tests (#429).
+
+Covers:
+- Bull node opens round 1, writes ``pending`` to state.
+- Bear node reads ``pending`` and finalizes the round.
+- Research manager produces DebateSummary from completed rounds.
+- Round count reads from preferences (default 1).
+- DebateSummary schema bounds (conviction_delta, max_lengths).
+- PM phase consumes ``debate_summaries`` from state when present.
+- Empty watchlist installs no-op nodes.
+- Phase factories return correct phase counts (1 round → 3 phases:
+  bull, bear, research-manager).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa: F401 — used for fake-completion dict shape
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant_atlas.phases.phase7cd_debate import (
+    DebateRound,
+    DebateRoundContribution,
+    DebateSummary,
+    _round_count,
+    build_phase7cd,
+    build_phase7cd_research_manager,
+    build_phase7cd_round,
+)
+from digiquant_atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+)
+
+
+def _state(
+    tickers: tuple[str, ...] = ("AAPL",), *, debate_rounds: int | None = None
+) -> AtlasResearchState:
+    config = AtlasConfigBundle(
+        watchlist=list(tickers),
+        preferences=({"debate_rounds": debate_rounds} if debate_rounds is not None else {}),
+    )
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=config,
+    )
+    state.phase6_bias_row = {"date": "2026-04-26"}
+    state.phase7c_analysts = {
+        ticker: {
+            "ticker": ticker,
+            "conviction_score": 2,
+            "stance": "buy",
+            "thesis": f"{ticker} setup is constructive",
+            "risks": "",
+            "sources": [],
+        }
+        for ticker in tickers
+    }
+    return state
+
+
+def _bull_payload(ticker: str, round_number: int) -> str:
+    return json.dumps(
+        {
+            "role": "bull",
+            "ticker": ticker,
+            "round_number": round_number,
+            "argument": f"Bull case for {ticker}, round {round_number}",
+        }
+    )
+
+
+def _bear_payload(ticker: str, round_number: int) -> str:
+    return json.dumps(
+        {
+            "role": "bear",
+            "ticker": ticker,
+            "round_number": round_number,
+            "argument": f"Bear case for {ticker}, round {round_number}",
+        }
+    )
+
+
+def _summary_payload(ticker: str) -> str:
+    return json.dumps(
+        {
+            "ticker": ticker,
+            "rounds": [],
+            "bull_thesis": f"{ticker} bull synthesis",
+            "bear_thesis": f"{ticker} bear synthesis",
+            "net_stance": "bullish",
+            "conviction_delta": 1,
+        }
+    )
+
+
+# ─── Round count ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestRoundCount:
+    def test_default_is_one(self) -> None:
+        assert _round_count(_state()) == 1
+
+    def test_reads_from_preferences(self) -> None:
+        assert _round_count(_state(debate_rounds=2)) == 2
+
+    def test_clamps_to_max_5(self) -> None:
+        assert _round_count(_state(debate_rounds=99)) == 5
+
+    def test_clamps_to_min_1(self) -> None:
+        assert _round_count(_state(debate_rounds=0)) == 1
+        assert _round_count(_state(debate_rounds=-3)) == 1
+
+    def test_garbage_falls_back_to_default(self) -> None:
+        config = AtlasConfigBundle(preferences={"debate_rounds": "two"})
+        s = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26), config=config)
+        assert _round_count(s) == 1
+
+
+# ─── Debate models ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDebateModels:
+    def test_round_contribution_max_argument_length(self) -> None:
+        with pytest.raises(ValidationError):
+            DebateRoundContribution(
+                role="bull",
+                ticker="AAPL",
+                round_number=1,
+                argument="x" * 700,
+            )
+
+    def test_summary_conviction_delta_bounds(self) -> None:
+        for delta in (-3, 3):
+            with pytest.raises(ValidationError):
+                DebateSummary(
+                    ticker="AAPL",
+                    rounds=[],
+                    bull_thesis="a",
+                    bear_thesis="b",
+                    net_stance="neutral",
+                    conviction_delta=delta,
+                )
+
+    def test_round_count_max_5(self) -> None:
+        with pytest.raises(ValidationError):
+            DebateRound(
+                round_number=6,
+                bull_argument="a",
+                bear_argument="b",
+            )
+
+
+# ─── Single-round flow ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSingleRound:
+    def test_bull_then_bear_finalizes_round(self) -> None:
+        compiled = build_pipeline(
+            AtlasResearchState,
+            list(build_phase7cd_round(1, ["AAPL"])),
+        )
+        state = _state()
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            if body["role"] == "bull":
+                return _bull_payload(body["ticker"], body["round_number"])
+            return _bear_payload(body["ticker"], body["round_number"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        debate = final.phase7cd_debates["AAPL"]
+        assert "rounds" in debate
+        assert len(debate["rounds"]) == 1
+        assert "Bull case for AAPL, round 1" in debate["rounds"][0]["bull_argument"]
+        assert "Bear case for AAPL, round 1" in debate["rounds"][0]["bear_argument"]
+        # ``pending`` should be cleared after the bear node finalizes the round.
+        assert debate.get("pending", {}) == {}
+
+
+@pytest.mark.unit
+class TestResearchManager:
+    def test_manager_emits_debate_summary(self) -> None:
+        compiled = build_pipeline(
+            AtlasResearchState,
+            [build_phase7cd_research_manager(["AAPL"])],
+        )
+        state = _state()
+        # Simulate that the bull/bear nodes already produced a completed round.
+        state.phase7cd_debates = {
+            "AAPL": {
+                "rounds": [
+                    {
+                        "round_number": 1,
+                        "bull_argument": "Bull case",
+                        "bear_argument": "Bear case",
+                    }
+                ]
+            }
+        }
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            return _summary_payload(body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        summary = final.phase7cd_debates["AAPL"]
+        assert summary["bull_thesis"] == "AAPL bull synthesis"
+        assert summary["bear_thesis"] == "AAPL bear synthesis"
+        assert summary["net_stance"] == "bullish"
+        assert summary["conviction_delta"] == 1
+        # Rounds are preserved verbatim from state.
+        assert len(summary["rounds"]) == 1
+
+    def test_manager_emits_neutral_when_no_rounds(self) -> None:
+        """Defensive: if the bull/bear path was skipped, manager still produces a stable shape."""
+        compiled = build_pipeline(
+            AtlasResearchState,
+            [build_phase7cd_research_manager(["AAPL"])],
+        )
+        state = _state()
+        # No completed rounds in state → manager emits a neutral summary
+        # without calling the LLM.
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            side_effect=AssertionError("manager must not call LLM with no rounds"),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        summary = final.phase7cd_debates["AAPL"]
+        assert summary["net_stance"] == "neutral"
+        assert summary["conviction_delta"] == 0
+
+
+# ─── Full debate pipeline ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFullDebatePipeline:
+    def test_one_round_pipeline_writes_full_summary(self) -> None:
+        compiled = build_pipeline(
+            AtlasResearchState,
+            list(build_phase7cd(["AAPL", "MSFT"], rounds=1)),
+        )
+        state = _state(("AAPL", "MSFT"))
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            seg = body["segment"]
+            if seg.startswith("bull-researcher-"):
+                return _bull_payload(body["ticker"], body["round_number"])
+            if seg.startswith("bear-researcher-"):
+                return _bear_payload(body["ticker"], body["round_number"])
+            return _summary_payload(body["ticker"])
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        for ticker in ("AAPL", "MSFT"):
+            summary = final.phase7cd_debates[ticker]
+            assert summary["net_stance"] == "bullish"
+            assert summary["bull_thesis"] == f"{ticker} bull synthesis"
+            assert len(summary["rounds"]) == 1
+
+
+@pytest.mark.unit
+class TestPhaseFactoryShape:
+    def test_one_round_returns_three_phases(self) -> None:
+        phases = build_phase7cd(["AAPL"], rounds=1)
+        assert len(phases) == 3
+        assert phases[0].name == "phase7cd_bull_round1"
+        assert phases[1].name == "phase7cd_bear_round1"
+        assert phases[2].name == "phase7cd_research_manager"
+
+    def test_two_rounds_returns_five_phases(self) -> None:
+        phases = build_phase7cd(["AAPL"], rounds=2)
+        assert len(phases) == 5
+        assert phases[-1].name == "phase7cd_research_manager"
+
+    def test_empty_watchlist_yields_noop_phases(self) -> None:
+        phases = build_phase7cd([], rounds=1)
+        assert len(phases) == 3
+        for phase in phases:
+            assert len(phase.nodes) == 1
+            assert "noop" in phase.nodes[0].name
+
+
+# ─── PM integration ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPmConsumesDebateSummaries:
+    def test_pm_phase_inputs_includes_debate_summaries_when_present(self) -> None:
+        from digiquant_atlas.phases.phase7d_pm import _pm_node
+
+        state = _state()
+        state.phase7cd_debates = {
+            "AAPL": {
+                "ticker": "AAPL",
+                "rounds": [],
+                "bull_thesis": "BULL",
+                "bear_thesis": "BEAR",
+                "net_stance": "bullish",
+                "conviction_delta": 1,
+            }
+        }
+
+        captured: dict[str, str] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p for p in user_block if isinstance(p, dict) and "PHASE_INPUTS" in p.get("text", "")
+            )
+            captured["text"] = inputs_part["text"]
+            return json.dumps({"recommended_portfolio": [], "actions": [], "notes": "ok"})
+
+        with patch("digigraph.graph.research_agent.chat_completion", side_effect=fake):
+            _pm_node(state)
+
+        assert "debate_summaries" in captured["text"]
+        assert "BULL" in captured["text"]
+        assert "bullish" in captured["text"]
+
+    def test_pm_works_with_empty_debate_summaries(self) -> None:
+        """Graphs that don't wire the debate phase still produce a decision."""
+        from digiquant_atlas.phases.phase7d_pm import _pm_node
+
+        state = _state()
+        # Default: phase7cd_debates = {} (no debate ran)
+
+        with patch(
+            "digigraph.graph.research_agent.chat_completion",
+            return_value=json.dumps(
+                {"recommended_portfolio": [], "actions": [], "notes": "no-debate"}
+            ),
+        ):
+            update = _pm_node(state)
+        assert update["phase7d_rebalance"]["notes"] == "no-debate"


### PR DESCRIPTION
## Summary

Inserts a Bull/Bear debate phase between Phase 7C and Phase 7D. For each ticker the bull and bear researchers exchange arguments for `N` rounds (default 1, configurable via `preferences["debate_rounds"]`); a research manager judges and emits a structured `DebateSummary`. PM consumes the summary as a sibling of the analyst payload — `net_stance` + `conviction_delta` adjust the decision.

## Architecture

```
Phase 7C (4-axis analysts → join)
    ↓
Phase 7C-D (NEW):
  bull-researcher-{ticker}    →  DebateRoundContribution
  bear-researcher-{ticker}    →  DebateRoundContribution (counter)
  research-manager-{ticker}   →  DebateSummary
    ↓
Phase 7D (PM reads DebateSummary + AnalystPayload)
```

## What changed

- **New** `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7cd_debate.py` — pure debate engine (243 lines).
- **New** `state.phase7cd_debates: Annotated[dict[str, dict], _merge_analyst_dict]`.
- **Updated** `phase7d_pm._pm_node` — `phase_inputs["debate_summaries"]` threaded.
- **Updated** `graph.py` — debate phase wired between 7C and 7D for baseline + delta runs.
- **Skills** `research-debate` (shared bull/bear) + `research-manager`.
- **17 new unit tests** in `test_phase7cd_debate.py`.

## Test plan

- [x] 261 / 261 atlas unit tests pass (was 244; +17 new).
- [x] `make score` passes 10 / 9 / 10 / 10.
- [x] PM backward-compat asserted — graphs that don't wire the debate phase still produce decisions (`test_pm_works_with_empty_debate_summaries`).
- [x] Empty-watchlist no-op asserted across all sub-phases.

## Cost note

Each ticker now triggers 3 additional LLM calls (bull / bear / manager) per round on top of the 4 specialists from #430. With default `debate_rounds=1` and `ATLAS_MAX_ANALYSTS=25`, the upper bound is 75 extra calls per run. Configurable down via `preferences["debate_rounds"]` if cost matters more than judgment quality on a given run.

Fixes #429