### PR TITLE
chore(ci): add baseline test suite with imports, schemas, CLI help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status batch-candidates parse-error hooks-install qr-logo up-observability down-observability atlas-validate
+.PHONY: build up down test test-unit test-e2e test-baseline doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status batch-candidates parse-error hooks-install qr-logo up-observability down-observability atlas-validate
 
 build:
 	docker compose build
@@ -19,6 +19,10 @@ test:
 # Unit only (no stack required).
 test-unit:
 	pytest -m unit -v --tb=short
+
+# Baseline gate — always-green imports + schemas + CLI help (no Docker, no network).
+test-baseline:
+	pytest -m baseline --tb=short -q
 
 # E2E only (requires: docker compose up -d). Skips if stack not up.
 test-e2e:

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,8 @@ markers =
     integration: Integration tests (HTTP to local or container).
     e2e: End-to-end tests (require stack: docker compose up or live servers).
     slow: Slow tests (e.g. full backtest).
+    baseline: Always-green gate tests (imports, schemas, CLI help). No external deps.
+    quarantine: Known-broken tests excluded from the baseline gate.
 
 filterwarnings =
     ignore::DeprecationWarning

--- a/tests/baseline/test_cli.py
+++ b/tests/baseline/test_cli.py
@@ -1,0 +1,35 @@
+"""Baseline CLI help tests — verify click entrypoints register cleanly.
+
+Uses click.testing.CliRunner (in-process) so no PYTHONPATH gymnastics or
+subprocess spawn are needed. Tests only --help, which never hits external
+services.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from digiquant.cli import main as digiquant_main
+
+
+@pytest.mark.baseline
+def test_digiquant_cli_help() -> None:
+    """Top-level digiquant CLI group registers and returns exit code 0."""
+    result = CliRunner().invoke(digiquant_main, ["--help"])
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.baseline
+def test_digiquant_prices_help() -> None:
+    """digiquant prices subgroup registers and returns exit code 0."""
+    result = CliRunner().invoke(digiquant_main, ["prices", "--help"])
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.baseline
+def test_digiquant_backtest_help() -> None:
+    """digiquant backtest command registers and returns exit code 0."""
+    result = CliRunner().invoke(digiquant_main, ["backtest", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--strategy" in result.output

--- a/tests/baseline/test_imports.py
+++ b/tests/baseline/test_imports.py
@@ -1,0 +1,45 @@
+"""Baseline import tests — verify all public packages can be imported.
+
+These tests have no external dependencies (no network, no Docker, no DB).
+They exist to catch import-time breakage (missing deps, circular imports,
+syntax errors) before any other test runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.baseline
+def test_digibase_imports() -> None:
+    import digibase  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digikey_imports() -> None:
+    import digikey  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digismith_imports() -> None:
+    import digismith  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digiclaw_imports() -> None:
+    import digiclaw  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digiquant_imports() -> None:
+    import digiquant  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digisearch_imports() -> None:
+    import digisearch  # noqa: F401
+
+
+@pytest.mark.baseline
+def test_digigraph_imports() -> None:
+    import digigraph  # noqa: F401

--- a/tests/baseline/test_schemas.py
+++ b/tests/baseline/test_schemas.py
@@ -1,0 +1,94 @@
+"""Baseline Pydantic v2 schema round-trip tests.
+
+Each test instantiates a core model with valid data and verifies that
+model_dump() returns a dict that can reconstruct an identical instance.
+No external dependencies required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.baseline
+def test_api_error_body_round_trip() -> None:
+    """digibase.errors.ApiErrorBody — required fields only."""
+    from digibase.errors import ApiErrorBody
+
+    data = {"code": "http_404", "message": "Not found"}
+    obj = ApiErrorBody(**data)
+    dumped = obj.model_dump()
+    assert dumped["code"] == "http_404"
+    assert dumped["message"] == "Not found"
+    assert dumped["request_id"] is None
+    ApiErrorBody(**dumped)
+
+
+@pytest.mark.baseline
+def test_api_error_envelope_round_trip() -> None:
+    """digibase.errors.ApiErrorEnvelope — nested model."""
+    from digibase.errors import ApiErrorBody, ApiErrorEnvelope
+
+    body = ApiErrorBody(code="validation_error", message="Bad input")
+    envelope = ApiErrorEnvelope(error=body)
+    dumped = envelope.model_dump()
+    assert dumped["error"]["code"] == "validation_error"
+    ApiErrorEnvelope(**dumped)
+
+
+@pytest.mark.baseline
+def test_token_claims_round_trip() -> None:
+    """digikey.models.TokenClaims — JWT claim model."""
+    from digikey.models import TokenClaims
+
+    data = {
+        "sub": "user-123",
+        "iss": "http://127.0.0.1:8005",
+        "aud": "digi-ecosystem",
+        "scopes": ["read", "write"],
+        "tenant_slug": "acme",
+    }
+    obj = TokenClaims(**data)
+    dumped = obj.model_dump()
+    assert dumped["sub"] == "user-123"
+    assert dumped["scopes"] == ["read", "write"]
+    TokenClaims(**dumped)
+
+
+@pytest.mark.baseline
+def test_smith_status_round_trip() -> None:
+    """digismith.config.SmithStatus — observability status model."""
+    from digismith.config import SmithStatus
+
+    data = {
+        "version": "0.1.0",
+        "tracing_configured": False,
+        "langsmith_sdk_installed": False,
+    }
+    obj = SmithStatus(**data)
+    dumped = obj.model_dump()
+    assert dumped["version"] == "0.1.0"
+    assert dumped["tracing_configured"] is False
+    SmithStatus(**dumped)
+
+
+@pytest.mark.baseline
+def test_backtest_result_round_trip() -> None:
+    """digiquant.models.BacktestResult — quant backtest result model."""
+    from digiquant.models import BacktestResult
+
+    data = {
+        "run_id": "bt-abc-001",
+        "strategy_name": "ema_cross",
+        "start_time": "2024-01-01T00:00:00",
+        "end_time": "2024-12-31T23:59:59",
+        "symbols": ["AAPL", "MSFT"],
+        "total_pnl": 1250.75,
+        "total_return_pct": 12.5,
+        "num_trades": 42,
+    }
+    obj = BacktestResult(**data)
+    dumped = obj.model_dump()
+    assert dumped["run_id"] == "bt-abc-001"
+    assert dumped["num_trades"] == 42
+    BacktestResult(**dumped)


### PR DESCRIPTION
## Summary
- Creates `tests/baseline/` with 15 always-green tests: package imports, Pydantic v2 schema round-trips, and CLI `--help` entrypoints
- Adds `baseline` and `quarantine` pytest markers to `pytest.ini`
- Adds `make test-baseline` Makefile target

This is the foundation for issue #293 (required status checks) — once this PR is green, the baseline check can be required on PRs.

## Test plan
- [ ] `pytest tests/baseline/ -v` — all 15 tests pass
- [ ] `make test-baseline` — runs cleanly
- [ ] No external services required (no Supabase, no yfinance)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)