### PR TITLE
feat(digiquant): compute-technicals + trading_calendar filter (#339)

### DIFF
--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -7,16 +7,59 @@ local dev (``python -m digiquant prices …``).
 from __future__ import annotations
 
 import json
+import logging
 import os
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import click
+import polars as pl
+
+_logger = logging.getLogger(__name__)
 
 
 @click.group()
 def prices() -> None:
     """Price / technicals / macro pipeline (migrated from Atlas scripts)."""
+
+
+# ─── Trading-calendar helpers ─────────────────────────────────────────────
+
+
+def _fetch_trading_days(client: Any, venue: str, *, page_size: int = 5000) -> pl.Series | None:
+    """Fetch all trading days for ``venue`` from the ``trading_calendar`` table.
+
+    Returns a :class:`polars.Series` of :class:`datetime.date` values for rows
+    where ``is_trading_day=True``, or ``None`` on error.  Paginates automatically
+    so callers are not limited by Supabase's default 1 000-row cap.
+    """
+    all_dates: list[date] = []
+    offset = 0
+    try:
+        while True:
+            resp = (
+                client.table("trading_calendar")
+                .select("date")
+                .eq("venue", venue)
+                .eq("is_trading_day", True)
+                .range(offset, offset + page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            for row in batch:
+                raw = row.get("date")
+                if raw:
+                    all_dates.append(date.fromisoformat(str(raw)[:10]))
+            if len(batch) < page_size:
+                break
+            offset += page_size
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("trading_calendar query failed for venue %s: %s", venue, exc)
+        return None
+    if not all_dates:
+        return None
+    return pl.Series("trading_days", all_dates)
 
 
 # ─── fetch-quotes ────────────────────────────────────────────────────────
@@ -117,6 +160,7 @@ def compute_technicals_cmd(
         upsert_price_technicals,
     )
     from digiquant.data.prices.technicals import MIN_BARS, compute_indicators
+    from digiquant.data.prices.ticker_venues import venue_for
 
     if tickers:
         universe = [t.strip().upper() for t in tickers.split(",") if t.strip()]
@@ -136,6 +180,24 @@ def compute_technicals_cmd(
         if client is None:
             raise click.ClickException("Supabase credentials not set.")
 
+    # Pre-fetch trading days per venue (once per venue, not once per ticker).
+    # Only fetched when --supabase is active so local/dry-run paths stay fast.
+    # Build ticker→venue map up front so the per-ticker loop avoids double lookup.
+    venue_trading_days: dict[str, pl.Series | None] = {}
+    ticker_venue: dict[str, str | None] = {}
+    if client is not None:
+        for t in universe:
+            ticker_venue[t] = venue_for(t)
+        for v in {v for v in ticker_venue.values() if v is not None}:
+            days_series = _fetch_trading_days(client, v)
+            if days_series is None:
+                _logger.warning(
+                    "No trading_calendar rows found for venue %s — "
+                    "technicals will be computed on all rows for tickers in this venue",
+                    v,
+                )
+            venue_trading_days[v] = days_series
+
     # Accumulate all tickers' indicator rows, then upsert once at the end —
     # cuts per-ticker HTTP round-trips to 1 (chunked by DEFAULT_CHUNK).
     all_rows: list[dict] = []
@@ -146,6 +208,22 @@ def compute_technicals_cmd(
             continue
         if target_date:
             df = df.filter(df["timestamp"] <= date.fromisoformat(target_date))
+
+        # Resolve trading-days filter. Filter df *before* compute_indicators so
+        # ind.height == df.height holds after the call (see assertion below).
+        trading_days: pl.Series | None = None
+        if venue_trading_days:
+            venue = ticker_venue.get(ticker)
+            if venue is not None:
+                trading_days = venue_trading_days.get(venue)
+            else:
+                _logger.warning(
+                    "No venue mapping for ticker %s — computing technicals on all rows",
+                    ticker,
+                )
+        if trading_days is not None and "timestamp" in df.columns:
+            df = df.filter(pl.col("timestamp").is_in(trading_days))
+
         ind = compute_indicators(df)
         if days and ind.height > days:
             ind = ind.tail(days)

--- a/digiquant/src/digiquant/data/prices/technicals.py
+++ b/digiquant/src/digiquant/data/prices/technicals.py
@@ -26,6 +26,7 @@ indicator column set defined in :data:`digiquant.data.prices.TECHNICAL_COLUMNS`.
 
 from __future__ import annotations
 
+import logging
 import math
 
 import polars as pl
@@ -34,6 +35,8 @@ from digiquant.data.prices import TECHNICAL_COLUMNS
 
 MIN_BARS = 30
 _TRADING_DAYS_YEAR = 252
+
+_logger = logging.getLogger(__name__)
 
 
 # ─── Low-level primitives ───────────────────────────────────────────────────
@@ -99,7 +102,10 @@ def _normalize(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
-def compute_indicators(df: pl.DataFrame) -> pl.DataFrame:
+def compute_indicators(
+    df: pl.DataFrame,
+    trading_days: pl.Series | None = None,
+) -> pl.DataFrame:
     """Compute all technical indicators defined in :data:`TECHNICAL_COLUMNS`.
 
     Parameters
@@ -107,13 +113,35 @@ def compute_indicators(df: pl.DataFrame) -> pl.DataFrame:
     df : pl.DataFrame
         OHLC(V) Polars frame sorted by date ascending. Must contain
         ``open``, ``high``, ``low``, ``close`` (case-insensitive).
+        The date column should be named ``timestamp``.
+    trading_days : pl.Series | None
+        Optional filter: a Series of :class:`datetime.date` values representing
+        valid trading days. When provided, rows whose ``timestamp`` column value
+        is not in ``trading_days`` are dropped *before* computation, so
+        indicators are only computed on real market sessions.
+
+        Graceful fallback: if ``trading_days`` is provided but empty, a warning
+        is logged and all rows are retained unchanged.
 
     Returns
     -------
     pl.DataFrame
-        Same length as input; columns = ``TECHNICAL_COLUMNS``. NaN/null
-        in leading rows where insufficient history exists.
+        Same length as (filtered) input; columns = ``TECHNICAL_COLUMNS``.
+        NaN/null in leading rows where insufficient history exists.
     """
+    if trading_days is not None:
+        if len(trading_days) == 0:
+            _logger.warning(
+                "trading_days filter is empty — computing technicals on all rows"
+            )
+        elif "timestamp" in df.columns:
+            df = df.filter(pl.col("timestamp").is_in(trading_days))
+        else:
+            _logger.warning(
+                "trading_days provided but DataFrame has no 'timestamp' column — "
+                "skipping filter and computing technicals on all rows"
+            )
+
     if df.is_empty():
         return pl.DataFrame({c: pl.Series(c, [], dtype=pl.Float64) for c in TECHNICAL_COLUMNS})
 

--- a/tests/dq/data/test_technicals.py
+++ b/tests/dq/data/test_technicals.py
@@ -8,6 +8,7 @@ matching against pandas_ta-era Atlas output.
 
 from __future__ import annotations
 
+import logging
 import math
 from datetime import date, timedelta
 
@@ -510,3 +511,106 @@ def test_zscore_50_and_200_match_reference() -> None:
     # 60-row fixture → zscore_200 is all None (insufficient window).
     _assert_close(out["zscore_50"].to_list(), _ref_zscore(closes, 50), tol=1e-9)
     assert all(v is None or math.isnan(v) for v in out["zscore_200"].to_list())
+
+
+# ─── trading_days filter tests ─────────────────────────────────────────────
+
+
+def _ohlcv_frame(dates: list[date]) -> pl.DataFrame:
+    """Minimal OHLCV frame for the given dates (values don't matter for filter tests)."""
+    n = len(dates)
+    close = [100.0 + i for i in range(n)]
+    open_ = [c - 0.5 for c in close]
+    high = [c + 1.0 for c in close]
+    low = [c - 1.0 for c in close]
+    volume = [1_000_000 + i * 100 for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": dates,
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        }
+    )
+
+
+@pytest.mark.unit
+def test_trading_days_filter_drops_non_trading_rows() -> None:
+    """Rows outside trading_days are excluded before computation."""
+    # 2024-01-02 = Tuesday (trading), 2024-01-06 = Saturday, 2024-01-07 = Sunday
+    dates = [date(2024, 1, 2), date(2024, 1, 6), date(2024, 1, 7)]
+    df = _ohlcv_frame(dates)
+    trading_days = pl.Series("trading_days", [date(2024, 1, 2)])
+
+    result = compute_indicators(df, trading_days=trading_days)
+    assert result.height == 1
+
+
+@pytest.mark.unit
+def test_trading_days_filter_keeps_all_matching_rows() -> None:
+    """All rows in trading_days are retained."""
+    dates = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4), date(2024, 1, 5)]
+    df = _ohlcv_frame(dates)
+    # All four days are trading days
+    trading_days = pl.Series("trading_days", dates)
+
+    result = compute_indicators(df, trading_days=trading_days)
+    assert result.height == 4
+
+
+@pytest.mark.unit
+def test_empty_trading_days_uses_all_rows(caplog) -> None:
+    """Empty trading_days logs a warning and retains all rows (graceful fallback)."""
+    dates = [date(2024, 1, 2), date(2024, 1, 3)]
+    df = _ohlcv_frame(dates)
+    empty_filter = pl.Series("trading_days", [], dtype=pl.Date)
+
+    with caplog.at_level(logging.WARNING, logger="digiquant.data.prices.technicals"):
+        result = compute_indicators(df, trading_days=empty_filter)
+
+    assert result.height == 2
+    assert "trading_days filter is empty" in caplog.text
+
+
+@pytest.mark.unit
+def test_no_filter_matches_existing_behavior() -> None:
+    """Without trading_days, behavior is unchanged (backwards compatible)."""
+    df = _fixture()
+    out_no_filter = compute_indicators(df)
+    out_none = compute_indicators(df, trading_days=None)
+    # Both should produce identical results.
+    assert out_no_filter.shape == out_none.shape
+    for col in out_no_filter.columns:
+        vals_a = out_no_filter[col].to_list()
+        vals_b = out_none[col].to_list()
+        for i, (a, b) in enumerate(zip(vals_a, vals_b)):
+            if a is None or (isinstance(a, float) and math.isnan(a)):
+                assert b is None or (isinstance(b, float) and math.isnan(b)), (
+                    f"col={col}, row={i}: expected null, got {b}"
+                )
+            else:
+                assert abs(a - b) < 1e-12, f"col={col}, row={i}: {a} != {b}"
+
+
+@pytest.mark.unit
+def test_trading_days_no_timestamp_column_uses_all_rows(caplog) -> None:
+    """If the DataFrame has no 'timestamp' column, filter is skipped with a warning."""
+    # Build a frame without a timestamp column (only OHLCV)
+    df = pl.DataFrame(
+        {
+            "open": [100.0, 101.0],
+            "high": [102.0, 103.0],
+            "low": [99.0, 100.0],
+            "close": [101.0, 102.0],
+            "volume": [1000, 2000],
+        }
+    )
+    trading_days = pl.Series("trading_days", [date(2024, 1, 2)])
+
+    with caplog.at_level(logging.WARNING, logger="digiquant.data.prices.technicals"):
+        result = compute_indicators(df, trading_days=trading_days)
+
+    assert result.height == 2
+    assert "no 'timestamp' column" in caplog.text


### PR DESCRIPTION
## Summary

- Adds optional `trading_days: pl.Series | None` parameter to `compute_indicators()` in `technicals.py`. When provided and non-empty, rows whose `timestamp` is not in the set are dropped before computation so indicators are only calculated on real market sessions.
- Graceful fallbacks: empty series logs a warning and retains all rows; missing `timestamp` column also falls back with a warning.
- Updates `compute_technicals_cmd` CLI: when `--supabase` is active, fetches trading days per venue from `trading_calendar` (paginated, one query per venue not per ticker), filters the DataFrame before calling `compute_indicators`, and preserves the existing `ind.height == df.height` invariant.
- Five new `@pytest.mark.unit` tests cover all filter branches: drops non-trading rows, keeps all matching rows, empty-series fallback, no-filter backward compat, missing-timestamp-column fallback.

## Test plan

- [ ] `pytest -m unit tests/dq/data/test_technicals.py -v` — all 18 tests pass
- [ ] `pytest -m unit tests/dq/ -v --tb=short` — no regressions in other test files

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)