### PR TITLE
chore(ci): branch protection script and policy doc

### DIFF
--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -13,7 +13,7 @@ always releasable.
 |---|---|---|
 | `baseline / tests` | `ci.yml` (job added by #291) | Cross-module smoke tests: import health, config loading, known regressions |
 | `ruff-and-scripts` | `ci.yml` | Ruff lint across all source trees + `tests/scripts/` unit tests |
-| `PR issue linkage` | `pr-linkage.yml` | Every PR body must contain `Closes #N`, `Fixes #N`, or `Resolves #N` |
+| `Require Fixes` | `pr-linkage.yml` | Every PR body must contain `Closes #N`, `Fixes #N`, or `Resolves #N` |
 
 `strict: true` is set, meaning the PR branch must be up-to-date with the base branch before
 merging. This prevents "works on my branch" situations where a passing PR would introduce a

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,0 +1,76 @@
+# Branch Protection Policy
+
+## Why branch protection matters
+
+PRs have landed on `develop` and `main` while CI was red or while no baseline tests ran.
+Branch protection makes the three most important status checks required gates — a PR cannot
+merge until all of them pass. This eliminates silent failures and keeps the default branch
+always releasable.
+
+## Required status checks
+
+| Check name | Workflow | What it validates |
+|---|---|---|
+| `baseline / tests` | `ci.yml` (job added by #291) | Cross-module smoke tests: import health, config loading, known regressions |
+| `ruff-and-scripts` | `ci.yml` | Ruff lint across all source trees + `tests/scripts/` unit tests |
+| `PR issue linkage` | `pr-linkage.yml` | Every PR body must contain `Closes #N`, `Fixes #N`, or `Resolves #N` |
+
+`strict: true` is set, meaning the PR branch must be up-to-date with the base branch before
+merging. This prevents "works on my branch" situations where a passing PR would introduce a
+regression when integrated.
+
+## Dependency
+
+**This script must be run after issue #291 (baseline CI suite) is merged and the
+`baseline / tests` check appears green on at least one PR.** Running it before #291 lands
+will register a required check that can never pass, blocking all merges.
+
+## How to apply protection
+
+Apply to `develop` (the default integration branch):
+
+```bash
+bash scripts/set-branch-protection.sh --branch develop
+```
+
+Apply to `main` (production):
+
+```bash
+bash scripts/set-branch-protection.sh --branch main
+```
+
+Preview what would be applied without calling the API:
+
+```bash
+bash scripts/set-branch-protection.sh --dry-run
+bash scripts/set-branch-protection.sh --branch main --dry-run
+```
+
+The script requires the `gh` CLI to be installed and authenticated (`gh auth login`).
+
+## Verify the configuration
+
+```bash
+gh api repos/digithings-ai/digithings/branches/develop/protection | python3 -m json.tool
+gh api repos/digithings-ai/digithings/branches/main/protection    | python3 -m json.tool
+```
+
+Look for `required_status_checks.contexts` to confirm the three checks are listed and
+`required_status_checks.strict` is `true`.
+
+## Emergency bypass procedure
+
+`enforce_admins` is intentionally set to `false`. Repository admins can merge a PR even
+when checks fail by clicking "Merge without waiting for requirements" on GitHub.
+
+Use this sparingly and only for genuine emergencies (e.g., a broken check infrastructure
+blocking a hotfix). After any admin bypass, open a follow-up issue and link it to the
+bypassed PR.
+
+Do **not** disable branch protection entirely — adjust it or fix the failing check instead.
+
+## Updating required checks
+
+If a check is renamed or replaced, re-run the script after updating the `contexts` array in
+`scripts/set-branch-protection.sh`. The `gh api PUT` call is idempotent — it replaces the
+full protection config each time.

--- a/scripts/set-branch-protection.sh
+++ b/scripts/set-branch-protection.sh
@@ -11,7 +11,7 @@
 # Required status checks configured:
 #   - "baseline / tests"  — the cross-module baseline suite (issue #291)
 #   - "ruff-and-scripts"  — lint + script unit tests (job in ci.yml)
-#   - "PR issue linkage"  — every PR must trace to a backlog issue (pr-linkage.yml)
+#   - "Require Fixes"  — every PR must trace to a backlog issue (pr-linkage.yml)
 #
 # Prerequisites:
 #   - gh CLI installed and authenticated (gh auth login)
@@ -28,9 +28,13 @@ REPO="digithings-ai/digithings"
 while [[ $# -gt 0 ]]; do
   case $1 in
     --dry-run) DRY_RUN=true; shift ;;
-    --branch)  BRANCH="$2"; shift 2 ;;
+    --branch)
+      if [[ $# -lt 2 || "$2" == --* ]]; then
+        echo "ERROR: --branch requires a value" >&2; exit 1
+      fi
+      BRANCH="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,20p' "$0" | sed 's/^# \?//'
+      sed -n '2,19p' "$0" | sed 's/^# \?//'
       exit 0
       ;;
     *) echo "ERROR: Unknown argument: $1" >&2; exit 1 ;;
@@ -61,7 +65,7 @@ PAYLOAD=$(cat <<'EOF'
     "contexts": [
       "baseline / tests",
       "ruff-and-scripts",
-      "PR issue linkage"
+      "Require Fixes"
     ]
   },
   "enforce_admins": false,

--- a/scripts/set-branch-protection.sh
+++ b/scripts/set-branch-protection.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# set-branch-protection.sh — Configure required status checks on a branch.
+#
+# Usage:
+#   bash scripts/set-branch-protection.sh [--branch BRANCH] [--dry-run]
+#
+# Options:
+#   --branch BRANCH   Branch to protect (default: develop)
+#   --dry-run         Print the payload without calling the GitHub API
+#
+# Required status checks configured:
+#   - "baseline / tests"  — the cross-module baseline suite (issue #291)
+#   - "ruff-and-scripts"  — lint + script unit tests (job in ci.yml)
+#   - "PR issue linkage"  — every PR must trace to a backlog issue (pr-linkage.yml)
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated (gh auth login)
+#   - Issue #291 (baseline CI suite) merged and green before running live
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+BRANCH="develop"
+DRY_RUN=false
+REPO="digithings-ai/digithings"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run) DRY_RUN=true; shift ;;
+    --branch)  BRANCH="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "ERROR: Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Prerequisite check ────────────────────────────────────────────────────────
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found. Install: https://cli.github.com" >&2
+  exit 1
+fi
+if ! gh auth status &>/dev/null; then
+  echo "ERROR: Not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+# ── Build payload ─────────────────────────────────────────────────────────────
+# required_status_checks.strict=true  — branch must be up-to-date before merge.
+# contexts                            — these exact check names must pass.
+# enforce_admins=false                — admins can bypass in emergencies (use sparingly).
+# required_pull_request_reviews=null  — no mandatory review count for now; revisit
+#                                       once the team grows.
+# restrictions=null                   — no push restrictions beyond the checks above.
+PAYLOAD=$(cat <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "baseline / tests",
+      "ruff-and-scripts",
+      "PR issue linkage"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+)
+
+# ── Execute or dry-run ────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "DRY RUN: Would set protection on branch '$BRANCH' of $REPO with:"
+  echo "$PAYLOAD"
+else
+  echo "Setting branch protection on '$BRANCH'..." >&2
+  gh api "repos/$REPO/branches/$BRANCH/protection" \
+    -X PUT \
+    --input - <<< "$PAYLOAD"
+  echo "Branch protection set on '$BRANCH'."
+  echo ""
+  echo "Verify with:"
+  echo "  gh api repos/$REPO/branches/$BRANCH/protection | python3 -m json.tool"
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/set-branch-protection.sh` — idempotent `gh api PUT` script that configures three required status checks (`baseline / tests`, `ruff-and-scripts`, `PR issue linkage`) on any branch, with `--dry-run` and `--branch` flags
- Adds `docs/BRANCH_PROTECTION.md` — policy doc covering why these checks are required, how to apply and verify the config, and the emergency admin bypass procedure

## Dependency note

**Merge after #291 lands and baseline CI is green.** Running the script before the `baseline / tests` check exists will register an unsatisfiable required check, blocking all merges.

## Test plan

- [x] `bash scripts/set-branch-protection.sh --dry-run` prints payload without error
- [x] `bash scripts/set-branch-protection.sh --branch main --dry-run` prints payload for main
- [ ] After #291 merges: run live against `develop`, verify with `gh api repos/digithings-ai/digithings/branches/develop/protection | python3 -m json.tool`

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)