### PR TITLE
docs(digiquant): split docs/atlas vs docs/hermes; ARCHITECTURE.md re-shape (#478)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,20 @@ For full agent rules (applies to every IDE / coding agent), see [AGENTS.md](AGEN
 
 Services (Python):
 - **digigraph/** — orchestration brain (LangGraph, MCP tools, OpenAI-compatible API).
-- **digiquant/** — quant engine (NautilusTrader, strategy registry, **Atlas research sub-graph**).
+- **digiquant/** — quant engine (NautilusTrader, strategy registry, **Atlas research sub-graph + Hermes analysis sub-graph**).
 - **digisearch/** — RAG / search (ingest, chunking, embedding, vector search).
 - **digikey/** — JWT + scoped API keys (RS256, JWKS).
 - **digismith/** — tracing helpers + `/v1/status`.
 - **digiclaw/** — heartbeat / audit / MCP skill.
 - **digibase/** — shared HTTP/audit library.
 
-Atlas fully lives inside the digiquant module after epic [#297](https://github.com/digithings-ai/digithings/issues/297) (2026-04, [ADR-0014](docs/adr/0014-atlas-in-digiquant.md)): runtime at `digiquant/src/digiquant/atlas/`, runtime data at `digiquant/atlas/{skills,templates,config}/`, tests at `tests/dq/atlas/`, frontend at `frontend/atlas/`. The old `apps/digiquant-atlas/` tree is gone — if you see it in a doc, that doc is either historical (ADRs, `docs/plans/`) or stale.
+Atlas + Hermes are sibling sub-graphs inside the digiquant module:
+- **Atlas** (research): `digiquant/src/digiquant/atlas/` runtime, `digiquant/atlas/{skills,templates,config}/` data, `tests/dq/atlas/` tests, `frontend/atlas/` dashboard. Phases 1–7a; terminates at `phase7_synthesis`. Folded into digiquant in epic [#297](https://github.com/digithings-ai/digithings/issues/297) (2026-04, [ADR-0014](docs/adr/0014-atlas-in-digiquant.md)).
+- **Hermes** (analysis + PM + reflection): `digiquant/src/digiquant/hermes/` runtime, `digiquant/hermes/{skills,templates}/` data, `tests/dq/hermes/` tests. Phases 7c (4-axis analyst), 7cd (Bull/Bear debate), 7d (risk + PM allocation), 9 (closed-loop reflection). Split out of Atlas in epic [#471](https://github.com/digithings-ai/digithings/issues/471) (2026-04, [ADR-0015](docs/adr/0015-atlas-vs-hermes.md)) — handoff seam is `digiquant.atlas.snapshot.DigestPayload`.
+
+End-to-end production CLI: `python -m digiquant.hermes.chain --run-type baseline|delta|monthly` (the cron workflows use this). Standalone research-only: `python -m digiquant.atlas.graph`. Standalone Hermes from a saved digest: `python -m digiquant.hermes.graph --from-digest <state.json>`.
+
+The old `apps/digiquant-atlas/` tree is gone — if you see it in a doc, that doc is either historical (ADRs, `docs/plans/`) or stale.
 
 Frontend umbrella (see [ADR-0009](docs/adr/0009-frontend-umbrella.md)):
 - **frontend/design/** — `@digithings/design` workspace package (shared tokens, CSS primitives, vanilla-JS modules).

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -657,34 +657,73 @@ This service exposes a Prometheus `/metrics` endpoint (counter, histogram, in-fl
 
 All HTTP request bodies are typed with Pydantic v2 models using `ConfigDict(extra="forbid")`, which rejects unknown fields with HTTP 422 at the framework boundary. Shared validation-error shape lives in `digibase.errors`.
 
-## Atlas Sub-graph Integration (ADR-0009)
+## Atlas + Hermes Sub-graphs (ADR-0009 + ADR-0015)
 
-The DigiQuant Atlas research pipeline migrated from standalone
-skills + Supabase scripts into a DigiGraph sub-graph in issue #176, then
-folded fully into the digiquant module in epic #297.
-The sub-graph lives in `digiquant/src/digiquant/atlas/` and
-composes DigiGraph's generic research-agent + pipeline-builder primitives
-into a 9-phase deterministic pipeline.
+DigiQuant ships two sibling sub-graphs that compose end-to-end:
+
+- **Atlas** (`digiquant/src/digiquant/atlas/`) — research only. Phases 1–7a
+  produce a daily `DigestPayload` via `phase7_synthesis`. Atlas migrated
+  from standalone skills + Supabase scripts into a DigiGraph sub-graph
+  (#176), then folded fully into the digiquant module (epic #297).
+- **Hermes** (`digiquant/src/digiquant/hermes/`) — analysis, debate,
+  portfolio mgmt, reflection. Phases 7c (4-axis analyst), 7cd (Bull/Bear
+  debate), 7d (risk debate + PM allocation memo), 9 (closed-loop
+  reflection) consume Atlas's digest and produce analyst payloads + a
+  rebalance decision + a reflection record. Split from Atlas in epic
+  #471 per [ADR-0015](../docs/adr/0015-atlas-vs-hermes.md).
+
+The handoff seam is the existing `digiquant.atlas.snapshot.DigestPayload`
+contract — the only symbol Hermes imports from Atlas runtime.
+
+### Atlas (research)
 
 - Entry point: `digiquant.atlas.graph.build_atlas_graph(run_type, deps, watchlist)`
-  plus `digiquant.atlas.graph.AtlasInput` — the stable contract DigiClaw
-  (#219) invokes on schedule.
+  plus `digiquant.atlas.graph.AtlasInput` — the stable contract.
 - Three run modes: `baseline` (Sunday), `delta` (Mon–Sat with triage
   carry-forward), `monthly` (month-end synthesis).
-- Persistence per ADR-0009: writes to existing Supabase `documents` /
-  `daily_snapshots` tables via `supabase_io.publish_document` /
-  `publish_daily_snapshot`. The legacy `scripts/publish_document.py` and
-  `scripts/materialize_snapshot.py` are frozen — marked as such in their
-  headers.
-- Skills as injected context: each phase node loads a `SKILL.md` file and
-  passes it to the DigiGraph generic research agent alongside a Pydantic
-  output model. No prompt ports; skills stay authoritative as Markdown.
-  11 near-duplicate sector skills were collapsed into one templated
-  `sector-research` skill + `config/sectors.yaml`.
+- Skills under `digiquant/atlas/skills/` (alt-data, institutional, macro,
+  asset-class, equity, sector-research, digest, monthly-synthesis, …).
+  Loaded via `digiquant.atlas.skills.load_skill`.
+- Standalone CLI: `python -m digiquant.atlas.graph` — useful for
+  research-only consumers (e.g. SITAAS-style deployments) and tests.
+- Terminal `publish_phase` is wired only when `deps.publish` is provided;
+  the chain orchestrator passes `None` so publish runs once at the end.
+
+### Hermes (analysis + PM + reflection)
+
+- Entry points:
+  - `digiquant.hermes.chain.run_atlas_then_hermes(atlas_input, deps)` —
+    end-to-end: Atlas (no publish) → Hermes → terminal `publish_phase`.
+    The cron workflows (`atlas-baseline.yml`, `atlas-delta.yml`,
+    `atlas-monthly.yml`) invoke `python -m digiquant.hermes.chain` for
+    this path.
+  - `digiquant.hermes.graph.build_hermes_graph(watchlist, deps)` plus
+    `python -m digiquant.hermes.graph --from-digest <state.json>` for
+    isolated Hermes runs.
+- Skills under `digiquant/hermes/skills/` (4-axis analysts, research-debate,
+  research-manager, risk-aggressive/conservative, pipeline-evolution, plus
+  WAVE2 skills queued for h1–h7 expansion).
+  Loaded via `digiquant.hermes.skills.load_skill`. Cross-engine loads
+  raise `SkillNotFoundError`.
+- Schemas under `digiquant/hermes/templates/schemas/`. Loaded via
+  `digiquant.hermes.schemas.load_schema`.
+
+### Persistence
+
+Per ADR-0009: writes to Supabase `documents` / `daily_snapshots` /
+`decision_log` tables via `digiquant.atlas.supabase_io.publish_document` /
+`publish_daily_snapshot` / Hermes phase 9's `persist_pending`. The legacy
+`digiquant/scripts/atlas/publish_document.py` and `materialize_snapshot.py`
+are frozen — marked as such in their headers.
+
+Skills as injected context: each phase loads a `SKILL.md` file and passes
+it to DigiGraph's generic research agent alongside a Pydantic output
+model. No prompt ports; skills stay authoritative as Markdown. 11
+near-duplicate sector skills were collapsed into one templated
+`sector-research` skill + `config/sectors.yaml`.
 
 See `docs/adr/0009-atlas-supabase-persistence.md` for the persistence
-decision; `~/.claude/plans/1-yes-use-the-crispy-sky.md` for the full
-migration plan.
+decision and `docs/adr/0015-atlas-vs-hermes.md` for the engine split.
 
 ## DigiSearch Integration (#199)
 

--- a/digiquant/docs/atlas/agentic/ARCHITECTURE.md
+++ b/digiquant/docs/atlas/agentic/ARCHITECTURE.md
@@ -644,9 +644,9 @@ Atlas research sub-graph and produces `state.phase_hermes.pm_allocation_memo`,
 which `phase7d_rebalance` then deterministically turns into the
 `RebalanceDecision`.
 
-Full spec: [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) (topology diagram in §1.2,
+Full spec: [`HERMES_SUBGRAPH.md`](../../hermes/HERMES_SUBGRAPH.md) (topology diagram in §1.2,
 persistence mapping in §5). Wave 2 implementation units:
-[`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md).
+[`WAVE2_UNIT_SPECS.md`](../../hermes/WAVE2_UNIT_SPECS.md).
 
 Persistence lands in both `documents` (full payload) and the first-class
 tables introduced by migration 024: `theses`, `thesis_vehicles`,

--- a/digiquant/docs/hermes/AGENTS.md
+++ b/digiquant/docs/hermes/AGENTS.md
@@ -1,0 +1,94 @@
+# Hermes — agent operator guide
+
+> Sibling of [`digiquant/docs/atlas/AGENTS.md`](../atlas/AGENTS.md). Atlas owns
+> research; Hermes owns analysis + portfolio management + reflection.
+> Boundary contract: [ADR-0015](../../../docs/adr/0015-atlas-vs-hermes.md).
+
+## What Hermes does
+
+Hermes consumes the daily Atlas digest (`DigestPayload`) and produces:
+
+- **4-axis analyst payloads** per ticker (`phase7c_analyst`) — fundamental,
+  technical, sentiment, news. Output: `phase7c_analysts[ticker]`.
+- **Bull/Bear debate summaries** (`phase7cd_debate`) — N rounds, each with
+  bull + bear contributions and a research-manager synthesis.
+  Output: `phase7cd_debates[ticker]`.
+- **Risk debate + PM allocation memo** (`phase7d_pm`) — risk-aggressive vs
+  risk-conservative cases, then a portfolio-manager allocation memo.
+  Output: `phase7d_risk_debate` + `phase7d_rebalance`.
+- **Closed-loop reflection** (`phase9_evolution`) — alpha-vs-SPY scoring
+  on prior decisions + lesson proposals for the next baseline.
+  Output: `phase9_evolution`.
+
+## Entry points
+
+- **Production:** `python -m digiquant.hermes.chain --run-type baseline|delta`.
+  Drives Atlas first (research), then Hermes (analysis), then a single
+  terminal `publish_phase`. The cron workflows use this.
+- **Standalone (research-skipping):** `python -m digiquant.hermes.graph
+  --from-digest <state.json>` reads a serialised Atlas state and runs
+  Hermes only.
+- **Library:** `digiquant.hermes.chain.run_atlas_then_hermes(atlas_input,
+  deps)` for in-process invocation.
+
+## Skills
+
+Each phase loads its prompt from `digiquant/hermes/skills/<slug>/SKILL.md`
+via `digiquant.hermes.skills.load_skill`. The Atlas loader cannot resolve
+Hermes skills (and vice versa) — `SkillNotFoundError` if you try.
+
+| Phase | Skills loaded |
+|------|--------------|
+| `phase7c_analyst` | `fundamental-analyst`, `technical-analyst`, `sentiment-analyst`, `news-analyst` |
+| `phase7cd_debate` | `research-debate`, `research-manager` |
+| `phase7d_pm`      | `risk-aggressive`, `risk-conservative` |
+| `phase9_evolution`| `pipeline-evolution` |
+
+The seven WAVE2 skills (`thesis`, `thesis-tracker`, `thesis-vehicle-map`,
+`opportunity-screener`, `pm-allocation-memo`, `portfolio-manager`,
+`deliberation`) live in `digiquant/hermes/skills/` ahead of their first
+runtime caller — see [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md).
+
+## Schemas
+
+Hermes-side JSON-Schemas under `digiquant/hermes/templates/schemas/`:
+- analyst-side: `asset-recommendation`, `deep-dive`, `pipeline-review`
+- debate / deliberation: `deliberation-{session-index,transcript}`
+- PM: `pm-allocation-memo`, `rebalance-decision`, `thesis-vehicle-map`
+- reflection: `evolution-{sources,quality-log,proposals}`,
+  `market-thesis-exploration`
+- delta diff: `document-delta`
+
+Loaded via `digiquant.hermes.schemas.load_schema(name)`.
+
+## Persistence
+
+Hermes does not call Supabase directly. Phase outputs land in the shared
+`HermesState`; the chain orchestrator's terminal `publish_phase` (provided
+by `digiquant.atlas.phases.publish_phase`) flushes everything in one pass —
+analyst payloads land in `documents` with `document_key='analyst/<TICKER>'`,
+PM rebalance lands in `documents`, the digest goes to `daily_snapshots`.
+
+`phase9_evolution` writes `decision_log` rows when `Phase9Deps` is wired
+(production cron only — no-op on dry-run / fixture tests).
+
+## Testing
+
+```bash
+pytest tests/dq/hermes/ -m unit -v        # all Hermes phase tests + chain integration
+pytest tests/dq/atlas/ -m unit -v         # Atlas-side
+pytest tests/dq/ -m unit -v               # both + the rest of digiquant
+```
+
+The Hermes test tree is gated by `tests/dq/hermes/conftest.py` — skipped
+when `digigraph.graph.pipeline_builder` isn't importable (the standard
+`digiquant tests` CI job installs only `digiquant[dev]`; the full set runs
+in `atlas-graph-ci.yml`).
+
+## Useful files
+
+- [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) — architectural spec.
+- [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md) — Wave 2 expansion units.
+- [Atlas operator guide](../atlas/AGENTS.md) — research-side counterpart.
+- [Atlas runbook](../atlas/RUNBOOK.md) — operator playbook (covers both
+  engines today; may split when Hermes operations diverge).

--- a/digiquant/docs/hermes/HERMES_SUBGRAPH.md
+++ b/digiquant/docs/hermes/HERMES_SUBGRAPH.md
@@ -101,14 +101,14 @@ flowchart TD
 
 | Phase | Role | Skill(s) | Fan-out | Primary output |
 |-------|------|----------|---------|----------------|
-| `phase_h1_thesis_review` | Re-score active theses; update status (`ACTIVE` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED`) per `chk_theses_status` | [`thesis`](../../skills/thesis/SKILL.md), [`thesis-tracker`](../../skills/thesis-tracker/SKILL.md) | 1 | `ThesisReviewOutput` |
-| `phase_h2_market_thesis_exploration` | Discover new theses from macro + sector research | [`market-thesis-exploration`](../../skills/market-thesis-exploration/SKILL.md) | 1 | `MarketThesisExploration` |
-| `phase_h3_thesis_vehicle_map` | Map each thesis to candidate tickers | [`thesis-vehicle-map`](../../skills/thesis-vehicle-map/SKILL.md) | 1 | `ThesisVehicleMap` |
-| `phase_h4_opportunity_screener` | Rank universe; pick analyst roster | [`opportunity-screener`](../../skills/opportunity-screener/SKILL.md) | 1 | `OpportunityScreen` |
-| `phase_h5_asset_analyst` | Per-ticker blinded analyst recommendation | [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | N tickers | `AssetRecommendation` per ticker |
-| `phase_h6_deliberation` | PM↔analyst cyclic deliberation per ticker | [`deliberation`](../../skills/deliberation/SKILL.md), [`portfolio-manager`](../../skills/portfolio-manager/SKILL.md), [`asset-analyst`](../../skills/asset-analyst/SKILL.md) | N tickers (× rounds) | `DeliberationSession` per ticker |
-| `deep_dive_batch` | Resolve recess requests | [`deep-dive`](../../skills/deep-dive/SKILL.md) | M recesses | `DeepDiveNote` rows |
-| `phase_h7_pm_allocation_memo` | PM-authored allocation memo | [`pm-allocation-memo`](../../skills/pm-allocation-memo/SKILL.md) | 1 | `PMAllocationMemo` |
+| `phase_h1_thesis_review` | Re-score active theses; update status (`ACTIVE` / `CHALLENGED` / `CLOSED` / `INVALIDATED` / `PAUSED`) per `chk_theses_status` | [`thesis`](../../hermes/skills/thesis/SKILL.md), [`thesis-tracker`](../../hermes/skills/thesis-tracker/SKILL.md) | 1 | `ThesisReviewOutput` |
+| `phase_h2_market_thesis_exploration` | Discover new theses from macro + sector research | [`market-thesis-exploration`](../../atlas/skills/market-thesis-exploration/SKILL.md) | 1 | `MarketThesisExploration` |
+| `phase_h3_thesis_vehicle_map` | Map each thesis to candidate tickers | [`thesis-vehicle-map`](../../hermes/skills/thesis-vehicle-map/SKILL.md) | 1 | `ThesisVehicleMap` |
+| `phase_h4_opportunity_screener` | Rank universe; pick analyst roster | [`opportunity-screener`](../../hermes/skills/opportunity-screener/SKILL.md) | 1 | `OpportunityScreen` |
+| `phase_h5_asset_analyst` | Per-ticker blinded analyst recommendation | [`asset-analyst`](../../atlas/skills/asset-analyst/SKILL.md) | N tickers | `AssetRecommendation` per ticker |
+| `phase_h6_deliberation` | PM↔analyst cyclic deliberation per ticker | [`deliberation`](../../hermes/skills/deliberation/SKILL.md), [`portfolio-manager`](../../hermes/skills/portfolio-manager/SKILL.md), [`asset-analyst`](../../atlas/skills/asset-analyst/SKILL.md) | N tickers (× rounds) | `DeliberationSession` per ticker |
+| `deep_dive_batch` | Resolve recess requests | [`deep-dive`](../../atlas/skills/deep-dive/SKILL.md) | M recesses | `DeepDiveNote` rows |
+| `phase_h7_pm_allocation_memo` | PM-authored allocation memo | [`pm-allocation-memo`](../../hermes/skills/pm-allocation-memo/SKILL.md) | 1 | `PMAllocationMemo` |
 
 ---
 
@@ -158,7 +158,7 @@ Each per-ticker deliberation node is itself a **cyclic LangGraph sub-graph** wit
 
 ## 3. State additions to `AtlasResearchState`
 
-A new nested block is added to [`state.py`](../../src/digiquant_atlas/state.py):
+A new nested block is added to [`state.py`](../../../src/digiquant/atlas/state.py):
 
 ```python
 class PhaseHermesState(BaseModel):
@@ -199,14 +199,14 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 
 ### 4.2 `MarketThesisExploration` (phase_h2)
 
-- **Schema:** [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
+- **Schema:** [`market-thesis-exploration.schema.json`](../../hermes/templates/schemas/market-thesis-exploration.schema.json).
 - **Fields (body):** `executive_digest_pointer: str`, `deeper_dives: list[str]`, `theses: list[ThesisProposal]`.
 - **`ThesisProposal`:** `thesis_id` (≤32), `title` (≤200), `direction`, `statement` (≤4000), `validation_criteria: list[str]` (required, ≥1), `invalidation_criteria: list[str]` (required, ≥1), optional `headwinds / tailwinds / bull_case / bear_case`.
 - **Validation:** `thesis_id` unique within the run; direction ∈ {`long`, `short`, `pair`, `hedge`, `avoid`}.
 
 ### 4.3 `ThesisVehicleMap` (phase_h3)
 
-- **Schema:** [`thesis-vehicle-map.schema.json`](../../templates/schemas/thesis-vehicle-map.schema.json).
+- **Schema:** [`thesis-vehicle-map.schema.json`](../../hermes/templates/schemas/thesis-vehicle-map.schema.json).
 - **Fields (body):** `mappings: list[ThesisVehicleMapping]`.
 - **`ThesisVehicleMapping`:** `thesis_id` (must reference h1+h2 theses), `candidate_tickers: list[str]` (min 1; each ≤12 chars, must be in `config.watchlist` or flagged as `extra-universe`), `rationale` (≤4000), `exclusion_reasons: list[str]`, `user_mandate_notes: list[str]`.
 - **Validation:** every `thesis_id` in the output must appear in `state.phase_hermes.thesis_review.reviewed_theses` with non-`CLOSED` status, or in `market_thesis_exploration.theses`.
@@ -220,15 +220,15 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 
 ### 4.5 `AssetRecommendation` (phase_h5)
 
-- **Schema:** [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+- **Schema:** [`asset-recommendation.schema.json`](../../hermes/templates/schemas/asset-recommendation.schema.json).
 - **Fields (body):** `context: PriceContext` (`price`, `day_pct`, `segment_bias`), `bull_case: list[str]`, `bear_case: list[str]`, `verdict: Verdict`, optional `catalysts`, `risk_flags`.
 - **`Verdict`:** `bias`, `thesis_status`, `recommended_weight_pct: float` (0–100), `rationale` (≤2000).
 - **Validation:** blinded — must **not** reference `current_weights` or `portfolio.json`; `recommended_weight_pct` ignored if `bias == "avoid"`. This model replaces `phase7c_analyst.AnalystPayload` (see §7).
 
 ### 4.6 `DeliberationSession` (phase_h6)
 
-- **Schema (transcript):** [`deliberation-transcript.schema.json`](../../templates/schemas/deliberation-transcript.schema.json).
-- **Schema (session index):** [`deliberation-session-index.schema.json`](../../templates/schemas/deliberation-session-index.schema.json).
+- **Schema (transcript):** [`deliberation-transcript.schema.json`](../../hermes/templates/schemas/deliberation-transcript.schema.json).
+- **Schema (session index):** [`deliberation-session-index.schema.json`](../../hermes/templates/schemas/deliberation-session-index.schema.json).
 - **Fields:**
   - Transcript `body`: `trigger_summary: list[str]`, `rounds: list[DeliberationRound]`, `final_decisions: list[FinalDecision]`.
   - `DeliberationRound`: `label`, `sections: list[{heading, markdown}]` — canonical heading values, in round order: `"analyst"` (analyst-present), `"pm_challenge"` (PM push-back), `"analyst_defense"` (analyst rebuttal), `"pm_decision"` (PM commit to converge/continue), optional `"recess_reason"` (populated only when `recess_triggered=True`). Writers MUST use these exact strings so downstream readers can index by heading without a regex. Plus Hermes-added `converged: bool`, `recess_triggered: bool`, `deep_dive_document_key: str | None`, `round_number: int`.
@@ -238,7 +238,7 @@ One model per H-phase. Each is validated against the schema under [`templates/sc
 
 ### 4.7 `PMAllocationMemo` (phase_h7)
 
-- **Schema:** [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json).
+- **Schema:** [`pm-allocation-memo.schema.json`](../../hermes/templates/schemas/pm-allocation-memo.schema.json).
 - **Fields (body):** `narrative: str` (≤12000), `turnover_discipline: str` (≤4000), `target_weights_rationale: list[TargetWeightRationale]`, `open_questions: list[str]`.
 - **`TargetWeightRationale`:** `ticker`, `target_weight_pct` (0–100), `prior_weight_pct: float | None`, `rationale` (≤2000), `deliberation_document_key: str | None`.
 - **Validation:** sum of `target_weight_pct` ≤ 100 + cash tolerance (configurable, default 101); every non-null `deliberation_document_key` must resolve to a row in `deliberation_sessions`.
@@ -306,7 +306,7 @@ W2-A applies 025 to dev before W2-B / W2-D can green their persistence tests. No
 
 ## 6. Delta-run behavior
 
-Triage ([`triage.py`](../../src/digiquant_atlas/triage.py)) is extended with Hermes-tier rules in W2-H:
+Triage ([`triage.py`](../../../src/digiquant/atlas/triage.py)) is extended with Hermes-tier rules in W2-H:
 
 | Phase | Baseline (Sun) | Delta (Mon–Fri) | Monthly |
 |-------|----------------|-----------------|---------|
@@ -332,7 +332,7 @@ Carried entries still surface in the Phase 9 post-mortem so operators can see wh
 
 ### 7.1 `phase7c_analyst` (current) → `phase_h5_asset_analyst` (new)
 
-**Decision: replace.** The existing [`phase7c_analyst.py`](../../src/digiquant_atlas/phases/phase7c_analyst.py) emits a minimal `AnalystPayload` (`conviction_score`, `stance`, `thesis`, `risks`). `phase_h5` emits the richer `AssetRecommendation` governed by the existing [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json) — bull/bear cases, context block, verdict with `recommended_weight_pct`, thesis linkage.
+**Decision: replace.** The existing [`phase7c_analyst.py`](../../../src/digiquant/atlas/phases/phase7c_analyst.py) emits a minimal `AnalystPayload` (`conviction_score`, `stance`, `thesis`, `risks`). `phase_h5` emits the richer `AssetRecommendation` governed by the existing [`asset-recommendation.schema.json`](../../hermes/templates/schemas/asset-recommendation.schema.json) — bull/bear cases, context block, verdict with `recommended_weight_pct`, thesis linkage.
 
 - **W2-E deletes** `phase7c_analyst.py` and `state.phase7c_analysts`.
 - Callers move to `state.phase_hermes.asset_recommendations`.
@@ -341,7 +341,7 @@ Carried entries still surface in the Phase 9 post-mortem so operators can see wh
 
 ### 7.2 `phase7d_rebalance` (current) consumes `phase_h7_pm_allocation_memo`
 
-[`phase7d_pm.py`](../../src/digiquant_atlas/phases/phase7d_pm.py) currently reads `state.phase7c_analysts` directly and re-derives allocations. Under Hermes, phase_h7 writes the allocation memo and phase7d becomes a **pure transform**:
+[`phase7d_pm.py`](../../../src/digiquant/atlas/phases/phase7d_pm.py) currently reads `state.phase7c_analysts` directly and re-derives allocations. Under Hermes, phase_h7 writes the allocation memo and phase7d becomes a **pure transform**:
 
 - New input to `phase7d`: `state.phase_hermes.pm_allocation_memo`.
 - `phase7d` maps `PMAllocationMemo.target_weights_rationale` → `RebalanceDecision.recommended_portfolio` + derives `RebalanceAction` list by diffing against `config.preferences.current_weights`.

--- a/digiquant/docs/hermes/README.md
+++ b/digiquant/docs/hermes/README.md
@@ -1,0 +1,62 @@
+# Hermes — analysis, portfolio mgmt, risk, reflection
+
+Hermes is the analysis half of the DigiQuant pipeline. It consumes a
+research [`DigestPayload`](../../src/digiquant/atlas/snapshot.py) produced by
+[Atlas](../atlas/) and produces analyst reports, an allocation memo, and a
+reflection record.
+
+See [ADR-0015](../../../docs/adr/0015-atlas-vs-hermes.md) for the
+responsibility boundary.
+
+## Phases
+
+| Phase | Purpose | Skills |
+|------|---------|--------|
+| `phase7c_analyst` | 4-axis analyst specialisation per ticker (#430) | `fundamental-analyst`, `technical-analyst`, `sentiment-analyst`, `news-analyst` |
+| `phase7cd_debate` | Bull/Bear adversarial debate per ticker (#429) | `research-debate`, `research-manager` |
+| `phase7d_pm` | Risk-aggressive vs conservative debate + PM allocation (#431) | `risk-aggressive`, `risk-conservative`, `pm-allocation-memo` |
+| `phase9_evolution` | Closed-loop reflection / alpha scoring (#432) | `pipeline-evolution` |
+
+## Code layout
+
+```
+digiquant/
+├── src/digiquant/hermes/
+│   ├── __init__.py
+│   ├── state.py                 ← HermesState (alias for AtlasResearchState today)
+│   ├── graph.py                 ← build_hermes_graph(...)
+│   ├── chain.py                 ← run_atlas_then_hermes(...)
+│   └── phases/
+│       ├── phase7c_analyst.py
+│       ├── phase7cd_debate.py
+│       ├── phase7d_pm.py
+│       └── phase9_evolution.py
+├── hermes/
+│   ├── skills/                  ← analyst / debate / PM / risk / reflection prompts
+│   └── templates/schemas/       ← analyst / deliberation / evolution JSON-Schemas
+└── docs/hermes/                 ← this directory
+```
+
+## CLI entry points
+
+- `python -m digiquant.atlas.graph --run-type baseline|delta|monthly` — research only.
+- `python -m digiquant.hermes.graph --from-digest <path>` — Hermes only over a saved Atlas state JSON.
+- `python -m digiquant.hermes.chain --run-type baseline|delta|monthly` — full Atlas → Hermes → publish chain. **This is what cron uses.**
+
+## Documents
+
+- [`HERMES_SUBGRAPH.md`](HERMES_SUBGRAPH.md) — full sub-graph spec (topology, persistence, schemas).
+- [`WAVE2_UNIT_SPECS.md`](WAVE2_UNIT_SPECS.md) — implementation units for the Wave 2 expansion (h1 thesis review, h2 market-thesis exploration, h3 vehicle map, h4 opportunity screen, h5 asset analyst, h6 deliberation, h7 PM allocation memo).
+- [`AGENTS.md`](AGENTS.md) — agent operator guide.
+
+## Test layout
+
+```
+tests/dq/hermes/
+├── conftest.py                     ← collection gate (digigraph importable)
+├── test_phase7c_specialists.py
+├── test_phase7cd_debate.py
+├── test_phase7d_risk_debate.py
+├── test_phase9_reflection.py
+└── test_chain_atlas_then_hermes.py ← Atlas → Hermes integration
+```

--- a/digiquant/docs/hermes/WAVE2_UNIT_SPECS.md
+++ b/digiquant/docs/hermes/WAVE2_UNIT_SPECS.md
@@ -105,7 +105,7 @@ class ThesisReviewOutput(BaseModel):
 
 - Create: `digiquant/src/digiquant/atlas/phases/phase_h2_market_thesis_exploration.py`.
 - Modify: `digiquant/src/digiquant/atlas/graph.py` — wire after h1.
-- Pydantic model `MarketThesisExploration` in the phase module, validated against existing [`market-thesis-exploration.schema.json`](../../templates/schemas/market-thesis-exploration.schema.json).
+- Pydantic model `MarketThesisExploration` in the phase module, validated against existing [`market-thesis-exploration.schema.json`](../../hermes/templates/schemas/market-thesis-exploration.schema.json).
 
 **Inline Pydantic contract:**
 
@@ -195,7 +195,7 @@ class OpportunityScreen(BaseModel):
 
 **Files:**
 
-- Create: `digiquant/src/digiquant/atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../templates/schemas/asset-recommendation.schema.json).
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h5_asset_analyst.py` — per-ticker fan-out over `state.phase_hermes.opportunity_screen.roster`; Pydantic `AssetRecommendation` validated against [`asset-recommendation.schema.json`](../../hermes/templates/schemas/asset-recommendation.schema.json).
 
 **Inline Pydantic contract:**
 
@@ -301,7 +301,7 @@ class DeliberationSession(BaseModel):
 
 **Files:**
 
-- Create: `digiquant/src/digiquant/atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
+- Create: `digiquant/src/digiquant/atlas/phases/phase_h7_pm_allocation_memo.py` — single node; loads `pm-allocation-memo` skill; Pydantic `PMAllocationMemo` validated against [`pm-allocation-memo.schema.json`](../../hermes/templates/schemas/pm-allocation-memo.schema.json). Conditional router: skip when no deliberation session ran this run (see HERMES_SUBGRAPH §6).
 
 **Inline Pydantic contract:**
 


### PR DESCRIPTION
## Summary

Mirrors the runtime split (#472–#475) in the documentation layout. Each engine now has its own README + AGENTS so operators land on the right surface.

### Moved
- `digiquant/docs/atlas/agentic/HERMES_SUBGRAPH.md` → `digiquant/docs/hermes/`
- `digiquant/docs/atlas/agentic/WAVE2_UNIT_SPECS.md` → `digiquant/docs/hermes/`

Link rot inside the moved files repointed (`../../skills/<slug>` → `../../{atlas,hermes}/skills/<slug>` based on caller-side rule; `../../templates/schemas/` similarly; `../../src/digiquant_atlas/` → `../../../src/digiquant/atlas/`).

### New
- `digiquant/docs/hermes/README.md` — orientation: phases, code layout, CLI entry points, doc index, test layout.
- `digiquant/docs/hermes/AGENTS.md` — operator guide: what Hermes does, how to invoke it (standalone vs chain), skill/schema/persistence contract, testing.

### Updated
- `digiquant/ARCHITECTURE.md` "Atlas Sub-graph Integration" section split into two sub-sections under "Atlas + Hermes Sub-graphs (ADR-0009 + ADR-0015)". Each engine block lists entry points, skill/schema homes, CLI invocation. DigestPayload documented as the boundary contract.
- `digiquant/docs/atlas/agentic/ARCHITECTURE.md` — two links repointed to the new `../../hermes/...` location.
- Root `CLAUDE.md` "Project at a glance": digiquant bullet now mentions both sub-graphs; the orientation paragraph documents Atlas + Hermes file homes + the three CLI entry points.

## Verification

- `pytest tests/dq/ -m unit` → **614 passed**
- `python scripts/check_doc_links.py` → **OK (133 markdown files)** (+1 from the new docs/hermes/ tree)
- Grep sweep — no stale "Atlas runs the analyst / PM / risk debate" prose remains in active docs

## Test plan

- [ ] CI: digiquant + atlas tests green
- [ ] CI: actionlint + doc-links green

After this lands, only **#476** (CI path-filter extensions) remains in epic #471.

Closes #478
Refs #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)