### PR TITLE
fix(digiquant): wire phase_slug in _monthly_node so monthly-digest model pin is effective

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -86,6 +86,12 @@ phase_models:
   # deepseek-v3.1:671b: 671B, strong reasoning + coding, confirmed free tier.
   master-digest: "ollama-cloud/deepseek-v3.1:671b"
 
+  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier as
+  # master-digest). Without an explicit entry this falls back to get_model_for_mode()
+  # which tries the best list in order; kimi-k2-thinking is first and is now behind
+  # a subscription paywall (403, Apr 2026). Pin to the same free-tier model.
+  monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
+
   # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
   # llm-decision: reasoning free-preferred
   # [tier: reasoning] — Portfolio allocation decision with real investment stakes.

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -113,6 +113,7 @@ def run_research_agent(
     phase_slug: str | None = None,
     temperature: float = 0.1,
     max_retries: int = 1,
+    max_tokens: int = 4096,
 ) -> T:
     """Run one research-agent LLM call and return a validated Pydantic instance.
 
@@ -134,6 +135,10 @@ def run_research_agent(
         temperature: LLM temperature; default 0.1 (analyst work wants determinism).
         max_retries: How many times to re-call with the validator error appended
             before giving up. Default 1.
+        max_tokens: Maximum output tokens for the completion. Default 4096 — large
+            enough for all current output models while preventing Gemini Flash's
+            OpenAI-compat endpoint from silently truncating JSON at ~512 tokens
+            when response_format=json_schema is set without an explicit limit.
 
     Provider notes:
         ``response_format=json_schema`` is passed to the API call so that providers
@@ -168,7 +173,11 @@ def run_research_agent(
     last_error: Exception | None = None
     for attempt in range(max_retries + 1):
         raw = chat_completion(
-            effective_model, messages, temperature=temperature, response_format=response_format
+            effective_model,
+            messages,
+            temperature=temperature,
+            response_format=response_format,
+            max_tokens=max_tokens,
         )
         if isinstance(raw, tuple):  # defensive: chat_completion returns tuple only with tools
             raw = raw[0]

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -138,6 +138,7 @@ def _llm_cache_key(
     messages: list[dict[str, Any]],
     temperature: float,
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str:
     """Return a stable SHA-256 cache key for the given completion parameters."""
     payload = json.dumps(
@@ -146,6 +147,7 @@ def _llm_cache_key(
             "messages": messages,
             "temperature": temperature,
             "response_format": response_format,
+            "max_tokens": max_tokens,
         },
         sort_keys=True,
     )
@@ -425,6 +427,7 @@ def chat_completion(
     tools: list[dict[str, Any]] | None = None,
     tool_choice: str | dict[str, Any] = "auto",
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str | tuple[str, list[dict[str, Any]] | None]:
     """
     Chat completion. When tools=None: returns content string (backward compatible).
@@ -469,7 +472,7 @@ def chat_completion(
     # Check cache for tool-free requests (tool calls have side effects; don't cache them)
     cache_key: str | None = None
     if not tools:
-        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format)
+        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format, max_tokens)
         cached = _llm_cache_get(cache_key)
         if cached is not None:
             logger.debug("LLM cache hit: model=%s key=%s…", effective_model, cache_key[:8])
@@ -479,6 +482,8 @@ def chat_completion(
         "messages": messages,
         "temperature": temperature,
     }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
     if tools:
         kwargs["tools"] = tools
         kwargs["tool_choice"] = tool_choice

--- a/digiquant/docs/schemas/atlas_snapshot.v1.json
+++ b/digiquant/docs/schemas/atlas_snapshot.v1.json
@@ -248,7 +248,7 @@
         "title": {
           "anyOf": [
             {
-              "maxLength": 300,
+              "maxLength": 600,
               "type": "string"
             },
             {

--- a/digiquant/src/digiquant/atlas/phases/phase_monthly.py
+++ b/digiquant/src/digiquant/atlas/phases/phase_monthly.py
@@ -57,6 +57,7 @@ def _monthly_node(state: AtlasResearchState) -> dict[str, Any]:
         phase_inputs=phase_inputs,
         shared_context=_shared_context(state),
         output_model=MonthlyDigest,
+        phase_slug="monthly-digest",
     )
     return {"phase7_digest": result.model_dump(mode="json")}
 

--- a/digiquant/src/digiquant/atlas/segments.py
+++ b/digiquant/src/digiquant/atlas/segments.py
@@ -67,7 +67,7 @@ class Source(BaseModel):
     """One source cited by the segment's findings."""
 
     id: str = Field(max_length=64, description="Stable identifier used by Finding.source_ids")
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/atlas/snapshot.py
+++ b/digiquant/src/digiquant/atlas/snapshot.py
@@ -107,7 +107,7 @@ class Source(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(max_length=64)
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
@@ -52,15 +52,15 @@ class DebateRoundContribution(BaseModel):
     role: Literal["bull", "bear"]
     ticker: str = Field(max_length=16)
     round_number: int = Field(ge=1, le=5)
-    argument: str = Field(max_length=600)
+    argument: str = Field(max_length=1200)
 
 
 class DebateRound(BaseModel):
     """One full bull-then-bear exchange."""
 
     round_number: int = Field(ge=1, le=5)
-    bull_argument: str = Field(max_length=600)
-    bear_argument: str = Field(max_length=600)
+    bull_argument: str = Field(max_length=1200)
+    bear_argument: str = Field(max_length=1200)
 
 
 class DebateSummary(BaseModel):

--- a/tests/dq/atlas/test_phase_monthly.py
+++ b/tests/dq/atlas/test_phase_monthly.py
@@ -1,0 +1,149 @@
+"""Isolated tests for the monthly-digest phase model-routing fix.
+
+Regression guard for the bug reported by Copilot on PR #525:
+  _monthly_node() was not passing phase_slug="monthly-digest" to
+  run_research_agent(), so the monthly-digest config entry in
+  model_modes.yaml was never consulted and the call fell through to
+  get_model_for_mode() — reproducing the kimi-k2-thinking 403 path.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from digiquant.atlas.phases.phase_monthly import MonthlyDigest, _monthly_node
+from digiquant.atlas.state import AtlasConfigBundle, AtlasResearchState
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _minimal_state() -> AtlasResearchState:
+    return AtlasResearchState(
+        run_type="monthly",
+        run_date=date(2026, 5, 1),
+        config=AtlasConfigBundle(watchlist=["AAPL"]),
+    )
+
+
+def _monthly_payload() -> str:
+    return json.dumps(
+        {
+            "segment": "monthly-digest",
+            "date": "2026-05-01",
+            "bias": "neutral",
+            "headline": "Month-end regime review",
+            "material_findings": [],
+            "sources": [],
+            "notes": "",
+            "market_regime_snapshot": "Stable",
+            "alt_data_dashboard": "Neutral",
+            "institutional_summary": "Flat",
+            "asset_classes_summary": "Mixed",
+            "us_equities_summary": "Flat",
+            "thesis_tracker": "",
+            "portfolio_recommendations": "",
+            "actionable_summary": [],
+            "risk_radar": [],
+            "segment_freshness": {},
+            "month_over_month_regime_delta": "",
+        }
+    )
+
+
+# ─── Config layer ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMonthlyDigestModelConfig:
+    def test_phase_slug_returns_pinned_model(self) -> None:
+        """get_model_for_phase("monthly-digest") must return the free-tier pin."""
+        from digigraph.llm import get_model_for_phase
+
+        model = get_model_for_phase("monthly-digest")
+        assert model == "ollama-cloud/deepseek-v3.1:671b", (
+            f"monthly-digest should be pinned to deepseek-v3.1:671b, got {model!r}"
+        )
+
+    def test_phase_slug_not_none(self) -> None:
+        """The config entry must not be missing (None triggers the 403 fallback)."""
+        from digigraph.llm import get_model_for_phase
+
+        assert get_model_for_phase("monthly-digest") is not None
+
+
+# ─── Call-site routing ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMonthlyNodePassesPhaseSlug:
+    def test_run_research_agent_called_with_phase_slug(self) -> None:
+        """_monthly_node must pass phase_slug='monthly-digest' so the pinned model is used."""
+        state = _minimal_state()
+
+        # run_research_agent is imported lazily inside _monthly_node, so we patch
+        # the function at its definition site so the lazy import picks up the mock.
+        with patch(
+            "digigraph.graph.research_agent.run_research_agent",
+        ) as mock_rra:
+            mock_rra.return_value = MonthlyDigest(
+                segment="monthly-digest",
+                date=date(2026, 5, 1),
+                bias="neutral",
+                headline="ok",
+                market_regime_snapshot="",
+                alt_data_dashboard="",
+                institutional_summary="",
+                asset_classes_summary="",
+                us_equities_summary="",
+            )
+            _monthly_node(state)
+
+        assert mock_rra.call_count == 1
+        _, kwargs = mock_rra.call_args
+        assert kwargs.get("phase_slug") == "monthly-digest", (
+            f"Expected phase_slug='monthly-digest', got {kwargs.get('phase_slug')!r}. "
+            "Without this the model_modes.yaml entry is never consulted."
+        )
+
+    def test_kimi_not_called_in_best_mode(self) -> None:
+        """In best mode the pinned model must win; kimi-k2-thinking must NOT be called.
+
+        Simulates the production failure: get_model_for_mode() would return
+        kimi-k2-thinking in best mode, but phase_slug routing must intercept first.
+        """
+        state = _minimal_state()
+
+        called_models: list[str] = []
+
+        def fake_chat(model: str, *args: Any, **kwargs: Any) -> str:
+            called_models.append(model)
+            return _monthly_payload()
+
+        with (
+            # Simulate best mode returning kimi (the 403 path) to prove it's bypassed.
+            patch("digigraph.llm._get_llm_mode", return_value="best"),
+            patch(
+                "digigraph.graph.research_agent.chat_completion",
+                side_effect=fake_chat,
+            ),
+            patch(
+                "digiquant.atlas.skills.load_skill",
+                return_value="Monthly synthesis skill text",
+            ),
+        ):
+            _monthly_node(state)
+
+        assert called_models, "LLM must be called"
+        for m in called_models:
+            assert "kimi" not in m.lower(), (
+                f"kimi-k2-thinking must not be selected in best mode; got {m!r}"
+            )
+        assert all("deepseek" in m.lower() for m in called_models), (
+            f"Expected deepseek model via phase_slug pin; got {called_models}"
+        )

--- a/tests/dq/atlas/test_phase_monthly.py
+++ b/tests/dq/atlas/test_phase_monthly.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 from datetime import date
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -136,7 +136,7 @@ class TestDebateModels:
                 role="bull",
                 ticker="AAPL",
                 round_number=1,
-                argument="x" * 700,
+                argument="x" * 1300,
             )
 
     def test_summary_conviction_delta_bounds(self) -> None:

--- a/tests/dq/hermes/test_phase7d_risk_debate.py
+++ b/tests/dq/hermes/test_phase7d_risk_debate.py
@@ -176,7 +176,7 @@ class TestRiskDebateSchemaBounds:
 
         with pytest.raises(ValidationError):
             RiskDebateSummary(
-                aggressive_case="x" * 700,  # exceeds 600
+                aggressive_case="x" * 1300,  # exceeds 1200
                 conservative_case="ok",
                 key_tension="ok",
             )
@@ -185,7 +185,7 @@ class TestRiskDebateSchemaBounds:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            RiskCase(case="x" * 700)
+            RiskCase(case="x" * 1300)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Addresses the Copilot review comment on PR #525.

- **Root cause:** `_monthly_node()` called `run_research_agent(...)` without `phase_slug="monthly-digest"`, so `get_model_for_phase()` was never consulted. The model routing fell through to `get_model_for_mode()` which in `best` mode still selected `kimi-k2-thinking` (403 since Apr 2026) — making the `config/model_modes.yaml` pin in PR #525 a dead-code no-op.
- **Fix:** Add `phase_slug="monthly-digest"` to the `run_research_agent()` call in `phase_monthly._monthly_node()`.
- **Tests:** New `tests/dq/atlas/test_phase_monthly.py` with 4 isolated unit tests covering the config layer, the call-site kwarg, and end-to-end model routing (kimi not called even when best mode is active).

Includes all changes from PR #525 (cherry-picked) plus this fix on top.

## Test plan

- [x] `pytest tests/dq/atlas/test_phase_monthly.py -v` — 4/4 pass
- [x] `pytest tests/dq/atlas/ tests/dq/hermes/ -m unit` — 306/306 pass, zero regressions

Closes #499

https://claude.ai/code/session_01GdzSTVdRBTVomLK5VEskoW