### PR TITLE
fix(digichat): keyboard UX guards — Cmd+/ input focus + DropdownMenu keydown

### DIFF
--- a/frontend/digichat/src/components/chat-shell.tsx
+++ b/frontend/digichat/src/components/chat-shell.tsx
@@ -345,6 +345,14 @@ export function ChatShell({
     const onKey = (e: KeyboardEvent) => {
       const meta = e.metaKey || e.ctrlKey;
       if (meta && e.key === "/") {
+        const active = document.activeElement;
+        if (
+          active instanceof HTMLInputElement ||
+          active instanceof HTMLTextAreaElement ||
+          (active instanceof HTMLElement && active.isContentEditable)
+        ) {
+          return;
+        }
         e.preventDefault();
         setCollapsed((v) => !v);
       } else if (e.key === "Escape" && settingsOpen) {
@@ -408,6 +416,7 @@ export function ChatShell({
                         <DropdownMenuTrigger
                           aria-label={`Actions for ${t.title}`}
                           onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
                           className="text-muted-foreground hover:text-foreground"
                         >
                           <MoreHorizontal className="size-3.5" />


### PR DESCRIPTION
## Summary
- **#281**: Guards the global `Cmd+/` sidebar shortcut — now skips when `activeElement` is an input, textarea, or contenteditable element. Prevents swallowing characters on non-US keyboard layouts.
- **#280**: Adds `onKeyDown={(e) => e.stopPropagation()}` to the sidebar thread row's `DropdownMenuTrigger` — symmetric with the existing `onClick` stopPropagation. Prevents Enter/Space on the more-actions button from simultaneously opening the menu and navigating to the thread.

## Test plan
- [ ] `npm run lint` — passes
- [ ] `npm run test` — vitest passes
- [ ] `npm run build` — succeeds
- [ ] Manual: `Cmd+/` toggles sidebar when focus is outside input; does NOT toggle when chat input has focus
- [ ] Manual: Enter on sidebar thread row → navigates; Enter on more-actions (⋯) button → opens menu only

Closes #280
Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)