### PR TITLE
chore(db): capture MCP-applied prod migrations (030 dup-index drop, 031 fx RLS)

### DIFF
--- a/digiquant/supabase/migrations/030_drop_duplicate_indexes_positions_events.sql
+++ b/digiquant/supabase/migrations/030_drop_duplicate_indexes_positions_events.sql
@@ -1,0 +1,15 @@
+-- 030_drop_duplicate_indexes_positions_events.sql
+--
+-- Run with:  supabase db push   (or paste into the Supabase SQL editor)
+--
+-- Performance advisor WARN (duplicate_index): `positions` and `position_events`
+-- each carried two identical btree(ticker, date DESC) indexes:
+--   positions:       idx_positions_ticker  ≡  idx_positions_ticker_date
+--   position_events: idx_events_ticker     ≡  idx_events_ticker_date
+-- Drop the redundant one in each (keep the *_date-named one). Idempotent.
+--
+-- Already applied to prod 2026-06-08 via MCP; this file captures it so a clean
+-- `supabase db push` reproduces the schema. Refs #524.
+
+DROP INDEX IF EXISTS public.idx_positions_ticker;
+DROP INDEX IF EXISTS public.idx_events_ticker;

--- a/digiquant/supabase/migrations/031_fx_economic_calendar_rls.sql
+++ b/digiquant/supabase/migrations/031_fx_economic_calendar_rls.sql
@@ -1,0 +1,25 @@
+-- 031_fx_economic_calendar_rls.sql
+--
+-- Run with:  supabase db push   (or paste into the Supabase SQL editor)
+--
+-- Security advisor ERROR (rls_disabled_in_public): `fx_economic_calendar` was
+-- PostgREST-exposed with RLS disabled. It entered prod via an out-of-repo
+-- migration (`001_fx_economic_calendar`, 2026-06). Enable RLS + anon read,
+-- mirroring the other public reference tables (price_history / trading_calendar);
+-- server-side writers use the service role, which bypasses RLS.
+--
+-- Also pins the mutable search_path on trigger_set_updated_at (advisor WARN
+-- function_search_path_mutable). Idempotent.
+--
+-- Already applied to prod 2026-06-08 via MCP; this file captures it so a clean
+-- `supabase db push` reproduces the schema. Refs #524.
+
+ALTER TABLE public.fx_economic_calendar ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fx_economic_calendar_anon_select ON public.fx_economic_calendar;
+CREATE POLICY fx_economic_calendar_anon_select
+  ON public.fx_economic_calendar
+  FOR SELECT TO anon
+  USING (true);
+
+ALTER FUNCTION public.trigger_set_updated_at() SET search_path = '';


### PR DESCRIPTION
Commits the two schema fixes already applied to prod via the Supabase MCP during the xAI-cutover DB cleanup, so the repo reproduces prod and history stays aligned.

- **030** — drop duplicate `btree(ticker, date DESC)` indexes on `positions` + `position_events` (perf advisor: duplicate_index).
- **031** — enable RLS + anon-read on `fx_economic_calendar` (security advisor ERROR: rls_disabled_in_public) + pin `trigger_set_updated_at` search_path.

Both idempotent (`DROP INDEX IF EXISTS`, `DROP POLICY IF EXISTS`, `ENABLE RLS`, `ALTER FUNCTION … SET`), so re-running `supabase db push` is safe even though prod already has them.

Part of #524 (broader repo↔prod migration reconciliation — 6 out-of-repo `backfill_*` migrations, `portfolio_*`/`fx_economic_calendar` tables, unapplied `028`, deep-history trim — still pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)