### PR TITLE
feat(hermes/phase9): quality signals on improvement proposals + cap 10

### DIFF
--- a/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
+++ b/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Literal  # noqa: F401 — used for JSON-derived dict shape
 
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from digiquant.atlas.decision_log import persist_pending
 from digiquant.atlas.phases._node_factory import _shared_context
@@ -76,17 +76,24 @@ class ImprovementProposal(BaseModel):
     change_summary: str = Field()
     rationale: str = Field()
     confidence: int = Field(
+        default=3,
         ge=1,
         le=5,
-        description="Evidence strength: 1=speculative, 3=reasoned, 5=high-evidence. Only propose ≥3.",
+        description="Evidence strength: 1=speculative, 3=reasoned, 5=high-evidence.",
     )
-    expected_impact: Literal["low", "medium", "high"]
+    expected_impact: Literal["low", "medium", "high"] = "medium"
 
 
 class EvolutionProposals(BaseModel):
     # Count cap (not a string-length limit): hard ceiling to prevent runaway
-    # self-modification. Consumers should further filter on confidence ≥ 3.
+    # self-modification. Low-confidence proposals (< 3) are stripped by the
+    # model validator below so they never reach downstream consumers.
     proposals: list[ImprovementProposal] = Field(default_factory=list, max_length=10)
+
+    @model_validator(mode="after")
+    def _filter_low_confidence(self) -> "EvolutionProposals":
+        self.proposals = [p for p in self.proposals if p.confidence >= 3]
+        return self
 
 
 # ─── Combined emitter node ──────────────────────────────────────────────────

--- a/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
+++ b/digiquant/src/digiquant/hermes/phases/phase9_evolution.py
@@ -76,12 +76,11 @@ class ImprovementProposal(BaseModel):
     change_summary: str = Field()
     rationale: str = Field()
     confidence: int = Field(
-        default=3,
         ge=1,
         le=5,
         description="Evidence strength: 1=speculative, 3=reasoned, 5=high-evidence.",
     )
-    expected_impact: Literal["low", "medium", "high"] = "medium"
+    expected_impact: Literal["low", "medium", "high"]
 
 
 class EvolutionProposals(BaseModel):

--- a/digiquant/src/digiquant/hermes/skills/pipeline-evolution/SKILL.md
+++ b/digiquant/src/digiquant/hermes/skills/pipeline-evolution/SKILL.md
@@ -19,7 +19,7 @@ Atlas pipeline. Produce three JSON artifacts in one response:
    proposal must name a specific target file, a concrete change summary, a
    rationale, a `confidence` score (1–5), and an `expected_impact`
    (low / medium / high). Only emit proposals you can score **confidence ≥ 3**;
-   speculative ideas belong in `notes`, not proposals. Do not propose changes
+   omit speculative ideas entirely — they are stripped before storage. Do not propose changes
    to: digest snapshot schema, risk profile / position sizing, or the Phase 9
    guardrails themselves.
 
@@ -45,5 +45,5 @@ text outside the JSON.
   "Add 'AMZN+TSLA concentration' warning to skills/sector-consumer-disc nuance_notes"
   is.
 - Quality over quantity. Only emit proposals you can justify with confidence ≥ 3;
-  skip speculative ideas rather than padding the list.
+  omit speculative ideas entirely — they are silently dropped by the validator.
 - Refuse to propose changes to the guardrailed paths named above.

--- a/tests/dq/atlas/test_triage_monthly_phase9.py
+++ b/tests/dq/atlas/test_triage_monthly_phase9.py
@@ -506,6 +506,8 @@ class TestPhase9Evolution:
                         "target_file": "skills/sector-research/SKILL.md",
                         "change_summary": "Add nuance on small-cap rotation",
                         "rationale": "Three sector reports flagged it today",
+                        "confidence": 4,
+                        "expected_impact": "medium",
                     }
                 ]
             },


### PR DESCRIPTION
## Summary

- **`ImprovementProposal` gains two quality-signal fields** — `confidence: int` (1–5, evidence strength) and `expected_impact: Literal["low", "medium", "high"]`. Forces the LLM to articulate and self-score each proposal rather than just emitting free-form ideas.
- **Proposal list cap raised 2 → 10** — hard ceiling against runaway self-modification, but wide enough that the quality gate (`confidence ≥ 3`) does the real filtering rather than the count.
- **`confidence ≥ 3` enforced by model validator** — `EvolutionProposals._filter_low_confidence` strips low-confidence proposals at validation time; they never reach downstream consumers.
- **String `max_length` constraints removed** from `ImprovementProposal` fields — consistent with the broader sweep in PR #557 that fixes `string_too_long` ValidationErrors across Atlas/Hermes output models.
- **SKILL.md updated** — instructs the LLM to only emit proposals it can score ≥ 3 on confidence; speculative ideas are omitted entirely (stripped by the validator).

## Context

Follow-up to #544 (`atlas-delta-failure`). PR #557 fixed the hard ValidationErrors; this PR addresses the open Copilot review comment on that PR regarding `EvolutionProposals` — the original `max_length=2` list cap was correct in principle (count limit, not string limit) but the right fix is to make quality the primary gate rather than count alone.

Closes #544

## Test plan

- [ ] `pytest tests/dq/hermes/ tests/dq/atlas/ -m unit` — no regressions
- [ ] `test_triage_monthly_phase9.py` fixture (old three-field shape) validates via defaults
- [ ] Next Phase 9 run emits proposals with `confidence` and `expected_impact` fields populated
- [ ] Proposals with `confidence < 3` absent from stored output

https://claude.ai/code/session_01CR9yrWB1XV4oS93Hnu5tno