### PR TITLE
chore(root): reconcile Atlas workflow paths after teardown (#319)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -47,12 +47,12 @@ jobs:
           cache-dependency-path: |
             digibase/pyproject.toml
             digigraph/pyproject.toml
-            apps/digiquant-atlas/pyproject.toml
+            digiquant/pyproject.toml
 
-      - name: Install Atlas (workspace deps include digismith)
+      - name: Install Atlas (workspace deps include digismith + digiquant[atlas])
         run: |
-          bash scripts/install-workspace.sh digigraph
-          pip install -e "./apps/digiquant-atlas[supabase]"
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
 
       - name: Resolve run date
         id: resolve

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -45,12 +45,12 @@ jobs:
           cache-dependency-path: |
             digibase/pyproject.toml
             digigraph/pyproject.toml
-            apps/digiquant-atlas/pyproject.toml
+            digiquant/pyproject.toml
 
-      - name: Install Atlas (workspace deps include digismith)
+      - name: Install Atlas (workspace deps include digismith + digiquant[atlas])
         run: |
-          bash scripts/install-workspace.sh digigraph
-          pip install -e "./apps/digiquant-atlas[supabase]"
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
 
       - name: Resolve run date
         id: resolve

--- a/.github/workflows/atlas-graph-ci.yml
+++ b/.github/workflows/atlas-graph-ci.yml
@@ -1,18 +1,29 @@
 name: atlas graph ci
 
 # Unit tests + lint + actionlint for the Atlas sub-graph package and its
-# scheduler workflows. Scoped with path filters so it only runs when
-# something in apps/digiquant-atlas/ or .github/workflows/atlas-*.yml changes.
+# scheduler workflows. Complements `digiquant tests` — that job installs
+# only `digiquant[dev]`, which doesn't pull `digigraph`, so atlas tests get
+# skipped there (see tests/dq/atlas/conftest.py). This workflow installs
+# the full monorepo workspace via install-workspace.sh, so the atlas
+# pipeline tests actually run.
 
 on:
   push:
     branches: [main, develop]
     paths:
-      - "apps/digiquant-atlas/**"
+      - "digiquant/src/digiquant/atlas/**"
+      - "digiquant/atlas/**"
+      - "digiquant/scripts/atlas/**"
+      - "digiquant/supabase/**"
+      - "tests/dq/atlas/**"
       - ".github/workflows/atlas-*.yml"
   pull_request:
     paths:
-      - "apps/digiquant-atlas/**"
+      - "digiquant/src/digiquant/atlas/**"
+      - "digiquant/atlas/**"
+      - "digiquant/scripts/atlas/**"
+      - "digiquant/supabase/**"
+      - "tests/dq/atlas/**"
       - ".github/workflows/atlas-*.yml"
 
 permissions:

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -112,12 +112,12 @@ jobs:
           cache-dependency-path: |
             digibase/pyproject.toml
             digigraph/pyproject.toml
-            apps/digiquant-atlas/pyproject.toml
+            digiquant/pyproject.toml
 
-      - name: Install Atlas (workspace deps include digismith)
+      - name: Install Atlas (workspace deps include digismith + digiquant[atlas])
         run: |
-          bash scripts/install-workspace.sh digigraph
-          pip install -e "./apps/digiquant-atlas[supabase]"
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
 
       - name: Resolve run date
         id: resolve

--- a/.github/workflows/digiquant-prices.yml
+++ b/.github/workflows/digiquant-prices.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Fetch quotes -> update cache -> upsert price_history
         run: |
           python -m digiquant prices fetch-quotes \
-            --watchlist apps/digiquant-atlas/config/watchlist.md \
+            --watchlist digiquant/atlas/config/watchlist.md \
             --cache-dir data/price-history \
             --supabase
       - name: Compute technicals -> upsert price_technicals
@@ -164,7 +164,7 @@ jobs:
         # Default --sources is fred,yahoo (issue #328 dropped Frankfurter+FNG).
         run: |
           python -m digiquant prices fetch-macro \
-            --manifest apps/digiquant-atlas/config/macro_series.yaml \
+            --manifest digiquant/atlas/config/macro_series.yaml \
             --supabase
       - name: Update persistent failure issue
         if: failure()


### PR DESCRIPTION
## Summary

Phase 4 of the Atlas teardown ([epic #297](https://github.com/digithings-ai/digithings/issues/297)). Updates the 5 Atlas-related workflows to reflect the new `digiquant/`-rooted layout established in #315/#316/#317.

The original ticket called for *moving* Atlas's nested `apps/digiquant-atlas/.github/workflows/` into the root tree — that subtree was already deleted in #316 (those workflows never ran; GitHub Actions only reads root `.github/workflows/`). What remained was reconciling the stale `apps/digiquant-atlas/*` references in the surviving workflows.

### Changes
- **`atlas-graph-ci.yml`** — path filters drop `apps/digiquant-atlas/**`, add the new `digiquant/{src/digiquant/atlas, atlas, scripts/atlas, supabase}/**` + `tests/dq/atlas/**`. Comment clarifies how this complements the standard `digiquant tests` job.
- **`atlas-baseline.yml`, `atlas-delta.yml`, `atlas-monthly.yml`** — cache-dependency-path swaps `apps/digiquant-atlas/pyproject.toml` (deleted in #316) for `digiquant/pyproject.toml`. Install step now uses `bash scripts/install-workspace.sh digiquant` + `pip install -e ./digiquant[atlas]`.
- **`digiquant-prices.yml`** — `--watchlist` + `--manifest` CLI args repointed to `digiquant/atlas/config/` (moved from `apps/digiquant-atlas/config/` in #315).

## Verification

- `actionlint .github/workflows/atlas-*.yml digiquant-prices.yml` — clean
- `grep -rn apps/digiquant-atlas .github/` — zero matches

## Test plan

- [ ] CI: actionlint green
- [ ] CI: atlas graph ci green (lint + tests on new paths)
- [ ] Post-merge: `workflow_dispatch` dry-run of `atlas-baseline.yml` / `atlas-delta.yml` to validate the rewritten install steps in production runners

Closes #319
Refs #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)