### PR TITLE
feat(digigraph): retry transient LLM failures + workflow-level retry

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -31,7 +31,12 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # 240 min accommodates the broader inner LLM-retry budget (#461):
+    # ``_create_with_retry`` now backs off up to 12 attempts × 300s
+    # ceiling per call. Workflow-level bash retry below adds a 2nd
+    # outer layer for cases where a sustained provider outage exhausts
+    # the inner budget.
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
 
@@ -88,11 +93,31 @@ jobs:
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
-          python -m digiquant_atlas.graph \
-            --run-type baseline \
-            --run-date "${{ steps.resolve.outputs.run_date }}" \
-            $DRY_FLAG \
-            2>&1 | tee artifacts/run.log
+
+          # Outer workflow-level retry — last line of defense against
+          # provider outages longer than the in-process retry budget
+          # in ``_create_with_retry`` (12 attempts × 300s ceiling per
+          # LLM call). Three full pipeline attempts with 5/15-min waits
+          # between them; total worst-case ≈ 2h45m before giving up.
+          MAX_OUTER_ATTEMPTS=3
+          OUTER_BACKOFF=(0 300 900)
+          attempt=1
+          while : ; do
+            sleep "${OUTER_BACKOFF[$((attempt-1))]}"
+            echo "── Pipeline attempt ${attempt}/${MAX_OUTER_ATTEMPTS} ──"
+            if python -m digiquant_atlas.graph \
+                --run-type baseline \
+                --run-date "${{ steps.resolve.outputs.run_date }}" \
+                $DRY_FLAG \
+                2>&1 | tee -a artifacts/run.log; then
+              break
+            fi
+            if [ "${attempt}" -ge "${MAX_OUTER_ATTEMPTS}" ]; then
+              echo "Pipeline failed after ${MAX_OUTER_ATTEMPTS} attempts."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -31,7 +31,10 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 120 min covers up to 3 outer pipeline attempts (5/15-min backoff)
+    # × the in-process LLM retry budget (12 × 300s) for the trimmer
+    # delta path. See atlas-baseline.yml for the rationale (#461).
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 
@@ -87,12 +90,28 @@ jobs:
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
-          python -m digiquant_atlas.graph \
-            --run-type delta \
-            --run-date "${{ steps.resolve.outputs.run_date }}" \
-            --auto-baseline \
-            $DRY_FLAG \
-            2>&1 | tee artifacts/run.log
+
+          # Outer workflow-level retry — see atlas-baseline.yml (#461).
+          MAX_OUTER_ATTEMPTS=3
+          OUTER_BACKOFF=(0 300 900)
+          attempt=1
+          while : ; do
+            sleep "${OUTER_BACKOFF[$((attempt-1))]}"
+            echo "── Pipeline attempt ${attempt}/${MAX_OUTER_ATTEMPTS} ──"
+            if python -m digiquant_atlas.graph \
+                --run-type delta \
+                --run-date "${{ steps.resolve.outputs.run_date }}" \
+                --auto-baseline \
+                $DRY_FLAG \
+                2>&1 | tee -a artifacts/run.log; then
+              break
+            fi
+            if [ "${attempt}" -ge "${MAX_OUTER_ATTEMPTS}" ]; then
+              echo "Pipeline failed after ${MAX_OUTER_ATTEMPTS} attempts."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -98,7 +98,10 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 180 min covers up to 3 outer pipeline attempts × inner LLM retry
+    # budget for the monthly rollup (smaller scope than baseline but
+    # touches the same external providers). See #461 for rationale.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 
@@ -141,11 +144,27 @@ jobs:
             DRY_FLAG="--dry-run"
           fi
           set -o pipefail
-          python -m digiquant_atlas.graph \
-            --run-type monthly \
-            --run-date "${{ steps.resolve.outputs.run_date }}" \
-            $DRY_FLAG \
-            2>&1 | tee artifacts/run.log
+
+          # Outer workflow-level retry — see atlas-baseline.yml (#461).
+          MAX_OUTER_ATTEMPTS=3
+          OUTER_BACKOFF=(0 300 900)
+          attempt=1
+          while : ; do
+            sleep "${OUTER_BACKOFF[$((attempt-1))]}"
+            echo "── Pipeline attempt ${attempt}/${MAX_OUTER_ATTEMPTS} ──"
+            if python -m digiquant_atlas.graph \
+                --run-type monthly \
+                --run-date "${{ steps.resolve.outputs.run_date }}" \
+                $DRY_FLAG \
+                2>&1 | tee -a artifacts/run.log; then
+              break
+            fi
+            if [ "${attempt}" -ge "${MAX_OUTER_ATTEMPTS}" ]; then
+              echo "Pipeline failed after ${MAX_OUTER_ATTEMPTS} attempts."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
 
       - name: Upload logs
         if: always()

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -355,27 +355,54 @@ def get_client() -> OpenAI:
 
 
 def _create_with_retry(client: Any, **kwargs: Any) -> Any:
-    """Call client.chat.completions.create with exponential backoff on 429."""
-    from openai import RateLimitError
+    """Call client.chat.completions.create with backoff on transient errors.
 
-    max_attempts = 7
+    Retries on:
+    - ``RateLimitError`` (429) — model-side throughput cap (Ollama/Groq).
+    - ``InternalServerError`` (5xx, including Gemini's "503 high demand"
+      response) — provider-side transient unavailability.
+    - ``APIConnectionError`` — TCP / DNS / proxy blips.
+    - ``APITimeoutError`` — request timeout from the OpenAI client.
+
+    Other exceptions (auth, bad-request, malformed-prompt) propagate
+    immediately so the caller sees the real error instead of a long
+    pointless wait.
+
+    Backoff: starts at 5s, doubles per attempt, capped at 300s. Jitter
+    of up to 25%% on top to avoid thundering-herd retries when many
+    parallel phase-7C/7CD nodes hit the same 503 simultaneously. Total
+    budget at the default 12 attempts is roughly 30 minutes — long
+    enough to ride out a typical Google/Groq incident.
+    """
+    from openai import (
+        APIConnectionError,
+        APITimeoutError,
+        InternalServerError,
+        RateLimitError,
+    )
+
+    transient = (RateLimitError, InternalServerError, APIConnectionError, APITimeoutError)
+
+    max_attempts = 12
     delay = 5.0
     for attempt in range(max_attempts):
         try:
             return client.chat.completions.create(**kwargs)
-        except RateLimitError:
+        except transient as exc:
             if attempt >= max_attempts - 1:
                 raise
             jitter = random.uniform(0.0, delay * 0.25)
             wait = delay + jitter
+            kind = type(exc).__name__
             logger.warning(
-                "Ollama 429 (attempt %d/%d): waiting %.1fs before retry",
+                "%s (attempt %d/%d): waiting %.1fs before retry",
+                kind,
                 attempt + 1,
                 max_attempts,
                 wait,
             )
             time.sleep(wait)
-            delay = min(delay * 2, 120.0)
+            delay = min(delay * 2, 300.0)
 
 
 @_traceable("chat_completion")

--- a/tests/dg/test_llm.py
+++ b/tests/dg/test_llm.py
@@ -212,6 +212,157 @@ class TestGetClient:
 
 
 @pytest.mark.unit
+class TestCreateWithRetry:
+    """_create_with_retry() retries on transient errors with backoff.
+
+    Regression coverage for the Gemini 503 outage that took down two real
+    atlas-baseline runs in 2026-04. Previously the helper only caught
+    ``RateLimitError``; ``InternalServerError`` (Gemini's "high demand"
+    503) and connection blips fell through and killed the pipeline.
+    """
+
+    def _make_client(self, side_effect: object) -> MagicMock:
+        client = MagicMock()
+        client.chat.completions.create = MagicMock(side_effect=side_effect)
+        return client
+
+    def _http_response(self) -> MagicMock:
+        # Minimum viable shape for openai SDK error constructors.
+        resp = MagicMock()
+        resp.status_code = 503
+        resp.request = MagicMock()
+        resp.request.method = "POST"
+        resp.request.url = (
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        )
+        resp.headers = {}
+        return resp
+
+    def test_returns_immediately_when_no_error(self) -> None:
+        from digigraph.llm import _create_with_retry
+
+        ok = MagicMock()
+        ok.choices = [MagicMock(message=MagicMock(content="ok"))]
+        client = MagicMock()
+        client.chat.completions.create = MagicMock(return_value=ok)
+
+        with patch("digigraph.llm.time.sleep") as mock_sleep:
+            assert _create_with_retry(client) is ok
+        mock_sleep.assert_not_called()
+
+    def test_retries_on_internal_server_error_then_succeeds(self) -> None:
+        """Transient 503 (Gemini high-demand) must retry, not raise."""
+        from openai import InternalServerError
+
+        from digigraph.llm import _create_with_retry
+
+        ok = MagicMock()
+        ok.choices = [MagicMock(message=MagicMock(content="ok"))]
+        err = InternalServerError(
+            message="503 high demand",
+            response=self._http_response(),
+            body={"error": {"code": 503, "message": "high demand"}},
+        )
+        client = self._make_client([err, err, ok])
+
+        with patch("digigraph.llm.time.sleep") as mock_sleep:
+            result = _create_with_retry(client)
+        assert result is ok
+        assert client.chat.completions.create.call_count == 3
+        # Two backoff sleeps between three attempts.
+        assert mock_sleep.call_count == 2
+
+    def test_retries_on_rate_limit_error(self) -> None:
+        """Existing 429 retry behavior must still work after the broadening."""
+        from openai import RateLimitError
+
+        from digigraph.llm import _create_with_retry
+
+        ok = MagicMock()
+        ok.choices = [MagicMock(message=MagicMock(content="ok"))]
+        err = RateLimitError(
+            message="429 rate limit",
+            response=self._http_response(),
+            body={"error": {"code": 429}},
+        )
+        client = self._make_client([err, ok])
+
+        with patch("digigraph.llm.time.sleep"):
+            result = _create_with_retry(client)
+        assert result is ok
+        assert client.chat.completions.create.call_count == 2
+
+    def test_retries_on_connection_error(self) -> None:
+        from openai import APIConnectionError
+
+        from digigraph.llm import _create_with_retry
+
+        ok = MagicMock()
+        ok.choices = [MagicMock(message=MagicMock(content="ok"))]
+        err = APIConnectionError(request=MagicMock())
+        client = self._make_client([err, ok])
+
+        with patch("digigraph.llm.time.sleep"):
+            result = _create_with_retry(client)
+        assert result is ok
+        assert client.chat.completions.create.call_count == 2
+
+    def test_does_not_retry_non_transient(self) -> None:
+        """Auth / bad-request / arbitrary errors must surface immediately."""
+        from digigraph.llm import _create_with_retry
+
+        client = self._make_client(ValueError("malformed prompt"))
+
+        with patch("digigraph.llm.time.sleep") as mock_sleep:
+            with pytest.raises(ValueError, match="malformed prompt"):
+                _create_with_retry(client)
+        mock_sleep.assert_not_called()
+        assert client.chat.completions.create.call_count == 1
+
+    def test_raises_after_max_attempts(self) -> None:
+        """When the upstream is sustained-down, eventually give up."""
+        from openai import InternalServerError
+
+        from digigraph.llm import _create_with_retry
+
+        err = InternalServerError(
+            message="503",
+            response=self._http_response(),
+            body={"error": {"code": 503}},
+        )
+        client = self._make_client(err)
+
+        with patch("digigraph.llm.time.sleep"):
+            with pytest.raises(InternalServerError):
+                _create_with_retry(client)
+        # Default budget is 12 attempts.
+        assert client.chat.completions.create.call_count == 12
+
+    def test_backoff_uses_exponential_doubling(self) -> None:
+        from openai import InternalServerError
+
+        from digigraph.llm import _create_with_retry
+
+        ok = MagicMock()
+        err = InternalServerError(
+            message="503",
+            response=self._http_response(),
+            body={"error": {"code": 503}},
+        )
+        client = self._make_client([err, err, err, ok])
+
+        with patch("digigraph.llm.time.sleep") as mock_sleep:
+            _create_with_retry(client)
+
+        sleep_args = [call.args[0] for call in mock_sleep.call_args_list]
+        # Base 5s with jitter up to +25%; doubling capped at 300s.
+        # Floor of each interval: 5, 10, 20.
+        assert sleep_args[0] >= 5.0
+        assert sleep_args[1] >= 10.0
+        assert sleep_args[2] >= 20.0
+
+
+@pytest.mark.unit
 class TestChatCompletion:
     """chat_completion() uses client and returns first choice content."""
 


### PR DESCRIPTION
## Summary

Both real `atlas-baseline` runs after migration 026 landed died on Gemini `503 "high demand"` before reaching Phase 4. The existing retry layer only caught `RateLimitError` (429); 5xx + connection blips + timeouts fell through.

This PR adds three composing layers of resilience:

1. **Inner LLM retry** (`_create_with_retry`) — now also catches `InternalServerError`, `APIConnectionError`, `APITimeoutError`. Budget bumped to 12 attempts × 300s ceiling (~30 min worst-case per call).
2. **Schema-validation retry** — unchanged; complementary error class.
3. **Workflow-level bash retry** — wraps the CLI invocation up to 3× with 0/300s/900s backoff between attempts in all three Atlas workflows. Job timeouts lifted (baseline 240 min, delta 120 min, monthly 180 min).

Worst-case total retry budget: ~2h45m before the workflow gives up.

## What this fixes

When Gemini Flash returns 503 "high demand" — exactly the failure class that just took down two consecutive runs — the pipeline now:
- Retries the individual call up to 12 times with exponential backoff
- If the 30-min inner budget is exhausted, the workflow waits 5 min and re-invokes the whole CLI
- If 2 outer retries also fail, waits 15 min and tries one more time

Auth errors, bad-request errors, and other non-transient classes still surface immediately so we don't waste 3 hours on a real bug.

## Test plan

- [x] 7 new unit tests in `TestCreateWithRetry` covering: no-retry success, 503 retry → success, 429 retry, connection-error retry, non-transient surface-immediately, exhaust-attempts-raise, exponential-doubling.
- [x] 39 / 39 `tests/dg/test_llm.py` pass.
- [x] 265 / 266 digigraph unit tests pass (1 pre-existing skip on optional sqlite extra, unrelated).
- [x] YAML + actionlint clean on all 3 modified workflows.
- [x] `make score` passes 10 / 10 / 10 / 10.

Fixes #461 follow-up.