### PR TITLE
refactor(config): per-phase model config for Atlas + Hermes pipeline

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -82,7 +82,6 @@ jobs:
           # Ollama Cloud for reasoning tier (phases 7, 7D) — 2 calls/day.
           OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_API_BASE: https://ollama.com/v1
-          DIGI_LLM_MODE: best
           # Cap Phase 7C fan-out to 25 tickers in CI (Gemini 10 RPM ≈ 3 min)
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -79,7 +79,6 @@ jobs:
           # Ollama Cloud for reasoning tier (phases 7, 7D) — 2 calls/day.
           OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_API_BASE: https://ollama.com/v1
-          DIGI_LLM_MODE: medium
           # Cap Phase 7C fan-out to 25 tickers in CI (Gemini 10 RPM ≈ 3 min)
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -135,7 +135,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           OPENAI_API_BASE: https://ollama.com/v1
           OLLAMA_MODEL: glm-5:cloud
-          DIGI_LLM_MODE: best
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           mkdir -p artifacts

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -1,92 +1,89 @@
-# Atlas pipeline — model selection configuration.
+# Atlas + Hermes pipeline — per-phase model configuration.
+#
+# Every phase has an explicit entry here. To tune a phase, change its value.
+# No environment-variable mode selection — what you set here is what runs.
+#
+# Key format:
+#   exact slug    — matches one phase (e.g. "macro")
+#   prefix-       — matches any slug starting with the prefix (e.g. "sector-"
+#                   matches sector-technology, sector-healthcare, …)
+#
+# Provider routing (automatic from the model string prefix):
+#   gemini/…           → GEMINI_API_KEY  → Google OpenAI-compat endpoint
+#   ollama-cloud/…     → OPENAI_API_KEY  → Ollama Cloud (OPENAI_API_BASE)
+#   groq/…             → GROQ_API_KEY    → Groq OpenAI-compat endpoint
 #
 # ── CAPABILITY TIERS ──────────────────────────────────────────────────────────
-# Every phase is tagged [tier: <extraction|research|reasoning>]. Use these tags
-# when substituting models — match model strength to the tier requirement.
-#
-# extraction
-#   Task:    Structured JSON parsing from short, well-defined inputs.
-#   Needs:   Schema compliance, speed, concurrency tolerance.
-#   Default: Gemini 2.5 Flash (250k TPM, 10 RPM).
-#   Upgrade: Claude Haiku 4.5, GPT-4o-mini, any fast/cheap model.
-#
-# research
-#   Task:    Multi-factor financial analysis over moderate context.
-#   Needs:   Financial reasoning, multi-paragraph output quality, 32k+ context.
-#   Default: Gemini 2.5 Flash (1M TPM, 1M ctx, strong analytical capability).
-#   Upgrade: Claude Sonnet 4.6, GPT-4o, Gemini 1.5/2.0 Pro.
-#
-# reasoning
-#   Task:    High-stakes synthesis and portfolio decision-making.
-#   Needs:   Cross-domain synthesis, internal consistency, financial judgment.
-#   Default: Ollama Cloud deepseek-v3.1:671b (671B, confirmed free Apr 2026).
-#   Upgrade: Claude Opus 4.7 + extended_thinking, GPT-o1/o3, DeepSeek R1,
-#            Gemini 2.5 Pro (paid tier).
-#
-# ── NOTE ON PHASE 7C ──────────────────────────────────────────────────────────
-# Phase 7C (analyst fan-out) ideally belongs in the research tier — writing a
-# 1200-char investment thesis and conviction score benefits from a larger model.
-# In practice, 25 parallel calls at ~1.4k tokens each (~35k total) exceeds the
-# free TPM budget of Groq's 70B model (12k TPM) but fits within the 8B model
-# (20k TPM). The 8B assignment is a throughput tradeoff, not an ideal choice.
-# If you have a paid Groq plan or reduce ATLAS_MAX_ANALYSTS, upgrade to
-# llama-3.3-70b-versatile for better thesis quality.
+# extraction  — structured JSON from short inputs; needs speed + schema compliance.
+# research    — multi-factor analysis, analytical prose, 32k+ context.
+# reasoning   — high-stakes synthesis reconciling 20+ signals; use best model.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Per-phase model overrides.
-# Key = segment_slug (exact) or prefix ending in "-" (prefix match for fan-out).
-# Values: provider/model_id. Unlisted phases fall back to default_model below.
 phase_models:
-  # Phase 1 — alt-data extraction (4 parallel segments, ~500 tokens each)
-  # [tier: extraction] — sentiment scores, CTA signals, options flow numbers
-  alt-sentiment-news: "gemini/gemini-2.5-flash"
-  alt-cta-positioning: "gemini/gemini-2.5-flash"
+
+  # ── Phase 1 — Alt-data extraction ──────────────────────────────────────────
+  # [tier: extraction] ~500 tokens each, 4 parallel segments.
+  alt-sentiment-news:      "gemini/gemini-2.5-flash"
+  alt-cta-positioning:     "gemini/gemini-2.5-flash"
   alt-options-derivatives: "gemini/gemini-2.5-flash"
-  alt-politician-signals: "gemini/gemini-2.5-flash"
+  alt-politician-signals:  "gemini/gemini-2.5-flash"
 
-  # Phase 2 — institutional flow extraction (2 segments, ~800 tokens each)
-  # [tier: extraction] — 13F signals, institutional order-flow tables
+  # ── Phase 2 — Institutional flow extraction ────────────────────────────────
+  # [tier: extraction] ~800 tokens each, 2 segments.
   inst-institutional-flows: "gemini/gemini-2.5-flash"
-  inst-hedge-fund-intel: "gemini/gemini-2.5-flash"
+  inst-hedge-fund-intel:    "gemini/gemini-2.5-flash"
 
-  # Phase 7C — per-ticker analyst fan-out (prefix match: analyst-AAPL, …)
+  # ── Phase 3 — Macro regime ─────────────────────────────────────────────────
+  # [tier: research] Single call; reads macro indicators + prior regime.
+  macro: "gemini/gemini-2.5-flash"
+
+  # ── Phase 4 — Asset classes ────────────────────────────────────────────────
+  # [tier: research] 5 parallel segments; cross-asset conviction calls.
+  bonds:         "gemini/gemini-2.5-flash"
+  commodities:   "gemini/gemini-2.5-flash"
+  forex:         "gemini/gemini-2.5-flash"
+  crypto:        "gemini/gemini-2.5-flash"
+  international: "gemini/gemini-2.5-flash"
+
+  # ── Phase 5 — US equities ──────────────────────────────────────────────────
+  # [tier: research] Top-down + 11-sector swarm (prefix match covers all sectors).
+  equity:    "gemini/gemini-2.5-flash"
+  "sector-": "gemini/gemini-2.5-flash"
+
+  # ── Phase 7C — Per-ticker analyst fan-out ──────────────────────────────────
   # [tier: extraction — throughput-constrained]
-  # ATLAS_MAX_ANALYSTS=25 in CI; ~35k tokens at 10 RPM ≈ 3 min (with backoff).
+  # 25 tickers × 4 axes = up to 100 parallel calls at ~1.4k tokens each.
+  # Gemini Flash 10 RPM ≈ 3 min with backoff (set ATLAS_MAX_ANALYSTS=25 in CI).
   "analyst-": "gemini/gemini-2.5-flash"
 
-  # Phase 7 — master digest synthesis (~8k tokens in, reads all phase 1–6 outputs)
-  # [tier: reasoning] — THE highest-stakes call; reconciles 20+ signals into
-  # a coherent, actionable daily snapshot. Use the best available model.
-  master-digest: "ollama-cloud/deepseek-v3.1:671b"
+  # ── Phase 7C-D — Bull / Bear adversarial debate ────────────────────────────
+  # [tier: research] N rounds × 3 nodes per ticker; prefix matches all tickers.
+  "bull-researcher-":  "gemini/gemini-2.5-flash"
+  "bear-researcher-":  "gemini/gemini-2.5-flash"
+  "research-manager-": "gemini/gemini-2.5-flash"
 
-  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier).
-  monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
+  # ── Phase 7D — Risk temperament debate ────────────────────────────────────
+  # [tier: research] Two nodes frame the risk envelope for the PM decision.
+  risk-aggressive:  "gemini/gemini-2.5-flash"
+  risk-conservative: "gemini/gemini-2.5-flash"
 
-  # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
-  # [tier: reasoning] — Portfolio allocation decision with real investment stakes.
+  # ── Phase 7D — PM rebalance ────────────────────────────────────────────────
+  # [tier: reasoning] ~12k token input; final portfolio allocation decision.
   pm-rebalance: "ollama-cloud/deepseek-v3.1:671b"
 
-  # Phase 9 — pipeline evolution / post-mortem (~4k tokens in)
-  # [tier: research] — Evaluates prior-day prediction quality, proposes
-  # pipeline improvements. Important but not a live investment decision.
+  # ── Phase 7 — Master digest synthesis ─────────────────────────────────────
+  # [tier: reasoning] ~8k token input; reconciles all phase 1–6 outputs.
+  master-digest: "ollama-cloud/deepseek-v3.1:671b"
+
+  # ── Phase monthly — Month-end rollup ───────────────────────────────────────
+  # [tier: reasoning] Same stakes as master-digest; cross-month regime shift.
+  monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
+
+  # ── Phase 9 — Closed-loop evolution ───────────────────────────────────────
+  # [tier: research] Evaluates prior-day prediction quality; proposes pipeline
+  # improvements. Important but not a live investment decision.
   phase9-evolution: "gemini/gemini-2.5-flash"
 
-  # Phases 3 (macro), 4 (asset classes), 5 (equity + sectors)
-  # [tier: research] — Fall through to default_model below.
-
-# Default model for phases without a phase_models entry (phases 3–5, debate
-# rounds, risk debaters, decision reflector). Set this to whatever provider
-# you have configured. GEMINI_API_KEY must be set for gemini/ models;
-# OPENAI_API_KEY + OPENAI_API_BASE for ollama-cloud/ models.
-default_model: "gemini/gemini-2.5-flash"
-
-# ── UPGRADE PATHS ─────────────────────────────────────────────────────────────
-# To change a specific phase, update its entry in phase_models above.
-# To change all research-tier phases (3–5 + debate), update default_model.
-# To use a different base URL or provider, update _EXTERNAL_PROVIDERS in
-# digigraph/src/digigraph/llm.py and add the corresponding API key env var.
-#
-#   extraction  → Claude Haiku 4.5, GPT-4o-mini, llama-3.3-70b (Groq paid)
-#   research    → Claude Sonnet 4.6, GPT-4o, Gemini 2.5 Pro (paid)
-#   reasoning   → Claude Opus 4.7 + extended_thinking, GPT-o1/o3, DeepSeek R1
-# ─────────────────────────────────────────────────────────────────────────────
+  # ── Decision reflector ─────────────────────────────────────────────────────
+  # [tier: research] Post-trade reflection; feeds back into next run's priors.
+  decision-reflector: "gemini/gemini-2.5-flash"

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -53,8 +53,12 @@ phase_models:
   # ── Phase 7C — Per-ticker analyst fan-out ──────────────────────────────────
   # [tier: extraction — throughput-constrained]
   # 25 tickers × 4 axes = up to 100 parallel calls at ~1.4k tokens each.
+  # Slugs: {axis}-analyst-{ticker} — prefix matches each axis independently.
   # Gemini Flash 10 RPM ≈ 3 min with backoff (set ATLAS_MAX_ANALYSTS=25 in CI).
-  "analyst-": "gemini/gemini-2.5-flash"
+  "technical-analyst-":   "gemini/gemini-2.5-flash"
+  "sentiment-analyst-":   "gemini/gemini-2.5-flash"
+  "news-analyst-":        "gemini/gemini-2.5-flash"
+  "fundamental-analyst-": "gemini/gemini-2.5-flash"
 
   # ── Phase 7C-D — Bull / Bear adversarial debate ────────────────────────────
   # [tier: research] N rounds × 3 nodes per ticker; prefix matches all tickers.

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -1,44 +1,27 @@
 # Atlas pipeline — model selection configuration.
-# Updated 2026-04-26.
 #
 # ── CAPABILITY TIERS ──────────────────────────────────────────────────────────
 # Every phase is tagged [tier: <extraction|research|reasoning>]. Use these tags
-# when substituting paid models or configuring a custom provider stack — match
-# model strength to the tier requirement, not just cost.
+# when substituting models — match model strength to the tier requirement.
 #
 # extraction
-#   Task:    Structured JSON parsing from short, well-defined inputs. Pulls
-#            specific fields (scores, tickers, numeric signals) from pre-fetched
-#            market text. No multi-step inference required.
+#   Task:    Structured JSON parsing from short, well-defined inputs.
 #   Needs:   Schema compliance, speed, concurrency tolerance.
-#   Free:    Gemini 2.5 Flash (250k TPM, 10 RPM; 41k tokens/run fits easily).
-#            Note: Groq free tier TPM reduced to 6k in 2026 — too low for 41k.
-#   Paid:    Claude Haiku 4.5, GPT-4o-mini, Gemma 2 9B, any fast/cheap model.
+#   Default: Gemini 2.5 Flash (250k TPM, 10 RPM).
+#   Upgrade: Claude Haiku 4.5, GPT-4o-mini, any fast/cheap model.
 #
 # research
-#   Task:    Multi-factor financial analysis over moderate context. Macro regime
-#            reads, sector deep-dives, asset-class conviction calls. Requires
-#            coherent analytical prose and domain knowledge.
+#   Task:    Multi-factor financial analysis over moderate context.
 #   Needs:   Financial reasoning, multi-paragraph output quality, 32k+ context.
-#   Free:    Gemini 2.5 Flash (1M TPM, 1M ctx, strong analytical capability).
-#   Paid:    Claude Sonnet 4.6, GPT-4o, Gemini 1.5/2.0 Pro.
+#   Default: Gemini 2.5 Flash (1M TPM, 1M ctx, strong analytical capability).
+#   Upgrade: Claude Sonnet 4.6, GPT-4o, Gemini 1.5/2.0 Pro.
 #
 # reasoning
-#   Task:    High-stakes synthesis and portfolio decision-making. The model must
-#            reconcile 20+ upstream signals, resolve contradictions, rank
-#            priorities, and produce actionable output that drives real investment
-#            decisions. This is where quality differences between models are
-#            most visible in production.
-#   Needs:   Cross-domain synthesis, internal consistency, financial judgment,
-#            extended reasoning / thinking mode where available.
-#   Free:    Ollama Cloud deepseek-v3.1:671b (671B, confirmed free Apr 2026; uses
-#            OPENAI_API_KEY credential).
-#            Note: kimi-k2-thinking moved behind Ollama subscription paywall (Apr 2026).
-#            Note: Gemini 2.5 Pro moved to paid-only in Dec 2025.
-#            Note: Groq reasoning models cap at 6k TPM — too low for 10k+ token calls.
-#            Note: deepseek-v4-flash, kimi-k2.5/k2.6, glm-5/5.1 require subscription.
-#   Paid:    Claude Opus 4.7 (with extended thinking), GPT-o1/o3, DeepSeek R1,
-#            Gemini 2.5 Pro (paid tier), any thinking/reasoning-class model.
+#   Task:    High-stakes synthesis and portfolio decision-making.
+#   Needs:   Cross-domain synthesis, internal consistency, financial judgment.
+#   Default: Ollama Cloud deepseek-v3.1:671b (671B, confirmed free Apr 2026).
+#   Upgrade: Claude Opus 4.7 + extended_thinking, GPT-o1/o3, DeepSeek R1,
+#            Gemini 2.5 Pro (paid tier).
 #
 # ── NOTE ON PHASE 7C ──────────────────────────────────────────────────────────
 # Phase 7C (analyst fan-out) ideally belongs in the research tier — writing a
@@ -52,115 +35,58 @@
 
 # Per-phase model overrides.
 # Key = segment_slug (exact) or prefix ending in "-" (prefix match for fan-out).
-# Values: provider/model_id. Unlisted phases fall back to defaults[DIGI_LLM_MODE].
+# Values: provider/model_id. Unlisted phases fall back to default_model below.
 phase_models:
   # Phase 1 — alt-data extraction (4 parallel segments, ~500 tokens each)
-  # llm-decision: extraction free-preferred throughput-constrained
   # [tier: extraction] — sentiment scores, CTA signals, options flow numbers
-  # Groq free tier reduced to 6k TPM in 2026 — too low for 41k tokens/run.
-  # Gemini Flash (250k TPM, 10 RPM) handles extraction at slightly lower throughput.
   alt-sentiment-news: "gemini/gemini-2.5-flash"
   alt-cta-positioning: "gemini/gemini-2.5-flash"
   alt-options-derivatives: "gemini/gemini-2.5-flash"
   alt-politician-signals: "gemini/gemini-2.5-flash"
 
   # Phase 2 — institutional flow extraction (2 segments, ~800 tokens each)
-  # llm-decision: extraction free-preferred throughput-constrained
   # [tier: extraction] — 13F signals, institutional order-flow tables
   inst-institutional-flows: "gemini/gemini-2.5-flash"
   inst-hedge-fund-intel: "gemini/gemini-2.5-flash"
 
   # Phase 7C — per-ticker analyst fan-out (prefix match: analyst-AAPL, …)
-  # llm-decision: extraction free-preferred throughput-constrained
   # [tier: extraction — throughput-constrained]
   # ATLAS_MAX_ANALYSTS=25 in CI; ~35k tokens at 10 RPM ≈ 3 min (with backoff).
   "analyst-": "gemini/gemini-2.5-flash"
 
   # Phase 7 — master digest synthesis (~8k tokens in, reads all phase 1–6 outputs)
-  # llm-decision: reasoning free-preferred
   # [tier: reasoning] — THE highest-stakes call; reconciles 20+ signals into
   # a coherent, actionable daily snapshot. Use the best available model.
-  # Gemini 2.5 Pro requires a paid key (moved behind paywall Dec 2025).
-  # deepseek-v4-flash requires an Ollama subscription (403, Apr 2026).
-  # kimi-k2-thinking moved behind Ollama subscription paywall (403, Apr 2026).
-  # deepseek-v3.1:671b: 671B, strong reasoning + coding, confirmed free tier.
   master-digest: "ollama-cloud/deepseek-v3.1:671b"
 
-  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier as
-  # master-digest). Without an explicit entry this falls back to get_model_for_mode()
-  # which tries the best list in order; kimi-k2-thinking is first and is now behind
-  # a subscription paywall (403, Apr 2026). Pin to the same free-tier model.
+  # Monthly synthesis — month-end rollup (~8k tokens; same reasoning tier).
   monthly-digest: "ollama-cloud/deepseek-v3.1:671b"
 
   # Phase 7D — PM rebalance decision (~12k tokens in, reads all analyst payloads)
-  # llm-decision: reasoning free-preferred
   # [tier: reasoning] — Portfolio allocation decision with real investment stakes.
   pm-rebalance: "ollama-cloud/deepseek-v3.1:671b"
 
   # Phase 9 — pipeline evolution / post-mortem (~4k tokens in)
-  # llm-decision: research free-preferred
   # [tier: research] — Evaluates prior-day prediction quality, proposes
   # pipeline improvements. Important but not a live investment decision.
   phase9-evolution: "gemini/gemini-2.5-flash"
 
   # Phases 3 (macro), 4 (asset classes), 5 (equity + sectors)
-  # [tier: research] — Fall through to defaults[DIGI_LLM_MODE]; Gemini Flash
-  # for medium/best modes. No entry needed here.
+  # [tier: research] — Fall through to default_model below.
 
-# Default model per DIGI_LLM_MODE (applies to phases without a phase_models entry).
-# llm-decision: research free-preferred
-# Gemini Flash: best free throughput for phases 3-5 (macro, asset class, equity research tier)
-# test:   local dev / smoke tests only — Ollama Cloud free tier.
-# medium: delta CI runs — Gemini Flash (research tier, no Ollama session-limit risk).
-# best:   baseline/monthly CI runs — Gemini Flash (research tier; reasoning phases
-#         use explicit phase_models entries above to get Gemini Pro).
-defaults:
-  test: ollama-cloud/rnj-1:cloud
-  medium: gemini/gemini-2.5-flash
-  best: gemini/gemini-2.5-flash
+# Default model for phases without a phase_models entry (phases 3–5, debate
+# rounds, risk debaters, decision reflector). Set this to whatever provider
+# you have configured. GEMINI_API_KEY must be set for gemini/ models;
+# OPENAI_API_KEY + OPENAI_API_BASE for ollama-cloud/ models.
+default_model: "gemini/gemini-2.5-flash"
 
-# ── PAID / CUSTOM PROVIDER UPGRADE PATHS ─────────────────────────────────────
-# To upgrade individual tiers, replace values in phase_models above:
-#
-#   extraction  → llama-3.3-70b-versatile (Groq paid), Claude Haiku 4.5
-#   research    → Claude Sonnet 4.6, GPT-4o, Gemini 2.5 Pro (paid)
-#   reasoning   → Claude Opus 4.7 + extended_thinking, GPT-o1/o3, DeepSeek R1
-#
-# To upgrade defaults (phases 3–5), change defaults.medium / defaults.best above.
+# ── UPGRADE PATHS ─────────────────────────────────────────────────────────────
+# To change a specific phase, update its entry in phase_models above.
+# To change all research-tier phases (3–5 + debate), update default_model.
 # To use a different base URL or provider, update _EXTERNAL_PROVIDERS in
 # digigraph/src/digigraph/llm.py and add the corresponding API key env var.
+#
+#   extraction  → Claude Haiku 4.5, GPT-4o-mini, llama-3.3-70b (Groq paid)
+#   research    → Claude Sonnet 4.6, GPT-4o, Gemini 2.5 Pro (paid)
+#   reasoning   → Claude Opus 4.7 + extended_thinking, GPT-o1/o3, DeepSeek R1
 # ─────────────────────────────────────────────────────────────────────────────
-
-# ── OLLAMA CLOUD MODEL CATALOG (reference for test-mode / local dev) ──────────
-
-# Smallest/fastest — smoke tests and local iteration.
-test:
-  - ollama-cloud/rnj-1:cloud              # 8B, fast, code + STEM, agentic
-  - ollama-cloud/ministral-3:cloud        # 3B, edge, vision, function calling
-
-# Balanced quality/speed.
-medium:
-  - ollama-cloud/qwen3-next:80b-cloud         # 80B MoE, hybrid GatedDeltaNet+Attention, 256K ctx
-  - ollama-cloud/minimax-m2.7:cloud           # SWE-Pro 56%, professional productivity, 200K ctx
-  - ollama-cloud/glm-4.7:cloud                # SWE-bench 73.8%, UI gen, coding + math
-  - ollama-cloud/qwen3-coder-next:cloud       # 80B MoE (3B active), efficient coding + agentic
-  - ollama-cloud/devstral-small-2:24b-cloud   # 24B, SWE-Bench 65.8%, Apache 2.0, Mistral
-  - ollama-cloud/nemotron-3-nano:30b-cloud    # 30B MoE+Mamba-2, 1M ctx, NVIDIA, reasoning toggle
-  - ollama-cloud/gemma4:31b-cloud             # 31B, Google, multimodal vision+audio, 256K ctx
-  - ollama-cloud/qwen3.5:cloud                # 397B MoE, 201 languages, 256K ctx (fallback)
-
-# Best/largest — full research runs, baseline, monthly synthesis.
-# (⚠ models marked [sub] require Ollama subscription as of Apr 2026)
-best:
-  - ollama-cloud/kimi-k2-thinking             # [sub] dedicated CoT/thinking model — moved to subscription Apr 2026
-  - ollama-cloud/deepseek-v3.1:671b           # 671B, strong reasoning + coding, confirmed free — REASONING TIER DEFAULT
-  - ollama-cloud/cogito-2.1:671b              # 671B, reasoning-focused, confirmed free
-  - ollama-cloud/nemotron-3-super             # 120B MoE (12B active), NVIDIA, 256K–1M ctx, confirmed free
-  - ollama-cloud/mistral-large-3:675b         # 675B Mistral, confirmed free
-  - ollama-cloud/qwen3-coder:480b             # 480B coding, confirmed free
-  - ollama-cloud/qwen3.5:397b                 # 397B MoE, 256K ctx, confirmed free (alias: qwen3.5:cloud)
-  - ollama-cloud/devstral-2:123b              # 123B, SWE-bench 72.2%, Mistral [sub]
-  - ollama-cloud/deepseek-v4-flash            # 284B MoE, 1M ctx [sub]
-  - ollama-cloud/deepseek-v4-pro              # [sub]
-  - ollama-cloud/glm-5.1                      # 744B MoE [sub]
-  - ollama-cloud/kimi-k2.6                    # [sub]

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -215,15 +215,20 @@ def _load_model_modes() -> dict[str, Any]:
 
 
 def get_model_for_mode() -> str:
-    """
-    Return the model id for the current DIGI_LLM_MODE (test|medium|best).
+    """Return the default model for phases without an explicit phase_models entry.
 
-    Values in ``model_modes*.yaml`` are usually **LiteLLM** ids (e.g. ``ollama/qwen3:8b``).
-    When ``OPENAI_API_BASE`` points at **Ollama's native OpenAI shim** (port 11434), use
-    :func:`resolve_effective_model` so ``ollama/`` is stripped (Ollama expects ``qwen3:8b``).
+    Resolution order:
+    1. ``default_model`` key in model_modes.yaml — the explicit config-driven default.
+    2. ``defaults[DIGI_LLM_MODE]`` — legacy fallback kept for non-Atlas digigraph agents
+       that still use the mode system (project_config, runner agents, etc.).
+    3. ``"gpt-4o-mini"`` — last-resort hard default.
     """
-    mode = _get_llm_mode()
     data = _load_model_modes()
+    model = data.get("default_model")
+    if model:
+        return str(model)
+    # Legacy path: mode-keyed defaults for digigraph agent runners.
+    mode = _get_llm_mode()
     defaults = data.get("defaults") or {}
     model = defaults.get(mode) or defaults.get("test")
     if model:

--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -215,19 +215,19 @@ def _load_model_modes() -> dict[str, Any]:
 
 
 def get_model_for_mode() -> str:
-    """Return the default model for phases without an explicit phase_models entry.
+    """Return the fallback model for phases without a phase_models entry.
 
-    Resolution order:
-    1. ``default_model`` key in model_modes.yaml — the explicit config-driven default.
-    2. ``defaults[DIGI_LLM_MODE]`` — legacy fallback kept for non-Atlas digigraph agents
-       that still use the mode system (project_config, runner agents, etc.).
-    3. ``"gpt-4o-mini"`` — last-resort hard default.
+    Atlas/Hermes phases all have explicit phase_models entries, so this is
+    reached only by non-Atlas digigraph agent runners that don't supply a
+    phase_slug. Resolution order:
+    1. ``default_model`` in model_modes.yaml — optional explicit fallback.
+    2. ``defaults[DIGI_LLM_MODE]`` — legacy mode-keyed fallback.
+    3. ``"gpt-4o-mini"`` — hard last resort.
     """
     data = _load_model_modes()
     model = data.get("default_model")
     if model:
         return str(model)
-    # Legacy path: mode-keyed defaults for digigraph agent runners.
     mode = _get_llm_mode()
     defaults = data.get("defaults") or {}
     model = defaults.get(mode) or defaults.get("test")

--- a/scripts/validate_model_routing.py
+++ b/scripts/validate_model_routing.py
@@ -57,7 +57,7 @@ def get_model_for_mode() -> str:
 # All slugs that Atlas/Hermes phases pass to run_research_agent(phase_slug=…).
 # Dynamic ones (per-ticker) are represented with a concrete example.
 
-_EXPLICIT_SLUGS: list[tuple[str, str]] = [
+ALL_SLUGS: list[tuple[str, str]] = [
     # Phase 1 — alt-data extraction
     ("alt-sentiment-news",       "Phase 1A — sentiment/news"),
     ("alt-cta-positioning",      "Phase 1B — CTA positioning"),
@@ -66,17 +66,15 @@ _EXPLICIT_SLUGS: list[tuple[str, str]] = [
     # Phase 2 — institutional flows
     ("inst-institutional-flows", "Phase 2A — ETF flows / 13D-G"),
     ("inst-hedge-fund-intel",    "Phase 2B — 13F / fund signals"),
-]
-
-# Phase 3-4 fall to defaults (no phase_models entry)
-_DEFAULT_TIER_SLUGS: list[tuple[str, str]] = [
+    # Phase 3 — macro
     ("macro",                    "Phase 3 — macro regime"),
+    # Phase 4 — asset classes
     ("bonds",                    "Phase 4A — fixed income"),
     ("commodities",              "Phase 4B — commodities"),
     ("forex",                    "Phase 4C — FX"),
     ("crypto",                   "Phase 4D — crypto"),
     ("international",            "Phase 4E — international"),
-    # Phase 5
+    # Phase 5 — equities
     ("equity",                   "Phase 5A — equity top-down"),
     ("sector-technology",        "Phase 5B — technology"),
     ("sector-healthcare",        "Phase 5C — healthcare"),
@@ -89,18 +87,18 @@ _DEFAULT_TIER_SLUGS: list[tuple[str, str]] = [
     ("sector-materials",         "Phase 5J — materials"),
     ("sector-real-estate",       "Phase 5K — real estate"),
     ("sector-comms",             "Phase 5L — communications"),
-    # Phase 7C analyst fan-out (prefix match: analyst-)
+    # Phase 7C — analyst fan-out (prefix: analyst-)
     ("analyst-AAPL",             "Phase 7C — analyst (example ticker)"),
-    # Phase 7CD debate nodes (per-ticker, fall to defaults)
+    # Phase 7CD — bull/bear debate (prefix per role)
     ("bull-researcher-AAPL",     "Phase 7CD — bull researcher"),
     ("bear-researcher-AAPL",     "Phase 7CD — bear researcher"),
     ("research-manager-AAPL",    "Phase 7CD — debate manager"),
-    # Phase 7D risk debate (fall to defaults)
+    # Phase 7D — risk debate
     ("risk-aggressive",          "Phase 7D — risk aggressive"),
     ("risk-conservative",        "Phase 7D — risk conservative"),
-    # Phase 7D PM — explicit pin
+    # Phase 7D — PM rebalance
     ("pm-rebalance",             "Phase 7D — PM rebalance"),
-    # Phase 7 synthesis — explicit pin
+    # Phase 7 — master digest synthesis
     ("master-digest",            "Phase 7 — master digest synthesis"),
     # Phase monthly — explicit pin
     ("monthly-digest",           "Phase monthly — month-end rollup"),

--- a/scripts/validate_model_routing.py
+++ b/scripts/validate_model_routing.py
@@ -48,8 +48,11 @@ def get_model_for_phase(slug: str) -> str | None:
 
 
 def get_model_for_mode() -> str:
-    mode = os.environ.get("DIGI_LLM_MODE", "test").lower().strip()
     data = _load_model_modes()
+    model = data.get("default_model")
+    if model:
+        return str(model)
+    mode = os.environ.get("DIGI_LLM_MODE", "test").lower().strip()
     defaults = data.get("defaults") or {}
     return defaults.get(mode) or defaults.get("test") or "gpt-4o-mini"
 
@@ -87,8 +90,11 @@ ALL_SLUGS: list[tuple[str, str]] = [
     ("sector-materials",         "Phase 5J — materials"),
     ("sector-real-estate",       "Phase 5K — real estate"),
     ("sector-comms",             "Phase 5L — communications"),
-    # Phase 7C — analyst fan-out (prefix: analyst-)
-    ("analyst-AAPL",             "Phase 7C — analyst (example ticker)"),
+    # Phase 7C — 4-axis analyst fan-out (prefix per axis)
+    ("technical-analyst-AAPL",   "Phase 7C — technical analyst (example ticker)"),
+    ("sentiment-analyst-AAPL",   "Phase 7C — sentiment analyst (example ticker)"),
+    ("news-analyst-AAPL",        "Phase 7C — news analyst (example ticker)"),
+    ("fundamental-analyst-AAPL", "Phase 7C — fundamental analyst (example ticker)"),
     # Phase 7CD — bull/bear debate (prefix per role)
     ("bull-researcher-AAPL",     "Phase 7CD — bull researcher"),
     ("bear-researcher-AAPL",     "Phase 7CD — bear researcher"),
@@ -107,9 +113,6 @@ ALL_SLUGS: list[tuple[str, str]] = [
     # Decision reflector (fall to defaults)
     ("decision-reflector",       "Decision reflector"),
 ]
-
-ALL_SLUGS = _EXPLICIT_SLUGS + _DEFAULT_TIER_SLUGS
-
 
 def _resolve(slug: str) -> str:
     return get_model_for_phase(slug) or get_model_for_mode()


### PR DESCRIPTION
## Summary

- **`config/model_modes.yaml`**: Complete rewrite with an explicit `phase_models` entry for every Atlas/Hermes phase (26+ slugs/prefixes). Removes the `default_model` catch-all and the `defaults.{test,medium,best}` tier system. Each phase is now independently tunable — change the model string for one phase without affecting any other.
- **`digigraph/src/digigraph/llm.py`**: Updated `get_model_for_mode()` docstring to reflect that all Atlas/Hermes phases are now explicit; legacy fallback path preserved for non-Atlas digigraph agent runners.
- **`scripts/validate_model_routing.py`**: Merged `_EXPLICIT_SLUGS` + `_DEFAULT_TIER_SLUGS` into a single `ALL_SLUGS` list, since the distinction between explicit and default-resolved phases no longer exists.

Also includes earlier commits on this branch:
- `fix(digigraph)`: `max_tokens=4096` default in `run_research_agent()` to prevent Gemini Flash JSON truncation
- `fix(digiquant)`: wire `phase_slug='monthly-digest'` in `_monthly_node()` so the model pin is honoured
- `refactor(config)`: replace `DIGI_LLM_MODE` tier system with explicit `default_model`
- `chore(scripts)`: add `validate_model_routing.py` — routing table + provider ping

## Test plan

- [ ] Run `python scripts/validate_model_routing.py --routing` and confirm every phase resolves to its expected model
- [ ] Run `make test-unit` — no regressions in digigraph/digiquant unit tests
- [ ] Verify `GEMINI_API_KEY` + `OPENAI_API_KEY` connectivity with `python scripts/validate_model_routing.py --ping`

Closes #539

https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaBh1HB4HWT16HKJ9h4fHK)_