### PR TITLE
fix(digichat): remove react-hooks/set-state-in-effect suppressions (#257)

### DIFF
--- a/frontend/digichat/src/components/connections-sheet.tsx
+++ b/frontend/digichat/src/components/connections-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Loader2, Plug, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -59,10 +59,10 @@ export function ConnectionsSheet() {
     }
   }, []);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #257: move into onOpenChange handler
-    if (open) void load();
-  }, [open, load]);
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) void load();
+  }
 
   async function onSave(e: React.FormEvent) {
     e.preventDefault();
@@ -116,11 +116,11 @@ export function ConnectionsSheet() {
 
   return (
     <>
-      <Button type="button" variant="outline" size="sm" onClick={() => setOpen(true)}>
+      <Button type="button" variant="outline" size="sm" onClick={() => handleOpenChange(true)}>
         <Plug className="mr-2 h-4 w-4" />
         Ecosystem
       </Button>
-      <Sheet open={open} onOpenChange={setOpen}>
+      <Sheet open={open} onOpenChange={handleOpenChange}>
         <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
         <SheetHeader>
           <SheetTitle>DigiThings connections</SheetTitle>

--- a/frontend/digichat/src/hooks/use-mobile.ts
+++ b/frontend/digichat/src/hooks/use-mobile.ts
@@ -1,20 +1,29 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+// Lazily cached so module load in SSR/test environments doesn't touch window
+let mql: MediaQueryList | null = null
+function getMql(): MediaQueryList {
+  if (!mql) mql = window.matchMedia(MOBILE_QUERY)
+  return mql
+}
+
+function subscribe(callback: () => void) {
+  const m = getMql()
+  m.addEventListener("change", callback)
+  return () => m.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return getMql().matches
+}
+
+function getServerSnapshot() {
+  return false // SSR: window is unavailable, default to non-mobile
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- #257: refactor to useSyncExternalStore
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
## Summary

- Refactor `use-mobile.ts` from `useState`+`useEffect` to `useSyncExternalStore`, eliminating the `set-state-in-effect` violation and caching the `MediaQueryList` at module level to avoid repeated `window.matchMedia()` calls on every render.
- Replace the `useEffect([open, load])` cascade in `connections-sheet.tsx` with a `handleOpenChange` handler wired to both the trigger `Button` (`onClick`) and the `Sheet` (`onOpenChange`), so `load()` is called at the correct event boundary rather than as a side-effectful state update inside an effect.
- Remove both `eslint-disable-next-line react-hooks/set-state-in-effect` suppressions.

## Test plan

- [x] `npm run lint` — zero ESLint errors, no disable comments remain
- [x] `npm run test` — all 27 unit tests pass
- [x] `npm run build` — Next.js production build succeeds

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)