### PR TITLE
test(atlas): pipeline simulation harness — zero LLM, zero DB

### DIFF
--- a/apps/digiquant-atlas/src/digiquant_atlas/testing/__init__.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/testing/__init__.py
@@ -1,0 +1,30 @@
+"""Atlas pipeline simulation harness.
+
+Use ``simulated_pipeline()`` from your tests to run the full LangGraph
+pipeline end-to-end without touching the real LLM provider or Supabase.
+The harness patches ``digigraph.graph.research_agent.chat_completion``
+with a deterministic dispatcher keyed by output schema name and threads
+a ``FakeSupabaseClient`` everywhere a real client would go.
+
+See ``simulator.py`` for the dispatch table + override mechanism.
+"""
+
+from __future__ import annotations
+
+from digiquant_atlas.testing.simulator import (
+    DEFAULT_RESPONSES,
+    SimulationRun,
+    parse_schema_name,
+    seed_supabase_client,
+    simulate_chat_completion,
+    simulated_pipeline,
+)
+
+__all__ = [
+    "DEFAULT_RESPONSES",
+    "SimulationRun",
+    "parse_schema_name",
+    "seed_supabase_client",
+    "simulate_chat_completion",
+    "simulated_pipeline",
+]

--- a/apps/digiquant-atlas/src/digiquant_atlas/testing/simulator.py
+++ b/apps/digiquant-atlas/src/digiquant_atlas/testing/simulator.py
@@ -1,0 +1,520 @@
+"""Deterministic Atlas pipeline simulator (no live LLM, no live Supabase).
+
+The simulator solves a concrete pain point: every full Atlas run hits LLM
+endpoints 30+ times. Repeated end-to-end tests that exercise the
+orchestration logic — phase wiring, state reducers, publish routing,
+triage, delta carry-forward — should not pay that cost. They should
+also not hit the real Supabase project.
+
+What this module provides:
+
+1. ``simulate_chat_completion(overrides=None)`` — a callable matching
+   ``digigraph.graph.research_agent.chat_completion``'s signature that
+   inspects the prompt's ``OUTPUT_SCHEMA (name: <ClassName>)`` block,
+   looks up the schema name in ``DEFAULT_RESPONSES``, and returns a
+   minimum-valid JSON payload. Per-test ``overrides`` win over the
+   defaults and accept either a dict (used for every call to that
+   schema) or a callable taking ``(messages, kwargs)`` for dynamic
+   responses.
+
+2. ``seed_supabase_client(...)`` — returns a ``FakeSupabaseClient``
+   pre-loaded with the minimum rows the pipeline reads on a routine
+   run: ``daily_snapshots`` (one prior baseline), ``documents`` (one
+   prior per-segment doc), ``price_technicals`` (recent freshness
+   probe rows), ``price_history`` (D-1 / D-2 close pairs for the
+   triage signal), and ``trading_calendar`` (a few NYSE entries). The
+   seed surface is intentionally narrow — tests that need richer state
+   pass extra rows via ``canned_extras``.
+
+3. ``simulated_pipeline(...)`` — context manager that patches
+   ``chat_completion`` for the duration, builds an
+   ``AtlasGraphDeps`` with the fake client wired through every seam
+   (preflight, triage, publish, phase 9, preflight-reflect), and
+   yields a ``SimulationRun`` with helpers for invoking the compiled
+   graph and inspecting both the final state and the captured Supabase
+   writes.
+
+Hard constraints honored:
+- Imports nothing from the real ``supabase`` Python client.
+- No file I/O, no network. ``ATLAS_MAX_ANALYSTS`` is honored when set
+  (phase 7C / 7C-D / debate caps respect it as in production).
+- Every default response is the smallest valid Pydantic body; tests
+  that care about specific values supply ``overrides``.
+
+Read the unit tests in ``tests/test_pipeline_simulation.py`` for the
+canonical usage shape.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any, Callable, Iterator
+from unittest.mock import patch
+
+from digiquant_atlas.graph import (
+    AtlasGraphDeps,
+    AtlasInput,
+    build_atlas_graph,
+    initial_state,
+)
+from digiquant_atlas.phases.phase9_evolution import Phase9Deps
+from digiquant_atlas.phases.preflight import PreflightDeps, PreflightReflectDeps
+from digiquant_atlas.phases.publish_phase import PublishDeps
+from digiquant_atlas.phases.triage_phase import TriageDeps
+from digiquant_atlas.state import AtlasConfigBundle, AtlasResearchState
+
+# Re-use the existing fake client + query implementation from the
+# unit-test suite. Importing from a tests module is unusual, but the
+# fake is the same shape every test in the project already depends on
+# and duplicating it here would be drift-prone.
+from tests.test_supabase_io import FakeSupabaseClient
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 1. Default responses keyed by output schema name
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Phase 1-5 segment reports all extend SegmentReport — same minimal core
+# plus per-segment extensions that are entirely optional. One ``_segment``
+# template covers all of them; per-axis dispatch happens above by schema
+# name only when the schema has required *new* fields.
+
+_TODAY = "2026-04-26"
+
+
+def _segment(slug: str, headline: str = "synthetic finding") -> dict[str, Any]:
+    """Minimum valid SegmentReport body for a given segment slug."""
+    return {
+        "segment": slug,
+        "date": _TODAY,
+        "bias": "neutral",
+        "headline": headline,
+        "material_findings": [],
+        "sources": [],
+        "notes": "",
+    }
+
+
+def _digest_body() -> dict[str, Any]:
+    """DigestSnapshot extends SegmentReport with required summary strings."""
+    return {
+        **_segment("master-digest", headline="synthetic regime"),
+        "market_regime_snapshot": "synthetic",
+        "alt_data_dashboard": "synthetic",
+        "institutional_summary": "synthetic",
+        "asset_classes_summary": "synthetic",
+        "us_equities_summary": "synthetic",
+        "thesis_tracker": "",
+        "portfolio_recommendations": "",
+        "actionable_summary": [],
+        "risk_radar": [],
+        "segment_freshness": {},
+    }
+
+
+def _phase9_body() -> dict[str, Any]:
+    return {
+        "sources": {"scored": [], "discoveries": []},
+        "quality": {
+            "predictions_checked": [],
+            "rubric": {
+                "accuracy": 3,
+                "completeness": 3,
+                "actionability": 3,
+                "conciseness": 3,
+                "source_quality": 3,
+            },
+        },
+        "proposals": {"proposals": []},
+    }
+
+
+def _specialist_body(axis: str = "technical", ticker: str = "AAPL") -> dict[str, Any]:
+    return {
+        "axis": axis,
+        "ticker": ticker,
+        "conviction_axis": 0.6,
+        "stance_axis": "buy",
+        "rationale": f"synthetic {axis} rationale for {ticker}",
+        "sources": [],
+    }
+
+
+def _debate_round_body(role: str = "bull", ticker: str = "AAPL") -> dict[str, Any]:
+    return {
+        "role": role,
+        "ticker": ticker,
+        "round_number": 1,
+        "argument": f"synthetic {role} argument for {ticker}",
+    }
+
+
+def _debate_summary_body(ticker: str = "AAPL") -> dict[str, Any]:
+    return {
+        "ticker": ticker,
+        "rounds": [],
+        "bull_thesis": "synthetic bull synthesis",
+        "bear_thesis": "synthetic bear synthesis",
+        "net_stance": "neutral",
+        "conviction_delta": 0,
+    }
+
+
+# Schemas that don't need per-call customization use a single canned dict.
+# Callers who do need it (per-ticker specialists / debaters) supply
+# ``overrides`` callables.
+DEFAULT_RESPONSES: dict[str, dict[str, Any]] = {
+    # Phase 1
+    "SentimentNewsReport": _segment("alt-sentiment-news"),
+    "CtaPositioningReport": _segment("alt-cta-positioning"),
+    "OptionsDerivativesReport": _segment("alt-options-derivatives"),
+    "PoliticianSignalsReport": _segment("alt-politician-signals"),
+    # Phase 2
+    "InstitutionalFlowsReport": _segment("inst-institutional-flows"),
+    "HedgeFundIntelReport": _segment("inst-hedge-fund-intel"),
+    # Phase 3 — narrow Literal fields per phase3_macro.py.
+    "MacroRegimeReport": {
+        **_segment("macro", headline="synthetic regime"),
+        "growth": "slowing",
+        "inflation": "cooling",
+        "policy": "neutral",
+        "risk_appetite": "mixed",
+        "regime_label": "Synthetic / Mixed / Neutral / Mixed",
+        "portfolio_implications": "",
+    },
+    # Phase 4 — every asset class shares the SegmentReport core; phase4
+    # extras are all optional.
+    "BondsReport": _segment("bonds"),
+    "CommoditiesReport": _segment("commodities"),
+    "ForexReport": _segment("forex"),
+    "CryptoReport": _segment("crypto"),
+    "InternationalReport": _segment("international"),
+    # Phase 5
+    "EquityOverviewReport": _segment("equity"),
+    "SectorReport": _segment("sector"),
+    # Phase 7
+    "DigestSnapshot": _digest_body(),
+    "MonthlyDigest": _digest_body(),
+    # Phase 7C 4-axis specialists
+    "SpecialistPayload": _specialist_body(),
+    # Phase 7C-D bull/bear debate
+    "DebateRoundContribution": _debate_round_body(),
+    "DebateSummary": _debate_summary_body(),
+    # Phase 7D risk debate
+    "RiskCase": {"case": "synthetic risk case"},
+    "RiskDebateSummary": {
+        "aggressive_case": "synthetic aggressive",
+        "conservative_case": "synthetic conservative",
+        "key_tension": "synthetic tension",
+    },
+    # Phase 7D PM
+    "RebalanceDecision": {
+        "recommended_portfolio": [],
+        "actions": [],
+        "notes": "synthetic rebalance",
+    },
+    # Phase 9
+    "Phase9Artifacts": _phase9_body(),
+    # #432 reflector skill — separate from Phase 9 artifacts.
+    "DecisionReflection": {"reflection": "synthetic reflection"},
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 2. Prompt parsing + chat_completion mock
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_SCHEMA_NAME_RE = re.compile(r"OUTPUT_SCHEMA \(name: (\w+)\)")
+_PHASE_INPUTS_RE = re.compile(r"PHASE_INPUTS[^:]*:\s*(\{.*\})", re.DOTALL)
+
+
+def parse_schema_name(messages: list[dict[str, Any]]) -> str | None:
+    """Extract the output-schema name from a prompt's OUTPUT_SCHEMA chunk.
+
+    Returns ``None`` if the chunk is missing — callers should treat that
+    as a wiring bug (every Atlas LLM call goes through ``run_research_agent``
+    which always includes the chunk).
+    """
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text", "")
+            m = _SCHEMA_NAME_RE.search(text)
+            if m:
+                return m.group(1)
+    return None
+
+
+def parse_phase_inputs(messages: list[dict[str, Any]]) -> dict[str, Any]:
+    """Extract the parsed PHASE_INPUTS body from a prompt.
+
+    Returns an empty dict if the chunk is missing or unparseable. Used
+    by override callables that want to specialize the response based on
+    e.g. the per-ticker ``ticker`` field.
+    """
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text", "")
+            m = _PHASE_INPUTS_RE.search(text)
+            if m:
+                try:
+                    return json.loads(m.group(1))
+                except json.JSONDecodeError:
+                    return {}
+    return {}
+
+
+OverrideValue = dict[str, Any] | Callable[[list[dict[str, Any]], dict[str, Any]], Any]
+
+
+def simulate_chat_completion(
+    overrides: dict[str, OverrideValue] | None = None,
+) -> Callable[..., str]:
+    """Build a ``chat_completion``-shaped callable with deterministic outputs.
+
+    The returned function dispatches on the ``OUTPUT_SCHEMA`` name in the
+    prompt:
+
+    1. If ``overrides[schema_name]`` is set, use it.
+       - dict → returned verbatim (after JSON-encoding).
+       - callable → invoked as ``fn(messages, kwargs)``; return value is
+         the response. If the callable returns a dict, the simulator
+         JSON-encodes it; if it returns a string, the simulator emits
+         it raw.
+    2. Otherwise look up ``DEFAULT_RESPONSES[schema_name]`` and JSON-encode.
+    3. If the schema isn't in either table, raise ``KeyError`` so the
+       test author sees a useful error instead of cryptic Pydantic
+       validation failures downstream.
+
+    The dispatcher also fills in per-call fields for schemas that need
+    per-ticker / per-axis customization (e.g. SpecialistPayload picks up
+    ``axis`` + ``ticker`` from PHASE_INPUTS so the ticker round-trips
+    through the assertion).
+    """
+    overrides = overrides or {}
+
+    def _emit(payload: Any) -> str:
+        if isinstance(payload, str):
+            return payload
+        return json.dumps(payload)
+
+    def _per_call_default(schema: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Per-call dynamic defaults — ticker / axis / role round-tripped."""
+        if schema == "SpecialistPayload":
+            return _specialist_body(
+                axis=str(inputs.get("axis", "technical")),
+                ticker=str(inputs.get("ticker", "AAPL")),
+            )
+        if schema == "DebateRoundContribution":
+            return _debate_round_body(
+                role=str(inputs.get("role", "bull")),
+                ticker=str(inputs.get("ticker", "AAPL")),
+            )
+        if schema == "DebateSummary":
+            return _debate_summary_body(ticker=str(inputs.get("ticker", "AAPL")))
+        return DEFAULT_RESPONSES[schema]
+
+    def chat_completion(*args: Any, **kwargs: Any) -> str:
+        # Signature: chat_completion(model, messages, **kwargs). Tolerate
+        # both positional and keyword forms; the agent calls this many
+        # different ways across phases.
+        messages = kwargs.get("messages")
+        if messages is None and len(args) >= 2:
+            messages = args[1]
+        messages = messages or []
+
+        schema = parse_schema_name(messages)
+        if schema is None:
+            raise RuntimeError(
+                "simulate_chat_completion: no OUTPUT_SCHEMA in prompt — "
+                "is the caller bypassing run_research_agent?"
+            )
+
+        inputs = parse_phase_inputs(messages)
+
+        if schema in overrides:
+            override = overrides[schema]
+            if callable(override):
+                return _emit(override(messages, kwargs))
+            return _emit(override)
+
+        if schema not in DEFAULT_RESPONSES and schema not in {
+            "SpecialistPayload",
+            "DebateRoundContribution",
+            "DebateSummary",
+        }:
+            raise KeyError(
+                f"simulate_chat_completion: no default response for schema {schema!r}; "
+                f"add it to DEFAULT_RESPONSES or pass an override."
+            )
+
+        return _emit(_per_call_default(schema, inputs))
+
+    return chat_completion
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 3. Seeded fake Supabase client
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _default_canned() -> dict[str, list[dict[str, Any]]]:
+    """Minimum prior state the pipeline reads on a routine baseline run."""
+    today = date.fromisoformat(_TODAY)
+    yesterday = (today - timedelta(days=1)).isoformat()
+    two_days_ago = (today - timedelta(days=2)).isoformat()
+
+    return {
+        "daily_snapshots": [
+            {
+                "date": yesterday,
+                "run_type": "baseline",
+                "baseline_date": None,
+                "snapshot": {"market_regime_snapshot": "prior baseline"},
+            }
+        ],
+        "documents": [],
+        "price_technicals": [
+            {"date": yesterday, "ticker": "AAPL"},
+            {"date": yesterday, "ticker": "MSFT"},
+        ],
+        "macro_series_observations": [{"obs_date": yesterday}],
+        "price_history": [
+            {"date": two_days_ago, "ticker": "AAPL", "close": 100.0},
+            {"date": yesterday, "ticker": "AAPL", "close": 100.5},
+            {"date": two_days_ago, "ticker": "MSFT", "close": 200.0},
+            {"date": yesterday, "ticker": "MSFT", "close": 201.0},
+            # Benchmark for #432 alpha computation.
+            {"date": two_days_ago, "ticker": "SPY", "close": 400.0},
+            {"date": yesterday, "ticker": "SPY", "close": 401.0},
+        ],
+        "trading_calendar": [
+            {"date": yesterday, "venue": "NYSE", "is_trading_day": True},
+            {"date": today.isoformat(), "venue": "NYSE", "is_trading_day": True},
+        ],
+        "decision_log": [],
+    }
+
+
+def seed_supabase_client(
+    canned_extras: dict[str, list[dict[str, Any]]] | None = None,
+) -> FakeSupabaseClient:
+    """Return a ``FakeSupabaseClient`` with default seed rows.
+
+    ``canned_extras`` is merged on top of the defaults — supply additional
+    rows for the tables your test cares about. Replacing the seed entirely
+    is intentional: build your own canned dict and pass it directly.
+    """
+    canned = _default_canned()
+    if canned_extras:
+        for table, extras in canned_extras.items():
+            canned.setdefault(table, [])
+            canned[table].extend(extras)
+    return FakeSupabaseClient(canned_reads=canned)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 4. End-to-end harness
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SimulationRun:
+    """Handle returned from ``simulated_pipeline``.
+
+    Test code typically calls ``invoke()`` once and then asserts against
+    the resulting state and the captured Supabase writes (``client.store``).
+    """
+
+    client: FakeSupabaseClient
+    deps: AtlasGraphDeps
+    config_bundle: AtlasConfigBundle = field(default_factory=AtlasConfigBundle)
+    captured_calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    def invoke(self, atlas_input: AtlasInput) -> AtlasResearchState:
+        """Build the graph for ``atlas_input`` and run it to completion.
+
+        Returns the final ``AtlasResearchState`` so tests can read every
+        ``phaseN_*`` field directly. The fake client's ``store`` carries
+        every write; the canned reads carry every prior-context probe.
+        """
+        graph = build_atlas_graph(
+            atlas_input.run_type,
+            deps=self.deps,
+            watchlist=atlas_input.watchlist,
+        )
+        state = initial_state(atlas_input, config=self.config_bundle)
+        result = graph.invoke(state)
+        return AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+
+@contextmanager
+def simulated_pipeline(
+    *,
+    watchlist: tuple[str, ...] = ("AAPL", "MSFT"),
+    overrides: dict[str, OverrideValue] | None = None,
+    canned_extras: dict[str, list[dict[str, Any]]] | None = None,
+    publish: bool = True,
+    triage: bool = True,
+    phase9: bool = False,
+    preflight_reflect: bool = False,
+    preferences: dict[str, Any] | None = None,
+) -> Iterator[SimulationRun]:
+    """Patch chat_completion + thread a fake client through every dep slot.
+
+    Parameters
+    ----------
+    watchlist
+        Tickers in scope. Drives Phase 7C / 7C-D / 7D fan-out width.
+    overrides
+        Per-schema response overrides (see ``simulate_chat_completion``).
+    canned_extras
+        Extra rows for the seeded fake client (merged on top of defaults).
+    publish, triage, phase9, preflight_reflect
+        Whether to wire the optional dep slots. Default behavior matches a
+        legacy graph (publish + triage on; phase9 + reflect off — those
+        require migrations 026/027).
+    preferences
+        Merged into ``AtlasConfigBundle.preferences`` so tests can flip
+        ``debate_rounds``, ``holding_days``, etc.
+    """
+    client = seed_supabase_client(canned_extras=canned_extras)
+    deps = AtlasGraphDeps(
+        preflight=PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(
+                watchlist=list(watchlist),
+                preferences=dict(preferences or {}),
+            ),
+        ),
+        publish=PublishDeps(client=client) if publish else None,
+        triage=TriageDeps(client=client) if triage else None,
+        phase9=Phase9Deps(client=client) if phase9 else None,
+        preflight_reflect=(PreflightReflectDeps(client=client) if preflight_reflect else None),
+    )
+    config_bundle = AtlasConfigBundle(
+        watchlist=list(watchlist),
+        preferences=dict(preferences or {}),
+    )
+
+    fake_chat = simulate_chat_completion(overrides=overrides)
+
+    with patch(
+        "digigraph.graph.research_agent.chat_completion",
+        side_effect=fake_chat,
+    ):
+        yield SimulationRun(client=client, deps=deps, config_bundle=config_bundle)

--- a/apps/digiquant-atlas/tests/test_pipeline_simulation.py
+++ b/apps/digiquant-atlas/tests/test_pipeline_simulation.py
@@ -1,0 +1,241 @@
+"""End-to-end Atlas pipeline simulation tests.
+
+These tests exercise the full LangGraph pipeline (preflight → all 9
+phases → publish) using ``digiquant_atlas.testing.simulator`` to mock
+both the LLM provider and Supabase. Zero network calls, zero token
+spend, zero DB writes.
+
+The point isn't to validate any single phase's prompt quality — that's
+what the focused per-phase tests are for. The point is to catch graph
+wiring bugs: phase ordering, state-reducer collisions, deps threading,
+publish-path routing, delta carry-forward, custom-research routing.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant_atlas.graph import AtlasInput
+from digiquant_atlas.testing import (
+    DEFAULT_RESPONSES,
+    parse_schema_name,
+    simulated_pipeline,
+)
+
+
+@pytest.mark.unit
+class TestSimulatorContract:
+    def test_default_responses_cover_all_known_schemas(self) -> None:
+        """Spot-check that the default response table covers the
+        load-bearing models. Per-call dynamic schemas are exempt."""
+        required = {
+            "SentimentNewsReport",
+            "MacroRegimeReport",
+            "DigestSnapshot",
+            "RebalanceDecision",
+            "RiskDebateSummary",
+            "Phase9Artifacts",
+        }
+        assert required.issubset(set(DEFAULT_RESPONSES.keys()))
+
+    def test_parse_schema_name_extracts_class_name(self) -> None:
+        msgs = [
+            {
+                "content": [
+                    {"text": "PHASE_INPUTS (today): {}"},
+                    {"text": "OUTPUT_SCHEMA (name: DigestSnapshot):\n{...}"},
+                ]
+            }
+        ]
+        assert parse_schema_name(msgs) == "DigestSnapshot"
+
+    def test_parse_schema_name_returns_none_when_missing(self) -> None:
+        assert parse_schema_name([{"content": [{"text": "no schema"}]}]) is None
+
+
+@pytest.mark.unit
+class TestBaselineEndToEnd:
+    def test_full_baseline_run_produces_publish_artifacts(self) -> None:
+        """Smoke test: invoke a baseline graph, assert every phase wrote
+        its piece of state and the publish phase routed the digest."""
+        with simulated_pipeline(watchlist=("AAPL", "MSFT")) as run:
+            final = run.invoke(
+                AtlasInput(
+                    run_type="baseline",
+                    run_date=date(2026, 4, 26),
+                    watchlist=("AAPL", "MSFT"),
+                )
+            )
+
+        # Phase 1-5 segment outputs landed.
+        assert final.phase1_outputs, "Phase 1 outputs missing"
+        assert final.phase2_outputs, "Phase 2 outputs missing"
+        assert final.phase3_output is not None, "Phase 3 macro missing"
+        assert final.phase4_outputs, "Phase 4 outputs missing"
+        assert final.phase5_outputs, "Phase 5 equity missing"
+
+        # Phase 6 bias row aggregated.
+        assert final.phase6_bias_row is not None
+        # Phase 7 digest synthesised.
+        assert final.phase7_digest is not None
+
+        # Phase 7C 4-axis specialists ran for every ticker (#430).
+        for ticker in ("AAPL", "MSFT"):
+            assert ticker in final.phase7c_specialists
+            assert set(final.phase7c_specialists[ticker].keys()) == {
+                "technical",
+                "sentiment",
+                "news",
+                "fundamental",
+            }
+            # Join produced an AnalystPayload for every ticker.
+            assert ticker in final.phase7c_analysts
+
+        # Phase 7C-D bull/bear debate produced summaries (#429).
+        for ticker in ("AAPL", "MSFT"):
+            debate = final.phase7cd_debates[ticker]
+            assert "net_stance" in debate
+
+        # Phase 7D risk debate (#431) + PM rebalance.
+        assert final.phase7d_risk_debate is not None
+        assert final.phase7d_rebalance is not None
+
+        # Phase 9 evolution emitted.
+        assert final.phase9_evolution is not None
+
+        # Publish phase wrote both daily_snapshots + per-segment documents.
+        assert "daily_snapshots" in run.client.store
+        assert len(run.client.store["daily_snapshots"]) == 1
+        assert run.client.store["daily_snapshots"][0]["run_type"] == "baseline"
+        assert "documents" in run.client.store
+        digest_rows = [r for r in run.client.store["documents"] if r["doc_type"] == "Daily Digest"]
+        assert len(digest_rows) == 1
+
+    def test_publish_skipped_when_dep_omitted(self) -> None:
+        """``publish=False`` keeps the run hermetic for orchestration tests
+        that don't care about the persistence path."""
+        with simulated_pipeline(watchlist=("AAPL",), publish=False) as run:
+            run.invoke(
+                AtlasInput(
+                    run_type="baseline",
+                    run_date=date(2026, 4, 26),
+                    watchlist=("AAPL",),
+                )
+            )
+        assert "daily_snapshots" not in run.client.store
+
+
+@pytest.mark.unit
+class TestDeltaCarryForward:
+    def test_delta_run_invokes_triage_and_publishes_digest_delta(self) -> None:
+        with simulated_pipeline(watchlist=("AAPL",)) as run:
+            final = run.invoke(
+                AtlasInput(
+                    run_type="delta",
+                    run_date=date(2026, 4, 26),
+                    baseline_date=date(2026, 4, 19),
+                    watchlist=("AAPL",),
+                )
+            )
+
+        # Triage decisions were generated for the run.
+        assert final.triage is not None
+        # Publish routed under the delta key + doc_type.
+        digest_rows = [r for r in run.client.store["documents"] if r["doc_type"] == "Daily Delta"]
+        assert len(digest_rows) == 1
+        assert digest_rows[0]["document_key"] == "digest-delta"
+
+
+@pytest.mark.unit
+class TestCustomResearchRouting:
+    def test_custom_prompt_routes_under_custom_research_doc_type(self) -> None:
+        with simulated_pipeline(watchlist=("AAPL",)) as run:
+            final = run.invoke(
+                AtlasInput(
+                    run_type="baseline",
+                    run_date=date(2026, 4, 26),
+                    watchlist=("AAPL",),
+                    custom_prompt="Drill into NVDA earnings risk.",
+                )
+            )
+
+        assert final.custom_prompt == "Drill into NVDA earnings risk."
+        # Custom research lands in documents but NOT in daily_snapshots
+        # (cadence stays clean).
+        custom_rows = [
+            r for r in run.client.store["documents"] if r["doc_type"] == "Custom Research"
+        ]
+        assert len(custom_rows) == 1
+        assert custom_rows[0]["document_key"].startswith("custom-research/")
+        assert "daily_snapshots" not in run.client.store
+
+
+@pytest.mark.unit
+class TestOverrides:
+    def test_override_callable_can_inspect_inputs(self) -> None:
+        """Per-call override receives the raw messages so it can specialize
+        on ticker/axis/role, etc."""
+        seen_tickers: list[str] = []
+
+        def custom_specialist(messages: list[dict], _kwargs: dict) -> dict:
+            from digiquant_atlas.testing.simulator import parse_phase_inputs
+
+            inputs = parse_phase_inputs(messages)
+            ticker = inputs.get("ticker", "?")
+            axis = inputs.get("axis", "?")
+            seen_tickers.append(ticker)
+            return {
+                "axis": axis,
+                "ticker": ticker,
+                "conviction_axis": 0.9,
+                "stance_axis": "buy",
+                "rationale": f"override for {ticker}",
+                "sources": [],
+            }
+
+        with simulated_pipeline(
+            watchlist=("AAPL", "MSFT"),
+            overrides={"SpecialistPayload": custom_specialist},
+        ) as run:
+            final = run.invoke(
+                AtlasInput(
+                    run_type="baseline",
+                    run_date=date(2026, 4, 26),
+                    watchlist=("AAPL", "MSFT"),
+                )
+            )
+
+        # 4 axes × 2 tickers = 8 specialist calls.
+        assert len(seen_tickers) == 8
+        # Every override response set conviction_axis=0.9, so the join's
+        # weighted average maps to a strong-buy conviction_score.
+        for ticker in ("AAPL", "MSFT"):
+            payload = final.phase7c_analysts[ticker]
+            assert payload["conviction_score"] >= 1
+
+
+@pytest.mark.unit
+class TestNoNetworkOrTokens:
+    def test_simulator_does_not_import_supabase_client(self) -> None:
+        """Hard rule: the simulator must not pull in the real client."""
+        import sys
+
+        from digiquant_atlas.testing import simulator  # noqa: F401
+
+        assert "supabase" not in sys.modules or all(
+            not name.startswith("supabase.")
+            or name == "supabase"
+            and not hasattr(sys.modules.get("supabase"), "create_client")
+            for name in sys.modules
+        )
+
+    def test_chat_completion_is_patched_inside_context(self) -> None:
+        """Outside the context manager, real chat_completion is restored."""
+        from digigraph.graph import research_agent
+
+        original = research_agent.chat_completion
+        with simulated_pipeline(watchlist=("AAPL",), publish=False) as _run:
+            assert research_agent.chat_completion is not original
+        assert research_agent.chat_completion is original


### PR DESCRIPTION
## Summary

Adds `digiquant_atlas.testing.simulator` so end-to-end orchestration tests run the full LangGraph pipeline without touching the real LLM provider or Supabase.

The simulator dispatches LLM calls on the prompt's `OUTPUT_SCHEMA (name: <ClassName>)` block — every Atlas phase already routes through `run_research_agent` which always emits that block, so the dispatcher works with zero phase-side changes.

## API

```python
from digiquant_atlas.testing import simulated_pipeline

with simulated_pipeline(watchlist=("AAPL", "MSFT")) as run:
    final = run.invoke(AtlasInput(run_type="baseline", run_date=...))
# final is the populated AtlasResearchState
# run.client.store carries every Supabase upsert the publish phase made
```

Per-test response overrides accept either a dict (verbatim) or a callable `(messages, kwargs) -> dict | str` for dynamic per-call responses (e.g. specializing on ticker / axis / role).

## What's covered (10 new tests)

- Full baseline run: all 9 phases write, publish lands `Daily Digest` + `daily_snapshots`.
- `publish=False` flag keeps the run hermetic.
- Delta run: triage populates, publish routes under `Daily Delta` / `digest-delta` key.
- Custom research: `custom_prompt` routes the digest under `Custom Research` and skips `daily_snapshots`.
- Per-call override callables can inspect inputs to specialize.
- Hard rule: simulator imports nothing from the real `supabase` client (regression test).
- `chat_completion` patch is correctly cleaned up on context exit.

## Test plan

- [x] 10 / 10 simulation tests pass.
- [x] 271 / 271 atlas unit tests pass overall.
- [x] `make score` passes 10 / 9 / 10 / 10.
- [x] No new dependencies. Re-uses existing `FakeSupabaseClient` from `tests/test_supabase_io.py`.

This branch is `chore/` rather than `task/` because there's no associated GitHub issue — the simulation harness was scoped from session conversation, not from the backlog. It addresses a tooling gap and unblocks cheap orchestration regression tests for every future phase.

## Cost

Zero. That's the point.