### PR TITLE
feat(digiquant): create digiquant.hermes package + move analysis phases (#472)

### DIFF
--- a/digiquant/src/digiquant/atlas/graph.py
+++ b/digiquant/src/digiquant/atlas/graph.py
@@ -32,10 +32,10 @@ from digiquant.atlas.phases.phase4_assetclass import build_phase4
 from digiquant.atlas.phases.phase5_equities import build_phase5
 from digiquant.atlas.phases.phase6_consolidate import build_phase6
 from digiquant.atlas.phases.phase7_synthesis import build_phase7
-from digiquant.atlas.phases.phase7c_analyst import build_phase7c
-from digiquant.atlas.phases.phase7cd_debate import build_phase7cd
-from digiquant.atlas.phases.phase7d_pm import build_phase7d
-from digiquant.atlas.phases.phase9_evolution import Phase9Deps, build_phase9
+from digiquant.hermes.phases.phase7c_analyst import build_phase7c
+from digiquant.hermes.phases.phase7cd_debate import build_phase7cd
+from digiquant.hermes.phases.phase7d_pm import build_phase7d
+from digiquant.hermes.phases.phase9_evolution import Phase9Deps, build_phase9
 from digiquant.atlas.phases.phase_monthly import build_phase_monthly
 from digiquant.atlas.phases.preflight import (
     PreflightDeps,

--- a/digiquant/src/digiquant/atlas/testing/simulator.py
+++ b/digiquant/src/digiquant/atlas/testing/simulator.py
@@ -61,7 +61,7 @@ from digiquant.atlas.graph import (
     build_atlas_graph,
     initial_state,
 )
-from digiquant.atlas.phases.phase9_evolution import Phase9Deps
+from digiquant.hermes.phases.phase9_evolution import Phase9Deps
 from digiquant.atlas.phases.preflight import PreflightDeps, PreflightReflectDeps
 from digiquant.atlas.phases.publish_phase import PublishDeps
 from digiquant.atlas.phases.triage_phase import TriageDeps

--- a/digiquant/src/digiquant/hermes/__init__.py
+++ b/digiquant/src/digiquant/hermes/__init__.py
@@ -1,0 +1,36 @@
+"""digiquant.hermes — analysis, portfolio mgmt, risk debate, reflection.
+
+Sibling sub-package of :mod:`digiquant.atlas`. See
+[ADR-0015](../../../docs/adr/0015-atlas-vs-hermes.md) for the responsibility
+boundary: Atlas owns research (phases 1–7a, terminating at
+``phase7_synthesis``), Hermes owns analysis + PM + risk + reflection
+(phases 7c, 7cd, 7d, 9).
+
+Public surface:
+    - :class:`digiquant.hermes.state.HermesState` — sub-graph state model.
+    - :func:`digiquant.hermes.graph.build_hermes_graph` — Hermes phases as
+      composable :class:`PipelinePhase` list (full chain orchestrator lands
+      in #473).
+
+Import direction (target state, ADR-0015):
+    - Atlas never imports from Hermes.
+    - Hermes imports only the digest contract types from
+      :mod:`digiquant.atlas.snapshot` plus shared state types from
+      :mod:`digiquant.atlas.state`.
+
+Transitional state in #472 (the package skeleton ticket):
+    Atlas's :func:`digiquant.atlas.graph.build_atlas_graph` still wires the
+    Hermes phases to keep the cron baseline / delta / monthly behaviour
+    identical across the package split — i.e. the four
+    ``from digiquant.hermes.phases.* import build_phase*`` lines in
+    ``digiquant/src/digiquant/atlas/graph.py`` are a temporary direction
+    violation. Issue #473 (Hermes graph + atlas→hermes chain) removes them
+    by introducing a top-level chain orchestrator that composes Atlas and
+    Hermes outside either package.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/digiquant/src/digiquant/hermes/graph.py
+++ b/digiquant/src/digiquant/hermes/graph.py
@@ -1,0 +1,55 @@
+"""Hermes graph — analysis sub-pipeline.
+
+This module exposes ``build_hermes_phases`` so callers (the existing Atlas
+graph builder today; the dedicated atlas→hermes chain orchestrator landing
+in #473) can compose the Hermes phases without touching their internals.
+
+The full ``build_hermes_graph(atlas_digest, deps)`` and
+``run_atlas_then_hermes(...)`` chain entry points are tracked on issue #473.
+For now Hermes phases plug into the existing ``digiquant.atlas.graph.build_atlas_graph``
+wiring — this keeps the cron baseline / delta / monthly behaviour identical
+across the package split.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from digiquant.hermes.phases.phase7c_analyst import build_phase7c
+from digiquant.hermes.phases.phase7cd_debate import build_phase7cd
+from digiquant.hermes.phases.phase7d_pm import build_phase7d
+from digiquant.hermes.phases.phase9_evolution import Phase9Deps, build_phase9
+
+if TYPE_CHECKING:
+    from digigraph.graph.pipeline_builder import PipelinePhase
+
+__all__ = [
+    "Phase9Deps",
+    "build_hermes_phases",
+    "build_phase7c",
+    "build_phase7cd",
+    "build_phase7d",
+    "build_phase9",
+]
+
+
+def build_hermes_phases(
+    *,
+    watchlist: list[str],
+    phase9_deps: Phase9Deps | None = None,
+    debate_rounds: int = 1,
+) -> list["PipelinePhase"]:
+    """Return the four Hermes phases as an ordered list.
+
+    Wiring contract:
+        phase7c (4-axis analyst, parallel fan-out) →
+        phase7cd (Bull/Bear debate, per-ticker fan-out) →
+        phase7d (risk debate + PM allocation memo) →
+        phase9 (closed-loop reflection / alpha scoring).
+    """
+    phases: list[PipelinePhase] = []
+    phases.extend(build_phase7c(watchlist))
+    phases.extend(build_phase7cd(watchlist, rounds=debate_rounds))
+    phases.extend(build_phase7d())
+    phases.append(build_phase9(phase9_deps))
+    return phases

--- a/digiquant/src/digiquant/hermes/phases/__init__.py
+++ b/digiquant/src/digiquant/hermes/phases/__init__.py
@@ -1,0 +1,15 @@
+"""Hermes phase nodes — analysis, debate, PM allocation, reflection.
+
+Each phase composes :class:`digigraph.graph.pipeline_builder.PipelinePhase`
+objects that operate on :class:`digiquant.hermes.state.HermesState` (today
+an alias for :class:`digiquant.atlas.state.AtlasResearchState`).
+
+Phases:
+    - ``phase7c_analyst``   — 4-axis analyst specialisation (#430).
+    - ``phase7cd_debate``   — Bull/Bear adversarial debate per ticker (#429).
+    - ``phase7d_pm``        — risk-aggressive vs risk-conservative debate +
+                              portfolio-manager allocation memo (#431).
+    - ``phase9_evolution``  — closed-loop reflection / alpha scoring (#432).
+"""
+
+from __future__ import annotations

--- a/digiquant/src/digiquant/hermes/phases/phase7c_analyst.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7c_analyst.py
@@ -39,7 +39,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
 from digiquant.atlas.phases._node_factory import _shared_context
-from digiquant.atlas.state import AtlasResearchState
+from digiquant.hermes.state import HermesState
 
 logger = logging.getLogger(__name__)
 
@@ -84,20 +84,20 @@ class AnalystPayload(BaseModel):
     sources: list[str] = Field(default_factory=list)
 
 
-def _macro_body(state: AtlasResearchState) -> dict[str, Any]:
+def _macro_body(state: HermesState) -> dict[str, Any]:
     if state.phase3_output is None or state.phase3_output.payload.source != "today":
         return {}
     return dict(state.phase3_output.payload.body)  # type: ignore[union-attr]
 
 
-def _phase5_equity_body(state: AtlasResearchState) -> dict[str, Any]:
+def _phase5_equity_body(state: HermesState) -> dict[str, Any]:
     slot = state.phase5_outputs.get("equity")
     if slot is None or slot.payload.source != "today":
         return {}
     return dict(slot.payload.body)  # type: ignore[union-attr]
 
 
-def _relevant_sectors_for(state: AtlasResearchState, ticker: str) -> dict[str, dict[str, Any]]:
+def _relevant_sectors_for(state: HermesState, ticker: str) -> dict[str, dict[str, Any]]:
     """Sector payloads that mention ``ticker`` in their top_tickers.
 
     Blinded-analyst rule: derived from public config, not from weight signals.
@@ -114,7 +114,7 @@ def _relevant_sectors_for(state: AtlasResearchState, ticker: str) -> dict[str, d
     }
 
 
-def _phase1_alt_data(state: AtlasResearchState) -> dict[str, dict[str, Any]]:
+def _phase1_alt_data(state: HermesState) -> dict[str, dict[str, Any]]:
     """All Phase 1 alt-data segment payloads (sentiment + positioning + options + politicians)."""
     return {
         slug: slot.payload.model_dump(mode="json")
@@ -123,7 +123,7 @@ def _phase1_alt_data(state: AtlasResearchState) -> dict[str, dict[str, Any]]:
     }
 
 
-def _phase2_institutional(state: AtlasResearchState) -> dict[str, dict[str, Any]]:
+def _phase2_institutional(state: HermesState) -> dict[str, dict[str, Any]]:
     return {
         slug: slot.payload.model_dump(mode="json")
         for slug, slot in state.phase2_outputs.items()
@@ -135,7 +135,7 @@ def _axis_inputs(
     *,
     axis: str,
     ticker: str,
-    state: AtlasResearchState,
+    state: HermesState,
 ) -> dict[str, Any]:
     """Per-axis ``phase_inputs`` block.
 
@@ -171,7 +171,7 @@ def _specialist_node_factory(axis: str, ticker: str):
 
     skill_slug = f"{axis}-analyst"
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         skill_text = load_skill(skill_slug)
         result = run_research_agent(
             skill_text=skill_text,
@@ -204,7 +204,7 @@ def _join_analyst_node_factory(ticker: str):
     ``sources`` unions across axes preserving insertion order.
     """
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         ticker_axes = state.phase7c_specialists.get(ticker, {})
         present = [ax for ax in _AXES if ax in ticker_axes]
         missing = [ax for ax in _AXES if ax not in ticker_axes]
@@ -296,7 +296,7 @@ def build_phase7c_specialists(tickers: list[str]) -> PipelinePhase:
     capped = _capped_tickers(tickers)
     if not capped:
 
-        def _noop(_state: AtlasResearchState) -> dict[str, Any]:
+        def _noop(_state: HermesState) -> dict[str, Any]:
             return {}
 
         return PipelinePhase(
@@ -320,7 +320,7 @@ def build_phase7c_join(tickers: list[str]) -> PipelinePhase:
     capped = _capped_tickers(tickers)
     if not capped:
 
-        def _noop(_state: AtlasResearchState) -> dict[str, Any]:
+        def _noop(_state: HermesState) -> dict[str, Any]:
             return {}
 
         return PipelinePhase(

--- a/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
@@ -33,7 +33,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
 from digiquant.atlas.phases._node_factory import _shared_context
-from digiquant.atlas.state import AtlasResearchState
+from digiquant.hermes.state import HermesState
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class DebateSummary(BaseModel):
     )
 
 
-def _round_count(state: AtlasResearchState) -> int:
+def _round_count(state: HermesState) -> int:
     """Resolve the configured round count from preferences (default 1)."""
     raw = state.config.preferences.get("debate_rounds", _DEFAULT_DEBATE_ROUNDS)
     try:
@@ -90,13 +90,13 @@ def _round_count(state: AtlasResearchState) -> int:
     return max(1, min(5, n))
 
 
-def _analyst_for(state: AtlasResearchState, ticker: str) -> dict[str, Any]:
+def _analyst_for(state: HermesState, ticker: str) -> dict[str, Any]:
     """Phase 7C analyst payload for this ticker (empty if missing)."""
     return dict(state.phase7c_analysts.get(ticker, {}))
 
 
 def _prior_rounds(
-    state: AtlasResearchState, ticker: str, role: Literal["bull", "bear"]
+    state: HermesState, ticker: str, role: Literal["bull", "bear"]
 ) -> list[dict[str, Any]]:
     """Return prior debate rounds plus, for the bear, the bull's pending
     contribution so it can read what's been argued this round."""
@@ -119,7 +119,7 @@ def _bull_node_factory(ticker: str):
 
     from digiquant.atlas.skills import load_skill
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         round_cap = _round_count(state)
         debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
         # Bull opens the next round; abort if we've already hit the cap.
@@ -158,7 +158,7 @@ def _bear_node_factory(ticker: str):
 
     from digiquant.atlas.skills import load_skill
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
         pending = dict(debate.get("pending") or {})
         if not pending.get("bull_argument"):
@@ -202,7 +202,7 @@ def _research_manager_node_factory(ticker: str):
 
     from digiquant.atlas.skills import load_skill
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         debate = dict(state.phase7cd_debates.get(ticker, {}) or {})
         rounds = list(debate.get("rounds") or [])
         if not rounds:
@@ -258,7 +258,7 @@ def _capped_tickers(tickers: list[str]) -> list[str]:
     return list(tickers)
 
 
-def _noop(_state: AtlasResearchState) -> dict[str, Any]:
+def _noop(_state: HermesState) -> dict[str, Any]:
     return {}
 
 

--- a/digiquant/src/digiquant/hermes/phases/phase7d_pm.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7d_pm.py
@@ -26,7 +26,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
 from digiquant.atlas.phases._node_factory import _shared_context
-from digiquant.atlas.state import AtlasResearchState
+from digiquant.hermes.state import HermesState
 
 
 class TargetWeight(BaseModel):
@@ -68,7 +68,7 @@ class RiskDebateSummary(BaseModel):
     key_tension: str = Field(max_length=300)
 
 
-def _build_risk_phase_inputs(state: AtlasResearchState, role: str) -> dict[str, Any]:
+def _build_risk_phase_inputs(state: HermesState, role: str) -> dict[str, Any]:
     """Common inputs for both debater nodes.
 
     Both debaters read the same upstream context (analyst payloads + bias
@@ -85,7 +85,7 @@ def _build_risk_phase_inputs(state: AtlasResearchState, role: str) -> dict[str, 
     }
 
 
-def _risk_aggressive_node(state: AtlasResearchState) -> dict[str, Any]:
+def _risk_aggressive_node(state: HermesState) -> dict[str, Any]:
     """Argues the growth/upside case for the proposed rebalance.
 
     One LLM call. The output is a ``RiskCase`` whose text seeds the
@@ -114,7 +114,7 @@ def _risk_aggressive_node(state: AtlasResearchState) -> dict[str, Any]:
     }
 
 
-def _risk_conservative_node(state: AtlasResearchState) -> dict[str, Any]:
+def _risk_conservative_node(state: HermesState) -> dict[str, Any]:
     """Argues the capital-preservation case + synthesizes the debate.
 
     Reads ``state.phase7d_risk_debate.aggressive_case`` written by the
@@ -140,7 +140,7 @@ def _risk_conservative_node(state: AtlasResearchState) -> dict[str, Any]:
     return {"phase7d_risk_debate": result.model_dump(mode="json")}
 
 
-def _pm_node(state: AtlasResearchState) -> dict[str, Any]:
+def _pm_node(state: HermesState) -> dict[str, Any]:
     """Single LLM call that does clean-slate + comparison in one pass.
 
     Splitting into two LLM calls was considered; folded into one because
@@ -208,7 +208,7 @@ def _load_pm_skill(loader: Any) -> str:
     raise RuntimeError("neither 'pm-allocation-memo' nor 'portfolio-manager' skill present")
 
 
-def _current_weights_from_config(state: AtlasResearchState) -> dict[str, float]:
+def _current_weights_from_config(state: HermesState) -> dict[str, float]:
     """Pull current portfolio weights from state.config.preferences.
 
     The upstream config loader (in commit 9's graph assembly) is expected

--- a/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
+++ b/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 
 from digiquant.atlas.decision_log import persist_pending
 from digiquant.atlas.phases._node_factory import _shared_context
-from digiquant.atlas.state import AtlasResearchState
+from digiquant.hermes.state import HermesState
 from digiquant.atlas.supabase_io import SupabaseClient
 
 
@@ -117,7 +117,7 @@ class Phase9Deps:
 
 def _phase9_node_factory(
     deps: Phase9Deps | None,
-) -> Callable[[AtlasResearchState], dict[str, Any]]:
+) -> Callable[[HermesState], dict[str, Any]]:
     """Build the Phase 9 node bound to ``deps``.
 
     Returns a closure that:
@@ -132,7 +132,7 @@ def _phase9_node_factory(
     a hard failure that loses the whole evolution snapshot.
     """
 
-    def _node(state: AtlasResearchState) -> dict[str, Any]:
+    def _node(state: HermesState) -> dict[str, Any]:
         # ── Phase A: decision-log persistence (non-LLM, Supabase write) ─
         if deps is not None:
             try:

--- a/digiquant/src/digiquant/hermes/state.py
+++ b/digiquant/src/digiquant/hermes/state.py
@@ -1,0 +1,37 @@
+"""Hermes sub-graph state.
+
+Right now ``HermesState`` is a re-export alias for
+:class:`digiquant.atlas.state.AtlasResearchState`. The four moved Hermes
+phases (7c / 7cd / 7d / 9) read from raw research-side state slots
+(``phase1_outputs``, ``phase2_outputs``, ``phase5_outputs``, etc.), not
+just the synthesised digest, so a clean digest-only contract is not yet
+viable without a substantial refactor of phase 7c's input shaping.
+
+Why an alias rather than a copy or reimport
+-------------------------------------------
+The phases type-hint ``HermesState`` rather than ``AtlasResearchState``
+deliberately. When the state extraction lands (planned follow-up to
+[ADR-0015](../../../../docs/adr/0015-atlas-vs-hermes.md), tracked as a
+future ticket on epic #471), the alias here will be replaced with a
+proper :class:`pydantic.BaseModel` whose surface is the digest plus
+Hermes-private slots. Phase code does not change — only this module does.
+
+Relationship to ADR-0015
+------------------------
+ADR-0015 names :class:`digiquant.atlas.snapshot.DigestPayload` as the
+"only symbol Hermes imports from Atlas." The pragmatic reality on the
+2026-04 split is that the analyst / debate / PM phases also touch raw
+phase-output slots. The ADR's spirit is preserved — Atlas runtime never
+calls into Hermes — but the import surface is wider than the ADR
+implies. Tightening to digest-only is a separate refactor.
+"""
+
+from __future__ import annotations
+
+from digiquant.atlas.state import AtlasResearchState
+
+# Alias — see module docstring. New code should import ``HermesState`` from
+# here so the eventual split lands without churning every phase file.
+HermesState = AtlasResearchState
+
+__all__ = ["HermesState"]

--- a/tests/dq/atlas/test_phase67.py
+++ b/tests/dq/atlas/test_phase67.py
@@ -18,8 +18,8 @@ from digiquant.atlas.phases.phase7_synthesis import (
     DigestSnapshot,
     build_phase7,
 )
-from digiquant.atlas.phases.phase7c_analyst import AnalystPayload, build_phase7c
-from digiquant.atlas.phases.phase7d_pm import RebalanceDecision, build_phase7d
+from digiquant.hermes.phases.phase7c_analyst import AnalystPayload, build_phase7c
+from digiquant.hermes.phases.phase7d_pm import RebalanceDecision, build_phase7d
 from digiquant.atlas.state import (
     AtlasConfigBundle,
     AtlasResearchState,

--- a/tests/dq/atlas/test_phase7c_specialists.py
+++ b/tests/dq/atlas/test_phase7c_specialists.py
@@ -22,7 +22,7 @@ import pytest
 
 from digigraph.graph.pipeline_builder import build_pipeline
 
-from digiquant.atlas.phases.phase7c_analyst import (
+from digiquant.hermes.phases.phase7c_analyst import (
     AnalystPayload,
     SpecialistPayload,
     _join_analyst_node_factory,

--- a/tests/dq/atlas/test_phase7cd_debate.py
+++ b/tests/dq/atlas/test_phase7cd_debate.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 
 from digigraph.graph.pipeline_builder import build_pipeline
 
-from digiquant.atlas.phases.phase7cd_debate import (
+from digiquant.hermes.phases.phase7cd_debate import (
     DebateRound,
     DebateRoundContribution,
     DebateSummary,
@@ -327,7 +327,7 @@ class TestPhaseFactoryShape:
 @pytest.mark.unit
 class TestPmConsumesDebateSummaries:
     def test_pm_phase_inputs_includes_debate_summaries_when_present(self) -> None:
-        from digiquant.atlas.phases.phase7d_pm import _pm_node
+        from digiquant.hermes.phases.phase7d_pm import _pm_node
 
         state = _state()
         state.phase7cd_debates = {
@@ -360,7 +360,7 @@ class TestPmConsumesDebateSummaries:
 
     def test_pm_works_with_empty_debate_summaries(self) -> None:
         """Graphs that don't wire the debate phase still produce a decision."""
-        from digiquant.atlas.phases.phase7d_pm import _pm_node
+        from digiquant.hermes.phases.phase7d_pm import _pm_node
 
         state = _state()
         # Default: phase7cd_debates = {} (no debate ran)

--- a/tests/dq/atlas/test_phase7d_risk_debate.py
+++ b/tests/dq/atlas/test_phase7d_risk_debate.py
@@ -11,7 +11,7 @@ import pytest
 
 from digigraph.graph.pipeline_builder import build_pipeline
 
-from digiquant.atlas.phases.phase7d_pm import (
+from digiquant.hermes.phases.phase7d_pm import (
     RiskCase,
     RiskDebateSummary,
     build_phase7d,
@@ -78,7 +78,7 @@ class TestRiskAggressiveNode:
         assert debate["key_tension"] == ""
 
     def test_aggressive_node_uses_risk_aggressive_skill(self) -> None:
-        from digiquant.atlas.phases.phase7d_pm import _risk_aggressive_node
+        from digiquant.hermes.phases.phase7d_pm import _risk_aggressive_node
 
         captured: dict[str, Any] = {}
 
@@ -126,7 +126,7 @@ class TestRiskConservativeNode:
 @pytest.mark.unit
 class TestPmReadsRiskDebate:
     def test_pm_node_phase_inputs_include_risk_debate_when_set(self) -> None:
-        from digiquant.atlas.phases.phase7d_pm import _pm_node
+        from digiquant.hermes.phases.phase7d_pm import _pm_node
 
         state = _state_for_debate()
         state.phase7d_risk_debate = {
@@ -156,7 +156,7 @@ class TestPmReadsRiskDebate:
 
     def test_pm_node_works_with_empty_risk_debate(self) -> None:
         """Backward-compat: PM must still produce a decision when no debate ran."""
-        from digiquant.atlas.phases.phase7d_pm import _pm_node
+        from digiquant.hermes.phases.phase7d_pm import _pm_node
 
         state = _state_for_debate()
         # No risk debate populated — simulate skipping the debater nodes.

--- a/tests/dq/atlas/test_phase9_reflection.py
+++ b/tests/dq/atlas/test_phase9_reflection.py
@@ -29,7 +29,7 @@ from digiquant.atlas.decision_log import (
     persist_pending,
     resolve_pending,
 )
-from digiquant.atlas.phases.phase9_evolution import Phase9Deps, build_phase9
+from digiquant.hermes.phases.phase9_evolution import Phase9Deps, build_phase9
 from digiquant.atlas.phases.preflight import (
     PreflightDeps,
     PreflightReflectDeps,
@@ -174,7 +174,7 @@ class TestPhaseAWritesPending:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Integration: the Phase 9 node calls persist_pending when Phase9Deps is provided."""
-        from digiquant.atlas.phases import phase9_evolution
+        from digiquant.hermes.phases import phase9_evolution
 
         client = FakeSupabaseClient()
         state = _seed_state_with_analysts(watchlist=("AAPL",))
@@ -209,7 +209,7 @@ class TestPhaseAWritesPending:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Default behaviour preserved: deps=None means no Supabase write."""
-        from digiquant.atlas.phases import phase9_evolution
+        from digiquant.hermes.phases import phase9_evolution
 
         called: dict[str, int] = {"persist": 0}
 
@@ -642,7 +642,7 @@ class TestLessonsInjection:
         """Phase 7D's _pm_node passes prior_context.decision_lessons as past_context."""
         from unittest.mock import patch
 
-        from digiquant.atlas.phases.phase7d_pm import _pm_node
+        from digiquant.hermes.phases.phase7d_pm import _pm_node
         from digiquant.atlas.state import PriorContext
 
         lessons = [{"ticker": "AAPL", "reflection": "Past lesson", "alpha": 0.02}]
@@ -660,7 +660,7 @@ class TestLessonsInjection:
 
         def fake_run(skill_text, phase_inputs, **kw):  # noqa: ARG001
             captured.update(phase_inputs)
-            from digiquant.atlas.phases.phase7d_pm import RebalanceDecision
+            from digiquant.hermes.phases.phase7d_pm import RebalanceDecision
 
             return RebalanceDecision()
 

--- a/tests/dq/atlas/test_triage_monthly_phase9.py
+++ b/tests/dq/atlas/test_triage_monthly_phase9.py
@@ -12,7 +12,7 @@ import pytest
 from digigraph.graph.pipeline_builder import build_pipeline
 
 from digiquant.atlas.phases._node_factory import SegmentNodeSpec, build_segment_node
-from digiquant.atlas.phases.phase9_evolution import Phase9Artifacts, build_phase9
+from digiquant.hermes.phases.phase9_evolution import Phase9Artifacts, build_phase9
 from digiquant.atlas.phases.phase_monthly import MonthlyDigest, build_phase_monthly
 from digiquant.atlas.state import (
     AtlasResearchState,


### PR DESCRIPTION
## Summary

Phase 1 of the Hermes extraction ([epic #471](https://github.com/digithings-ai/digithings/issues/471)). Splits the four analysis phases (analyst / Bull-Bear debate / risk + PM / reflection) out of `digiquant.atlas` into a sibling sub-package per [ADR-0015](https://github.com/digithings-ai/digithings/blob/develop/docs/adr/0015-atlas-vs-hermes.md).

### Moved (rename detection preserved)
- `digiquant/src/digiquant/atlas/phases/phase{7c_analyst,7cd_debate,7d_pm,9_evolution}.py` → `digiquant/src/digiquant/hermes/phases/`

### New
- **`digiquant/src/digiquant/hermes/__init__.py`** — public surface + ADR pointer
- **`digiquant/src/digiquant/hermes/state.py`** — `HermesState = AtlasResearchState` alias. Phase code already type-hints `HermesState`; the alias unblocks the future state extraction without churning every phase file.
- **`digiquant/src/digiquant/hermes/graph.py`** — `build_hermes_phases(...)` composes the four phases as an ordered `PipelinePhase` list. The full chain orchestrator + standalone `build_hermes_graph` arrive in #473.

### Transitional direction violation
ADR-0015's "Atlas never imports from Hermes" rule is **temporarily violated** by 4 lines in `digiquant/src/digiquant/atlas/graph.py` and 1 line in `simulator.py`: `build_atlas_graph` still wires the Hermes phases to keep cron baseline / delta / monthly behaviour identical across this PR. **Issue #473** removes those imports by introducing a top-level chain orchestrator that composes Atlas and Hermes outside either package. Documented in the Hermes module docstring.

## Verification

- `pytest tests/dq/ -m unit` → **610 passed**, 17 deselected
- `ruff check digiquant/src/digiquant/{atlas,hermes} tests/dq/atlas` → clean
- `python scripts/check_doc_links.py` → **OK (132 markdown files)**
- `pip install -e ./digiquant[atlas]` resolves Hermes too (same package, no extras change)
- Import direction inside Hermes is correct (only imports from `digiquant.atlas.{state,snapshot,skills,sectors_config,decision_log,supabase_io,phases._node_factory}`)

## Test plan

- [ ] CI: digiquant + atlas tests green
- [ ] CI: actionlint green (no workflow changes)
- [ ] CI: doc-links green
- [ ] After merge: #473 removes the transitional Atlas→Hermes import edges

Closes #472
Refs #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)