### PR TITLE
fix(prices): trim both sides on row mismatch, exc_info, regression tests

### DIFF
--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -128,7 +128,7 @@ def fetch_quotes_cmd(
                 res = upsert_price_history(client, all_rows)
                 total = res.rows
             except Exception as exc:  # noqa: BLE001
-                _logger.warning("price_history upsert failed (non-fatal): %s", exc)
+                _logger.warning("price_history upsert failed (non-fatal): %s", exc, exc_info=True)
                 click.echo(f"  warning: upsert skipped — {exc}", err=True)
         click.echo(f"  upserted {total} rows into price_history")
 
@@ -234,14 +234,19 @@ def compute_technicals_cmd(
             ts_series = df["timestamp"].tail(days)
         else:
             if ind.height != df.height:
-                # compute_indicators may drop warm-up rows; align timestamps to the tail.
+                # Defensive guard: compute_indicators preserves input length (NaN for
+                # warm-up windows), but an upstream filter or future implementation change
+                # could produce a different row count — align both sides to avoid a mismatch.
+                n = min(ind.height, df.height)
                 _logger.warning(
-                    "compute_indicators(%s) row count mismatch: ind=%d df=%d — trimming",
+                    "compute_indicators(%s) row count mismatch: ind=%d df=%d — trimming to %d",
                     ticker,
                     ind.height,
                     df.height,
+                    n,
                 )
-                ts_series = df["timestamp"].tail(ind.height)
+                ind = ind.tail(n)
+                ts_series = df["timestamp"].tail(n)
             else:
                 ts_series = df["timestamp"]
         rows = technicals_to_rows(ind, ticker, ts_series)
@@ -254,7 +259,7 @@ def compute_technicals_cmd(
             res = upsert_price_technicals(client, all_rows)
             total = res.rows
         except Exception as exc:  # noqa: BLE001
-            _logger.warning("price_technicals upsert failed (non-fatal): %s", exc)
+            _logger.warning("price_technicals upsert failed (non-fatal): %s", exc, exc_info=True)
             click.echo(f"  warning: upsert skipped — {exc}", err=True)
     if supabase and not dry_run:
         click.echo(f"  upserted {total} rows into price_technicals")

--- a/tests/dq/data/test_prices_cli.py
+++ b/tests/dq/data/test_prices_cli.py
@@ -1,0 +1,121 @@
+"""Regression tests for the `digiquant prices` CLI commands.
+
+Covers the graceful-exit behaviour introduced in #558: upsert failures must
+not propagate as a non-zero exit code, and the indicator row-count mismatch
+must be handled without raising.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+from click.testing import CliRunner
+
+from digiquant.cli.prices import compute_technicals_cmd, fetch_quotes_cmd
+from digiquant.data.prices import TECHNICAL_COLUMNS
+
+pytestmark = pytest.mark.unit
+
+# Lazy-import patch targets (the CLI uses `from X import Y` inside the function body).
+_WRITER = "digiquant.data.prices.supabase_writer"
+_CACHE = "digiquant.data.prices.history_cache"
+_TECH = "digiquant.data.prices.technicals"
+_VENUES = "digiquant.data.prices.ticker_venues"
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────
+
+
+def _fake_ohlcv(n: int = 30) -> pl.DataFrame:
+    dates = [date(2025, 1, 1) + timedelta(days=i) for i in range(n)]
+    return pl.DataFrame(
+        {
+            "timestamp": dates,
+            "open": [100.0] * n,
+            "high": [101.0] * n,
+            "low": [99.0] * n,
+            "close": [100.5] * n,
+            "volume": [1_000_000.0] * n,
+            "symbol": ["SPY"] * n,
+        }
+    )
+
+
+def _fake_ind(n: int) -> pl.DataFrame:
+    return pl.DataFrame({c: [1.0] * n for c in TECHNICAL_COLUMNS})
+
+
+# ─── fetch-quotes ─────────────────────────────────────────────────────────
+
+
+def test_fetch_quotes_dry_run_exits_zero(tmp_path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        fetch_quotes_cmd, ["--tickers", "SPY", "--dry-run", "--cache-dir", str(tmp_path)]
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_fetch_quotes_upsert_failure_exits_zero() -> None:
+    """A Supabase upsert error must not propagate as a non-zero exit code."""
+    runner = CliRunner()
+
+    with (
+        patch(f"{_WRITER}.build_supabase_client", return_value=object()),
+        patch(f"{_WRITER}.upsert_price_history", side_effect=RuntimeError("net failure")),
+        patch(f"{_CACHE}.incremental_update", return_value={"SPY": _fake_ohlcv(3)}),
+    ):
+        result = runner.invoke(fetch_quotes_cmd, ["--tickers", "SPY", "--supabase"])
+
+    assert result.exit_code == 0
+    combined = (result.output or "") + (result.stderr or "")
+    assert "warning" in combined.lower()
+
+
+# ─── compute-technicals ───────────────────────────────────────────────────
+
+
+def test_compute_technicals_upsert_failure_exits_zero(tmp_path) -> None:
+    """A Supabase upsert error in compute-technicals must not propagate."""
+    n = 30
+    runner = CliRunner()
+
+    with (
+        patch(f"{_WRITER}.build_supabase_client", return_value=object()),
+        patch(f"{_WRITER}.upsert_price_technicals", side_effect=RuntimeError("net failure")),
+        patch(f"{_CACHE}.load_cached", return_value=_fake_ohlcv(n)),
+        patch(f"{_TECH}.compute_indicators", return_value=_fake_ind(n)),
+        patch(f"{_VENUES}.venue_for", return_value=None),
+    ):
+        result = runner.invoke(
+            compute_technicals_cmd,
+            ["--tickers", "SPY", "--supabase", "--cache-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0
+    combined = (result.output or "") + (result.stderr or "")
+    assert "warning" in combined.lower()
+
+
+def test_compute_technicals_row_mismatch_trims_both_sides(tmp_path) -> None:
+    """When ind.height != df.height, both are trimmed to min length without raising."""
+    n_df, n_ind = 40, 33  # must exceed MIN_BARS (30); ind shorter simulates warm-up drops
+    runner = CliRunner()
+
+    with (
+        patch(f"{_WRITER}.build_supabase_client", return_value=None),
+        patch(f"{_CACHE}.load_cached", return_value=_fake_ohlcv(n_df)),
+        patch(f"{_TECH}.compute_indicators", return_value=_fake_ind(n_ind)),
+        patch(f"{_VENUES}.venue_for", return_value=None),
+    ):
+        result = runner.invoke(
+            compute_technicals_cmd,
+            ["--tickers", "SPY", "--cache-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0
+    # n_ind rows should be reported, not n_df
+    assert f"{n_ind:4d} indicator rows" in result.output


### PR DESCRIPTION
Follow-up to #558 addressing three Copilot review comments.

## Changes

- **Bug fix**: Row-mismatch branch in `compute_technicals_cmd` now trims *both* `ind` and `ts_series` to `min(ind.height, df.height)`. Previously only `ts_series` was trimmed, which would cause `technicals_to_rows` to raise if `ind.height > df.height`.
- **Diagnosability**: Added `exc_info=True` to both upsert warning log calls so stack traces appear in structured log sinks.
- **Tests**: New `tests/dq/data/test_prices_cli.py` with four unit tests covering: dry-run exits 0, upsert failure exits 0 for `fetch-quotes`, upsert failure exits 0 for `compute-technicals`, and row-mismatch trimming produces the correct indicator row count.

Closes #546

## Test plan

- [x] `pytest tests/dq/data/test_prices_cli.py -v` — 4 passed

https://claude.ai/code/session_01KzR9MqvtFifta8wTBHKiz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzR9MqvtFifta8wTBHKiz4)_