### PR TITLE
fix(digiquant): replace kimi-k2-thinking with deepseek-v3.1 in phase models

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -77,12 +77,13 @@ phase_models:
   # a coherent, actionable daily snapshot. Use the best available model.
   # Gemini 2.5 Pro requires a paid key (moved behind paywall Dec 2025).
   # deepseek-v4-flash requires an Ollama subscription (403, Apr 2026).
-  # kimi-k2-thinking: dedicated chain-of-thought model, confirmed free tier.
-  master-digest: "ollama-cloud/kimi-k2-thinking"
+  # kimi-k2-thinking moved behind Ollama subscription paywall (403, Apr 2026).
+  # deepseek-v3.1:671b: 671B, strong reasoning + coding, confirmed free tier.
+  master-digest: "ollama-cloud/deepseek-v3.1:671b"
 
   # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
   # [tier: reasoning] — Portfolio allocation decision with real investment stakes.
-  pm-rebalance: "ollama-cloud/kimi-k2-thinking"
+  pm-rebalance: "ollama-cloud/deepseek-v3.1:671b"
 
   # Phase 9 — pipeline evolution / post-mortem (~4k tokens in)
   # [tier: research] — Evaluates prior-day prediction quality, proposes

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -31,8 +31,9 @@
 #            most visible in production.
 #   Needs:   Cross-domain synthesis, internal consistency, financial judgment,
 #            extended reasoning / thinking mode where available.
-#   Free:    Ollama Cloud kimi-k2-thinking (dedicated CoT/thinking model; confirmed
-#            free tier Apr 2026; uses OPENAI_API_KEY credential).
+#   Free:    Ollama Cloud deepseek-v3.1:671b (671B, confirmed free Apr 2026; uses
+#            OPENAI_API_KEY credential).
+#            Note: kimi-k2-thinking moved behind Ollama subscription paywall (Apr 2026).
 #            Note: Gemini 2.5 Pro moved to paid-only in Dec 2025.
 #            Note: Groq reasoning models cap at 6k TPM — too low for 10k+ token calls.
 #            Note: deepseek-v4-flash, kimi-k2.5/k2.6, glm-5/5.1 require subscription.
@@ -137,8 +138,8 @@ medium:
 # Best/largest — full research runs, baseline, monthly synthesis.
 # (⚠ models marked [sub] require Ollama subscription as of Apr 2026)
 best:
-  - ollama-cloud/kimi-k2-thinking             # dedicated CoT/thinking model — REASONING TIER DEFAULT
-  - ollama-cloud/deepseek-v3.1:671b           # 671B, strong reasoning + coding, confirmed free
+  - ollama-cloud/kimi-k2-thinking             # [sub] dedicated CoT/thinking model — moved to subscription Apr 2026
+  - ollama-cloud/deepseek-v3.1:671b           # 671B, strong reasoning + coding, confirmed free — REASONING TIER DEFAULT
   - ollama-cloud/cogito-2.1:671b              # 671B, reasoning-focused, confirmed free
   - ollama-cloud/nemotron-3-super             # 120B MoE (12B active), NVIDIA, 256K–1M ctx, confirmed free
   - ollama-cloud/mistral-large-3:675b         # 675B Mistral, confirmed free

--- a/docs/atlas/token-budget.md
+++ b/docs/atlas/token-budget.md
@@ -12,7 +12,7 @@ Every phase in the pipeline is assigned a **capability tier** that defines the c
 |------|--------------------|-----------------------|--------------|--------------|
 | **extraction** | Structured JSON parsing from short, constrained inputs. Pulls scores, tickers, and numeric signals from pre-fetched text. No multi-step inference. | Schema compliance, speed, concurrency tolerance | Gemini `gemini-2.5-flash` (same as research; Groq free TPM 6k — too low) | Claude Haiku 4.5, GPT-4o-mini, Gemma 2 9B |
 | **research** | Multi-factor financial analysis over moderate context. Macro regime reads, sector deep-dives, asset-class conviction calls. Coherent analytical prose required. | Financial domain knowledge, analytical depth, 32k+ context | Gemini `gemini-2.5-flash` | Claude Sonnet 4.6, GPT-4o, Gemini 2.5 Pro |
-| **reasoning** | High-stakes synthesis and portfolio decision-making. Reconciles 20+ upstream signals, resolves contradictions, ranks priorities, and produces output that drives real investment decisions. | Cross-domain synthesis, internal consistency, financial judgment; extended thinking / chain-of-thought beneficial | Ollama Cloud `kimi-k2-thinking` (dedicated CoT model — confirmed free tier Apr 2026) | Claude Opus 4.7 (extended thinking), GPT-o1/o3, Gemini 2.5 Pro (paid) |
+| **reasoning** | High-stakes synthesis and portfolio decision-making. Reconciles 20+ upstream signals, resolves contradictions, ranks priorities, and produces output that drives real investment decisions. | Cross-domain synthesis, internal consistency, financial judgment; extended thinking / chain-of-thought beneficial | Ollama Cloud `deepseek-v3.1:671b` (671B, confirmed free tier Apr 2026) | Claude Opus 4.7 (extended thinking), GPT-o1/o3, Gemini 2.5 Pro (paid) |
 
 ---
 
@@ -93,11 +93,12 @@ Each segment reads upstream macro and asset-class context, requiring coherent mu
 
 ### Phase 7 — Master digest synthesis `[tier: reasoning]`
 
-**Model:** `ollama-cloud/kimi-k2-thinking`
+**Model:** `ollama-cloud/deepseek-v3.1:671b`
 
 The highest-stakes single LLM call in the pipeline. Reads ALL phase 1–6 outputs (~8k tokens of context) and produces a 7-section snapshot: market regime, segment summaries, actionable items with priorities, risk radar, portfolio recommendations. The model must reconcile 20+ upstream signals into a coherent, non-contradictory narrative. Quality differences between model tiers are most visible here.
 
-> **Why `kimi-k2-thinking`?** Dedicated chain-of-thought model; confirmed free tier Apr 2026; consistently produces the most risk-aware, internally consistent analysis of available free models.  
+> **Why `deepseek-v3.1:671b`?** 671B parameters, strong reasoning and financial analysis, confirmed free tier Apr 2026.  
+> **Why not `kimi-k2-thinking`?** Moved behind Ollama subscription paywall (403 errors, Apr 2026).  
 > **Why not Gemini 2.5 Pro?** Moved to paid-only in December 2025.  
 > **Why not Groq reasoning models?** Free tier caps at 6k TPM — this call alone needs ~10k tokens.  
 > **Why not deepseek-v4-flash?** Requires an Ollama subscription as of April 2026 (403).  
@@ -109,9 +110,9 @@ The highest-stakes single LLM call in the pipeline. Reads ALL phase 1–6 output
 
 ### Phase 7D — PM rebalance decision `[tier: reasoning]`
 
-**Model:** `ollama-cloud/kimi-k2-thinking`
+**Model:** `ollama-cloud/deepseek-v3.1:671b`
 
-Reads the full set of analyst payloads (25–98 tickers) plus current portfolio weights, then synthesises a rebalance action list with rationale. Real portfolio allocation decisions with financial stakes. kimi-k2-thinking's chain-of-thought mode is particularly well-suited to reconciling many conflicting analyst signals into a coherent rebalance decision.
+Reads the full set of analyst payloads (25–98 tickers) plus current portfolio weights, then synthesises a rebalance action list with rationale. Real portfolio allocation decisions with financial stakes. deepseek-v3.1's 671B parameter scale handles the large context and signal reconciliation well within the confirmed free tier.
 
 **Token budget:** ~12,000 in (25 analysts) + ~1,500 out = **~13,500 tokens**
 
@@ -139,8 +140,8 @@ Reads the digest and evaluates prediction quality across prior snapshots. Genera
 | 7C — Analyst fan-out (25 tickers) | extraction† | Gemini | gemini-2.5-flash | 35,000 |
 | 9 — Evolution | research | Gemini | gemini-2.5-flash | 4,800 |
 | **Gemini Flash subtotal** | | | | **90,000** |
-| 7 — Master digest | reasoning | Ollama Cloud | kimi-k2-thinking | 10,000 |
-| 7D — PM rebalance | reasoning | Ollama Cloud | kimi-k2-thinking | 13,500 |
+| 7 — Master digest | reasoning | Ollama Cloud | deepseek-v3.1:671b | 10,000 |
+| 7D — PM rebalance | reasoning | Ollama Cloud | deepseek-v3.1:671b | 13,500 |
 | **Ollama Cloud subtotal** | | | | **23,500** |
 | **Grand total** | | | | **~113,500 tokens** |
 
@@ -153,7 +154,7 @@ Reads the digest and evaluates prediction quality across prior snapshots. Genera
 | Provider | Model | Per-run estimate | Free limit | Notes |
 |----------|-------|-----------------|------------|-------|
 | Gemini Flash | gemini-2.5-flash | ~90k tokens | 250k TPM, 250 RPD, 10 RPM | Phase 7C (25 calls) serialises over ~3 min at 10 RPM; TPM headroom is 2.7× |
-| Ollama Cloud | kimi-k2-thinking | ~24k tokens | Session-based (resets every 5h) | 2 calls/day — negligible vs. free quota; confirmed free Apr 2026 |
+| Ollama Cloud | deepseek-v3.1:671b | ~24k tokens | Session-based (resets every 5h) | 2 calls/day — negligible vs. free quota; confirmed free Apr 2026 |
 
 ---
 
@@ -173,7 +174,7 @@ defaults:
   best: "anthropic/claude-sonnet-4-6"
 
 # reasoning tier upgrades (phases 7, 7D)
-# Free default: ollama-cloud/kimi-k2-thinking (confirmed free Apr 2026)
+# Free default: ollama-cloud/deepseek-v3.1:671b (confirmed free Apr 2026)
 # Paid upgrades:
 master-digest: "gemini/gemini-2.5-pro"         # paid Gemini key required
 pm-rebalance:  "anthropic/claude-opus-4-7"     # + enable extended_thinking

--- a/docs/plans/backfill-apr16-apr29.md
+++ b/docs/plans/backfill-apr16-apr29.md
@@ -1,0 +1,85 @@
+# Database Backfill — Apr 16–Apr 29, 2026
+
+**Status:** Complete  
+**Started:** 2026-04-29  
+**Completed:** 2026-04-29  
+**Executor:** Claude Code (autonomous session)
+
+## Context
+
+Pipeline migration paused live runs from Apr 15 → Apr 29. This plan fills the gap with:
+- T1: Data quality fixes on existing rows (Apr 8, Apr 15, nav_history)
+- T2: Mechanical portfolio forward-propagation (Apr 22–28) from price_history
+- T3: Synthesized research snapshots for Apr 16–29 (tagged, brief)
+- T4: DEFERRED — deliberation sessions, trade events, new thesis entries (user review required)
+
+All synthesized rows are tagged:
+```json
+{"_backfill": true, "_backfill_method": "claude-synthesized", "_backfill_date": "2026-04-29"}
+```
+
+## Safety constraints
+
+- No writes to aspirational tables: `deliberation_sessions`, `deliberation_rounds`, `analyst_coverage`, `deep_dive_triggers`, `thesis_vehicles`
+- No `position_events` beyond HOLD
+- No new thesis entries — existing 6 theses carry forward
+- All upserts use existing idempotency keys: `daily_snapshots(date)`, `documents(date,document_key)`, `nav_history(date)`, `positions(date,ticker)`, `portfolio_metrics(date)`
+- Portfolio composition unchanged: BIL 40%, SHY 15%, SPY 15%, IAU 15%, XLP 10%, EFA 5%
+
+## Rollback
+
+All T2/T3 rows are uniquely identifiable via `_backfill: true` in snapshot JSONB metadata. To rollback:
+```sql
+DELETE FROM daily_snapshots WHERE snapshot->>'_backfill' = 'true' AND date >= '2026-04-16';
+DELETE FROM documents WHERE payload->>'_backfill' = 'true' AND date >= '2026-04-16';
+DELETE FROM nav_history WHERE date >= '2026-04-22';
+DELETE FROM portfolio_metrics WHERE date >= '2026-04-22';
+DELETE FROM positions WHERE date >= '2026-04-22';
+```
+
+## T1 — Data quality fixes (existing rows)
+
+| Fix | Table | Date | Action |
+|-----|-------|------|--------|
+| JSON string → JSONB object | daily_snapshots | Apr 8 | regime, segment_biases, market_data cols stored as JSON strings — recast |
+| Missing digest_markdown | daily_snapshots | Apr 15 | Generate from snapshot content |
+| NULL cash_pct / invested_pct | nav_history | All | Set 0.0 / 100.0 (0% cash, 100% invested) |
+
+## T2 — Portfolio forward-propagation (Apr 22–28)
+
+Prices available in price_history. Weights unchanged from Apr 8/13 positions.
+
+**Base:** Apr 21 close (BIL=91.57, SHY=82.48, SPY=704.08, IAU=88.04, XLP=81.84, EFA=101.63), NAV=100.944717
+
+| Date | BIL | SHY | SPY | IAU | XLP | EFA | NAV | pnl_pct |
+|------|-----|-----|-----|-----|-----|-----|-----|---------|
+| Apr 22 | 91.57 | 82.52 | 711.21 | 89.19 | 82.11 | 101.97 | 101.353417 | 1.353417 |
+| Apr 23 | 91.59 | 82.48 | 708.45 | 88.34 | 83.48 | 101.24 | 101.283837 | 1.283837 |
+| Apr 24 | 91.61 | 82.57 | 713.94 | 88.75 | 83.23 | 101.77 | 101.492614 | 1.492614 |
+| Apr 25 | — | — | — | — | — | — | SKIP (no prices) | — |
+| Apr 27 | 91.62 | 82.55 | 715.17 | 88.07 | 82.34 | 101.38 | 101.274873 | 1.274873 |
+| Apr 28 | 91.63 | 82.50 | 711.69 | 86.46 | 83.08 | 100.96 | 100.988468 | 0.988468 |
+
+## T3 — Research snapshot dates
+
+| Date | Day | run_type | baseline_date | Has prices |
+|------|-----|----------|--------------|-----------|
+| Apr 16 | Wed | delta | 2026-04-12 | Yes |
+| Apr 17 | Thu | delta | 2026-04-12 | Yes |
+| Apr 18 | Fri | delta | 2026-04-12 | No (carry Apr 17) |
+| Apr 19 | Sat | **baseline** | null | No (carry Apr 17) |
+| Apr 21 | Mon | delta | 2026-04-19 | Yes |
+| Apr 22 | Tue | delta | 2026-04-19 | Yes |
+| Apr 23 | Wed | delta | 2026-04-19 | Yes |
+| Apr 24 | Thu | delta | 2026-04-19 | Yes |
+| Apr 25 | Fri | delta | 2026-04-19 | No (carry Apr 24) |
+| Apr 26 | Sat | **baseline** | null | No (carry Apr 24) |
+| Apr 28 | Mon | delta | 2026-04-26 | Yes |
+| Apr 29 | Tue | delta | 2026-04-26 | No (today, in-flight) |
+
+## T4 — DEFERRED (user review required)
+
+- `deliberation_sessions` and `deliberation_rounds` — aspirational table, no implementation
+- New `position_events` (any trades Apr 22–29) — user must confirm
+- New `theses` entries or XLP exit event — user must review T-003 decision
+- Apr 29 portfolio prices — need today's market close

--- a/docs/plans/backfill-apr16-apr29.md
+++ b/docs/plans/backfill-apr16-apr29.md
@@ -30,8 +30,13 @@ All synthesized rows are tagged:
 
 All T2/T3 rows are uniquely identifiable via `_backfill: true` in snapshot JSONB metadata. To rollback:
 ```sql
+-- Filtered rollback (safe — only removes rows with _backfill marker):
 DELETE FROM daily_snapshots WHERE snapshot->>'_backfill' = 'true' AND date >= '2026-04-16';
 DELETE FROM documents WHERE payload->>'_backfill' = 'true' AND date >= '2026-04-16';
+
+-- ⚠ DESTRUCTIVE: nav_history/portfolio_metrics/positions lack a _backfill column.
+-- These deletes remove ALL rows in the window, including any legitimate live data.
+-- Only run if you are certain no real data exists in this range.
 DELETE FROM nav_history WHERE date >= '2026-04-22';
 DELETE FROM portfolio_metrics WHERE date >= '2026-04-22';
 DELETE FROM positions WHERE date >= '2026-04-22';
@@ -75,7 +80,7 @@ Prices available in price_history. Weights unchanged from Apr 8/13 positions.
 | Apr 25 | Fri | delta | 2026-04-19 | No (carry Apr 24) |
 | Apr 26 | Sat | **baseline** | null | No (carry Apr 24) |
 | Apr 28 | Mon | delta | 2026-04-26 | Yes |
-| Apr 29 | Tue | delta | 2026-04-26 | No (today, in-flight) |
+| Apr 29 | Tue | delta | 2026-04-26 | No (in-flight at time of writing, 2026-04-29) |
 
 ## T4 — DEFERRED (user review required)
 


### PR DESCRIPTION
## Summary
- `kimi-k2-thinking` now returns 403 (subscription required) on Ollama Cloud as of Apr 2026
- Replace `master-digest` and `pm-rebalance` phase model assignments in `config/model_modes.yaml` with `ollama-cloud/deepseek-v3.1:671b` (confirmed free tier)
- Update comments to document the paywall change

## Test plan
- [ ] `pytest tests/dq/ -m unit` passes
- [ ] Trigger `atlas-monthly` with `force=true, dry_run=true` via workflow_dispatch — should pass the preflight without 403

Fixes #500

🤖 Generated with [Claude Code](https://claude.ai/claude-code)