### PR TITLE
fix(digiquant): patch atlas/hermes Pydantic string overflows + monthly-digest model pin

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -86,6 +86,12 @@ phase_models:
   # deepseek-v3.1:671b: 671B, strong reasoning + coding, confirmed free tier.
   master-digest: "ollama-cloud/deepseek-v3.1:671b"
 
+  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier as
+  # master-digest). Without an explicit entry this falls back to get_model_for_mode()
+  # which tries the best list in order; kimi-k2-thinking is first and is now behind
+  # a subscription paywall (403, Apr 2026). Pin to the same free-tier model.
+  monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
+
   # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
   # llm-decision: reasoning free-preferred
   # [tier: reasoning] — Portfolio allocation decision with real investment stakes.

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -113,6 +113,7 @@ def run_research_agent(
     phase_slug: str | None = None,
     temperature: float = 0.1,
     max_retries: int = 1,
+    max_tokens: int = 4096,
 ) -> T:
     """Run one research-agent LLM call and return a validated Pydantic instance.
 
@@ -134,6 +135,10 @@ def run_research_agent(
         temperature: LLM temperature; default 0.1 (analyst work wants determinism).
         max_retries: How many times to re-call with the validator error appended
             before giving up. Default 1.
+        max_tokens: Maximum output tokens for the completion. Default 4096 — large
+            enough for all current output models while preventing Gemini Flash's
+            OpenAI-compat endpoint from silently truncating JSON at ~512 tokens
+            when response_format=json_schema is set without an explicit limit.
 
     Provider notes:
         ``response_format=json_schema`` is passed to the API call so that providers
@@ -168,7 +173,11 @@ def run_research_agent(
     last_error: Exception | None = None
     for attempt in range(max_retries + 1):
         raw = chat_completion(
-            effective_model, messages, temperature=temperature, response_format=response_format
+            effective_model,
+            messages,
+            temperature=temperature,
+            response_format=response_format,
+            max_tokens=max_tokens,
         )
         if isinstance(raw, tuple):  # defensive: chat_completion returns tuple only with tools
             raw = raw[0]

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -138,6 +138,7 @@ def _llm_cache_key(
     messages: list[dict[str, Any]],
     temperature: float,
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str:
     """Return a stable SHA-256 cache key for the given completion parameters."""
     payload = json.dumps(
@@ -146,6 +147,7 @@ def _llm_cache_key(
             "messages": messages,
             "temperature": temperature,
             "response_format": response_format,
+            "max_tokens": max_tokens,
         },
         sort_keys=True,
     )
@@ -425,6 +427,7 @@ def chat_completion(
     tools: list[dict[str, Any]] | None = None,
     tool_choice: str | dict[str, Any] = "auto",
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str | tuple[str, list[dict[str, Any]] | None]:
     """
     Chat completion. When tools=None: returns content string (backward compatible).
@@ -469,7 +472,7 @@ def chat_completion(
     # Check cache for tool-free requests (tool calls have side effects; don't cache them)
     cache_key: str | None = None
     if not tools:
-        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format)
+        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format, max_tokens)
         cached = _llm_cache_get(cache_key)
         if cached is not None:
             logger.debug("LLM cache hit: model=%s key=%s…", effective_model, cache_key[:8])
@@ -479,6 +482,8 @@ def chat_completion(
         "messages": messages,
         "temperature": temperature,
     }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
     if tools:
         kwargs["tools"] = tools
         kwargs["tool_choice"] = tool_choice

--- a/digiquant/docs/schemas/atlas_snapshot.v1.json
+++ b/digiquant/docs/schemas/atlas_snapshot.v1.json
@@ -248,7 +248,7 @@
         "title": {
           "anyOf": [
             {
-              "maxLength": 300,
+              "maxLength": 600,
               "type": "string"
             },
             {

--- a/digiquant/src/digiquant/atlas/segments.py
+++ b/digiquant/src/digiquant/atlas/segments.py
@@ -67,7 +67,7 @@ class Source(BaseModel):
     """One source cited by the segment's findings."""
 
     id: str = Field(max_length=64, description="Stable identifier used by Finding.source_ids")
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/atlas/snapshot.py
+++ b/digiquant/src/digiquant/atlas/snapshot.py
@@ -107,7 +107,7 @@ class Source(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(max_length=64)
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
@@ -52,15 +52,15 @@ class DebateRoundContribution(BaseModel):
     role: Literal["bull", "bear"]
     ticker: str = Field(max_length=16)
     round_number: int = Field(ge=1, le=5)
-    argument: str = Field(max_length=600)
+    argument: str = Field(max_length=1200)
 
 
 class DebateRound(BaseModel):
     """One full bull-then-bear exchange."""
 
     round_number: int = Field(ge=1, le=5)
-    bull_argument: str = Field(max_length=600)
-    bear_argument: str = Field(max_length=600)
+    bull_argument: str = Field(max_length=1200)
+    bear_argument: str = Field(max_length=1200)
 
 
 class DebateSummary(BaseModel):

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -136,7 +136,7 @@ class TestDebateModels:
                 role="bull",
                 ticker="AAPL",
                 round_number=1,
-                argument="x" * 700,
+                argument="x" * 1300,
             )
 
     def test_summary_conviction_delta_bounds(self) -> None:

--- a/tests/dq/hermes/test_phase7d_risk_debate.py
+++ b/tests/dq/hermes/test_phase7d_risk_debate.py
@@ -176,7 +176,7 @@ class TestRiskDebateSchemaBounds:
 
         with pytest.raises(ValidationError):
             RiskDebateSummary(
-                aggressive_case="x" * 700,  # exceeds 600
+                aggressive_case="x" * 1300,  # exceeds 1200
                 conservative_case="ok",
                 key_tension="ok",
             )
@@ -185,7 +185,7 @@ class TestRiskDebateSchemaBounds:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            RiskCase(case="x" * 700)
+            RiskCase(case="x" * 1300)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Workflow run audit identified two open failure issues (#496, #499) sharing the same class of root cause. Three targeted patches applied.

### Fix 1 — `monthly-digest` model pin (`config/model_modes.yaml`)

**Root cause of #499:** `monthly-digest` had no explicit `phase_models` entry, so `get_model_for_phase()` returned `None` and fell through to `get_model_for_mode()`. In `best` mode that walks the `best` list — `kimi-k2-thinking` is first and now requires an Ollama subscription (403 since Apr 2026). Retried 3× outer + 12× inner, all failed.

**Fix:** Pin `monthly-digest` to `ollama-cloud/deepseek-v3.1:671b` — same free-tier model already used for `master-digest` and `pm-rebalance`.

### Fix 2 — `Source.title` max_length 300 → 600 (`atlas/segments.py` + `atlas/snapshot.py`)

**Root cause of #496 (partial):** LLM generates source titles 300–550 characters long. `HedgeFundIntelReport` hit this in the delta run, but any phase using `SegmentReport.sources` can fail the same way.

**Fix:** Raise limit to 600 in both `segments.Source` and `snapshot.Source` (these are parallel models for the two persistence layers).

### Fix 3 — Debate argument limits 600 → 1200 (`hermes/phases/phase7cd_debate.py`)

**Preemptive:** `DebateArgument.argument`, `DebateRound.bull_argument`, `DebateRound.bear_argument` were all at `max_length=600` — the same value that broke `RiskCase.case` and `RiskDebateSummary.conservative_case` (fixed in #508 to 1200). The Bull/Bear debate phase generates similarly verbose content; raising now before the next scheduled delta run hits it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('config/model_modes.yaml'))"` — YAML valid
- [x] `config/model_modes.yaml phase_models['monthly-digest']` → `ollama-cloud/deepseek-v3.1:671b`
- [ ] `pytest tests/dq/ -m unit --tb=short` — no regressions
- [ ] Next `atlas-delta` run — no `string_too_long` on `sources.*.title`
- [ ] Next `atlas-monthly` run — no 403 from `kimi-k2-thinking`

Closes #499
Partially closes #496 (the `Source.title` path; `RiskCase`/`RiskDebateSummary` were fixed in #508)

https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK)_