### PR TITLE
docs(agents): Cursor Cloud dev environment setup guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,51 @@
 Canonical rules for all agents in this repo are in **[CLAUDE.md](CLAUDE.md)** — read that first.
 
 Claude Code loads `CLAUDE.md` at session start. Cursor agents use `.cursor/rules/digithings.mdc`; Copilot uses `.github/copilot-instructions.md` — both generated from `agents.yml` by `make agents-init`.
+
+## Cursor Cloud specific instructions
+
+### Runtime prerequisites (one-time on a fresh VM)
+
+- **Python 3.12+** with `python3.12-venv` (`apt install python3.12-venv`) and **`lsof`** (used by `scripts/run_stack_local.sh`).
+- **Node.js 22** (repo CI pin).
+- **Docker** is optional. Cursor Cloud VMs may not have Docker; use the host-native stack instead (below).
+
+### Dependency install
+
+The VM update script creates `.venv`, runs `scripts/install-workspace.sh --with-dev` (put `.venv/bin` on `PATH` first — the script calls `python`, not `python3`), installs `digiquant[nautilus]`, `litellm[proxy]`, and root `npm ci` plus Linux native bindings for DigiChat Vitest (see `.github/workflows/digichat-test.yml`).
+
+Activate before Python commands: `source .venv/bin/activate` or `PATH="$PWD/.venv/bin:$PATH"`.
+
+Copy config once per session if missing: `cp .env.example .env` (set `GROQ_API_KEY` for LLM workflow tests).
+
+### Running services without Docker
+
+```bash
+PATH="$PWD/.venv/bin:$PATH" make stack-local   # DigiKey :8005, DigiGraph :8000, DigiQuant :8001, DigiSearch :8002, DigiSmith :8003, LiteLLM :4000
+PATH="$PWD/.venv/bin:$PATH" ./scripts/stop_stack_local.sh
+```
+
+DigiChat dev UI (needs `frontend/digichat/.env.local` + optional `make up-digichat-db` for Postgres): `make digichat-dev` → http://127.0.0.1:3000.
+
+### Lint / test commands (no stack required)
+
+| Command | Purpose |
+|---------|---------|
+| `make test-baseline` | Fast always-green gate (imports, schemas, CLI) |
+| `make test-unit` | Full Python unit + DigiChat Vitest (see caveats) |
+| `npm run test --workspace digichat` | DigiChat Vitest only |
+| `.venv/bin/ruff check <component>/src` | Python lint |
+
+**Linux caveat:** NautilusTrader can **SIGABRT** when backtest engine tests run under pytest on Linux (tracked #42). `make test-unit` may abort mid-run; use `make test-baseline` and targeted `pytest -m unit tests/dg/ tests/dk/` for a safe subset. Live `POST /run_backtest` against a running DigiQuant may also crash the process on some Linux hosts.
+
+**LLM workflow:** `POST /workflow` on DigiGraph requires a provider key in `.env` (e.g. `GROQ_API_KEY`). JWT exchange via DigiKey works without it.
+
+### Issue a dev API key (stack-local)
+
+```bash
+export DIGIKEY_DATABASE_URL="sqlite:////workspace/.local_digikey.sqlite" DIGIKEY_ALLOW_DEV_GLOBAL=1
+PATH="$PWD/.venv/bin:$PATH" python -m digikey.cli issue-key --tenant default --label dev --scopes '*' --kind dev_global
+# Exchange: POST http://127.0.0.1:8005/v1/oauth/token  {"grant_type":"api_key","api_key":"dgk_live_..."}
+```
+
+Standard commands are also documented in root `README.md` and `Makefile`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Cursor Cloud specific instructions** to `AGENTS.md` documenting how to develop in this monorepo when Docker is unavailable (host-native `make stack-local`), including dependency install order, test caveats (Nautilus Linux SIGABRT), and dev API key bootstrap.

The VM update script installs Python workspace packages, LiteLLM proxy, and npm workspaces with Linux native bindings for DigiChat Vitest.

Fixes #602

## Verified locally

- `make test-baseline` — 15 passed
- `ruff check` on core packages — clean
- `npm run test --workspace digichat` — 80 passed
- `make stack-local` — all services healthy on 8000–8003, 8005
- JWT exchange + DigiQuant `/strategies` + DigiSearch `/query` smoke demo

## Notes

- LLM `POST /workflow` requires `GROQ_API_KEY` in `.env`
- Full `make test-unit` may SIGABRT on Linux due to Nautilus under pytest (#42)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95cb154e-382b-4b18-898d-70562953992a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95cb154e-382b-4b18-898d-70562953992a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

