### PR TITLE
fix(digiquant): clamp calendar sync start to exchange_calendars rolling window

### DIFF
--- a/digiquant/src/digiquant/data/prices/calendar_sync.py
+++ b/digiquant/src/digiquant/data/prices/calendar_sync.py
@@ -36,11 +36,14 @@ produces the same rows and the database write is a no-op aside from
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 # ─── Venue constants ──────────────────────────────────────────────────────
 
@@ -151,10 +154,10 @@ def _calendar_session_dates(
     cal = get_calendar(_VENUE_TO_MIC[venue])
     # exchange_calendars has a rolling ~20-year window. Clamp start so we never
     # raise DateOutOfBounds when the caller requests historical backfill.
-    effective_start = max(start, cal.first_session.date())
+    first_available = cal.first_session.date()
+    effective_start = max(start, first_available)
     if effective_start != start:
-        import logging as _log
-        _log.getLogger(__name__).info(
+        _logger.info(
             "calendar start clamped from %s to %s for venue %s (exchange_calendars window)",
             start,
             effective_start,

--- a/digiquant/src/digiquant/data/prices/calendar_sync.py
+++ b/digiquant/src/digiquant/data/prices/calendar_sync.py
@@ -130,11 +130,14 @@ def _iter_dates(start: date, end: date) -> Iterable[date]:
 
 def _calendar_session_dates(
     venue: str, start: date, end: date, *, get_calendar: Callable[[str], Any] | None = None
-) -> set[date]:
-    """Return the set of session dates for an equity venue.
+) -> tuple[set[date], date]:
+    """Return ``(session_dates, effective_start)`` for an equity venue.
 
-    The pandas ``DatetimeIndex`` returned by ``exchange_calendars`` is
-    flattened to ``set[date]`` immediately so callers never see pandas types.
+    ``effective_start`` may be later than ``start`` when ``exchange_calendars``
+    does not carry data that far back (it maintains a rolling ~20-year window).
+    Callers must use ``effective_start`` — not the original ``start`` — when
+    iterating over the date range so they don't generate rows for dates that
+    have no calendar coverage.
 
     ``get_calendar`` is dependency-injected for tests; production code passes
     ``None`` and we import the library lazily.
@@ -146,11 +149,22 @@ def _calendar_session_dates(
 
         get_calendar = ec.get_calendar
     cal = get_calendar(_VENUE_TO_MIC[venue])
-    sessions = cal.sessions_in_range(start.isoformat(), end.isoformat())
+    # exchange_calendars has a rolling ~20-year window. Clamp start so we never
+    # raise DateOutOfBounds when the caller requests historical backfill.
+    effective_start = max(start, cal.first_session.date())
+    if effective_start != start:
+        import logging as _log
+        _log.getLogger(__name__).info(
+            "calendar start clamped from %s to %s for venue %s (exchange_calendars window)",
+            start,
+            effective_start,
+            venue,
+        )
+    sessions = cal.sessions_in_range(effective_start.isoformat(), end.isoformat())
     # ``sessions`` is a pandas DatetimeIndex.  Iterating it yields pandas
     # Timestamps which expose ``.date()``.  We flatten to native dates here
     # and discard the pandas object — no pandas types leak past this line.
-    return {ts.date() for ts in sessions}
+    return {ts.date() for ts in sessions}, effective_start
 
 
 # ─── Row shaping ──────────────────────────────────────────────────────────
@@ -189,14 +203,15 @@ def build_equity_rows(
 ) -> list[dict[str, Any]]:
     """Build rows for an equity venue (``NYSE`` / ``NASDAQ``).
 
-    Every date in ``[start, end]`` produces exactly one row.  Sessions yielded
-    by ``exchange_calendars`` are tagged ``is_trading_day=True``; the remaining
-    weekday dates become ``is_trading_day=False, reason='holiday'`` and Sat/Sun
-    become ``reason='weekend'``.
+    Every date in ``[effective_start, end]`` produces exactly one row, where
+    ``effective_start`` is clamped to the calendar's earliest available session
+    (see :func:`_calendar_session_dates`).  Sessions are tagged
+    ``is_trading_day=True``; weekday non-sessions become ``reason='holiday'``;
+    Sat/Sun become ``reason='weekend'``.
     """
-    sessions = _calendar_session_dates(venue, start, end, get_calendar=get_calendar)
+    sessions, effective_start = _calendar_session_dates(venue, start, end, get_calendar=get_calendar)
     rows: list[dict[str, Any]] = []
-    for d in _iter_dates(start, end):
+    for d in _iter_dates(effective_start, end):
         if d in sessions:
             row = CalendarRow(d, venue, True, None)
         elif d.weekday() >= 5:  # Saturday=5, Sunday=6

--- a/tests/dq/data/test_calendar_sync.py
+++ b/tests/dq/data/test_calendar_sync.py
@@ -68,6 +68,11 @@ class _FakeTimestamp:
 class _FakeCalendar:
     name: str
     sessions: list[date] = field(default_factory=list)
+    first_session_date: date = field(default_factory=lambda: date(2006, 1, 3))
+
+    @property
+    def first_session(self) -> _FakeTimestamp:
+        return _FakeTimestamp(self.first_session_date)
 
     def sessions_in_range(self, start: str, end: str) -> _FakeSessions:
         s = date.fromisoformat(start)
@@ -105,7 +110,7 @@ NYSE_2023_HOLIDAYS: set[date] = {
 
 def _nyse_2023_calendar() -> _FakeCalendar:
     sessions = _us_business_days(date(2023, 1, 1), date(2023, 12, 31), holidays=NYSE_2023_HOLIDAYS)
-    return _FakeCalendar(name="XNYS", sessions=sessions)
+    return _FakeCalendar(name="XNYS", sessions=sessions, first_session_date=sessions[0])
 
 
 def _make_get_calendar(calendars: dict[str, _FakeCalendar]):
@@ -223,6 +228,35 @@ def test_nasdaq_uses_xnas_mic() -> None:
     # routing NASDAQ → XNAS produces is_trading_day=False on Jan 2.
     assert by_date["2024-01-02"]["is_trading_day"] is False
     assert by_date["2024-01-03"]["is_trading_day"] is True
+
+
+@pytest.mark.unit
+def test_equity_rows_clamp_start_to_calendar_window() -> None:
+    """When start predates first_session, rows begin at first_session (not start).
+
+    Regression for the April 2026 EOD macro outage: --start 1950-01-01 raised
+    exchange_calendars.DateOutOfBounds because the library only carries ~20 years
+    of data.  The fix clamps start to cal.first_session before querying and
+    iterating, so no fake 'holiday' rows are emitted for dates before coverage.
+    """
+    cal = _FakeCalendar(
+        name="XNYS",
+        sessions=[date(2024, 3, 4), date(2024, 3, 5)],
+        first_session_date=date(2024, 3, 1),
+    )
+    rows = build_equity_rows(
+        VENUE_NYSE,
+        date(1950, 1, 1),  # far-past start — would raise DateOutOfBounds in production
+        date(2024, 3, 5),
+        get_calendar=_make_get_calendar({"XNYS": cal}),
+    )
+    dates = {r["date"] for r in rows}
+    # No rows before first_session — pre-calendar dates must not be generated.
+    assert all(d >= "2024-03-01" for d in dates)
+    # Rows for both known sessions are present and correct.
+    by_date = {r["date"]: r for r in rows}
+    assert by_date["2024-03-04"]["is_trading_day"] is True
+    assert by_date["2024-03-05"]["is_trading_day"] is True
 
 
 # ─── CRYPTO — synthetic 24x7 ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `exchange_calendars` maintains a rolling ~20-year lookback for equity venues. The EOD macro workflow passes `--start 1950-01-01`, which started raising `DateOutOfBounds` on 2026-04-28 when the XNYS `first_session` rolled to `2006-04-28`.
- `_calendar_session_dates` now clamps `start` to `max(start, cal.first_session.date())` before calling `sessions_in_range`, and returns `(sessions, effective_start)`.
- `build_equity_rows` uses `effective_start` for iteration — no spurious `'holiday'` rows are emitted for dates before calendar coverage.
- `_FakeCalendar` mock gains a `first_session` property; regression test confirms `--start 1950-01-01` no longer raises and produces no pre-coverage rows.

## Test plan

- [ ] `pytest tests/dq/data/test_calendar_sync.py -m unit` — 25 tests pass, including new `test_equity_rows_clamp_start_to_calendar_window`
- [ ] Trigger EOD macro dry run after merge to confirm step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)