### PR TITLE
fix(atlas): make publish succeed — valid documents.category + daily_snapshots legacy NOT NULL migration

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
@@ -25,6 +25,32 @@ class PublishDeps:
     client: SupabaseClient
 
 
+# ``documents.category`` must satisfy the ``chk_documents_category`` CHECK
+# constraint (migration 002/011): one of synthesis, macro, asset-class, equity,
+# sector, alt-data, institutional, portfolio, delta, output, rollup, deep-dive.
+# Map each segment slug to its phase's category; unmapped slugs fall back to the
+# catch-all "output". (Passing the old default "research" violated the
+# constraint and failed every publish — issue #628.)
+_ASSET_CLASS_SLUGS = frozenset({"bonds", "commodities", "forex", "crypto", "international"})
+
+
+def _segment_category(slug: str) -> str:
+    """Return a constraint-valid ``documents.category`` for a segment slug."""
+    if slug.startswith("alt-"):
+        return "alt-data"
+    if slug.startswith("inst-"):
+        return "institutional"
+    if slug == "macro":
+        return "macro"
+    if slug in _ASSET_CLASS_SLUGS:
+        return "asset-class"
+    if slug == "equity":
+        return "equity"
+    if slug.startswith("sector-"):
+        return "sector"
+    return "output"
+
+
 def _publish_segment_bag(
     *,
     client: SupabaseClient,
@@ -45,6 +71,7 @@ def _publish_segment_bag(
             run_type=run_type,
             title=f"{slug} {date_str}",
             date_str=date_str,
+            category=_segment_category(slug),
             segment=slug,
         )
         published.append(artifact)
@@ -81,6 +108,7 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     run_type=run_type,
                     title=f"macro {date_str}",
                     date_str=date_str,
+                    category="macro",
                     segment="macro",
                 )
             )
@@ -94,16 +122,19 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                 digest_key = f"custom-research/{state.run_id}"
                 digest_doc_type: str | None = "Custom Research"
                 title = f"Atlas Custom Research {date_str}"
+                digest_category = "output"
             elif run_type == "delta":
                 digest_key = "digest-delta"
                 digest_doc_type = "Daily Delta"
                 title = f"Atlas Daily Delta {date_str}"
+                digest_category = "delta"
             else:
                 # ``monthly`` never reaches publish (deps=None for monthly);
                 # baseline is the only remaining ``run_type`` that lands here.
                 digest_key = "digest"
                 digest_doc_type = "Daily Digest"
                 title = f"Atlas Daily Digest {date_str}"
+                digest_category = "synthesis"
 
             artifacts.append(
                 publish_document(
@@ -114,6 +145,7 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     run_type=run_type,
                     title=title,
                     date_str=date_str,
+                    category=digest_category,
                 )
             )
             if not state.custom_prompt:
@@ -138,6 +170,7 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     run_type=run_type,
                     title=f"{ticker} analyst {date_str}",
                     date_str=date_str,
+                    category="deep-dive",
                     segment="analyst",
                     sector=ticker,
                 )
@@ -153,6 +186,7 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     run_type=run_type,
                     title=f"PM Rebalance {date_str}",
                     date_str=date_str,
+                    category="portfolio",
                 )
             )
 

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -200,7 +200,7 @@ def publish_document(
     run_type: str,
     title: str,
     date_str: str,
-    category: str = "research",
+    category: str = "output",
     segment: str | None = None,
     sector: str | None = None,
     content_markdown: str | None = None,

--- a/digiquant/supabase/migrations/029_daily_snapshots_legacy_nullable.sql
+++ b/digiquant/supabase/migrations/029_daily_snapshots_legacy_nullable.sql
@@ -1,0 +1,27 @@
+-- 029_daily_snapshots_legacy_nullable.sql — make the deprecated flat
+-- daily_snapshots columns (regime, market_data) NULLABLE.
+--
+-- Run with:  supabase db push   (or paste into the Supabase SQL editor)
+--
+-- Why:
+-- The Atlas publish adapter (olympus/atlas/supabase_io.publish_daily_snapshot)
+-- writes the full digest into the `snapshot` JSONB column and intentionally
+-- leaves the original flat columns unset — see its docstring: "the legacy
+-- column set (bias fields, etc.) is populated by downstream readers or a
+-- follow-up schema migration — not this adapter." THIS is that follow-up
+-- migration, which was never written.
+--
+-- `regime` and `market_data` were declared NOT NULL (migrations 001 / 011), so
+-- after the adapter moved to the `snapshot` JSONB, every daily_snapshots upsert
+-- failed with PostgREST 23502 — blocking all baseline/delta publishes. (The
+-- Gemini rate-limit failures masked it by aborting runs before publish; the
+-- xAI cutover (#627) surfaced it via a full local end-to-end run.)
+--
+-- Reader-safe: all consumers read the `snapshot` JSONB (snapshot.regime,
+-- snapshot.market_data, snapshot.portfolio, …), not these flat top-level
+-- columns. Making them nullable unblocks publish without touching any reader.
+--
+-- Refs #524 (schema anomaly cleanup), #628 / #627 (publish failures).
+
+ALTER TABLE daily_snapshots ALTER COLUMN regime DROP NOT NULL;
+ALTER TABLE daily_snapshots ALTER COLUMN market_data DROP NOT NULL;

--- a/tests/dq/atlas/test_publish_category.py
+++ b/tests/dq/atlas/test_publish_category.py
@@ -1,0 +1,89 @@
+"""Guard: publish must only write constraint-valid ``documents.category`` values.
+
+Regression test for #628 — publish_document() defaulted to category="research",
+which is NOT in the chk_documents_category CHECK constraint, so every baseline /
+delta publish failed with PostgREST 23514. This test pins the segment->category
+mapping and asserts every category the publish path can emit is allow-listed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.atlas.phases.publish_phase import _segment_category
+
+# Source of truth: chk_documents_category in
+# digiquant/supabase/migrations/{002_schema_hardening,011_unpartition_snapshots_documents}.sql
+ALLOWED_CATEGORIES = frozenset(
+    {
+        "synthesis",
+        "macro",
+        "asset-class",
+        "equity",
+        "sector",
+        "alt-data",
+        "institutional",
+        "portfolio",
+        "delta",
+        "output",
+        "rollup",
+        "deep-dive",
+    }
+)
+
+# Categories the publish node passes explicitly (not via _segment_category):
+# digest (synthesis / delta / output), analysts (deep-dive), pm-rebalance (portfolio),
+# macro (macro). Kept in sync with publish_phase.build_publish_node.
+EXPLICIT_CATEGORIES = {"synthesis", "delta", "output", "deep-dive", "portfolio", "macro"}
+
+
+@pytest.mark.unit
+class TestPublishCategoryConstraint:
+    @pytest.mark.parametrize(
+        "slug, expected",
+        [
+            ("alt-sentiment-news", "alt-data"),
+            ("alt-cta-positioning", "alt-data"),
+            ("inst-institutional-flows", "institutional"),
+            ("inst-hedge-fund-intel", "institutional"),
+            ("macro", "macro"),
+            ("bonds", "asset-class"),
+            ("commodities", "asset-class"),
+            ("forex", "asset-class"),
+            ("crypto", "asset-class"),
+            ("international", "asset-class"),
+            ("equity", "equity"),
+            ("sector-technology", "sector"),
+            ("sector-healthcare", "sector"),
+            ("some-unmapped-slug", "output"),  # safe catch-all
+        ],
+    )
+    def test_segment_category_mapping(self, slug: str, expected: str) -> None:
+        assert _segment_category(slug) == expected
+
+    def test_all_segment_categories_are_constraint_valid(self) -> None:
+        """Every segment slug from the live model_modes phases maps to an allowed category."""
+        sample_slugs = [
+            "alt-sentiment-news",
+            "alt-cta-positioning",
+            "alt-options-derivatives",
+            "alt-politician-signals",
+            "inst-institutional-flows",
+            "inst-hedge-fund-intel",
+            "macro",
+            "bonds",
+            "commodities",
+            "forex",
+            "crypto",
+            "international",
+            "equity",
+            "sector-technology",
+            "sector-energy",
+            "anything-else",
+        ]
+        for slug in sample_slugs:
+            assert _segment_category(slug) in ALLOWED_CATEGORIES, slug
+
+    def test_explicit_categories_are_constraint_valid(self) -> None:
+        """The hard-coded digest/analyst/pm categories must also be allow-listed."""
+        assert EXPLICIT_CATEGORIES <= ALLOWED_CATEGORIES


### PR DESCRIPTION
## Bug (Closes #628)
`publish_document()` defaulted to `category="research"` and `publish_phase.py` never overrode it — but `chk_documents_category` only allows `synthesis, macro, asset-class, equity, sector, alt-data, institutional, portfolio, delta, output, rollup, deep-dive`. So **every** baseline/delta publish failed with PostgREST `23514`.

This was masked for weeks by the Gemini rate-limit failures that aborted runs *before* the publish phase. The xAI cutover (#627) removed those failures, and a full **local end-to-end run** (LM Studio gemma-4-e4b) then ran the whole pipeline and surfaced this at the publish step. (Last successful baseline was 2026-05-04 — prod's constraint was tightened to match the migrations ~5 weeks ago.) Related: schema-anomaly cleanup #524.

## Fix
- **`publish_phase.py`** — `_segment_category()` maps each segment slug to a valid category (alt-data / institutional / macro / asset-class / equity / sector) with an `output` catch-all; explicit valid categories for the digest (synthesis/delta/output), per-ticker analysts (deep-dive), PM rebalance (portfolio), and macro.
- **`supabase_io.py`** — change the unsafe `publish_document` default `research` → `output`.
- **tests** — `test_publish_category.py` guards that every emitted category is in the constraint allow-list.

## Verification
- Confirmed all `doc_type` values the publish path sends are in `chk_documents_doc_type` (no second constraint issue).
- `make score` 10/10; ruff clean; 56 atlas publish/graph/supabase unit tests pass (16 new).
- Full publish-path proof comes from the next real run (the local e2e reached publish and this was the failing step).

Refs #524, #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)