### PR TITLE
ci: extend atlas-graph-ci.yml to lint + test Hermes (#476)

### DIFF
--- a/.github/workflows/atlas-graph-ci.yml
+++ b/.github/workflows/atlas-graph-ci.yml
@@ -11,11 +11,19 @@ on:
   push:
     branches: [main, develop]
     paths:
+      # Atlas (research) tree
       - "digiquant/src/digiquant/atlas/**"
       - "digiquant/atlas/**"
       - "digiquant/scripts/atlas/**"
       - "digiquant/supabase/**"
       - "tests/dq/atlas/**"
+      # Hermes (analysis + PM + reflection) tree — same workflow runs both
+      # engines' lint + test surfaces. See ADR-0015. Revisit splitting into
+      # hermes-graph-ci.yml once Hermes's test set grows large enough to
+      # warrant its own job.
+      - "digiquant/src/digiquant/hermes/**"
+      - "digiquant/hermes/**"
+      - "tests/dq/hermes/**"
       - ".github/workflows/atlas-*.yml"
   pull_request:
     paths:
@@ -24,6 +32,9 @@ on:
       - "digiquant/scripts/atlas/**"
       - "digiquant/supabase/**"
       - "tests/dq/atlas/**"
+      - "digiquant/src/digiquant/hermes/**"
+      - "digiquant/hermes/**"
+      - "tests/dq/hermes/**"
       - ".github/workflows/atlas-*.yml"
 
 permissions:
@@ -45,13 +56,23 @@ jobs:
           bash scripts/install-workspace.sh --with-dev digiquant
 
       - name: Ruff check
-        run: ruff check digiquant/src/digiquant/atlas tests/dq/atlas
+        run: |
+          ruff check \
+            digiquant/src/digiquant/atlas \
+            digiquant/src/digiquant/hermes \
+            tests/dq/atlas \
+            tests/dq/hermes
 
       - name: Ruff format check
-        run: ruff format --check digiquant/src/digiquant/atlas tests/dq/atlas
+        run: |
+          ruff format --check \
+            digiquant/src/digiquant/atlas \
+            digiquant/src/digiquant/hermes \
+            tests/dq/atlas \
+            tests/dq/hermes
 
       - name: Pytest
-        run: pytest -m unit tests/dq/atlas/ -v --tb=short
+        run: pytest -m unit tests/dq/atlas/ tests/dq/hermes/ -v --tb=short
 
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Final ticket of the Hermes-extraction epic ([#471](https://github.com/digithings-ai/digithings/issues/471)). After this lands, the epic is **done**.

### Path filters
Push + pull_request triggers extended to cover the Hermes tree:
- `digiquant/src/digiquant/hermes/**`
- `digiquant/hermes/**` (skills + templates data)
- `tests/dq/hermes/**`

### Lint + pytest scope
- `ruff check` + `ruff format --check` now cover **both** `digiquant/src/digiquant/{atlas,hermes}` and `tests/dq/{atlas,hermes}`.
- `pytest -m unit tests/dq/atlas/ tests/dq/hermes/` — single invocation runs both trees.

### Single-workflow rationale
Hermes's test surface today is small (4 phase tests + 1 chain integration test). One workflow runs both engines: install full workspace once, lint + test both, single CI signal. Revisit splitting into a separate `hermes-graph-ci.yml` when Hermes outgrows its share.

## Verification

- `actionlint` → clean
- Local CI-equivalent commands — `ruff check` + `ruff format --check` + `pytest -m unit tests/dq/atlas/ tests/dq/hermes/` → **298 passed**, all clean

## Test plan

- [ ] CI: `tests` (atlas graph ci) green and now covers Hermes lint + tests
- [ ] CI: actionlint green

Closes #476  
Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)