### PR TITLE
feat(digigraph): OpenBB MCP server registration with free provider defaults

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -1,0 +1,28 @@
+# MCP server registry
+# Free providers are enabled by default.
+# Premium providers require env vars to be set.
+
+mcp_servers:
+  openbb:
+    description: "OpenBB financial data MCP server (yfinance, FRED, SEC EDGAR)"
+    enabled: true
+    tool_exposure_mode: summary  # Use summary mode to save context tokens
+    free_providers:
+      - name: yfinance
+        enabled: true
+      - name: fred
+        enabled: true
+        # Free key: https://fred.stlouisfed.org/docs/api/api_key.html
+        api_key_env: FRED_API_KEY
+        optional: true  # works without key but with rate limits
+      - name: sec_edgar
+        enabled: true
+      - name: fama_french
+        enabled: true
+    premium_providers:
+      - name: intrinio
+        enabled_if_env: INTRINIO_API_KEY
+      - name: benzinga
+        enabled_if_env: BENZINGA_API_KEY
+      - name: polygon
+        enabled_if_env: POLYGON_API_KEY

--- a/digigraph/src/digigraph/orchestration/registry.py
+++ b/digigraph/src/digigraph/orchestration/registry.py
@@ -7,9 +7,18 @@ Skills are named bundles of tool names with optional when(context) -> bool.
 from __future__ import annotations
 
 import hashlib
+import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any, Callable
+
+import yaml
+from pydantic import BaseModel, Field
+
+log = logging.getLogger(__name__)
+
 
 class ToolExposureMode(Enum):
     """Controls how tools are serialised for injection into the agent context.
@@ -20,6 +29,26 @@ class ToolExposureMode(Enum):
 
     SUMMARY = "summary"
     DETAILED = "detailed"
+
+
+class _ProviderConfig(BaseModel):
+    """A single provider entry (free or premium) from mcp_servers.yaml."""
+
+    name: str
+    enabled: bool = True
+    api_key_env: str | None = None
+    optional: bool = False
+    enabled_if_env: str | None = None
+
+
+class _MCPServerConfig(BaseModel):
+    """Per-server block from mcp_servers.yaml."""
+
+    description: str = ""
+    enabled: bool = True
+    tool_exposure_mode: ToolExposureMode = ToolExposureMode.SUMMARY
+    free_providers: list[_ProviderConfig] = Field(default_factory=list)
+    premium_providers: list[_ProviderConfig] = Field(default_factory=list)
 
 
 # Handler: (args, context) -> str | dict. Dict may include dataset_ref for stored_datasets merge.
@@ -195,3 +224,123 @@ def list_registered_tools_detailed() -> list[dict[str, Any]]:
             "dynamic_schema": schema_factory is not None,
         })
     return out
+
+
+def _resolve_mcp_config_path(config_path: str) -> Path:
+    """Resolve mcp_servers.yaml path.
+
+    Tries the given path as-is (absolute or relative to cwd), then relative to
+    the repository root (two levels up from this file: src/digigraph/orchestration/).
+    """
+    p = Path(config_path)
+    if p.is_absolute():
+        return p
+    if p.exists():
+        return p.resolve()
+    # Fallback: resolve relative to repo root (this file is digigraph/src/digigraph/orchestration/)
+    repo_root = Path(__file__).parent.parent.parent.parent.parent
+    candidate = repo_root / config_path
+    if candidate.exists():
+        return candidate.resolve()
+    return p.resolve()
+
+
+def register_mcp_server(
+    name: str,
+    config_path: str = "config/mcp_servers.yaml",
+    mode: ToolExposureMode = ToolExposureMode.SUMMARY,
+) -> list[dict[str, Any]]:
+    """Load an MCP server entry from config and return tool descriptors for active providers.
+
+    Free providers are always included (if ``enabled: true``).  Premium providers are
+    included only when their ``enabled_if_env`` environment variable is set.
+
+    Note: this function returns descriptors only — wiring descriptors into
+    ``register_tool()`` happens in a follow-up unit once the OpenBB MCP client is
+    integrated.
+
+    Args:
+        name: Key under ``mcp_servers:`` in the config file (e.g. ``"openbb"``).
+        config_path: Path to ``mcp_servers.yaml`` (absolute or relative to repo root).
+        mode: ``SUMMARY`` (default) returns compact descriptors to save context tokens;
+            ``DETAILED`` returns full OpenAI function-tool schema stubs.
+
+    Returns:
+        List of tool descriptor dicts, one per active provider.  Each dict has at
+        minimum ``name`` and ``description``; ``DETAILED`` mode additionally has
+        ``type`` and ``function`` keys matching the OpenAI function-call schema.
+    """
+    resolved = _resolve_mcp_config_path(config_path)
+    if not resolved.exists():
+        log.warning("register_mcp_server: config not found at %s — returning empty list", resolved)
+        return []
+
+    raw: dict[str, Any] = yaml.safe_load(resolved.read_text()) or {}
+    servers_raw: dict[str, Any] = raw.get("mcp_servers", {})
+    server_raw: dict[str, Any] | None = servers_raw.get(name)
+    if server_raw is None:
+        log.warning("register_mcp_server: server %r not found in %s", name, resolved)
+        return []
+
+    server_cfg = _MCPServerConfig.model_validate(server_raw)
+    if not server_cfg.enabled:
+        log.info("register_mcp_server: server %r is disabled — skipping", name)
+        return []
+
+    descriptors: list[dict[str, Any]] = []
+
+    # Free providers — included unconditionally when enabled.
+    for provider in server_cfg.free_providers:
+        if not provider.enabled:
+            continue
+        descriptors.append(_make_descriptor(name, provider, mode))
+
+    # Premium providers — included only if their env var is set.
+    for provider in server_cfg.premium_providers:
+        env_var = provider.enabled_if_env
+        if env_var and not os.environ.get(env_var):
+            log.info(
+                "register_mcp_server: skipping premium provider %r — %s not set",
+                provider.name,
+                env_var,
+            )
+            continue
+        descriptors.append(_make_descriptor(name, provider, mode))
+
+    return descriptors
+
+
+def _make_descriptor(
+    server_name: str,
+    provider: _ProviderConfig,
+    mode: ToolExposureMode,
+) -> dict[str, Any]:
+    """Build a tool descriptor for a provider in the requested exposure mode."""
+    tool_name = f"{server_name}__{provider.name}"
+    short_description = f"Financial data via {provider.name} (OpenBB/{server_name})"
+
+    if mode is ToolExposureMode.SUMMARY:
+        return {
+            "name": tool_name,
+            "description": short_description,
+            "provider": provider.name,
+            "server": server_name,
+        }
+
+    return {
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "description": short_description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Ticker symbol or identifier (provider-specific).",
+                    },
+                },
+                "required": [],
+            },
+        },
+    }

--- a/tests/dg/test_mcp_registry.py
+++ b/tests/dg/test_mcp_registry.py
@@ -1,0 +1,174 @@
+"""Unit tests for register_mcp_server() — OpenBB MCP server registration (issue #401)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from digigraph.orchestration.registry import ToolExposureMode, register_mcp_server
+
+
+@pytest.fixture()
+def mcp_config(tmp_path: Path) -> Path:
+    """Write a minimal mcp_servers.yaml to a temp directory and return its path."""
+    cfg = tmp_path / "mcp_servers.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+        mcp_servers:
+          openbb:
+            description: "OpenBB financial data MCP server"
+            enabled: true
+            tool_exposure_mode: summary
+            free_providers:
+              - name: yfinance
+                enabled: true
+              - name: fred
+                enabled: true
+                api_key_env: FRED_API_KEY
+                optional: true
+              - name: sec_edgar
+                enabled: true
+              - name: fama_french
+                enabled: true
+            premium_providers:
+              - name: intrinio
+                enabled_if_env: INTRINIO_API_KEY
+              - name: benzinga
+                enabled_if_env: BENZINGA_API_KEY
+              - name: polygon
+                enabled_if_env: POLYGON_API_KEY
+        """)
+    )
+    return cfg
+
+
+@pytest.mark.unit
+def test_free_providers_enabled_without_keys(
+    mcp_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """yfinance, fred, sec_edgar, fama_french are returned even when no premium keys are set."""
+    monkeypatch.delenv("INTRINIO_API_KEY", raising=False)
+    monkeypatch.delenv("BENZINGA_API_KEY", raising=False)
+    monkeypatch.delenv("POLYGON_API_KEY", raising=False)
+    # FRED_API_KEY is optional — should not affect free-provider inclusion.
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+
+    result = register_mcp_server("openbb", config_path=str(mcp_config))
+
+    names = {d["name"] for d in result}
+    assert "openbb__yfinance" in names
+    assert "openbb__fred" in names
+    assert "openbb__sec_edgar" in names
+    assert "openbb__fama_french" in names
+
+
+@pytest.mark.unit
+def test_premium_providers_skipped_without_keys(
+    mcp_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Premium providers are excluded when their env vars are absent."""
+    monkeypatch.delenv("INTRINIO_API_KEY", raising=False)
+    monkeypatch.delenv("BENZINGA_API_KEY", raising=False)
+    monkeypatch.delenv("POLYGON_API_KEY", raising=False)
+
+    result = register_mcp_server("openbb", config_path=str(mcp_config))
+
+    names = {d["name"] for d in result}
+    assert "openbb__intrinio" not in names
+    assert "openbb__benzinga" not in names
+    assert "openbb__polygon" not in names
+
+
+@pytest.mark.unit
+def test_premium_provider_included_when_key_set(
+    mcp_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A premium provider is included when its env var is set."""
+    monkeypatch.setenv("INTRINIO_API_KEY", "test-key-value")
+    monkeypatch.delenv("BENZINGA_API_KEY", raising=False)
+    monkeypatch.delenv("POLYGON_API_KEY", raising=False)
+
+    result = register_mcp_server("openbb", config_path=str(mcp_config))
+
+    names = {d["name"] for d in result}
+    assert "openbb__intrinio" in names
+    assert "openbb__benzinga" not in names
+
+
+@pytest.mark.unit
+def test_summary_mode_used_by_default(
+    mcp_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default mode is SUMMARY: descriptors have 'name', 'description', 'provider', 'server'
+    keys but NOT the full OpenAI 'type'/'function' keys."""
+    monkeypatch.delenv("INTRINIO_API_KEY", raising=False)
+
+    result = register_mcp_server("openbb", config_path=str(mcp_config))
+
+    assert result, "Expected at least one descriptor"
+    first = result[0]
+    assert "name" in first
+    assert "description" in first
+    assert "provider" in first
+    assert "server" in first
+    # SUMMARY should NOT include OpenAI function-tool schema keys.
+    assert "type" not in first
+    assert "function" not in first
+
+
+@pytest.mark.unit
+def test_detailed_mode_returns_openai_schema(
+    mcp_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DETAILED mode returns OpenAI function-tool schema with 'type' and 'function' keys."""
+    monkeypatch.delenv("INTRINIO_API_KEY", raising=False)
+
+    result = register_mcp_server(
+        "openbb", config_path=str(mcp_config), mode=ToolExposureMode.DETAILED
+    )
+
+    assert result, "Expected at least one descriptor"
+    first = result[0]
+    assert first.get("type") == "function"
+    assert "function" in first
+    assert "name" in first["function"]
+    assert "description" in first["function"]
+    assert "parameters" in first["function"]
+
+
+@pytest.mark.unit
+def test_missing_config_returns_empty(tmp_path: Path) -> None:
+    """When the config file doesn't exist, return an empty list (no exception)."""
+    result = register_mcp_server(
+        "openbb", config_path=str(tmp_path / "nonexistent.yaml")
+    )
+    assert result == []
+
+
+@pytest.mark.unit
+def test_unknown_server_name_returns_empty(mcp_config: Path) -> None:
+    """When the requested server name is not in the config, return an empty list."""
+    result = register_mcp_server("unknown_server", config_path=str(mcp_config))
+    assert result == []
+
+
+@pytest.mark.unit
+def test_disabled_server_returns_empty(tmp_path: Path) -> None:
+    """When the server's 'enabled' flag is false, return an empty list."""
+    cfg = tmp_path / "mcp_servers.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+        mcp_servers:
+          openbb:
+            description: "disabled server"
+            enabled: false
+            free_providers:
+              - name: yfinance
+                enabled: true
+            premium_providers: []
+        """)
+    )
+    result = register_mcp_server("openbb", config_path=str(cfg))
+    assert result == []


### PR DESCRIPTION
## Summary

- Add `config/mcp_servers.yaml` declaring OpenBB as the default financial-data MCP server
- Free providers (yfinance, FRED, SEC EDGAR, Fama-French) enabled by default
- Premium providers (Intrinio, Benzinga, Polygon) opt-in via env vars (`INTRINIO_API_KEY`, `BENZINGA_API_KEY`, `POLYGON_API_KEY`)
- Add `register_mcp_server()` to `digigraph/src/digigraph/orchestration/registry.py` returning tool descriptors (SUMMARY or DETAILED mode)
- Add `ToolExposureMode` enum placeholder (TODO: replace with import from #404)
- Pydantic v2 models (`_ProviderConfig`, `_MCPServerConfig`) validate the YAML config
- 8 unit tests in `tests/dg/test_mcp_registry.py` covering free/premium gating, mode shapes, and error paths

**Depends on #404 — merge this after #404 lands.**

## Test plan

- [x] `pytest -m unit tests/dg/test_mcp_registry.py -v` — 8/8 pass
- [x] `pytest -m unit tests/dg/ -v` — 274/275 pass (1 pre-existing failure: missing `langgraph-checkpoint-sqlite` optional dep)
- [x] `ruff check` — clean

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)