### PR TITLE
fix(digichat): replace SheetTrigger asChild with Base UI render prop

### DIFF
--- a/frontend/digichat/src/components/byok-settings-panel.tsx
+++ b/frontend/digichat/src/components/byok-settings-panel.tsx
@@ -252,23 +252,24 @@ export function BYOKSettingsPanel({ inline = false }: { inline?: boolean } = {})
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      {/* @ts-expect-error #258: Base UI Trigger uses `render` prop, not `asChild`; refactor pending. Runtime-safe — prop is spread. */}
-      <SheetTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="gap-1.5 text-muted-foreground"
-          aria-label={isSet ? "BYOK key configured" : "Configure your own API key"}
-        >
-          <Key className="size-4" />
-          <span className="hidden sm:inline">
-            {isSet ? "BYOK" : "Use my key"}
-          </span>
-          {isSet && (
-            <span className="ml-0.5 size-2 rounded-full bg-emerald-400" aria-hidden />
-          )}
-        </Button>
+      <SheetTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground"
+            aria-label={isSet ? "BYOK key configured" : "Configure your own API key"}
+          />
+        }
+      >
+        <Key className="size-4" />
+        <span className="hidden sm:inline">
+          {isSet ? "BYOK" : "Use my key"}
+        </span>
+        {isSet && (
+          <span className="ml-0.5 size-2 rounded-full bg-emerald-400" aria-hidden />
+        )}
       </SheetTrigger>
       <SheetContent side="right" className="w-full max-w-md">
         <SheetHeader className="mb-6">


### PR DESCRIPTION
## Summary
- Removes `@ts-expect-error #258` suppression that was added as a temporary workaround in #255
- `SheetTrigger` now uses Base UI's `render` prop pattern instead of Radix `asChild`
- Children (Key icon, label, status dot) are now direct children of `SheetTrigger` which Base UI merges into the rendered element

## Test plan
- [ ] `npm run lint` — passes with no @ts-expect-error for #258
- [ ] `npm run test` — vitest passes
- [ ] `npm run build` — Next.js build succeeds
- [ ] BYOK trigger button opens sheet and accepts keyboard navigation

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)