### PR TITLE
chore(root): finalize Atlas teardown — sweep stale docstrings + drop empty shell (#320)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,14 @@ For full agent rules (applies to every IDE / coding agent), see [AGENTS.md](AGEN
 
 Services (Python):
 - **digigraph/** — orchestration brain (LangGraph, MCP tools, OpenAI-compatible API).
-- **digiquant/** — quant engine (NautilusTrader, strategy registry).
+- **digiquant/** — quant engine (NautilusTrader, strategy registry, **Atlas research sub-graph**).
 - **digisearch/** — RAG / search (ingest, chunking, embedding, vector search).
 - **digikey/** — JWT + scoped API keys (RS256, JWKS).
 - **digismith/** — tracing helpers + `/v1/status`.
 - **digiclaw/** — heartbeat / audit / MCP skill.
 - **digibase/** — shared HTTP/audit library.
+
+Atlas fully lives inside the digiquant module after epic [#297](https://github.com/digithings-ai/digithings/issues/297) (2026-04, [ADR-0014](docs/adr/0014-atlas-in-digiquant.md)): runtime at `digiquant/src/digiquant/atlas/`, runtime data at `digiquant/atlas/{skills,templates,config}/`, tests at `tests/dq/atlas/`, frontend at `frontend/atlas/`. The old `apps/digiquant-atlas/` tree is gone — if you see it in a doc, that doc is either historical (ADRs, `docs/plans/`) or stale.
 
 Frontend umbrella (see [ADR-0009](docs/adr/0009-frontend-umbrella.md)):
 - **frontend/design/** — `@digithings/design` workspace package (shared tokens, CSS primitives, vanilla-JS modules).

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -660,13 +660,14 @@ All HTTP request bodies are typed with Pydantic v2 models using `ConfigDict(extr
 ## Atlas Sub-graph Integration (ADR-0009)
 
 The DigiQuant Atlas research pipeline migrated from standalone
-skills + Supabase scripts into a DigiGraph sub-graph in issue #176.
-The sub-graph lives in `apps/digiquant-atlas/src/digiquant_atlas/` and
+skills + Supabase scripts into a DigiGraph sub-graph in issue #176, then
+folded fully into the digiquant module in epic #297.
+The sub-graph lives in `digiquant/src/digiquant/atlas/` and
 composes DigiGraph's generic research-agent + pipeline-builder primitives
 into a 9-phase deterministic pipeline.
 
-- Entry point: `digiquant_atlas.graph.build_atlas_graph(run_type, deps, watchlist)`
-  plus `digiquant_atlas.graph.AtlasInput` — the stable contract DigiClaw
+- Entry point: `digiquant.atlas.graph.build_atlas_graph(run_type, deps, watchlist)`
+  plus `digiquant.atlas.graph.AtlasInput` — the stable contract DigiClaw
   (#219) invokes on schedule.
 - Three run modes: `baseline` (Sunday), `delta` (Mon–Sat with triage
   carry-forward), `monthly` (month-end synthesis).
@@ -746,7 +747,7 @@ deterministic ids let the Chroma backend's id-collision upsert behavior do
 the same job in production.
 
 **Triggering — current state (pull-based):** Atlas's `publish_phase`
-(`apps/digiquant-atlas/src/digiquant_atlas/phases/publish_phase.py`)
+(`digiquant/src/digiquant/atlas/phases/publish_phase.py`)
 writes to Supabase. A poller or follow-up explicit call is responsible
 for driving `ingest_atlas_document` against each `(date, document_key)`
 returned in `state.published`.

--- a/digiquant/docs/atlas/DEPLOYMENT.md
+++ b/digiquant/docs/atlas/DEPLOYMENT.md
@@ -8,10 +8,10 @@ Companion workflows (in `.github/workflows/`):
 
 | Workflow | Trigger | Command | Timeout |
 | --- | --- | --- | --- |
-| `atlas-baseline.yml` | `cron '0 12 * * SAT'` + `workflow_dispatch` | `python -m digiquant_atlas.graph --run-type baseline --run-date <today>` | 120 min |
-| `atlas-delta.yml` | `cron '0 12 * * MON-FRI'` + `workflow_dispatch` | `python -m digiquant_atlas.graph --run-type delta --auto-baseline --run-date <today>` | 45 min |
-| `atlas-monthly.yml` | `cron '0 14 28-31 * *'` + last-weekday guard | `python -m digiquant_atlas.graph --run-type monthly --run-date <today>` | 60 min |
-| `atlas-graph-ci.yml` | `push` / `pull_request` touching `apps/digiquant-atlas/**` | unit tests + ruff + `actionlint` | 15 min |
+| `atlas-baseline.yml` | `cron '0 12 * * SAT'` + `workflow_dispatch` | `python -m digiquant.atlas.graph --run-type baseline --run-date <today>` | 120 min |
+| `atlas-delta.yml` | `cron '0 12 * * MON-FRI'` + `workflow_dispatch` | `python -m digiquant.atlas.graph --run-type delta --auto-baseline --run-date <today>` | 45 min |
+| `atlas-monthly.yml` | `cron '0 14 28-31 * *'` + last-weekday guard | `python -m digiquant.atlas.graph --run-type monthly --run-date <today>` | 60 min |
+| `atlas-graph-ci.yml` | `push` / `pull_request` touching `digiquant/{src/digiquant/atlas, atlas, scripts/atlas, supabase}/**` or `tests/dq/atlas/**` | unit tests + ruff + `actionlint` | 15 min |
 
 ## Required repo secrets
 

--- a/digiquant/docs/atlas/agentic/ARCHITECTURE.md
+++ b/digiquant/docs/atlas/agentic/ARCHITECTURE.md
@@ -608,7 +608,7 @@ Run `python3 scripts/validate-provider-keys.py` after adding keys to `.env` to s
 ## DigiGraph Sub-graph Orchestration (issue #176, ADR-0009)
 
 The 9-phase pipeline described above is now orchestrated by a DigiGraph
-sub-graph in `apps/digiquant-atlas/src/digiquant_atlas/`. Skill files in
+sub-graph in `digiquant/src/digiquant/atlas/`. Skill files in
 `skills/<slug>/SKILL.md` remain the authoritative "what to research"
 instructions — they are injected into a generic research agent at runtime
 rather than ported as prompt code.

--- a/digiquant/docs/atlas/agentic/WAVE2_UNIT_SPECS.md
+++ b/digiquant/docs/atlas/agentic/WAVE2_UNIT_SPECS.md
@@ -32,7 +32,7 @@ W2-H — parallel after W2-A
 
 **Files (create/modify):**
 
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/supabase_io.py` — add writer functions:
+- Modify: `digiquant/src/digiquant/atlas/supabase_io.py` — add writer functions:
   - `write_thesis_vehicles(rows: list[ThesisVehicleRow]) -> list[PublishedArtifact]`
   - `write_deliberation_session(row: DeliberationSessionRow) -> PublishedArtifact`
   - `write_deliberation_rounds(rows: list[DeliberationRoundRow]) -> list[PublishedArtifact]`
@@ -40,8 +40,8 @@ W2-H — parallel after W2-A
   - `write_deep_dive_triggers(rows: list[DeepDiveTriggerRow]) -> list[PublishedArtifact]`
   - `upsert_theses(rows: list[ThesisRow]) -> list[PublishedArtifact]` (may already exist). Writes **only** the canonical `theses` columns from migration 001: `date`, `thesis_id`, `name`, `vehicle`, `invalidation`, `status`, `notes`. There is **no** `evidence_log` column on `theses` — the per-day evidence trail lives in the `'Thesis Review'` document payload (`body.reviewed_theses[].evidence[]`), not in a relational column. Do NOT add an `evidence_log` column; if a future reader wants indexed evidence, propose it in a separate migration.
 - Create: `digiquant/supabase/migrations/025_hermes_doc_types.sql` — extends `chk_documents_doc_type` to include `'Thesis Review'` and `'Opportunity Screen'` (see [HERMES_SUBGRAPH §5.1](HERMES_SUBGRAPH.md#51-migration-025--hermes-doc_type-additions-stub-implemented-in-w2-a)). Keep every existing token from migration 023 in the new CHECK. Apply to dev DB before W2-B / W2-D start.
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/supabase_rows.py` — typed dataclasses/Pydantic for the five row types above.
-- Modify: tests FakeSupabaseClient in `apps/digiquant-atlas/tests/conftest.py` — record writes per-table for assertion.
+- Create: `digiquant/src/digiquant/atlas/supabase_rows.py` — typed dataclasses/Pydantic for the five row types above.
+- Modify: tests FakeSupabaseClient in `tests/dq/atlas/conftest.py` — record writes per-table for assertion.
 
 **Tests:**
 
@@ -61,10 +61,10 @@ W2-H — parallel after W2-A
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h1_thesis_review.py` — single-node phase; loads `thesis` + `thesis-tracker` skills; outputs `ThesisReviewOutput`.
-- Create: `apps/digiquant-atlas/templates/schemas/thesis-review.schema.json` — envelope `{schema_version, doc_type="Thesis Review", date, meta, body}` (Title-Case token matching migration 025's extension to `chk_documents_doc_type`; see [HERMES_SUBGRAPH §5.1](HERMES_SUBGRAPH.md#51-migration-025--hermes-doc_type-additions-stub-implemented-in-w2-a)); body per [HERMES_SUBGRAPH §4.1](HERMES_SUBGRAPH.md#41-thesisreviewoutput-phase_h1). `body.reviewed_theses[].new_status` is constrained to the seven tokens allowed by `chk_theses_status` (`ACTIVE` / `MONITORING` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED` / `NEW`); `body.reviewed_theses[].resolution` (optional) is `"win" | "loss"`, required iff `new_status == "CLOSED"`. Persistence writes the status to the `theses` row and the evidence list to the document payload — there is no relational `evidence_log` field.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — add `PhaseHermesState` scaffold + `RecessRequest` + new reducers `_merge_session_dict`, `_append_list`. Add `phase_hermes: PhaseHermesState` field to `AtlasResearchState`.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire `phase_h1_thesis_review` after `phase6_consolidate`.
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h1_thesis_review.py` — single-node phase; loads `thesis` + `thesis-tracker` skills; outputs `ThesisReviewOutput`.
+- Create: `digiquant/atlas/templates/schemas/thesis-review.schema.json` — envelope `{schema_version, doc_type="Thesis Review", date, meta, body}` (Title-Case token matching migration 025's extension to `chk_documents_doc_type`; see [HERMES_SUBGRAPH §5.1](HERMES_SUBGRAPH.md#51-migration-025--hermes-doc_type-additions-stub-implemented-in-w2-a)); body per [HERMES_SUBGRAPH §4.1](HERMES_SUBGRAPH.md#41-thesisreviewoutput-phase_h1). `body.reviewed_theses[].new_status` is constrained to the seven tokens allowed by `chk_theses_status` (`ACTIVE` / `MONITORING` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED` / `NEW`); `body.reviewed_theses[].resolution` (optional) is `"win" | "loss"`, required iff `new_status == "CLOSED"`. Persistence writes the status to the `theses` row and the evidence list to the document payload — there is no relational `evidence_log` field.
+- Modify: `digiquant/src/digiquant/atlas/state.py` — add `PhaseHermesState` scaffold + `RecessRequest` + new reducers `_merge_session_dict`, `_append_list`. Add `phase_hermes: PhaseHermesState` field to `AtlasResearchState`.
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — wire `phase_h1_thesis_review` after `phase6_consolidate`.
 
 **Inline Pydantic contract (authoritative for W2-B):**
 
@@ -103,8 +103,8 @@ class ThesisReviewOutput(BaseModel):
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h2_market_thesis_exploration.py`.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire after h1.
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h2_market_thesis_exploration.py`.
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — wire after h1.
 - Pydantic model `MarketThesisExploration` in the phase module, validated against existing [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
 
 **Inline Pydantic contract:**
@@ -145,10 +145,10 @@ class MarketThesisExploration(BaseModel):
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h3_thesis_vehicle_map.py`.
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h4_opportunity_screener.py`.
-- Create: `apps/digiquant-atlas/templates/schemas/opportunity-screen.schema.json` — envelope `{schema_version, doc_type="Opportunity Screen", date, meta, body}` (Title-Case token; added to `chk_documents_doc_type` by migration 025).
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h3→h4.
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h3_thesis_vehicle_map.py`.
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h4_opportunity_screener.py`.
+- Create: `digiquant/atlas/templates/schemas/opportunity-screen.schema.json` — envelope `{schema_version, doc_type="Opportunity Screen", date, meta, body}` (Title-Case token; added to `chk_documents_doc_type` by migration 025).
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — wire h3→h4.
 
 **Inline Pydantic contracts:**
 
@@ -195,7 +195,7 @@ class OpportunityScreen(BaseModel):
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
 
 **Inline Pydantic contract:**
 
@@ -220,9 +220,9 @@ class AssetRecommendation(BaseModel):
     risk_flags: list[str] = Field(default_factory=list)
     # Blinded rule: MUST NOT read config/portfolio.json current_weights.
 ```
-- **Delete:** `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7c_analyst.py`.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — remove `phase7c_analysts` field and `AnalystPayload`. **Decision (pre-made — do not re-litigate):** `_merge_analyst_dict` is kept AND renamed to `_merge_ticker_dict`; both h5 (`asset_recommendations`) and h6 (`deliberation_sessions`) reuse it — there is only one ticker-keyed merge policy in Hermes so the neutral name is clearer. Update [`HERMES_SUBGRAPH §3`](HERMES_SUBGRAPH.md#3-state-additions-to-atlasresearchstate) to reference `_merge_ticker_dict` in the same PR (replace the two `_merge_analyst_dict` / `_merge_session_dict` annotations with one shared reducer).
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — swap `build_phase7c` call for `build_phase_h5`.
+- **Delete:** `digiquant/src/digiquant/atlas/phases/phase7c_analyst.py`.
+- Modify: `digiquant/src/digiquant/atlas/state.py` — remove `phase7c_analysts` field and `AnalystPayload`. **Decision (pre-made — do not re-litigate):** `_merge_analyst_dict` is kept AND renamed to `_merge_ticker_dict`; both h5 (`asset_recommendations`) and h6 (`deliberation_sessions`) reuse it — there is only one ticker-keyed merge policy in Hermes so the neutral name is clearer. Update [`HERMES_SUBGRAPH §3`](HERMES_SUBGRAPH.md#3-state-additions-to-atlasresearchstate) to reference `_merge_ticker_dict` in the same PR (replace the two `_merge_analyst_dict` / `_merge_session_dict` annotations with one shared reducer).
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — swap `build_phase7c` call for `build_phase_h5`.
 - Modify: any tests referencing `phase7c_analysts` or `AnalystPayload`.
 
 **Tests:**
@@ -243,10 +243,10 @@ class AssetRecommendation(BaseModel):
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h6_deliberation.py` — per-ticker fan-out; each ticker node is a nested `StateGraph` (analyst_present → pm_challenge → converge_check → loop/exit) compiled once at phase-build time.
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/_deliberation_loop.py` — nested graph builder; isolated for unit-testing the loop independently.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h6 after h5.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/state.py` — confirm `RecessRequest` + `_append_list` from W2-B are used.
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h6_deliberation.py` — per-ticker fan-out; each ticker node is a nested `StateGraph` (analyst_present → pm_challenge → converge_check → loop/exit) compiled once at phase-build time.
+- Create: `digiquant/src/digiquant/atlas/phases/_deliberation_loop.py` — nested graph builder; isolated for unit-testing the loop independently.
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — wire h6 after h5.
+- Modify: `digiquant/src/digiquant/atlas/state.py` — confirm `RecessRequest` + `_append_list` from W2-B are used.
 - Persistence: writes `documents` (`doc_type='Deliberation Transcript'` per ticker + one `doc_type='Deliberation Session Index'`; Title-Case tokens already in migration-023 allowlist) + `deliberation_sessions` (run-level; `kind` ∈ `{'baseline', 'delta_scoped', 'monthly'}`) + `deliberation_rounds` (per round per ticker) + `deep_dive_triggers` (per `RecessRequest`; `triggered_by='pm_recess'` — see W2-F phase_h6). Adapters from W2-A.
 - Env var reader: `ATLAS_DELIBERATION_MAX_ROUNDS` with default 6 (canonical definition: [HERMES_SUBGRAPH §2.2](HERMES_SUBGRAPH.md#22-safety-cap)).
 
@@ -301,7 +301,7 @@ class DeliberationSession(BaseModel):
 
 **Files:**
 
-- Create: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
 
 **Inline Pydantic contract:**
 
@@ -320,8 +320,8 @@ class PMAllocationMemo(BaseModel):
     open_questions: list[str] = Field(default_factory=list)
     # Validation: sum(target_weight_pct) <= 100 + cash tolerance (default 101).
 ```
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/phases/phase7d_pm.py` — replace LLM call with deterministic transform that reads `state.phase_hermes.pm_allocation_memo` and current weights, emits `RebalanceDecision`. Remove skill loading.
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/graph.py` — wire h7 after h6 (or after `deep_dive_batch` when present); phase7d consumes h7.
+- Modify: `digiquant/src/digiquant/atlas/phases/phase7d_pm.py` — replace LLM call with deterministic transform that reads `state.phase_hermes.pm_allocation_memo` and current weights, emits `RebalanceDecision`. Remove skill loading.
+- Modify: `digiquant/src/digiquant/atlas/graph.py` — wire h7 after h6 (or after `deep_dive_batch` when present); phase7d consumes h7.
 
 **Tests:**
 
@@ -342,8 +342,8 @@ class PMAllocationMemo(BaseModel):
 
 **Files:**
 
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/triage.py` — add rule kinds `hermes_thesis_drift`, `hermes_ticker_filter`, `hermes_memo_gate`. Extend gate signature to support ticker-keyed Carried markers; document the split (per-segment vs per-ticker).
-- Modify: `apps/digiquant-atlas/src/digiquant_atlas/phases/_node_factory.py` — accept per-ticker triage gate for h5/h6 builders.
+- Modify: `digiquant/src/digiquant/atlas/triage.py` — add rule kinds `hermes_thesis_drift`, `hermes_ticker_filter`, `hermes_memo_gate`. Extend gate signature to support ticker-keyed Carried markers; document the split (per-segment vs per-ticker).
+- Modify: `digiquant/src/digiquant/atlas/phases/_node_factory.py` — accept per-ticker triage gate for h5/h6 builders.
 - Add Hermes phases to the canonical rule table in `_default_rules()` per HERMES_SUBGRAPH §6.
 
 **Tests:**
@@ -365,7 +365,7 @@ Every Wave 2 unit prompt should include:
 1. Read [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) and your unit's section in this file.
 2. Read the skill file(s) your phase loads.
 3. Follow the `task/<slug>` branch convention; PR target is `module/digiquant-atlas`.
-4. Tests pass: `pytest apps/digiquant-atlas/tests -m unit -v`.
+4. Tests pass: `pytest tests/dq/atlas -m unit -v`.
 5. `make doc-check` passes (no link regressions).
 6. `make score` passes the 4-dim gate.
 7. Commit message: `feat(atlas): <unit title>` + `Refs #178`.

--- a/digiquant/scripts/atlas/materialize_snapshot.py
+++ b/digiquant/scripts/atlas/materialize_snapshot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ─── FROZEN ─────────────────────────────────────────────────────────────────
-# Superseded by ``apps/digiquant-atlas/src/digiquant.atlas/supabase_io.py::
+# Superseded by ``digiquant/src/digiquant/atlas/supabase_io.py::
 # publish_daily_snapshot``, called from Phase 7 of the Atlas sub-graph
 # (issue #176). Kept for manual-backfill operator use only.
 #

--- a/digiquant/scripts/atlas/publish_document.py
+++ b/digiquant/scripts/atlas/publish_document.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ─── FROZEN ─────────────────────────────────────────────────────────────────
-# This script is superseded by ``apps/digiquant-atlas/src/digiquant.atlas/
+# This script is superseded by ``digiquant/src/digiquant/atlas/
 # supabase_io.py::publish_document``, called from the Atlas sub-graph
 # (issue #176). It stays on disk as an operator escape hatch for manual
 # backfills but is not invoked by the scheduled pipeline.

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -70,14 +70,14 @@ def check(label: str, passed: bool, detail: str = "") -> bool:
 
 # ── resolve repo / package root ────────────────────────────────────────────────
 _here = Path(__file__).resolve().parent
-_atlas_dir = _here.parent  # apps/digiquant-atlas/
+_atlas_dir = _here.parent  # digiquant/
 _repo_root = _atlas_dir.parent.parent  # repo root
 
 
 def _ensure_importable() -> None:
     """Add monorepo src paths to sys.path if not already importable."""
     for rel in [
-        "apps/digiquant-atlas/src",
+        "digiquant/src",
         "digigraph/src",
         "digibase/src",
         "digismith/src",
@@ -225,7 +225,7 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=textwrap.dedent("""\
             Tip: load your local env before running:
-              export $(grep -v '^#' apps/digiquant-atlas/config/supabase.env | xargs)
+              export $(grep -v '^#' digiquant/atlas/config/supabase.env | xargs)
               export GEMINI_API_KEY=...
         """),
     )

--- a/digiquant/src/digiquant/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/atlas/phases/_node_factory.py
@@ -47,7 +47,7 @@ class SegmentNodeSpec:
     """Stable slug written into SegmentPayload.segment and the output dict key."""
 
     skill_slug: str
-    """Path in ``apps/digiquant-atlas/skills/<slug>/SKILL.md`` — the 'what to research'."""
+    """Path in ``digiquant/atlas/skills/<slug>/SKILL.md`` — the 'what to research'."""
 
     output_model: type[BaseModel]
     """Pydantic class the LLM output must validate against."""

--- a/digiquant/src/digiquant/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/atlas/phases/preflight.py
@@ -44,7 +44,7 @@ class PreflightDeps:
 
     Dependency-injected so the phase-4 integration test and the production
     graph builder both get the same entry point. ``config_loader`` is a
-    caller-supplied closure that reads ``apps/digiquant-atlas/config/*``
+    caller-supplied closure that reads ``digiquant/atlas/config/*``
     (or a test fixture) and returns an ``AtlasConfigBundle``.
     """
 

--- a/digiquant/src/digiquant/atlas/schemas.py
+++ b/digiquant/src/digiquant/atlas/schemas.py
@@ -1,6 +1,6 @@
 """Authoritative-schema loader.
 
-JSON Schemas under ``apps/digiquant-atlas/templates/`` are the system of
+JSON Schemas under ``digiquant/atlas/templates/`` are the system of
 record for segment payload shapes. Pydantic models in later commits are
 validated *against* these schemas — never re-authored from scratch.
 

--- a/digiquant/src/digiquant/atlas/skills.py
+++ b/digiquant/src/digiquant/atlas/skills.py
@@ -1,6 +1,6 @@
 """Skill-file loader.
 
-A skill is a ``skills/<slug>/SKILL.md`` under ``apps/digiquant-atlas/skills/``.
+A skill is a ``skills/<slug>/SKILL.md`` under ``digiquant/atlas/skills/``.
 The file has YAML frontmatter (``name``, ``description``) followed by Markdown
 instructions. Only the Markdown body is relevant at inference time; the
 frontmatter exists for human catalog tooling.
@@ -10,7 +10,7 @@ Design:
 - Optional ``load_skill_with_frontmatter`` returns (frontmatter_dict, body)
   for code paths that need both (e.g. the skills catalog CI check in #176's
   commit 9).
-- Skills directory is resolved relative to the ``apps/digiquant-atlas/``
+- Skills directory is resolved relative to the ``digiquant/``
   package root so tests + production use the same path.
 """
 

--- a/digiquant/supabase/SCHEMA.md
+++ b/digiquant/supabase/SCHEMA.md
@@ -99,6 +99,6 @@ erDiagram
 3. If the new table holds a structured projection of a `documents` payload,
    add a reference to it in this file under the "Hermes deliberation"
    section pattern and cite the source ADR.
-4. Add a test under `apps/digiquant-atlas/tests/test_migration_NNN.py`
+4. Add a test under `tests/dq/atlas/test_migration_NNN.py`
    following the pattern in `test_migration_024.py` — pure-SQL parse check
    for offline unit tests, or `psycopg` round-trip for integration.

--- a/frontend/atlas/README.md
+++ b/frontend/atlas/README.md
@@ -54,12 +54,11 @@ the shared palette. No chart library was swapped.
 
 ```bash
 # From repo root
-npm install                  # links workspace packages
-cd apps/digiquant-atlas/frontend
-npm run dev                  # http://localhost:3000/digiquant-atlas/
-npm run build                # static export (output: 'export')
-npm run lint
-npm run test                 # Vitest (lib/**/*.test.ts + components/**/*.test.tsx)
+npm install                                # links workspace packages
+npm --workspace frontend/atlas run dev     # http://localhost:3000/digiquant-atlas/
+npm --workspace frontend/atlas run build   # static export (output: 'export')
+npm --workspace frontend/atlas run lint
+npm --workspace frontend/atlas run test    # Vitest (lib/**/*.test.ts + components/**/*.test.tsx)
 ```
 
 ## Environment variables

--- a/tests/dq/atlas/test_snapshot.py
+++ b/tests/dq/atlas/test_snapshot.py
@@ -133,7 +133,7 @@ class TestSnapshotEnvelope:
         """Feed a realistic ``daily_snapshots`` row — the shape ``publish_daily_snapshot`` writes.
 
         Mirrors the row dict pattern in
-        ``apps/digiquant-atlas/tests/test_supabase_io.py``.
+        ``tests/dq/atlas/test_supabase_io.py``.
         """
         row = {
             "id": "row-1",

--- a/tests/dq/data/test_calendar_sync.py
+++ b/tests/dq/data/test_calendar_sync.py
@@ -383,7 +383,7 @@ def test_upsert_empty_rows_is_noop() -> None:
 
 
 # Tickers that the daily backfill pipeline writes price_history rows for.  Pulled
-# from apps/digiquant-atlas/config/watchlist.md, excluding the spread-pair and
+# from digiquant/atlas/config/watchlist.md, excluding the spread-pair and
 # macro-indicator sections (those are derived/relative, not directly fetched).
 WATCHLIST_PRICE_TICKERS: tuple[str, ...] = (
     # US equities — market cap


### PR DESCRIPTION
## Summary

Final phase of the Atlas teardown ([epic #297](https://github.com/digithings-ai/digithings/issues/297)). With this merge, **the entire epic is done** — `apps/digiquant-atlas/` no longer exists, and the `apps/` parent dir is empty (untracked, removed locally).

### Stale-reference sweep
Files that still carried `apps/digiquant-atlas/` references in active code or docstrings — repointed:

- **Atlas runtime:** `digiquant/src/digiquant/atlas/{schemas,skills}.py` + `phases/{preflight,_node_factory}.py`
- **Frozen scripts:** `digiquant/scripts/atlas/{materialize_snapshot,publish_document,validate-providers}.py`
- **Architecture docs:** `digiquant/ARCHITECTURE.md` + `digiquant/docs/atlas/{DEPLOYMENT,agentic/ARCHITECTURE,agentic/WAVE2_UNIT_SPECS}.md`
- **Schema doc:** `digiquant/supabase/SCHEMA.md`
- **Frontend quickstart:** `frontend/atlas/README.md`
- **Test comments:** `tests/dq/atlas/test_snapshot.py`, `tests/dq/data/test_calendar_sync.py`

### Memory note for future agents
`CLAUDE.md` "Project at a glance" now explicitly calls out the fold (links #297 + ADR-0014) and lists the canonical Atlas paths (`digiquant/src/digiquant/atlas/` runtime, `digiquant/atlas/` data, `frontend/atlas/` frontend, `tests/dq/atlas/` tests). Auto-loaded every session, so future agents won't trip on stale references.

### Intentionally retained references
- ADRs (`0009`, `0010`, `0011`, `0013`, `0014`) — immutable historical records
- `docs/plans/atlas-full-migration-wave1.md` + `docs/plans/backlog-reshape/` — migration-plan archives
- `digiquant/docs/atlas/ops/{DIGITHINGS-WAVE1-PLAN,MIGRATION-ROADMAP-DIGITHINGS}.md` — historical roadmap
- Migration-history comments in `ruff.toml` + `digiquant/pyproject.toml`

## Verification

- `pytest tests/dq/atlas/ -m unit` → **294 passed**
- `ruff check digiquant/src/digiquant/atlas tests/dq/atlas` → clean
- `python scripts/check_doc_links.py` → **OK (131 markdown files)**

## Test plan

- [ ] CI: digiquant + atlas tests green
- [ ] CI: doc-links + actionlint green

Closes #320
Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)