### PR TITLE
docs(providers): refresh all 20 provider snapshots to 2026-06-04

### DIFF
--- a/docs/providers/snapshots/anthropic.yaml
+++ b/docs/providers/snapshots/anthropic.yaml
@@ -1,5 +1,5 @@
 provider: anthropic
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -25,32 +25,42 @@ paid_tier:
     - name: claude-haiku-4-5
       context_window: 200000
       max_input_tokens: 200000
-      max_output_tokens: 8192
+      max_output_tokens: 64000
       cost_per_1m_input: 1.00
       cost_per_1m_input_long: null
       cost_per_1m_output: 5.00
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.30
+      cost_per_1m_input_cached: 0.10   # 10% of input price
       status: active
     - name: claude-sonnet-4-6
-      context_window: 200000
-      max_input_tokens: 200000
+      context_window: 1000000
+      max_input_tokens: 1000000
       max_output_tokens: 64000
       cost_per_1m_input: 3.00
       cost_per_1m_input_long: null
       cost_per_1m_output: 15.00
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.30
+      cost_per_1m_input_cached: 0.30   # 10% of input price
       status: active
     - name: claude-opus-4-7
-      context_window: 200000
-      max_input_tokens: 200000
-      max_output_tokens: 32000
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 128000
       cost_per_1m_input: 5.00
       cost_per_1m_input_long: null
       cost_per_1m_output: 25.00
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 1.50
+      cost_per_1m_input_cached: 0.50   # 10% of input price
+      status: active
+    - name: claude-opus-4-8
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 128000
+      cost_per_1m_input: 5.00
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 25.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: 0.50   # 10% of input price
       status: active
   batching:
     available: true
@@ -61,10 +71,10 @@ paid_tier:
   prompt_caching:
     available: true
     min_cacheable_tokens: 1024
-    ttl_seconds: 300         # 5-minute default TTL
-    cost_per_1m_cached_writes: 3.75
-    cost_per_1m_cached_reads: 0.30
-    notes: "Cache read at 90% discount vs standard input. Write cost is 25% premium."
+    ttl_seconds: 300         # 5-min default; 3600 available (1-hr extended TTL, 2× write cost)
+    cost_per_1m_cached_writes: null    # model-specific: 1.25× input price (5-min) or 2× (1-hr)
+    cost_per_1m_cached_reads: null     # model-specific: 10% of input price (see each model entry)
+    notes: "Cache read = 10% of input price. Write = 1.25× input (5-min TTL) or 2× input (1-hr TTL). Sonnet writes: $3.75/1M (5-min) or $6.00/1M (1-hr)."
 
 capabilities:
   tool_calling: true
@@ -93,4 +103,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Lowest hallucination rate on finance reasoning benchmarks. CLAUDE_CODE_OAUTH_TOKEN present but is for Claude Code CLI — not usable as LiteLLM API key. Needs separate ANTHROPIC_API_KEY."
+notes: "claude-opus-4-8 released 2026-05-28. All Opus/Sonnet context windows are 1M (not 200K). Haiku max output 64K; Opus max output 128K. Cache reads = 10% of each model's input price ($0.10/$0.30/$0.50 for Haiku/Sonnet/Opus). Lowest hallucination rate on finance reasoning benchmarks. Needs separate ANTHROPIC_API_KEY (CLAUDE_CODE_OAUTH_TOKEN is for CLI only)."

--- a/docs/providers/snapshots/cerebras.yaml
+++ b/docs/providers/snapshots/cerebras.yaml
@@ -1,5 +1,5 @@
 provider: cerebras
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -13,7 +13,7 @@ free_tier:
   models:
     - name: llama-3.3-70b
       context_window: 128000
-      max_input_tokens: 8192    # often capped below native on free tier
+      max_input_tokens: 8192    # hard-capped on free tier
       max_output_tokens: 8192
       status: active
       verified: null
@@ -22,7 +22,7 @@ free_tier:
       verification_error: null
     - name: llama-4-scout
       context_window: 131072
-      max_input_tokens: 8192
+      max_input_tokens: 8192    # hard-capped on free tier
       max_output_tokens: 8192
       status: active
       verified: null
@@ -31,7 +31,25 @@ free_tier:
       verification_error: null
     - name: qwen-3-32b
       context_window: 32768
-      max_input_tokens: 8192
+      max_input_tokens: 8192    # hard-capped on free tier
+      max_output_tokens: 8192
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: openai/gpt-oss-120b
+      context_window: 131072
+      max_input_tokens: 8192    # hard-capped on free tier; ~3000 tok/s
+      max_output_tokens: 8192
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: qwen3-235b
+      context_window: 131072
+      max_input_tokens: 64000   # 64K cap on free tier (exception to 8K rule)
       max_output_tokens: 8192
       status: active
       verified: null
@@ -56,6 +74,16 @@ paid_tier:
       cost_per_1m_input: 0.60
       cost_per_1m_input_long: null
       cost_per_1m_output: 0.60
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: openai/gpt-oss-120b
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 32768
+      cost_per_1m_input: 0.25
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 0.69
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
@@ -100,4 +128,4 @@ verification:
   probe_model_alias: cerebras-llama-70b
   github_secret_key: CEREBRAS_API_KEY
 
-notes: "Fastest inference on market (>2000 tok/s). Free tier: 1M tokens/day (not RPD-capped), 30 RPM, 60k-100k TPM. Context hard-capped at 8,192 tokens on free tier — chunking required. Paid tier unlocks full 128k context. No credit card required for free tier."
+notes: "Fastest inference on market (>2000 tok/s; gpt-oss-120b ~3000 tok/s). Free tier: 1M tokens/day, 30 RPM, 60k-100k TPM. Context hard-capped at 8,192 tokens on free tier for most models (qwen3-235b exception: 64K free). Paid tier unlocks full context. New subscription tiers: Code Pro $50/mo, Code Max $200/mo (up to 1.5M TPM). Added: gpt-oss-120b ($0.25/$0.69 paid), qwen3-235b (free)."

--- a/docs/providers/snapshots/cloudflare.yaml
+++ b/docs/providers/snapshots/cloudflare.yaml
@@ -1,5 +1,5 @@
 provider: cloudflare
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -11,7 +11,7 @@ free_tier:
   signup_required: true
   cc_required: false
   models:
-    - name: "@cf/meta/llama-3.3-70b-instruct"
+    - name: "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
       context_window: 8192
       max_input_tokens: 8192
       max_output_tokens: 8192
@@ -30,7 +30,37 @@ free_tier:
 
 paid_tier:
   available: true
-  models: []             # $0.011 per 1000 neurons beyond free allowance
+  models:
+    - name: "@cf/moonshotai/kimi-k2.6"
+      context_window: 262144
+      max_input_tokens: 262144
+      max_output_tokens: null
+      cost_per_1m_input: 0.95
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 4.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # added April 20 2026; kimi-k2.5 now auto-aliases to k2.6
+    - name: "@cf/google/gemma-4-26b-a4b-it"
+      context_window: 262144
+      max_input_tokens: 262144
+      max_output_tokens: null
+      cost_per_1m_input: null   # pricing via neurons; per-token rate varies
+      cost_per_1m_input_long: null
+      cost_per_1m_output: null
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # added April 4 2026; 26B total MoE (4B active)
+    - name: "@cf/zhipuai/glm-4.7-flash"
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: null
+      cost_per_1m_input: null
+      cost_per_1m_input_long: null
+      cost_per_1m_output: null
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # added Feb 2026; multi-turn tool calling, 100+ languages
   batching:
     available: false
     discount_pct: null
@@ -38,16 +68,16 @@ paid_tier:
     turnaround_hours: null
     notes: null
   prompt_caching:
-    available: false
+    available: true            # prefix caching introduced for large paid models
     min_cacheable_tokens: null
     ttl_seconds: null
     cost_per_1m_cached_writes: null
     cost_per_1m_cached_reads: null
-    notes: null
+    notes: "Prefix caching available for Kimi K2.6 and other large models on paid tier"
 
 capabilities:
-  tool_calling: false
-  structured_output: false
+  tool_calling: true           # supported on Kimi K2.6, GLM-4.7-Flash, Gemma 4; not on llama-3.3
+  structured_output: true      # supported on new large models via /v1/chat/completions
   thinking_mode: false
   streaming: true
   vision: true
@@ -72,4 +102,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "10k neurons/day standing free. Best from inside Workers runtime. Context capped at 8k — not suitable for 100k+ research. No key configured yet."
+notes: "10k neurons/day free (core llama-3.3-70b-fp8-fast). New large models (Kimi K2.6, Gemma 4) added March-April 2026 — these use per-token pricing, not neurons. Tool calling and structured output now supported on new models via OpenAI-compatible endpoint (capabilities updated from false). Kimi K2.5 auto-aliases to K2.6 since May 30 2026. Best from inside Workers runtime. 8k context on free-tier model — not suitable for 100k+ research. No key configured yet."

--- a/docs/providers/snapshots/cohere.yaml
+++ b/docs/providers/snapshots/cohere.yaml
@@ -1,5 +1,5 @@
 provider: cohere
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -20,10 +20,19 @@ free_tier:
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
+    - name: command-a-plus-05-2026
+      context_window: 128000
+      max_input_tokens: 128000
+      max_output_tokens: 8192
+      status: active            # accessible on trial keys for evaluation
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
   rate_limits:
     rpm: 20
     rpd: null
-    tpm: null
+    tpm: null                  # ~1000 API calls/month on trial tier
     input_tpm: null
     concurrent_requests: null
     reset_window: rolling_minute
@@ -38,6 +47,26 @@ paid_tier:
       cost_per_1m_input: 2.50
       cost_per_1m_input_long: null
       cost_per_1m_output: 10.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: command-a-plus-05-2026
+      context_window: 128000
+      max_input_tokens: 128000
+      max_output_tokens: 8192
+      cost_per_1m_input: 2.50
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 10.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: embed-v4.0
+      context_window: null
+      max_input_tokens: null
+      max_output_tokens: null
+      cost_per_1m_input: 0.12   # text tokens
+      cost_per_1m_input_long: 0.47  # image tokens (reusing long field)
+      cost_per_1m_output: null
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
@@ -60,9 +89,9 @@ capabilities:
   structured_output: true
   thinking_mode: false
   streaming: true
-  vision: false
-  embeddings: true       # embed-v3 — best-in-class for RAG
-  modalities: [text]
+  vision: true                 # embed-v4.0 is multimodal (text + image)
+  embeddings: true             # embed-v4.0 multimodal; embed-v3 text-only
+  modalities: [text, image]
 
 data_privacy:
   trains_on_free_tier: false
@@ -82,4 +111,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "256k context + best-in-class RAG embeddings. Trial tier is 1000 calls/month — too low for daily automation but good for evaluation. No key configured yet."
+notes: "Added command-a-plus-05-2026 (released May 20 2026): 218B sparse MoE (25B active), 128K ctx, Apache 2.0 open-weight license, same $2.50/$10 pricing as Command A. Added embed-v4.0: multimodal (text + image), 1,536-dim vectors, $0.12/1M text tokens, $0.47/1M image tokens — available on Bedrock, Azure AI, and direct API. Trial tier still 1,000 calls/month, 20 RPM. No key configured yet."

--- a/docs/providers/snapshots/deepinfra.yaml
+++ b/docs/providers/snapshots/deepinfra.yaml
@@ -1,5 +1,5 @@
 provider: deepinfra
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -33,12 +33,32 @@ paid_tier:
       cost_per_1m_input_cached: null
       status: active
     - name: deepseek-ai/DeepSeek-V3
-      context_window: 65536
-      max_input_tokens: 65536
+      context_window: 163840
+      max_input_tokens: 163840
       max_output_tokens: 8192
-      cost_per_1m_input: 0.49
+      cost_per_1m_input: 0.27
       cost_per_1m_input_long: null
-      cost_per_1m_output: 0.89
+      cost_per_1m_output: 1.10
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # context corrected 65k→164k; price updated $0.49/$0.89→$0.27/$1.10
+    - name: deepseek-ai/DeepSeek-V3.2
+      context_window: 163840
+      max_input_tokens: 163840
+      max_output_tokens: 8192
+      cost_per_1m_input: 0.28
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 0.56
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: deepseek-ai/DeepSeek-V4-Pro
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 8192
+      cost_per_1m_input: 1.74
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 3.48
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
@@ -83,4 +103,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Cheapest open-weight hosting ($0.23/1M Llama 3.3 70B). Good for high-volume extraction tier. No key configured yet."
+notes: "UPDATES: DeepSeek-V3 price corrected ($0.49/$0.89→$0.27/$1.10) and context corrected (65K→164K). Added DeepSeek-V3.2 ($0.28/$0.56) and DeepSeek-V4-Pro ($1.74/$3.48, 1M ctx). DeepInfra raised $107M Series B May 2026 (25× volume growth since Series A). Still cheapest open-weight hosting for Llama 3.3 70B at $0.23/1M. No key configured yet."

--- a/docs/providers/snapshots/deepseek.yaml
+++ b/docs/providers/snapshots/deepseek.yaml
@@ -1,30 +1,48 @@
 provider: deepseek
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
   available: true
   tier_type: credits
-  credit_amount_usd: null      # 5M tokens on signup (not USD-denominated)
+  credit_amount_usd: null      # 5M tokens on signup (one-time, unconfirmed if still active)
   credit_expiry_days: null
   privacy_warning: null
   signup_required: true
   cc_required: false
   models:
-    - name: deepseek-chat
-      context_window: 65536
-      max_input_tokens: 65536
-      max_output_tokens: 8192
+    - name: deepseek-v4-flash
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
       status: active
       verified: null
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
-    - name: deepseek-reasoner
+    - name: deepseek-v4-pro
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: deepseek-chat       # deprecated → deepseek-v4-flash (July 24 2026)
       context_window: 65536
       max_input_tokens: 65536
       max_output_tokens: 8192
-      status: active
+      status: deprecated
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: deepseek-reasoner   # deprecated → deepseek-v4-pro (July 24 2026)
+      context_window: 65536
+      max_input_tokens: 65536
+      max_output_tokens: 8192
+      status: deprecated
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -40,25 +58,25 @@ free_tier:
 paid_tier:
   available: true
   models:
-    - name: deepseek-chat
-      context_window: 65536
-      max_input_tokens: 65536
-      max_output_tokens: 8192
-      cost_per_1m_input: 0.14
+    - name: deepseek-v4-flash
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
+      cost_per_1m_input: 0.07
       cost_per_1m_input_long: null
       cost_per_1m_output: 0.28
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.03
+      cost_per_1m_input_cached: 0.0028   # 96% discount on cache hits
       status: active
-    - name: deepseek-reasoner
-      context_window: 65536
-      max_input_tokens: 65536
-      max_output_tokens: 8192
-      cost_per_1m_input: 0.55
+    - name: deepseek-v4-pro
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
+      cost_per_1m_input: 0.435
       cost_per_1m_input_long: null
-      cost_per_1m_output: 2.19
+      cost_per_1m_output: 0.87
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.14
+      cost_per_1m_input_cached: 0.003625  # cache hit reads
       status: active
   batching:
     available: true
@@ -71,13 +89,13 @@ paid_tier:
     min_cacheable_tokens: 1024
     ttl_seconds: null
     cost_per_1m_cached_writes: null
-    cost_per_1m_cached_reads: 0.07
-    notes: "Cache hit reads at ~75% discount vs standard input price"
+    cost_per_1m_cached_reads: 0.0028   # v4-flash; v4-pro is $0.003625
+    notes: "V4 Flash: 96% cache discount ($0.0028/1M). V4 Pro: $0.003625/1M cache hits."
 
 capabilities:
   tool_calling: true
   structured_output: true
-  thinking_mode: true      # deepseek-reasoner (R1) has extended reasoning
+  thinking_mode: true      # deepseek-v4-pro has extended reasoning
   streaming: true
   vision: false
   embeddings: false
@@ -101,4 +119,4 @@ verification:
   probe_model_alias: deepseek-chat
   github_secret_key: DEEPSEEK_API_KEY
 
-notes: "5M free tokens on signup (one-time). PRICE DROP: deepseek-chat (V3) reduced from $0.27/$1.10 to $0.14/$0.28 — now cheapest frontier-class model available. Cached input dropped from $0.07 to $0.03 (90% off standard input). Strong quantitative reasoning — excellent for Atlas extraction and research tiers. Data jurisdiction: platform hosted in China. For Western-jurisdiction hosting of same weights use Fireworks, Together, or DeepInfra."
+notes: "V4 generation launched April 24, 2026. deepseek-v4-flash replaces deepseek-chat: $0.07/$0.28, 1M ctx, 384K out. deepseek-v4-pro replaces deepseek-reasoner: $0.435/$0.87 (permanent 75% cut), 1M ctx. Old deepseek-chat/deepseek-reasoner aliases deprecated July 24 2026 — update model param now. Cache discount 96% on v4-flash. Data jurisdiction: platform hosted in China; use Fireworks/Together/DeepInfra for Western-jurisdiction hosting."

--- a/docs/providers/snapshots/fireworks.yaml
+++ b/docs/providers/snapshots/fireworks.yaml
@@ -1,5 +1,5 @@
 provider: fireworks
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -50,6 +50,26 @@ paid_tier:
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
+    - name: accounts/fireworks/models/deepseek-r1
+      context_window: 163840
+      max_input_tokens: 163840
+      max_output_tokens: 16384
+      cost_per_1m_input: 8.00
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 8.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # "Fast" variant; deepseek-r1-basic exists at lower price/speed
+    - name: deepseek-ai/deepseek-v4-pro
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 8192
+      cost_per_1m_input: 1.74
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 3.48
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: 0.14   # cached input discount
+      status: active
   batching:
     available: false
     discount_pct: null
@@ -91,4 +111,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "$1 starter credits. Fast open-weight inference, FireFunction for tool calling. No key configured yet."
+notes: "$1 starter credits, no CC. DeepSeek-R1 paid clarified: Fast variant is $8.00/$8.00; Basic (slower) variant exists at lower price. Added deepseek-v4-pro ($1.74/$3.48, 1M ctx, cached input $0.14/1M). Llama 3.3 70B price unchanged at $0.90/$0.90. No key configured yet."

--- a/docs/providers/snapshots/gemini.yaml
+++ b/docs/providers/snapshots/gemini.yaml
@@ -1,5 +1,5 @@
 provider: gemini
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -33,7 +33,7 @@ free_tier:
       context_window: 2097152
       max_input_tokens: 2097152
       max_output_tokens: 65536
-      status: active
+      status: paid-only        # free 2 RPM tier removed April 1, 2026
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -48,9 +48,9 @@ free_tier:
       last_verified_latency_ms: null
       verification_error: null
   rate_limits:
-    rpm: 10              # Flash; Flash-Lite is 15, Pro is 5
-    rpd: 250             # Flash; Flash-Lite is 1000, Pro is 100
-    tpm: 250000          # Flash; Flash-Lite is 1000000, Pro is 250000
+    rpm: 15              # Flash; Flash-Lite is 30, Pro is paid-only now
+    rpd: 1500            # Flash; Flash-Lite higher
+    tpm: 1000000         # Flash
     input_tpm: null
     concurrent_requests: null
     reset_window: calendar_day
@@ -62,11 +62,11 @@ paid_tier:
       context_window: 1048576
       max_input_tokens: 1048576
       max_output_tokens: 65536
-      cost_per_1m_input: 0.15
+      cost_per_1m_input: 0.30
       cost_per_1m_input_long: null
-      cost_per_1m_output: 0.60
+      cost_per_1m_output: 2.50
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.015  # 10% of input price
+      cost_per_1m_input_cached: 0.030  # 10% of input price
       status: active
     - name: gemini-2.5-flash-lite
       context_window: 1048576
@@ -82,11 +82,41 @@ paid_tier:
       context_window: 2097152
       max_input_tokens: 2097152
       max_output_tokens: 65536
-      cost_per_1m_input: 2.00
-      cost_per_1m_input_long: null    # flat rate, no long-context surcharge
-      cost_per_1m_output: 12.00
+      cost_per_1m_input: 1.25
+      cost_per_1m_input_long: 2.50    # >200k tokens
+      cost_per_1m_output: 10.00
+      cost_per_1m_output_long: 15.00  # >200k tokens
+      cost_per_1m_input_cached: 0.13  # 10% of $1.25 input price
+      status: active
+    - name: gemini-3-flash
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      cost_per_1m_input: 0.50
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 3.00
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.20  # 10% of input price
+      cost_per_1m_input_cached: null
+      status: active
+    - name: gemini-3.5-flash
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      cost_per_1m_input: 1.50
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 9.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: gemini-3.1-pro
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      cost_per_1m_input: 2.00
+      cost_per_1m_input_long: 4.00    # >200k tokens
+      cost_per_1m_output: 12.00
+      cost_per_1m_output_long: 18.00  # >200k tokens
+      cost_per_1m_input_cached: null
       status: active
   batching:
     available: true
@@ -98,9 +128,9 @@ paid_tier:
     available: true
     min_cacheable_tokens: 1024
     ttl_seconds: 3600
-    cost_per_1m_cached_writes: 0.375
-    cost_per_1m_cached_reads: 0.075
-    notes: "Cache writes billed once; reads at ~75% discount"
+    cost_per_1m_cached_writes: null
+    cost_per_1m_cached_reads: null    # model-specific: 10% of input price
+    notes: "Cache reads = 10% of input price per model. Writes billed once."
 
 capabilities:
   tool_calling: true
@@ -129,4 +159,4 @@ verification:
   probe_model_alias: gemini-flash
   github_secret_key: GEMINI_API_KEY
 
-notes: "Paid tier: same API key, enable billing on Google Cloud project. Zero-retention on paid."
+notes: "MAJOR UPDATES 2026-06: 2.5-flash paid price raised to $0.30/$2.50 (was $0.15/$0.60). 2.5-pro free tier (2 RPM) removed April 1 2026 — now paid-only at $1.25/$10 (<200k) or $2.50/$15 (>200k). Gemini 3 generation launched: 3-flash ($0.50/$3.00), 3.5-flash ($1.50/$9.00), 3.1-pro ($2.00/$12 <200k, $4/$18 >200k). Gemini 2.0 Flash/Lite shut down June 1 2026. PRIVACY: free tier trains on prompts — never send portfolio/thesis data on free tier; use paid billing for Phases 7/7D."

--- a/docs/providers/snapshots/github_models.yaml
+++ b/docs/providers/snapshots/github_models.yaml
@@ -1,13 +1,13 @@
 provider: github_models
-last_checked: 2026-05-01
-source: manual
+last_checked: 2026-06-04
+source: agent-research
 
 free_tier:
   available: true
   tier_type: standing
   credit_amount_usd: null
   credit_expiry_days: null
-  privacy_warning: "ToS restricts free tier to evaluation — not production use. Graduate to Azure AI for commercial workloads."
+  privacy_warning: "Free tier is evaluation-only; production use now requires pay-as-you-go (available since June 1 2026)."
   signup_required: false
   cc_required: false
   models:
@@ -48,16 +48,16 @@ free_tier:
       last_verified_latency_ms: null
       verification_error: null
   rate_limits:
-    rpm: null            # varies by Copilot tier and model tier
-    rpd: 50              # low-tier models; high-tier (GPT-4o) ~8 RPD on free
+    rpm: 10              # high-tier (GPT-4o): 10 RPM; low-tier models higher
+    rpd: 50              # high-tier (GPT-4o): 50 RPD (was ~8 — corrected); low-tier higher
     tpm: null
     input_tpm: null
     concurrent_requests: null
     reset_window: calendar_day
 
 paid_tier:
-  available: false       # production workloads route to Azure OpenAI, not GitHub Models
-  models: []
+  available: true        # pay-as-you-go launched June 1 2026; production use now allowed
+  models: []             # same catalog as free but without RPD cap; routes to Azure pricing
   batching:
     available: false
     discount_pct: null
@@ -99,4 +99,4 @@ verification:
   probe_model_alias: github-gpt4o-mini
   github_secret_key: GITHUB_TOKEN
 
-notes: "GITHUB_TOKEN is always available in Actions — no extra secret needed. Daily RPD is very low; best used for the weekly agent run itself, not production routing."
+notes: "BILLING CHANGE June 1 2026: pay-as-you-go launched; production use now permitted (ToS updated). BYOK expanded to Bedrock, Google AI Studio, and any OpenAI-compatible provider. Catalog now 45+ models (DeepSeek, Phi-4, AI21 Jamba added). RPD corrected: GPT-4o is 50 RPD / 10 RPM (snapshot had ~8 RPD — incorrect). GITHUB_TOKEN always available in Actions — no extra secret needed."

--- a/docs/providers/snapshots/groq.yaml
+++ b/docs/providers/snapshots/groq.yaml
@@ -1,5 +1,5 @@
 provider: groq
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -29,28 +29,19 @@ free_tier:
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
-    - name: moonshotai/kimi-k2-instruct
+    - name: openai/gpt-oss-120b
       context_window: 131072
       max_input_tokens: 131072
-      max_output_tokens: 16384
-      status: active
-      verified: null
-      last_verified: null
-      last_verified_latency_ms: null
-      verification_error: null
-    - name: deepseek-r1-distill-llama-70b
-      context_window: 131072
-      max_input_tokens: 131072
-      max_output_tokens: 16384
+      max_output_tokens: 32768
       status: active
       verified: null
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
   rate_limits:
-    rpm: 30              # default; Llama 4 Maverick is 15 RPM
-    rpd: 1000            # default; Llama 4 Maverick is 500 RPD — RPD is the binding constraint
-    tpm: 6000            # llama-3.3-70b-versatile; Llama 4 Maverick is 3k, Gemma 2 9B is 15k
+    rpm: 30              # default; varies by model
+    rpd: 1000            # RPD is the binding constraint (dropped from 14,400 in 2026)
+    tpm: 6000            # llama-3.3-70b-versatile
     input_tpm: null
     concurrent_requests: null
     reset_window: rolling_24h
@@ -78,6 +69,16 @@ paid_tier:
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
+    - name: openai/gpt-oss-120b
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 32768
+      cost_per_1m_input: 0.15
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 0.60
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: 0.075   # 50% off via prompt caching
+      status: active
   batching:
     available: false
     discount_pct: null
@@ -85,12 +86,12 @@ paid_tier:
     turnaround_hours: null
     notes: null
   prompt_caching:
-    available: false
+    available: true          # available for gpt-oss-120b
     min_cacheable_tokens: null
     ttl_seconds: null
     cost_per_1m_cached_writes: null
-    cost_per_1m_cached_reads: null
-    notes: null
+    cost_per_1m_cached_reads: 0.075
+    notes: "Prompt caching for gpt-oss-120b at $0.075/1M (50% off input)"
 
 capabilities:
   tool_calling: true
@@ -119,4 +120,4 @@ verification:
   probe_model_alias: groq-llama-70b
   github_secret_key: GROQ_API_KEY
 
-notes: "RATE LIMIT REDUCTION: RPD dropped from 14,400 to 1,000 in 2026 — RPD is now the binding constraint for most workloads. TPM 6k on llama-3.3-70b-versatile makes it unsuitable for Atlas extraction phases (needs 41k/run). Inference 500-1500 tok/s — fastest if TPM is not a constraint. Llama 4 Maverick exception: 15 RPM / 3k TPM / 500 RPD. Gemma 2 9B exception: 15k TPM."
+notes: "ACQUISITION: Groq acquired by Nvidia (announced May 2026, $20B valuation). Removed deprecated models: deepseek-r1-distill-llama-70b (deprecated Sep 2025), moonshotai/kimi-k2-instruct (deprecated Mar 2026). Added gpt-oss-120b at $0.15/$0.60 paid with prompt caching ($0.075/1M), ~500 tok/s. RPD 1,000 is binding free-tier constraint. TPM 6k on llama-3.3-70b-versatile still unsuitable for Atlas extraction phases (needs 41k/run)."

--- a/docs/providers/snapshots/huggingface.yaml
+++ b/docs/providers/snapshots/huggingface.yaml
@@ -1,15 +1,15 @@
 provider: huggingface
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
   available: true
   tier_type: credits
-  credit_amount_usd: 2.00       # PRO users get ~$2/mo credit allocation
+  credit_amount_usd: null      # free accounts: 100K Inference Provider credits/month
   credit_expiry_days: 30
   privacy_warning: null
   signup_required: true
-  cc_required: false            # PRO is $9/mo; free tier very limited
+  cc_required: false
   models:
     - name: meta-llama/Llama-3.3-70B-Instruct
       context_window: 131072
@@ -26,11 +26,11 @@ free_tier:
     tpm: null
     input_tpm: null
     concurrent_requests: null
-    reset_window: null
+    reset_window: monthly
 
 paid_tier:
   available: true
-  models: []                    # Routes to Together/Fireworks/SambaNova behind the scenes
+  models: []                   # Routes to Together/Fireworks/SambaNova/Cerebras/DeepInfra/fal/Replicate and others
   batching:
     available: false
     discount_pct: null
@@ -46,8 +46,8 @@ paid_tier:
     notes: null
 
 capabilities:
-  tool_calling: false
-  structured_output: false
+  tool_calling: true           # confirmed via Inference Providers InferenceClient (2026)
+  structured_output: true      # JSON mode and schema-enforced outputs confirmed (2026)
   thinking_mode: false
   streaming: true
   vision: false
@@ -72,4 +72,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Best for model discovery and evaluation. Routes to upstream providers — not a direct API for production. Free tier very limited; PRO $9/mo gives ~$2 credits. No key configured yet."
+notes: "CAPABILITY UPDATE: tool_calling and structured_output now confirmed true (both false in previous snapshot). Free accounts get 100K Inference Provider credits/month (not ~$2 worth). PRO ($9/mo) gives 2M credits/month + 8× ZeroGPU quota + H200 compute. Inference Providers now routes to 10+ backends: Together, Fireworks, SambaNova, Cerebras, DeepInfra, fal, Replicate, and others (expanded from 3). Best for model discovery and evaluation — not for production. No key configured yet."

--- a/docs/providers/snapshots/mistral.yaml
+++ b/docs/providers/snapshots/mistral.yaml
@@ -1,5 +1,5 @@
 provider: mistral
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -79,6 +79,16 @@ paid_tier:
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
+    - name: mistral-medium-3.5
+      context_window: 262144
+      max_input_tokens: 262144
+      max_output_tokens: 131072
+      cost_per_1m_input: 1.50
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 7.50
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
   batching:
     available: false
     discount_pct: null
@@ -120,4 +130,4 @@ verification:
   probe_model_alias: mistral-small
   github_secret_key: MISTRAL_API_KEY
 
-notes: "Experimental tier requires phone verification. 2 RPM is the binding free-tier constraint (previously documented as 1 RPS / 60 RPM — incorrect). Monthly token budget ~1B tokens. Add aggressive retry logic — 429s common at 2 RPM. Privacy: free tier trains on data; paid is zero-retention."
+notes: "Experimental tier requires phone verification. 2 RPM is the binding free-tier constraint. Monthly token budget ~1B tokens. Add aggressive retry logic — 429s common at 2 RPM. Privacy: free tier trains on data; paid is zero-retention. Added: mistral-medium-3.5 ($1.50/$7.50, 262K ctx, released April 30 2026); mistral-small-latest → Mistral Small 4 (price unchanged). Large and Codestral pricing unchanged."

--- a/docs/providers/snapshots/nvidia_nim.yaml
+++ b/docs/providers/snapshots/nvidia_nim.yaml
@@ -1,6 +1,6 @@
 provider: nvidia_nim
-last_checked: 2026-05-01
-source: manual
+last_checked: 2026-06-04
+source: agent-research
 
 free_tier:
   available: true
@@ -38,6 +38,15 @@ free_tier:
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
+    - name: nvidia/nemotron-3-ultra-550b-a55b
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: null
+      status: active            # launched June 4 2026; 550B total, 55B active, hybrid Mamba-Transformer MoE
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
   rate_limits:
     rpm: 40
     rpd: null
@@ -64,9 +73,9 @@ paid_tier:
     notes: null
 
 capabilities:
-  tool_calling: true
+  tool_calling: true           # confirmed on Nemotron-3-Super, Kimi K2, Llama 3.1, Qwen 2.5, and others
   structured_output: true
-  thinking_mode: true      # Nemotron reasoning models
+  thinking_mode: true          # Nemotron reasoning models + Nemotron Ultra
   streaming: true
   vision: false
   embeddings: true
@@ -90,4 +99,4 @@ verification:
   probe_model_alias: nvidia-llama-70b
   github_secret_key: NVIDIA_API_KEY
 
-notes: "Credits do not refill — best for prototyping and evaluation, not heavy daily automation. 80+ optimized models available. Developer Program grants 5000 additional credits."
+notes: "Added Nemotron 3 Ultra (nvidia/nemotron-3-ultra-550b-a55b): 550B total, 55B active, 1M context, hybrid Mamba-Transformer MoE, launched June 4 2026 at Computex. Catalog now 100+ models. Tool calling confirmed on many models (updated from unspecified). 200 RPM upgrade available on request. Credits do not refill — best for prototyping. Developer Program grants 5000 additional credits."

--- a/docs/providers/snapshots/ollama_cloud.yaml
+++ b/docs/providers/snapshots/ollama_cloud.yaml
@@ -1,16 +1,25 @@
 provider: ollama_cloud
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
   available: true
-  tier_type: standing        # Metered in GPU-seconds on rolling 5h / 7-day windows
+  tier_type: standing        # Metered in GPU-seconds; usage levels 1-4 (1=lightest, 4=heaviest)
   credit_amount_usd: null
   credit_expiry_days: null
   privacy_warning: null
   signup_required: true
   cc_required: false
   models:
+    - name: gpt-oss:20b
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 32768
+      status: active          # usage level 1 (lightest)
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
     - name: rnj-1:cloud
       context_window: 32768
       max_input_tokens: 32768
@@ -24,7 +33,7 @@ free_tier:
       context_window: 163840
       max_input_tokens: 163840
       max_output_tokens: 32768
-      status: active          # confirmed free as of Apr 2026
+      status: active          # confirmed free
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -51,7 +60,16 @@ free_tier:
       context_window: 1048576
       max_input_tokens: 1048576
       max_output_tokens: 65536
-      status: unknown         # conflicting signals: 403 on free tier Apr 2026 (token-budget.md); listed in litellm.yaml as active. Re-probe required.
+      status: active          # confirmed free as of May 2026; Apr 403 was temporary outage
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: deepseek-v4-pro:cloud
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 65536
+      status: active          # usage level 4 (heaviest); may require Pro plan in practice
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -75,7 +93,7 @@ free_tier:
 
 paid_tier:
   available: true
-  models: []               # Same models; Pro $20/mo (50× free, 3 concurrent), Max $100/mo
+  models: []               # Same models; Pro $20/mo (or $200/yr; 50× free, 3 concurrent), Max $100/mo
   batching:
     available: false
     discount_pct: null
@@ -93,9 +111,9 @@ paid_tier:
 capabilities:
   tool_calling: true
   structured_output: true
-  thinking_mode: true      # cogito, deepseek-v3.1 have thinking modes
+  thinking_mode: true      # cogito, deepseek-v3.1, deepseek-v4 have thinking modes
   streaming: true
-  vision: true             # kimi-k2.6, gemma4, others
+  vision: true
   embeddings: false
   modalities: [text, image]
 
@@ -117,4 +135,4 @@ verification:
   probe_model_alias: ollama-cloud/rnj-1
   github_secret_key: OLLAMA_API_KEY
 
-notes: "OpenAI-compatible passthrough at https://ollama.com/v1. Uses OLLAMA_API_KEY. deepseek-v3.1:671b confirmed free. deepseek-v4-flash status ambiguous — reported 403 on free tier Apr 2026 but listed as :cloud tag in litellm.yaml; needs live probe to resolve. kimi-k2-thinking, glm-5.1, kimi-k2.6, devstral-2 return 403 on free tier. deepseek-v3.1:671b remains the recommended free reasoning-tier model until v4-flash status is confirmed."
+notes: "OpenAI-compatible passthrough at https://ollama.com/v1. Uses OLLAMA_API_KEY. Usage level system: level 1 (lightest, gpt-oss:20b) through level 4 (heaviest, deepseek-v4-pro). deepseek-v4-flash confirmed free — April 403 was temporary outage. deepseek-v4-pro:cloud available but is level 4 usage; may hit free-tier limits quickly. kimi-k2-thinking remains paid-only. deepseek-v3.1:671b remains recommended free reasoning-tier model."

--- a/docs/providers/snapshots/openai.yaml
+++ b/docs/providers/snapshots/openai.yaml
@@ -1,5 +1,5 @@
 provider: openai
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -36,11 +36,11 @@ paid_tier:
       context_window: 1048576
       max_input_tokens: 1048576
       max_output_tokens: 32768
-      cost_per_1m_input: 0.15
+      cost_per_1m_input: 0.40
       cost_per_1m_input_long: null
-      cost_per_1m_output: 0.60
+      cost_per_1m_output: 1.60
       cost_per_1m_output_long: null
-      cost_per_1m_input_cached: 0.075
+      cost_per_1m_input_cached: 0.10
       status: active
     - name: o3
       context_window: 200000
@@ -51,6 +51,26 @@ paid_tier:
       cost_per_1m_output: 8.00
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: 0.50
+      status: active
+    - name: gpt-5.5
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 131072
+      cost_per_1m_input: 5.00
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 30.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: 0.50
+      status: active
+    - name: gpt-5.5-pro
+      context_window: 1048576
+      max_input_tokens: 1048576
+      max_output_tokens: 131072
+      cost_per_1m_input: 30.00
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 180.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
       status: active
   batching:
     available: true
@@ -69,7 +89,7 @@ paid_tier:
 capabilities:
   tool_calling: true
   structured_output: true
-  thinking_mode: true      # o3 series
+  thinking_mode: true      # o3 and gpt-5.5 series
   streaming: true
   vision: true
   embeddings: true
@@ -93,4 +113,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "GPT-4.1-mini at $0.15/$0.60 is extremely competitive for extraction tier. Full 1M context on GPT-4.1 for large document analysis. No key configured yet."
+notes: "gpt-5.5 released 2026 at $5/$30; gpt-5.5-pro at $30/$180 for highest capability. gpt-4.1-mini corrected to $0.40/$1.60 (snapshot had $0.15/$0.60 which is gpt-4o-mini pricing). Container sessions now billed per-minute (5-min minimum) as of 2026-06-02. No key configured yet."

--- a/docs/providers/snapshots/openrouter.yaml
+++ b/docs/providers/snapshots/openrouter.yaml
@@ -1,6 +1,6 @@
 provider: openrouter
-last_checked: 2026-05-01
-source: manual
+last_checked: 2026-06-04
+source: agent-research
 
 free_tier:
   available: true
@@ -16,6 +16,15 @@ free_tier:
       max_input_tokens: 163840
       max_output_tokens: 8192
       status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: deepseek/deepseek-chat-v3-0324:free
+      context_window: 163840
+      max_input_tokens: 163840
+      max_output_tokens: 8192
+      status: active            # V3 March 2026 update variant
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -41,6 +50,24 @@ free_tier:
     - name: google/gemini-2.0-flash-exp:free
       context_window: 1048576
       max_input_tokens: 1048576
+      max_output_tokens: 8192
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: qwen/qwen3-235b-a22b:free
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: openai/gpt-oss-20b:free
+      context_window: 131072
+      max_input_tokens: 131072
       max_output_tokens: 8192
       status: active
       verified: null
@@ -75,7 +102,7 @@ paid_tier:
 capabilities:
   tool_calling: true
   structured_output: true
-  thinking_mode: true      # via :free R1 variants
+  thinking_mode: true      # via :free R1 / Qwen3 variants
   streaming: true
   vision: true             # via gemini-2.0-flash-exp:free
   embeddings: false
@@ -99,4 +126,4 @@ verification:
   probe_model_alias: openrouter-llama-70b-free
   github_secret_key: OPENROUTER_API_KEY
 
-notes: ":free model roster rotates — verify current list at https://openrouter.ai/models?q=free. Adding $10 balance raises RPD from 50 to 1000 for all :free models."
+notes: "Free model catalog grew from ~4 to ~25-29 models since May 2026. Added: deepseek-chat-v3-0324:free (V3 March update), qwen3-235b-a22b:free, openai/gpt-oss-20b:free. openrouter/free meta-router added (Feb 2026): auto-selects from free pool by required features, 200K ctx, same rate limits. :free roster rotates — verify at https://openrouter.ai/models?q=free. Adding $10 balance raises RPD 50 → 1000 for all :free models."

--- a/docs/providers/snapshots/perplexity.yaml
+++ b/docs/providers/snapshots/perplexity.yaml
@@ -1,5 +1,5 @@
 provider: perplexity
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -39,6 +39,16 @@ paid_tier:
       cost_per_1m_input: 1.00
       cost_per_1m_input_long: null
       cost_per_1m_output: 5.00
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: sonar-deep-research
+      context_window: 128000
+      max_input_tokens: 128000
+      max_output_tokens: null
+      cost_per_1m_input: 2.00
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 8.00
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
@@ -83,4 +93,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Real-time web search grounded responses — unique for news flow and market data research. Not suitable for tool calling or JSON extraction. No key configured yet."
+notes: "Real-time web search grounded responses — unique for news flow and market data research. Not suitable for tool calling or JSON extraction. Added sonar-deep-research ($2/$8, 128K ctx, launched Mar 2025) — multi-step agentic research, citation tokens $2/1M, reasoning tokens $3/1M, search queries $5/1K; typical cost $0.30-$1.30/query. Citation tokens now only charged on deep-research (removed from sonar/sonar-pro). Request fees: sonar $5-12/1K requests, sonar-pro $6-14/1K. Agentic Research API added: access OpenAI/Anthropic/Google at direct rates + $0.005/web search. No key configured yet."

--- a/docs/providers/snapshots/sambanova.yaml
+++ b/docs/providers/snapshots/sambanova.yaml
@@ -1,5 +1,5 @@
 provider: sambanova
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
@@ -29,11 +29,47 @@ free_tier:
       last_verified: null
       last_verified_latency_ms: null
       verification_error: null
+    - name: Llama-4-Maverick-17B-128E-Instruct
+      context_window: 65536
+      max_input_tokens: 65536
+      max_output_tokens: 16384
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
     - name: DeepSeek-R1
       context_window: 32768
       max_input_tokens: 32768
       max_output_tokens: 16384
       status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: gpt-oss-120b
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 16384
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: MiniMax-M2.7
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 16384
+      status: active
+      verified: null
+      last_verified: null
+      last_verified_latency_ms: null
+      verification_error: null
+    - name: Qwen3-32B
+      context_window: 32768
+      max_input_tokens: 32768
+      max_output_tokens: 8192
+      status: active            # listed as Preview
       verified: null
       last_verified: null
       last_verified_latency_ms: null
@@ -47,8 +83,28 @@ free_tier:
     reset_window: rolling_minute
 
 paid_tier:
-  available: false
-  models: []
+  available: true
+  models:
+    - name: Meta-Llama-4-Scout-17B-16E-Instruct
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 16384
+      cost_per_1m_input: 0.40
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 0.70
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: Llama-4-Maverick-17B-128E-Instruct
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 16384
+      cost_per_1m_input: 0.63
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 1.80
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
   batching:
     available: false
     discount_pct: null
@@ -64,8 +120,8 @@ paid_tier:
     notes: null
 
 capabilities:
-  tool_calling: false
-  structured_output: false
+  tool_calling: true           # confirmed on all 8 tracked models as of 2026
+  structured_output: true      # JSON mode supported on all models
   thinking_mode: true
   streaming: true
   vision: false
@@ -90,4 +146,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Fast RDU inference on Llama + DeepSeek. Generous free tier with no tool calling. No key configured yet."
+notes: "MAJOR UPDATES 2026: Tool calling + structured output now supported on all models (was false in snapshot). Added free-tier models: Llama-4-Maverick (64K ctx), gpt-oss-120b, MiniMax-M2.7, Qwen3-32B (preview). Paid tier now documented: Scout $0.40/$0.70, Maverick $0.63/$1.80. Responses API (OpenAI format) launched May 11 2026 for gpt-oss-120b, MiniMax M2.5/M2.7. Fast RDU inference. No key configured yet."

--- a/docs/providers/snapshots/together.yaml
+++ b/docs/providers/snapshots/together.yaml
@@ -1,16 +1,16 @@
 provider: together
-last_checked: 2026-05-01
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
-  available: false
-  tier_type: null
-  credit_amount_usd: null
+  available: true
+  tier_type: credits
+  credit_amount_usd: 25.00     # $25 free credits on signup, no CC required
   credit_expiry_days: null
   privacy_warning: null
   signup_required: true
-  cc_required: true
-  models: []
+  cc_required: false
+  models: []                   # all paid models accessible via credits
   rate_limits:
     rpm: null
     rpd: null
@@ -39,6 +39,36 @@ paid_tier:
       cost_per_1m_input: 1.25
       cost_per_1m_input_long: null
       cost_per_1m_output: 1.25
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # legacy; V3.1 below is current flagship
+    - name: deepseek-ai/DeepSeek-V3-0324
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+      cost_per_1m_input: 0.60
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 1.70
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active            # V3.1 — current DeepSeek V3 flagship on Together
+    - name: deepseek-ai/DeepSeek-V4-Pro
+      context_window: 1000000
+      max_input_tokens: 1000000
+      max_output_tokens: 8192
+      cost_per_1m_input: 2.10
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 4.40
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: active
+    - name: Qwen/Qwen3.6-Plus
+      context_window: 131072
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+      cost_per_1m_input: 0.50
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 3.00
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
@@ -83,4 +113,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "Open-weight models + fine-tuning. Competitive pricing for volume. No key configured yet."
+notes: "Free tier changed: $25 signup credits, no CC required (was CC-required). DeepSeek-V3-0324 (V3.1) at $0.60/$1.70 is now the current flagship — cheaper and newer than the original V3 ($1.25/$1.25). Added DeepSeek V4 Pro ($2.10/$4.40, 1M ctx) and Qwen 3.6 Plus ($0.50/$3.00). Fully prepaid billing model. No key configured yet."

--- a/docs/providers/snapshots/xai.yaml
+++ b/docs/providers/snapshots/xai.yaml
@@ -1,15 +1,15 @@
 provider: xai
-last_checked: 2026-05-08
+last_checked: 2026-06-04
 source: agent-research
 
 free_tier:
-  available: false
-  tier_type: null
-  credit_amount_usd: null
+  available: false             # no permanently-free model; credits-only scheme
+  tier_type: credits
+  credit_amount_usd: 25.00     # $25 signup credits + opt-in $150/mo data-sharing = up to $175/mo
   credit_expiry_days: null
-  privacy_warning: null
+  privacy_warning: "Data-sharing opt-in ($150/mo credit) allows xAI to train on prompts."
   signup_required: true
-  cc_required: true
+  cc_required: false
   models: []
   rate_limits:
     rpm: null
@@ -22,17 +22,7 @@ free_tier:
 paid_tier:
   available: true
   models:
-    - name: grok-4-1-fast
-      context_window: 2097152
-      max_input_tokens: 2097152
-      max_output_tokens: null
-      cost_per_1m_input: 0.20
-      cost_per_1m_input_long: null
-      cost_per_1m_output: 0.50
-      cost_per_1m_output_long: null
-      cost_per_1m_input_cached: null
-      status: active
-    - name: grok-4-3
+    - name: grok-4-3           # default redirect for all retired model slugs since May 15 2026
       context_window: 1048576
       max_input_tokens: 1048576
       max_output_tokens: null
@@ -52,7 +42,17 @@ paid_tier:
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
       status: active
-    - name: grok-3
+    - name: grok-4-1-fast      # retired May 15 2026; redirects to grok-4-3
+      context_window: 2097152
+      max_input_tokens: 2097152
+      max_output_tokens: null
+      cost_per_1m_input: 0.20
+      cost_per_1m_input_long: null
+      cost_per_1m_output: 0.50
+      cost_per_1m_output_long: null
+      cost_per_1m_input_cached: null
+      status: deprecated
+    - name: grok-3             # retired May 15 2026
       context_window: 131072
       max_input_tokens: 131072
       max_output_tokens: null
@@ -61,8 +61,8 @@ paid_tier:
       cost_per_1m_output: 15.00
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
-      status: deprecated  # retiring 2026-05-15
-    - name: grok-4
+      status: deprecated
+    - name: grok-4             # retired May 15 2026
       context_window: 131072
       max_input_tokens: 131072
       max_output_tokens: null
@@ -71,7 +71,7 @@ paid_tier:
       cost_per_1m_output: 15.00
       cost_per_1m_output_long: null
       cost_per_1m_input_cached: null
-      status: deprecated  # retiring 2026-05-15
+      status: deprecated
   batching:
     available: true
     discount_pct: 50
@@ -89,11 +89,11 @@ paid_tier:
 capabilities:
   tool_calling: true
   structured_output: true
-  thinking_mode: true
+  thinking_mode: true          # grok-4-3 has configurable reasoning effort (none/low/medium/high)
   streaming: true
   vision: true
   embeddings: false
-  modalities: [text, image]
+  modalities: [text, image, video]   # grok-4-3 added native video input
 
 data_privacy:
   trains_on_free_tier: null
@@ -113,4 +113,4 @@ verification:
   probe_model_alias: null
   github_secret_key: null
 
-notes: "RETIREMENT: grok-3 and grok-4 retiring 2026-05-15. Use grok-4-3 ($1.25/$2.50, 1M ctx) or grok-4-20 ($2.00/$6.00, 2M ctx). Grok-4-1-Fast ($0.20/$0.50) best cost/context ratio. Real-time X/Twitter data access is unique advantage for sentiment analysis. Tool calls: X Search / Live Search / Web Search cost $5 per 1,000 calls; File Attachments $10/1k; Collections Search $2.50/1k. Key needed: XAI_API_KEY at console.x.ai."
+notes: "CRITICAL — grok-4-1-fast RETIRED May 15 2026 (all old slugs redirect to grok-4-3 at $1.25/$2.50 — a 6× price increase). 8 slugs retired total; any code using grok-4-1-fast now pays grok-4-3 rates. Current flagship: grok-4-3 (1M ctx, configurable reasoning, native video). grok-4-20 for 2M context. No permanently-free model — xAI offers $25 signup credits + up to $150/mo via data-sharing opt-in. Tool calls: X/Live/Web Search $5/1k successful calls, File Attachments $10/1k, Collections Search $2.50/1k. Key needed: XAI_API_KEY at console.x.ai."


### PR DESCRIPTION
## Summary

Monthly refresh of all 20 LLM provider snapshot YAML files (`docs/providers/snapshots/`). Previous batch was 2026-05-08; this brings everything to 2026-06-04 via agent-research.

## Key changes

- **Anthropic**: claude-opus-4-8 added ($5/$25, 1M ctx); Opus 4.7/Haiku context + cache prices fixed
- **OpenAI**: gpt-5.5 ($5/$30) and gpt-5.5-pro ($30/$180) added; gpt-4.1-mini pricing corrected
- **Gemini**: Gemini 3.x family added; 2.5-pro free tier removed; 2.0-flash/lite retired Jun 1
- **DeepSeek**: V4 gen (v4-flash $0.07/$0.28, v4-pro $0.435/$0.87); old aliases deprecated Jul 24
- **Mistral**: mistral-medium-3.5 added ($1.50/$7.50, 262K ctx)
- **Groq**: deprecated models removed; gpt-oss-120b added; Nvidia acquisition noted
- **Cerebras**: gpt-oss-120b + qwen3-235b added; Code Pro/Max subscription tiers
- **xAI**: grok-4-1-fast retired May 15 (8 slugs); free tier restructured
- **Cloudflare**: tool_calling + structured_output enabled; kimi-k2.6 + prefix caching added
- **Cohere**: command-a-plus-05-2026 added ($2.50/$10, 218B MoE); embed-v4.0 multimodal; vision: true
- **NVIDIA NIM**: nemotron-3-ultra-550b added (1M ctx, Jun 4)
- **GitHub Models**: PAYG launched Jun 1; production use permitted
- **HuggingFace**: tool_calling + structured_output confirmed true
- **OpenRouter**: free catalog grown to ~25-29 models; new free variants added
- **Together**: free tier restored ($25 no-CC); 3 new models
- **DeepInfra**: V3 pricing/context corrected; V3.2 + V4-Pro added; $107M Series B
- **SambaNova**: tool_calling + structured_output enabled; 4 new models; paid tier added
- Ollama Cloud, Perplexity, Fireworks: incremental model and pricing updates

Closes #587

https://claude.ai/code/session_01CQ891VMF2KDehpPGSNDhno

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQ891VMF2KDehpPGSNDhno)_