### PR TITLE
feat(digigraph): add ToolExposureMode enum for progressive tool discovery

### DIFF
--- a/digigraph/src/digigraph/orchestration/__init__.py
+++ b/digigraph/src/digigraph/orchestration/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from digigraph.orchestration.registry import (
     ToolContext,
+    ToolExposureMode,
     execute,
     get_tools,
     list_registered_tools_detailed,
@@ -18,6 +19,7 @@ from digigraph.orchestration.registry import (
 
 __all__ = [
     "ToolContext",
+    "ToolExposureMode",
     "execute",
     "get_tools",
     "list_registered_tools_detailed",

--- a/digigraph/src/digigraph/orchestration/registry.py
+++ b/digigraph/src/digigraph/orchestration/registry.py
@@ -8,7 +8,19 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable
+
+class ToolExposureMode(Enum):
+    """Controls how tools are serialised for injection into the agent context.
+
+    SUMMARY:  one-line ``tool_name: description`` strings — minimises context window usage.
+    DETAILED: full OpenAI function-tool dicts — backwards-compatible default.
+    """
+
+    SUMMARY = "summary"
+    DETAILED = "detailed"
+
 
 # Handler: (args, context) -> str | dict. Dict may include dataset_ref for stored_datasets merge.
 ToolHandler = Callable[[dict[str, Any], "ToolContext"], str | dict[str, Any]]
@@ -74,12 +86,29 @@ def register_skill(
     _skills[skill_id] = (list(tool_names), when)
 
 
-def get_tools(skill_ids: list[str], context: ToolContext) -> list[dict[str, Any]]:
-    """Return OpenAI tool dicts for the given skills and context. Only includes tools
-    from skills whose when predicate passes (or has no when). Deduplicates by tool name.
+def get_tools(
+    skill_ids: list[str],
+    context: ToolContext,
+    mode: ToolExposureMode = ToolExposureMode.DETAILED,
+) -> list[dict[str, Any]] | list[str]:
+    """Return tool descriptors for the given skills and context.
+
+    Only includes tools from skills whose when predicate passes (or has no when).
+    Deduplicates by tool name.
+
+    Args:
+        skill_ids: Skill identifiers to collect tools from.
+        context:   Execution context (allowlists, session, etc.).
+        mode:      Exposure mode.
+                   ``DETAILED`` (default) — returns a list of OpenAI function-tool dicts
+                   (full JSON schema); backwards-compatible.
+                   ``SUMMARY`` — returns a list of ``"tool_name: description"`` strings,
+                   one per tool, for injecting a compact tool manifest into a system prompt.
     """
     seen: set[str] = set()
-    out: list[dict[str, Any]] = []
+    out_detailed: list[dict[str, Any]] = []
+    out_summary: list[str] = []
+
     for skill_id in skill_ids:
         if skill_id not in _skills:
             continue
@@ -99,8 +128,17 @@ def get_tools(skill_ids: list[str], context: ToolContext) -> list[dict[str, Any]
             if context.allowed_tool_names is not None:
                 if not tname or tname not in context.allowed_tool_names:
                     continue
-            out.append(td)
-    return out
+            if mode is ToolExposureMode.SUMMARY:
+                description = ""
+                if isinstance(td, dict):
+                    fn = td.get("function") or {}
+                    description = fn.get("description") or ""
+                tool_name = tname or name
+                out_summary.append(f"{tool_name}: {description}" if description else tool_name)
+            else:
+                out_detailed.append(td)
+
+    return out_summary if mode is ToolExposureMode.SUMMARY else out_detailed
 
 
 def execute(name: str, args: dict[str, Any], context: ToolContext) -> str | dict[str, Any]:

--- a/digigraph/src/digigraph/skills/registry.py
+++ b/digigraph/src/digigraph/skills/registry.py
@@ -7,7 +7,7 @@ from typing import Any, Callable
 
 # Import to ensure tools and skills are registered when skills are used.
 from digigraph.orchestration import builtin as _  # noqa: F401
-from digigraph.orchestration.registry import ToolContext, get_tools
+from digigraph.orchestration.registry import ToolContext, ToolExposureMode, get_tools
 
 
 @dataclass
@@ -29,6 +29,17 @@ def register_skill(skill: Skill) -> None:
     _skill_meta[skill.id] = skill
 
 
-def get_tools_for_skills(skill_ids: list[str], context: ToolContext) -> list[dict[str, Any]]:
-    """Return OpenAI tool dicts for the given skill ids and context. Uses orchestration registry."""
-    return get_tools(skill_ids, context)
+def get_tools_for_skills(
+    skill_ids: list[str],
+    context: ToolContext,
+    mode: ToolExposureMode = ToolExposureMode.DETAILED,
+) -> list[dict[str, Any]] | list[str]:
+    """Return tool descriptors for the given skill ids and context.
+
+    Args:
+        skill_ids: Skill identifiers to collect tools from.
+        context:   Execution context passed to the orchestration registry.
+        mode:      Exposure mode — ``DETAILED`` (default, full OpenAI dicts) or
+                   ``SUMMARY`` (compact ``"name: description"`` strings).
+    """
+    return get_tools(skill_ids, context, mode=mode)

--- a/tests/dg/test_tool_exposure_mode.py
+++ b/tests/dg/test_tool_exposure_mode.py
@@ -1,0 +1,222 @@
+"""Unit tests for ToolExposureMode: progressive tool discovery (issue #404)."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from digigraph.orchestration.registry import (
+    ToolContext,
+    ToolExposureMode,
+    get_tools,
+    register_skill,
+    register_tool,
+)
+from digigraph.orchestration.registry import _skills as _reg_skills
+from digigraph.orchestration.registry import _tools as _reg_tools
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TOOL_A = "__unit_exposure_tool_a__"
+_TOOL_B = "__unit_exposure_tool_b__"
+_SKILL_ID = "__unit_exposure_skill__"
+
+
+def _make_context() -> ToolContext:
+    return ToolContext(
+        session_id=None,
+        run_data_dir=None,
+        index_name="test",
+        index_config={},
+        state={},
+    )
+
+
+def _make_schema(name: str, description: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "The search query"},
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _handler(args: dict, ctx: object) -> str:
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_registry():
+    """Remove probe tools/skills before and after each test to avoid leaking global state."""
+    for key in (_TOOL_A, _TOOL_B):
+        _reg_tools.pop(key, None)
+    _reg_skills.pop(_SKILL_ID, None)
+
+    yield
+
+    for key in (_TOOL_A, _TOOL_B):
+        _reg_tools.pop(key, None)
+    _reg_skills.pop(_SKILL_ID, None)
+
+
+@pytest.fixture()
+def registered_tools():
+    """Register two probe tools and a skill bundling them."""
+    register_tool(_TOOL_A, _make_schema(_TOOL_A, "Search the knowledge base"), _handler)
+    register_tool(_TOOL_B, _make_schema(_TOOL_B, "Fetch a document by URL"), _handler)
+    register_skill(_SKILL_ID, [_TOOL_A, _TOOL_B])
+    return [_TOOL_A, _TOOL_B]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_default_mode_is_detailed():
+    """Default mode must be DETAILED for backwards compatibility."""
+    assert ToolExposureMode.DETAILED == ToolExposureMode("detailed")
+    sig = inspect.signature(get_tools)
+    default = sig.parameters["mode"].default
+    assert default is ToolExposureMode.DETAILED
+
+
+@pytest.mark.unit
+def test_detailed_mode_returns_full_schema(registered_tools):
+    """DETAILED mode returns OpenAI tool dicts with full JSON schema."""
+    ctx = _make_context()
+    result = get_tools([_SKILL_ID], ctx, mode=ToolExposureMode.DETAILED)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    for td in result:
+        assert isinstance(td, dict)
+        assert "type" in td
+        assert "function" in td
+        fn = td["function"]
+        assert "name" in fn
+        assert "description" in fn
+        assert "parameters" in fn
+        # Full schema includes properties
+        assert "properties" in fn["parameters"]
+
+
+@pytest.mark.unit
+def test_summary_mode_returns_one_liners(registered_tools):
+    """SUMMARY mode returns 'tool_name: description' strings, not dicts."""
+    ctx = _make_context()
+    result = get_tools([_SKILL_ID], ctx, mode=ToolExposureMode.SUMMARY)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+    for item in result:
+        assert isinstance(item, str)
+        # Must be a single line
+        assert "\n" not in item
+        # Must follow 'name: description' format
+        assert ": " in item
+
+    names = [line.split(": ")[0] for line in result]
+    assert _TOOL_A in names
+    assert _TOOL_B in names
+
+
+@pytest.mark.unit
+def test_summary_mode_content_matches_description(registered_tools):
+    """SUMMARY strings must carry the tool's registered description."""
+    ctx = _make_context()
+    result = get_tools([_SKILL_ID], ctx, mode=ToolExposureMode.SUMMARY)
+
+    summary_map = {line.split(": ", 1)[0]: line.split(": ", 1)[1] for line in result}
+    assert summary_map[_TOOL_A] == "Search the knowledge base"
+    assert summary_map[_TOOL_B] == "Fetch a document by URL"
+
+
+@pytest.mark.unit
+def test_detailed_mode_via_enum_string_value():
+    """ToolExposureMode can be constructed from string values."""
+    assert ToolExposureMode("summary") is ToolExposureMode.SUMMARY
+    assert ToolExposureMode("detailed") is ToolExposureMode.DETAILED
+
+
+@pytest.mark.unit
+def test_summary_mode_empty_description():
+    """SUMMARY mode handles a tool with no description gracefully (emits just the name)."""
+    name = "__unit_exposure_no_desc__"
+    _reg_tools.pop(name, None)
+    skill_id = "__unit_exposure_no_desc_skill__"
+    _reg_skills.pop(skill_id, None)
+    try:
+        schema = {
+            "type": "function",
+            "function": {
+                "name": name,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        register_tool(name, schema, _handler)
+        register_skill(skill_id, [name])
+
+        ctx = _make_context()
+        result = get_tools([skill_id], ctx, mode=ToolExposureMode.SUMMARY)
+
+        assert len(result) == 1
+        assert isinstance(result[0], str)
+        # No colon appended when description is absent
+        assert result[0] == name
+    finally:
+        _reg_tools.pop(name, None)
+        _reg_skills.pop(skill_id, None)
+
+
+@pytest.mark.unit
+def test_tool_exposure_mode_exported_from_orchestration_package():
+    """ToolExposureMode must be importable from the orchestration package (for issue #401)."""
+    from digigraph.orchestration import ToolExposureMode as _imported
+
+    assert _imported is ToolExposureMode
+
+
+@pytest.mark.unit
+def test_detailed_mode_deduplicates_tools():
+    """Tools appearing in multiple skills are included only once (existing behaviour, both modes)."""
+    name = "__unit_exposure_dedup__"
+    _reg_tools.pop(name, None)
+    skill_a = "__unit_exposure_dedup_skill_a__"
+    skill_b = "__unit_exposure_dedup_skill_b__"
+    _reg_skills.pop(skill_a, None)
+    _reg_skills.pop(skill_b, None)
+    try:
+        register_tool(name, _make_schema(name, "Dedup probe"), _handler)
+        register_skill(skill_a, [name])
+        register_skill(skill_b, [name])
+
+        ctx = _make_context()
+        result_detailed = get_tools([skill_a, skill_b], ctx, mode=ToolExposureMode.DETAILED)
+        result_summary = get_tools([skill_a, skill_b], ctx, mode=ToolExposureMode.SUMMARY)
+
+        assert len(result_detailed) == 1
+        assert len(result_summary) == 1
+    finally:
+        _reg_tools.pop(name, None)
+        _reg_skills.pop(skill_a, None)
+        _reg_skills.pop(skill_b, None)


### PR DESCRIPTION
## Summary

- Adds `ToolExposureMode` enum (`SUMMARY` / `DETAILED`) to `digigraph/orchestration/registry.py`
- Updates `get_tools()` to accept `mode: ToolExposureMode = ToolExposureMode.DETAILED` — `DETAILED` is the backwards-compatible default returning full OpenAI tool dicts; `SUMMARY` returns compact `"tool_name: description"` strings to reduce context window usage
- Threads `mode` through `get_tools_for_skills()` in `skills/registry.py`
- Exports `ToolExposureMode` from `digigraph.orchestration` so downstream consumers (e.g. issue #401 OpenBB MCP registration) can import it from the package root
- Adds 8 `@pytest.mark.unit` tests covering SUMMARY/DETAILED output shape, backwards-compat default, description content, empty-description edge case, deduplication, and public import path

## Test plan

- [x] `pytest -m unit tests/dg/test_tool_exposure_mode.py -v` — 8/8 pass
- [x] `pytest -m unit tests/dg/ -v` — 274 pass, 1 pre-existing failure (missing `langgraph-checkpoint-sqlite` package, unrelated)
- [x] `ruff check` — all checks passed
- [x] Backwards compatibility: all existing callers of `get_tools()` / `get_tools_for_skills()` omit `mode` and get full DETAILED schemas as before

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)