### PR TITLE
feat(digigraph): structured outputs for research agent (response_format json_schema)

### DIFF
--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -134,12 +134,25 @@ def run_research_agent(
         temperature: LLM temperature; default 0.1 (analyst work wants determinism).
         max_retries: How many times to re-call with the validator error appended
             before giving up. Default 1.
+
+    Provider notes:
+        ``response_format=json_schema`` is passed to the API call so that providers
+        that support native structured output (Gemini Flash, OpenAI) enforce the
+        schema at token-generation time. Providers that silently ignore the field
+        (Ollama, some LiteLLM backends) fall back to the prompt-embedded
+        OUTPUT_SCHEMA block. The Pydantic field_validator on output models acts
+        as a third defense-in-depth layer for synonym normalization regardless of
+        which path is taken.
     """
     effective_model = (
         model or (get_model_for_phase(phase_slug) if phase_slug else None) or get_model_for_mode()
     )
     schema = output_model.model_json_schema()
     schema_name = output_model.__name__
+    response_format: dict[str, Any] = {
+        "type": "json_schema",
+        "json_schema": {"name": schema_name, "schema": schema},
+    }
     content_parts = _format_scope_block(
         skill_text=skill_text,
         phase_inputs=phase_inputs,
@@ -154,7 +167,9 @@ def run_research_agent(
 
     last_error: Exception | None = None
     for attempt in range(max_retries + 1):
-        raw = chat_completion(effective_model, messages, temperature=temperature)
+        raw = chat_completion(
+            effective_model, messages, temperature=temperature, response_format=response_format
+        )
         if isinstance(raw, tuple):  # defensive: chat_completion returns tuple only with tools
             raw = raw[0]
         try:

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -133,10 +133,21 @@ _llm_cache: dict[str, tuple[str, float]] = {}
 _LLM_CACHE_MAXSIZE = 256
 
 
-def _llm_cache_key(model: str, messages: list[dict[str, Any]], temperature: float) -> str:
+def _llm_cache_key(
+    model: str,
+    messages: list[dict[str, Any]],
+    temperature: float,
+    response_format: dict[str, Any] | None = None,
+) -> str:
     """Return a stable SHA-256 cache key for the given completion parameters."""
     payload = json.dumps(
-        {"model": model, "messages": messages, "temperature": temperature}, sort_keys=True
+        {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "response_format": response_format,
+        },
+        sort_keys=True,
     )
     return hashlib.sha256(payload.encode()).hexdigest()
 
@@ -413,6 +424,7 @@ def chat_completion(
     temperature: float = 0.2,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: str | dict[str, Any] = "auto",
+    response_format: dict[str, Any] | None = None,
 ) -> str | tuple[str, list[dict[str, Any]] | None]:
     """
     Chat completion. When tools=None: returns content string (backward compatible).
@@ -423,6 +435,13 @@ def chat_completion(
     the corresponding external provider client. If the required API key env
     var is not set, falls back to the default Ollama client with a warning.
     All other model strings use the existing Ollama/LiteLLM path.
+
+    response_format: OpenAI-compatible structured-output descriptor, e.g.
+        ``{"type": "json_schema", "json_schema": {"name": "Foo", "schema": {...}}}``.
+        Mutually exclusive with ``tools`` — ignored when tools is non-empty.
+        Providers: Gemini Flash (OpenAI-compat endpoint) and OpenAI support
+        json_schema. Ollama / LiteLLM silently ignore unknown fields, so the
+        prompt-embedded OUTPUT_SCHEMA block remains the primary contract.
     """
     provider, model_id = _parse_provider_prefix(model)
     if provider is not None:
@@ -450,7 +469,7 @@ def chat_completion(
     # Check cache for tool-free requests (tool calls have side effects; don't cache them)
     cache_key: str | None = None
     if not tools:
-        cache_key = _llm_cache_key(effective_model, messages, temperature)
+        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format)
         cached = _llm_cache_get(cache_key)
         if cached is not None:
             logger.debug("LLM cache hit: model=%s key=%s…", effective_model, cache_key[:8])
@@ -463,6 +482,9 @@ def chat_completion(
     if tools:
         kwargs["tools"] = tools
         kwargs["tool_choice"] = tool_choice
+    elif response_format:
+        # tools and response_format are mutually exclusive in the OpenAI API.
+        kwargs["response_format"] = response_format
     r = _create_with_retry(client, **kwargs)
     if not r.choices:
         return "" if not tools else ("", None)

--- a/docs/adr/0016-structured-outputs-research-agent.md
+++ b/docs/adr/0016-structured-outputs-research-agent.md
@@ -1,0 +1,84 @@
+# ADR-0016 — Structured outputs for the research agent
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Related issue:** [#492](https://github.com/digithings-ai/digithings/issues/492)
+- **Related fix:** [#490](https://github.com/digithings-ai/digithings/issues/490) (bias Literal failures that motivated this ADR)
+
+## Context
+
+The Atlas research pipeline ([ADR-0014](0014-atlas-in-digiquant.md)) calls `run_research_agent`
+for every phase node. The agent instructs the LLM to return a single JSON object matching a
+Pydantic schema embedded in the prompt (`OUTPUT_SCHEMA` block). This is prompt-engineering only —
+the model is free to produce any token sequence.
+
+In April 2026 a 14-day pipeline outage was traced to two Pydantic `literal_error` failures:
+
+- `SegmentReport.bias` received `"positive"` (not in `["bullish", "bearish", ...]`).
+- `CtaPositioningReport.cta_flow_bias` received `"mixed"` (not in the then-three-value set).
+
+Both are cases where Gemini Flash paraphrased an allowed value instead of emitting the exact
+string. The immediate fix (PR #491) adds `field_validator(mode="before")` synonym normalisation
+and expands the `cta_flow_bias` Literal. This ADR records the second layer: native structured
+output at the API level.
+
+## Decision
+
+Pass `response_format={"type": "json_schema", "json_schema": {"name": ..., "schema": ...}}`
+to `chat_completion` for every `run_research_agent` call.
+
+`chat_completion` adds `response_format` to the API request when:
+1. The caller supplies it **and**
+2. `tools` is not set — `tools` and `response_format` are mutually exclusive in the OpenAI API.
+
+`response_format` is included in the LLM cache key so that different schemas never collide.
+
+## Provider compatibility
+
+| Provider | Endpoint | json_schema support | Notes |
+|----------|----------|--------------------|----|
+| Gemini Flash | `generativelanguage.googleapis.com/v1beta/openai/` | ✓ | `$defs`, `anyOf`, `enum` all handled natively; no schema pre-processing needed |
+| OpenAI | `api.openai.com/v1` | ✓ (non-strict) | Strict mode not used — see below |
+| Ollama (local) | port 11434 | ⚠ silently ignored | Falls back to prompt-embedded schema |
+| Ollama Cloud | `ollama.com/v1` | ⚠ silently ignored | Same as local |
+| LiteLLM proxy | configured `OPENAI_API_BASE` | varies | Passes through to backend; Gemini/OpenAI backends work |
+
+## Why not `strict: true`
+
+OpenAI strict mode requires every property to be listed in `required` with no defaults, and
+forbids `anyOf` with `null`. Pydantic models used in Atlas have many optional fields with
+`default_factory`, `None` defaults, and nullable types (`Bias | None`, `float | None`).
+Generating a strict-compatible schema would require pre-processing every model schema, adding
+fragility for no reliability gain over non-strict json_schema (which still produces valid JSON
+matching the schema for all fields the model emits).
+
+## Why `field_validator` stays
+
+Defense-in-depth. Three independent layers:
+
+1. **`response_format` json_schema** — prevents the model from generating non-conforming tokens
+   on providers that support it (Gemini, OpenAI).
+2. **Prompt-embedded `OUTPUT_SCHEMA`** — instructs the model on providers that silently ignore
+   `response_format` (Ollama, some LiteLLM backends).
+3. **`field_validator(mode="before")`** on `SegmentReport.bias` — normalises LLM synonyms
+   (`"positive"` → `"bullish"`) regardless of which path was taken.
+
+Removing the validator would couple correctness to provider support for `response_format`. The
+validator is cheap and has no downside.
+
+## Why `response_format` is not in `_stream_completion_one_turn`
+
+The streaming path (`chat_completion_with_tools` / DigiChat) is a tool-calling loop. Tools and
+`response_format` are mutually exclusive, so the streaming path never sends `response_format`.
+The research agent uses the non-streaming `chat_completion` path with no tools.
+
+## Consequences
+
+- Gemini Flash (the production model for all Atlas phases) now enforces the output schema at
+  token-generation time, eliminating the class of `literal_error` failures seen in April 2026.
+- OpenAI-backend deployments get the same guarantee.
+- Ollama / LiteLLM-only deployments are unchanged — they already relied on the prompt schema.
+- The LLM cache is correctly partitioned by schema: two different segment models will never
+  share a cached response.
+- `BadRequestError` from schema rejection is not caught — it propagates immediately so the
+  caller sees the real error (a schema that a provider rejects should be fixed, not retried).

--- a/tests/dg/test_research_agent.py
+++ b/tests/dg/test_research_agent.py
@@ -156,3 +156,21 @@ class TestRunResearchAgent:
                 model="test-model",
             )
         assert out.regime == "r"
+
+    def test_passes_response_format_to_chat_completion(self) -> None:
+        """run_research_agent must pass response_format derived from output_model to chat_completion."""
+        payload = json.dumps({"regime": "growth", "confidence": 0.9})
+        with patch("digigraph.graph.research_agent.chat_completion", return_value=payload) as mock:
+            run_research_agent(
+                skill_text="x",
+                phase_inputs={},
+                shared_context={},
+                output_model=_SampleOutput,
+                model="test-model",
+            )
+        _, kwargs = mock.call_args
+        rf = kwargs.get("response_format")
+        assert rf is not None, "response_format must be passed to chat_completion"
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "_SampleOutput"
+        assert "properties" in rf["json_schema"]["schema"]


### PR DESCRIPTION
## Summary

- `llm.chat_completion` gains a `response_format` keyword arg. When set and `tools` is absent, it's forwarded to the API so providers that support `json_schema` (Gemini Flash, OpenAI) enforce the schema at token-generation time. Mutually exclusive with `tools` per the OpenAI spec.
- `response_format` is included in the LLM cache key — different schemas never share a cached response.
- `run_research_agent` builds `response_format` from `output_model.model_json_schema()` and passes it on every call. Providers that ignore the field (Ollama, some LiteLLM backends) fall back to the existing prompt-embedded `OUTPUT_SCHEMA` block.
- `docs/adr/0016-structured-outputs-research-agent.md` records the decision, provider compatibility matrix, why `strict: true` is not used, and why `field_validator` stays as defense-in-depth.
- New test asserts `response_format` is forwarded with correct `type`, `name`, and `schema`.

Closes #492. Companion to #491 (bias Literal field_validator fix).

## Test plan

- [ ] `pytest tests/dg/test_research_agent.py tests/dg/test_llm.py -m unit` — 47 tests pass
- [ ] `pytest tests/dq/atlas/test_phase12.py -m unit` — 3 integration tests pass
- [ ] Review `docs/adr/0016` for accuracy against the implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)