### PR TITLE
fix(digiquant): normalize LLM synonym outputs for Bias + cta_flow_bias

### DIFF
--- a/digiquant/src/digiquant/atlas/phases/phase1_altdata.py
+++ b/digiquant/src/digiquant/atlas/phases/phase1_altdata.py
@@ -51,7 +51,7 @@ class CtaPositioningReport(SegmentReport):
 
     systematic_stance: Literal["long", "short", "neutral", "mixed"] | None = None
     futures_oi_trend: Literal["expanding", "contracting", "flat"] | None = None
-    cta_flow_bias: Literal["adding", "reducing", "neutral"] | None = None
+    cta_flow_bias: Literal["adding", "reducing", "neutral", "mixed"] | None = None
 
 
 class OptionsDerivativesReport(SegmentReport):

--- a/digiquant/src/digiquant/atlas/segments.py
+++ b/digiquant/src/digiquant/atlas/segments.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from datetime import date as _date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # Narrow stance vocabulary shared across asset classes / sectors.
@@ -30,6 +30,20 @@ Bias = Literal[
     "strong_bearish",
     "mixed",
 ]
+
+# LLM synonym → canonical Bias value. Applied before Pydantic validates the
+# Literal so models never hard-fail on reasonable paraphrases (e.g. Gemini
+# Flash returning "positive" instead of "bullish").
+_BIAS_SYNONYMS: dict[str, str] = {
+    "positive": "bullish",
+    "negative": "bearish",
+    "very_positive": "strong_bullish",
+    "strongly_bullish": "strong_bullish",
+    "strongly_positive": "strong_bullish",
+    "very_negative": "strong_bearish",
+    "strongly_bearish": "strong_bearish",
+    "strongly_negative": "strong_bearish",
+}
 
 
 class Finding(BaseModel):
@@ -89,3 +103,10 @@ class SegmentReport(BaseModel):
         description="Free-form analyst notes — uncertainty, contradictions, regime caveats.",
         max_length=2000,
     )
+
+    @field_validator("bias", mode="before")
+    @classmethod
+    def _normalize_bias(cls, v: object) -> object:
+        if isinstance(v, str):
+            return _BIAS_SYNONYMS.get(v.lower(), v)
+        return v

--- a/tests/dq/atlas/test_phase12.py
+++ b/tests/dq/atlas/test_phase12.py
@@ -78,6 +78,61 @@ def _dispatch_fake_completion(_model: str, messages: list[dict[str, Any]], **_: 
 
 
 @pytest.mark.unit
+class TestBiasNormalization:
+    """Regression tests for LLM synonym → canonical Bias mapping (issue #490)."""
+
+    def test_positive_maps_to_bullish(self) -> None:
+        from digiquant.atlas.segments import SegmentReport
+        from datetime import date
+
+        r = SegmentReport(
+            segment="test",
+            date=date(2026, 4, 29),
+            bias="positive",  # type: ignore[arg-type]
+            headline="test",
+        )
+        assert r.bias == "bullish"
+
+    def test_negative_maps_to_bearish(self) -> None:
+        from digiquant.atlas.segments import SegmentReport
+        from datetime import date
+
+        r = SegmentReport(
+            segment="test",
+            date=date(2026, 4, 29),
+            bias="negative",  # type: ignore[arg-type]
+            headline="test",
+        )
+        assert r.bias == "bearish"
+
+    def test_canonical_values_pass_through(self) -> None:
+        from digiquant.atlas.segments import SegmentReport
+        from datetime import date
+
+        for val in ("strong_bullish", "bullish", "neutral", "bearish", "strong_bearish", "mixed"):
+            r = SegmentReport(
+                segment="test",
+                date=date(2026, 4, 29),
+                bias=val,  # type: ignore[arg-type]
+                headline="test",
+            )
+            assert r.bias == val
+
+    def test_cta_flow_bias_accepts_mixed(self) -> None:
+        from digiquant.atlas.phases.phase1_altdata import CtaPositioningReport
+        from datetime import date
+
+        r = CtaPositioningReport(
+            segment="alt-cta-positioning",
+            date=date(2026, 4, 29),
+            bias="neutral",
+            headline="test",
+            cta_flow_bias="mixed",
+        )
+        assert r.cta_flow_bias == "mixed"
+
+
+@pytest.mark.unit
 class TestPhase1AltData:
     def test_fan_out_produces_four_segments(self) -> None:
         compiled = build_pipeline(AtlasResearchState, [build_phase1()])


### PR DESCRIPTION
## Summary

- **`segments.py`**: `field_validator(mode="before")` maps common LLM paraphrases to canonical `Bias` values (`"positive"` → `"bullish"`, `"negative"` → `"bearish"`, etc.) before Pydantic validates the `Literal` constraint.
- **`phase1_altdata.py`**: adds `"mixed"` to `cta_flow_bias` Literal — semantically valid when CTA flow is neither clearly adding nor reducing.
- **`test_phase12.py`**: four regression tests pinning both fixes.

## Problem

Gemini Flash returns `"positive"` for `SegmentReport.bias` and `"mixed"` for `CtaPositioningReport.cta_flow_bias`. Both cause Pydantic `literal_error` hard-fails on every Phase 1 run, exhausting all retries. The pipeline has produced **zero snapshots since 2026-04-15 (14-day outage)** — Olympus dashboard shows empty state to all users.

Confirmed in failure issues #449 and #462.

## Test plan

- [x] `pytest tests/dq/atlas/test_phase12.py` — 7 passed (4 new regression tests + 3 existing)
- [x] `pytest tests/dq/atlas/` — 250 passed
- [x] `ruff check` + `ruff format --check` — no issues
- [ ] Atlas delta cron run on merge (should produce first snapshot since 2026-04-15)

Closes #449
Closes #462
Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)