### PR TITLE
fix(digiquant/digigraph): patch atlas/hermes workflow failures — model routing, JSON truncation, string overflows

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -86,6 +86,12 @@ phase_models:
   # deepseek-v3.1:671b: 671B, strong reasoning + coding, confirmed free tier.
   master-digest: "ollama-cloud/deepseek-v3.1:671b"
 
+  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier as
+  # master-digest). Without an explicit entry this falls back to get_model_for_mode()
+  # which tries the best list in order; kimi-k2-thinking is first and is now behind
+  # a subscription paywall (403, Apr 2026). Pin to the same free-tier model.
+  monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
+
   # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
   # llm-decision: reasoning free-preferred
   # [tier: reasoning] — Portfolio allocation decision with real investment stakes.

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -113,6 +113,7 @@ def run_research_agent(
     phase_slug: str | None = None,
     temperature: float = 0.1,
     max_retries: int = 1,
+    max_tokens: int = 4096,
 ) -> T:
     """Run one research-agent LLM call and return a validated Pydantic instance.
 
@@ -134,6 +135,10 @@ def run_research_agent(
         temperature: LLM temperature; default 0.1 (analyst work wants determinism).
         max_retries: How many times to re-call with the validator error appended
             before giving up. Default 1.
+        max_tokens: Maximum output tokens for the completion. Default 4096 — large
+            enough for all current output models while preventing Gemini Flash's
+            OpenAI-compat endpoint from silently truncating JSON at ~512 tokens
+            when response_format=json_schema is set without an explicit limit.
 
     Provider notes:
         ``response_format=json_schema`` is passed to the API call so that providers
@@ -168,7 +173,11 @@ def run_research_agent(
     last_error: Exception | None = None
     for attempt in range(max_retries + 1):
         raw = chat_completion(
-            effective_model, messages, temperature=temperature, response_format=response_format
+            effective_model,
+            messages,
+            temperature=temperature,
+            response_format=response_format,
+            max_tokens=max_tokens,
         )
         if isinstance(raw, tuple):  # defensive: chat_completion returns tuple only with tools
             raw = raw[0]

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -138,6 +138,7 @@ def _llm_cache_key(
     messages: list[dict[str, Any]],
     temperature: float,
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str:
     """Return a stable SHA-256 cache key for the given completion parameters."""
     payload = json.dumps(
@@ -146,6 +147,7 @@ def _llm_cache_key(
             "messages": messages,
             "temperature": temperature,
             "response_format": response_format,
+            "max_tokens": max_tokens,
         },
         sort_keys=True,
     )
@@ -425,6 +427,7 @@ def chat_completion(
     tools: list[dict[str, Any]] | None = None,
     tool_choice: str | dict[str, Any] = "auto",
     response_format: dict[str, Any] | None = None,
+    max_tokens: int | None = None,
 ) -> str | tuple[str, list[dict[str, Any]] | None]:
     """
     Chat completion. When tools=None: returns content string (backward compatible).
@@ -469,7 +472,7 @@ def chat_completion(
     # Check cache for tool-free requests (tool calls have side effects; don't cache them)
     cache_key: str | None = None
     if not tools:
-        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format)
+        cache_key = _llm_cache_key(effective_model, messages, temperature, response_format, max_tokens)
         cached = _llm_cache_get(cache_key)
         if cached is not None:
             logger.debug("LLM cache hit: model=%s key=%s…", effective_model, cache_key[:8])
@@ -479,6 +482,8 @@ def chat_completion(
         "messages": messages,
         "temperature": temperature,
     }
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
     if tools:
         kwargs["tools"] = tools
         kwargs["tool_choice"] = tool_choice

--- a/digiquant/docs/schemas/atlas_snapshot.v1.json
+++ b/digiquant/docs/schemas/atlas_snapshot.v1.json
@@ -248,7 +248,7 @@
         "title": {
           "anyOf": [
             {
-              "maxLength": 300,
+              "maxLength": 600,
               "type": "string"
             },
             {

--- a/digiquant/src/digiquant/atlas/phases/phase_monthly.py
+++ b/digiquant/src/digiquant/atlas/phases/phase_monthly.py
@@ -57,6 +57,7 @@ def _monthly_node(state: AtlasResearchState) -> dict[str, Any]:
         phase_inputs=phase_inputs,
         shared_context=_shared_context(state),
         output_model=MonthlyDigest,
+        phase_slug="monthly-digest",
     )
     return {"phase7_digest": result.model_dump(mode="json")}
 

--- a/digiquant/src/digiquant/atlas/segments.py
+++ b/digiquant/src/digiquant/atlas/segments.py
@@ -67,7 +67,7 @@ class Source(BaseModel):
     """One source cited by the segment's findings."""
 
     id: str = Field(max_length=64, description="Stable identifier used by Finding.source_ids")
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/atlas/snapshot.py
+++ b/digiquant/src/digiquant/atlas/snapshot.py
@@ -107,7 +107,7 @@ class Source(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(max_length=64)
-    title: str | None = Field(default=None, max_length=300)
+    title: str | None = Field(default=None, max_length=600)
     url: str | None = Field(default=None, max_length=1000)
 
 

--- a/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/hermes/phases/phase7cd_debate.py
@@ -52,15 +52,15 @@ class DebateRoundContribution(BaseModel):
     role: Literal["bull", "bear"]
     ticker: str = Field(max_length=16)
     round_number: int = Field(ge=1, le=5)
-    argument: str = Field(max_length=600)
+    argument: str = Field(max_length=1200)
 
 
 class DebateRound(BaseModel):
     """One full bull-then-bear exchange."""
 
     round_number: int = Field(ge=1, le=5)
-    bull_argument: str = Field(max_length=600)
-    bear_argument: str = Field(max_length=600)
+    bull_argument: str = Field(max_length=1200)
+    bear_argument: str = Field(max_length=1200)
 
 
 class DebateSummary(BaseModel):

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -136,7 +136,7 @@ class TestDebateModels:
                 role="bull",
                 ticker="AAPL",
                 round_number=1,
-                argument="x" * 700,
+                argument="x" * 1300,
             )
 
     def test_summary_conviction_delta_bounds(self) -> None:

--- a/tests/dq/hermes/test_phase7d_risk_debate.py
+++ b/tests/dq/hermes/test_phase7d_risk_debate.py
@@ -176,7 +176,7 @@ class TestRiskDebateSchemaBounds:
 
         with pytest.raises(ValidationError):
             RiskDebateSummary(
-                aggressive_case="x" * 700,  # exceeds 600
+                aggressive_case="x" * 1300,  # exceeds 1200
                 conservative_case="ok",
                 key_tension="ok",
             )
@@ -185,7 +185,7 @@ class TestRiskDebateSchemaBounds:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            RiskCase(case="x" * 700)
+            RiskCase(case="x" * 1300)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Patches three distinct failure classes found in Atlas/Hermes scheduled workflow runs, plus a call-site bug caught in code review.

### Failures fixed

| Issue | Root cause | Fix |
|-------|-----------|-----|
| `atlas-monthly` 403 (kimi-k2-thinking subscription wall) | `model_modes.yaml` had no `monthly-digest` entry so the run fell through to `get_model_for_mode()` → `best` list → `kimi-k2-thinking` (paywall). AND `_monthly_node()` never passed `phase_slug` so `get_model_for_phase()` was never reached even after the config entry was added. | Pin `monthly-digest → deepseek-v3.1:671b` in `model_modes.yaml`; add `phase_slug="monthly-digest"` at call site in `phase_monthly.py`. |
| `atlas-delta` Pydantic validation errors (`Source.title`, debate arguments) | `Source.title max_length=300` in segments + snapshot; debate argument fields at 600. LLM generates 300–550 char titles and 600–1000 char arguments. | Raise `Source.title` 300→600 in `segments.py` + `snapshot.py`; raise `DebateRoundContribution.argument` + `DebateRound.{bull,bear}_argument` 600→1200 in `phase7cd_debate.py`. Update boundary tests + `atlas_snapshot.v1.json` artifact to match. |
| `atlas-baseline` `JSONDecodeError: Unterminated string` | PR #492 added `response_format=json_schema` to every `run_research_agent` call. Gemini Flash's OpenAI-compat endpoint defaults to ~512 output tokens when this flag is set without an explicit `max_tokens`, silently truncating JSON mid-string at ~2048 chars. | Add `max_tokens: int | None = None` to `llm.chat_completion()` (forwarded to API kwargs + cache key); add `max_tokens: int = 4096` default to `run_research_agent()`, threaded into every call. |

### Commits

- `b4983af` — model pin + Source.title overflow + debate argument limits
- `eaf9481` — boundary test updates to match raised limits
- `e59ded6` — sync `atlas_snapshot.v1.json` schema artifact (Source.title maxLength 300→600)
- `1e04ea8` — `max_tokens=4096` in `run_research_agent` / `chat_completion`
- `acb28df` — `phase_slug="monthly-digest"` at call site in `_monthly_node` (call-site bug caught by Copilot review)

### Audit results (Atlas + Hermes workflows)

Full model-API and DB-schema audit performed post-fix. Key results:

**Model API setup**
- All `run_research_agent()` calls supply `phase_slug` — no silent fallthrough to `get_model_for_mode()` remaining.
- `max_tokens=4096` applied uniformly via the new default; adequate for all current output models (largest typical output ~2k tokens).
- `temperature=0.1` applied uniformly; no overrides.
- WARN (non-blocking): `bull-researcher-{ticker}`, `bear-researcher-{ticker}`, `research-manager-{ticker}`, `risk-aggressive`, `risk-conservative`, `equity`, and sector slugs have no `phase_models` entry and use `defaults` (Gemini Flash). These are research-tier phases; explicit reasoning-tier pins can be added separately if output quality warrants it.

**Database schema**
- `SnapshotEnvelope` write path (`supabase_io.publish_daily_snapshot`) uses `model_dump(mode="json")` → JSONB upsert to `daily_snapshots.snapshot`.
- `schema_version=1` is stamped on every row; read path validates it.
- Hermes internal state fields (`phase7cd_debates`, `phase7d_risk_debate`, `phase7d_rebalance`) are NOT in the snapshot schema by design — they stay in memory / `documents` table only.
- Drift test suite (`test_snapshot.py`) covers field-name parity, schema-version defaults, extra-field rejection, row parsing, and on-disk JSON export freshness. No gaps found.

## Test plan

- [ ] `pytest tests/dq/ -m unit` — all unit tests pass (boundary tests updated to match new limits)
- [ ] `atlas-monthly` scheduled run completes without 403 error
- [ ] `atlas-baseline` scheduled run: no `JSONDecodeError: Unterminated string` in extraction phases
- [ ] `atlas-delta` scheduled run: no Pydantic `ValidationError` on `Source.title` or debate fields

Closes #499 (monthly 403)
Closes #496 (delta overflow)
Closes #526 (baseline JSON truncation)

https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK)_