### PR TITLE
fix(ci): remove invalid --model flag and add --workspace to cursor dispatch

### DIFF
--- a/.github/workflows/cursor-agent-dispatch.yml
+++ b/.github/workflows/cursor-agent-dispatch.yml
@@ -191,6 +191,7 @@ jobs:
             exit 0
           fi
           cursor-agent --force \
+            --workspace "$GITHUB_WORKSPACE" \
             -p "You are working on the DigiThings repository ($REPO).
           Task: $ISSUE_TITLE
           Issue: $ISSUE_URL
@@ -205,8 +206,7 @@ jobs:
           - PR title: feat($COMPONENT): $ISSUE_TITLE (#$ISSUE_NUMBER)
           - PR body must contain: Closes #$ISSUE_NUMBER
           - Scope too large? Relabel exec:claude, comment why, stop.
-          Full protocol: docs/agents/CURSOR_AGENT_ONBOARDING.md" \
-            --model claude-sonnet-4-6
+          Full protocol: docs/agents/CURSOR_AGENT_ONBOARDING.md"
 
       - name: Post dispatch comment
         if: always() && steps.quota.outputs.exhausted != 'true'


### PR DESCRIPTION
## Summary

- Removes `--model claude-sonnet-4-6` from the `cursor-agent` CLI call — Cursor handles model routing internally and does not accept Anthropic API model IDs. This was causing the CLI to exit non-zero on every dispatch run.
- Adds `--workspace "$GITHUB_WORKSPACE"` so the agent correctly locates the checked-out repo root in the Actions runner.

## Root cause

Issue #568 (smoke test) triggered the dispatch workflow and posted "CLI dispatch failed — check Actions log". The failure was traced to the unknown `--model` flag causing `cursor-agent` to reject the invocation before doing any work. The CLI install step was succeeding; only the run step was failing.

## Test plan

- [ ] Re-apply `exec:cursor` label to #568 (or close and reopen) to re-trigger dispatch
- [ ] Confirm workflow run posts "CLI dispatched" instead of "CLI dispatch failed"
- [ ] Confirm Cursor agent opens a PR for #568

Refs #554. Fixes #568 symptom.

https://claude.ai/code/session_01WurSPfpaqJpuqNabQjZEgM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WurSPfpaqJpuqNabQjZEgM)_