### PR TITLE
fix(digibase): repair NotionConnector lazy import

### DIFF
--- a/digibase/src/digibase/connectors/__init__.py
+++ b/digibase/src/digibase/connectors/__init__.py
@@ -7,9 +7,12 @@ types remain usable even when ``notion-client`` is not installed.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from digibase.connectors.base import ConnectorPayload, ConnectorResult
+
+if TYPE_CHECKING:
+    from digibase.connectors.notion import NotionConnector, UpsertResult
 
 __all__ = [
     "ConnectorPayload",
@@ -17,10 +20,6 @@ __all__ = [
     "NotionConnector",
     "UpsertResult",
 ]
-
-# Placeholders satisfy static export checks; resolved on first access via __getattr__.
-NotionConnector: Any = None
-UpsertResult: Any = None
 
 
 def __getattr__(name: str) -> Any:

--- a/tests/db/connectors/test_notion_connector.py
+++ b/tests/db/connectors/test_notion_connector.py
@@ -20,6 +20,17 @@ def mock_notion_client():
         yield mock_instance
 
 
+def test_lazy_import_resolves_notion_connector_class():
+    """NotionConnector must lazy-load to the real class, not a None placeholder."""
+    import digibase.connectors as connectors
+
+    cls = connectors.NotionConnector
+    assert cls is not None
+    assert cls.__name__ == "NotionConnector"
+    # Cached on module after first access
+    assert connectors.NotionConnector is cls
+
+
 def test_upsert_creates_new_row_when_no_match(mock_notion_client):
     """When no existing row matches, a new page is created."""
     mock_notion_client.request.return_value = {"results": []}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removes `NotionConnector = None` / `UpsertResult = None` placeholders that shadowed PEP 562 `__getattr__` — imports were returning `None` instead of the connector class.
- Uses `TYPE_CHECKING` imports for static analysis without eager `notion-client` load.
- Adds regression test ensuring lazy import resolves to the real class.

## Test plan

- [x] `pytest tests/db/connectors/test_notion_connector.py -v` (7 passed)

Fixes #618
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b36ce682-eb7f-4d1e-b76d-4fb051380f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b36ce682-eb7f-4d1e-b76d-4fb051380f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

