### PR TITLE
fix(atlas): correct xAI model id (grok-4.3) + preflight tolerates fresh DB

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4-3).
+          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           # Replaces the Gemini free tier whose rate limits broke daily runs (#569/#570/#572).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4-3).
+          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           # Replaces the Gemini free tier whose rate limits broke daily runs (#569/#570/#572).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -132,7 +132,7 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4-3).
+          # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -15,7 +15,7 @@
 #   ollama-cloud/…     → OPENAI_API_KEY  → Ollama Cloud (OPENAI_API_BASE)
 #
 # ── CURRENT ROUTING: xAI / Grok (paid) ─────────────────────────────────────────
-# Every phase runs on `xai/grok-4-3` — xAI's flagship (1M-token context,
+# Every phase runs on `xai/grok-4.3` — xAI's flagship (1M-token context,
 # $1.25/$2.50 per 1M in/out as of 2026-06). This replaced the Gemini free tier,
 # whose 10 RPM / per-minute token caps caused the daily Atlas/Hermes workflows to
 # fail consistently (see issues #569 / #570 / #572). Grok's paid limits are high
@@ -34,70 +34,70 @@ phase_models:
 
   # ── Phase 1 — Alt-data extraction ──────────────────────────────────────────
   # [tier: extraction] ~500 tokens each, 4 parallel segments.
-  alt-sentiment-news:      "xai/grok-4-3"
-  alt-cta-positioning:     "xai/grok-4-3"
-  alt-options-derivatives: "xai/grok-4-3"
-  alt-politician-signals:  "xai/grok-4-3"
+  alt-sentiment-news:      "xai/grok-4.3"
+  alt-cta-positioning:     "xai/grok-4.3"
+  alt-options-derivatives: "xai/grok-4.3"
+  alt-politician-signals:  "xai/grok-4.3"
 
   # ── Phase 2 — Institutional flow extraction ────────────────────────────────
   # [tier: extraction] ~800 tokens each, 2 segments.
-  inst-institutional-flows: "xai/grok-4-3"
-  inst-hedge-fund-intel:    "xai/grok-4-3"
+  inst-institutional-flows: "xai/grok-4.3"
+  inst-hedge-fund-intel:    "xai/grok-4.3"
 
   # ── Phase 3 — Macro regime ─────────────────────────────────────────────────
   # [tier: research] Single call; reads macro indicators + prior regime.
-  macro: "xai/grok-4-3"
+  macro: "xai/grok-4.3"
 
   # ── Phase 4 — Asset classes ────────────────────────────────────────────────
   # [tier: research] 5 parallel segments; cross-asset conviction calls.
-  bonds:         "xai/grok-4-3"
-  commodities:   "xai/grok-4-3"
-  forex:         "xai/grok-4-3"
-  crypto:        "xai/grok-4-3"
-  international: "xai/grok-4-3"
+  bonds:         "xai/grok-4.3"
+  commodities:   "xai/grok-4.3"
+  forex:         "xai/grok-4.3"
+  crypto:        "xai/grok-4.3"
+  international: "xai/grok-4.3"
 
   # ── Phase 5 — US equities ──────────────────────────────────────────────────
   # [tier: research] Top-down + 11-sector swarm (prefix match covers all sectors).
-  equity:    "xai/grok-4-3"
-  "sector-": "xai/grok-4-3"
+  equity:    "xai/grok-4.3"
+  "sector-": "xai/grok-4.3"
 
   # ── Phase 7C — Per-ticker analyst fan-out ──────────────────────────────────
   # [tier: extraction] {axis}-analyst-{ticker} — prefix matches each axis.
   # Up to 25 tickers × 4 axes = 100 parallel calls in CI (ATLAS_MAX_ANALYSTS=25);
   # the cap bounds run time/cost rather than dodging an RPM wall on Grok.
-  "technical-analyst-":   "xai/grok-4-3"
-  "sentiment-analyst-":   "xai/grok-4-3"
-  "news-analyst-":        "xai/grok-4-3"
-  "fundamental-analyst-": "xai/grok-4-3"
+  "technical-analyst-":   "xai/grok-4.3"
+  "sentiment-analyst-":   "xai/grok-4.3"
+  "news-analyst-":        "xai/grok-4.3"
+  "fundamental-analyst-": "xai/grok-4.3"
 
   # ── Phase 7C-D — Bull / Bear adversarial debate ────────────────────────────
   # [tier: research] N rounds × 3 nodes per ticker; prefix matches all tickers.
-  "bull-researcher-":  "xai/grok-4-3"
-  "bear-researcher-":  "xai/grok-4-3"
-  "research-manager-": "xai/grok-4-3"
+  "bull-researcher-":  "xai/grok-4.3"
+  "bear-researcher-":  "xai/grok-4.3"
+  "research-manager-": "xai/grok-4.3"
 
   # ── Phase 7D — Risk temperament debate ────────────────────────────────────
   # [tier: research] Two nodes frame the risk envelope for the PM decision.
-  risk-aggressive:  "xai/grok-4-3"
-  risk-conservative: "xai/grok-4-3"
+  risk-aggressive:  "xai/grok-4.3"
+  risk-conservative: "xai/grok-4.3"
 
   # ── Phase 7D — PM rebalance ────────────────────────────────────────────────
   # [tier: reasoning] ~12k token input; final portfolio allocation decision.
-  pm-rebalance: "xai/grok-4-3"
+  pm-rebalance: "xai/grok-4.3"
 
   # ── Phase 7 — Master digest synthesis ─────────────────────────────────────
   # [tier: reasoning] ~8k token input; reconciles all phase 1–6 outputs.
-  master-digest: "xai/grok-4-3"
+  master-digest: "xai/grok-4.3"
 
   # ── Phase monthly — Month-end rollup ───────────────────────────────────────
   # [tier: reasoning] Same stakes as master-digest; cross-month regime shift.
-  monthly-digest: "xai/grok-4-3"
+  monthly-digest: "xai/grok-4.3"
 
   # ── Phase 9 — Closed-loop evolution ───────────────────────────────────────
   # [tier: research] Evaluates prior-day prediction quality; proposes pipeline
   # improvements. Important but not a live investment decision.
-  phase9-evolution: "xai/grok-4-3"
+  phase9-evolution: "xai/grok-4.3"
 
   # ── Decision reflector ─────────────────────────────────────────────────────
   # [tier: research] Post-trade reflection; feeds back into next run's priors.
-  decision-reflector: "xai/grok-4-3"
+  decision-reflector: "xai/grok-4.3"

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -179,11 +179,12 @@ def check_supabase() -> bool:
                 f"latest baseline: {latest} — --auto-baseline will resolve",
             )
         else:
-            check(
-                "Prior baseline exists",
-                False,
-                "No baseline rows in daily_snapshots — delta --auto-baseline will fail",
-            )
+            # Informational only — do NOT gate. A baseline run creates the first
+            # snapshot; only a delta run with --auto-baseline needs a prior one
+            # (the chain's own preflight errors there if truly required). On a
+            # fresh/seeded DB this is expected, so it must not fail the preflight.
+            print(f"  {SKIP}  Prior baseline exists")
+            print("        none yet — OK for a baseline seed; delta --auto-baseline would need one")
         return connected
     except (
         OSError,

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -4,7 +4,7 @@ Atlas provider validation — run before triggering a real pipeline run.
 
 Checks (in order):
   1. Required env vars are present
-  2. xAI API key is valid (1-token ping to grok-4-3)
+  2. xAI API key is valid (1-token ping to grok-4.3)
      Note: all phases route through xAI Grok (config/model_modes.yaml).
      This replaced the Gemini free tier, whose rate limits broke daily runs
      (#569/#570/#572).
@@ -107,7 +107,7 @@ def check_env_vars() -> bool:
     return all_ok
 
 
-def check_xai(model: str = "grok-4-3") -> bool:
+def check_xai(model: str = "grok-4.3") -> bool:
     print(_bold("\n2. xAI connectivity"))
     api_key = os.environ.get("XAI_API_KEY", "").strip()
     if not api_key:
@@ -256,7 +256,7 @@ def main() -> int:
     check_env_vars()
 
     if not args.skip_llm:
-        check_xai("grok-4-3")
+        check_xai("grok-4.3")
 
     if not args.skip_db:
         check_supabase()

--- a/docs/atlas/token-budget.md
+++ b/docs/atlas/token-budget.md
@@ -2,7 +2,7 @@
 
 *Last updated: 2026-06-07.*
 
-> **⚠️ Current routing (2026-06): all phases run on `xai/grok-4-3`.**
+> **⚠️ Current routing (2026-06): all phases run on `xai/grok-4.3`.**
 > `config/model_modes.yaml` now routes every phase to xAI Grok (the flagship,
 > 1M-token context). This replaced the **Gemini free tier**, whose 10 RPM /
 > per-minute token caps caused the daily Atlas/Hermes workflows to fail
@@ -10,7 +10,7 @@
 > describe the **capability tiers** (why each phase needs extraction vs research
 > vs reasoning) and the original free-tier design — that analysis still holds;
 > only the concrete provider/model has changed. Token *budgets* (counts) are
-> approximate and model-independent. xAI Grok pricing (2026-06): grok-4-3
+> approximate and model-independent. xAI Grok pricing (2026-06): grok-4.3
 > $1.25 / $2.50 per 1M in/out — a full baseline run is a few cents.
 
 ---

--- a/tests/dq/atlas/test_phase_monthly.py
+++ b/tests/dq/atlas/test_phase_monthly.py
@@ -65,13 +65,13 @@ class TestMonthlyDigestModelConfig:
         """get_model_for_phase("monthly-digest") must return the pinned reasoning model.
 
         Pipeline cut over from the rate-limited Gemini/Ollama free tiers to paid
-        xAI Grok (issues #569/#570/#572); monthly-digest is now pinned to grok-4-3.
+        xAI Grok (issues #569/#570/#572); monthly-digest is now pinned to grok-4.3.
         """
         from digigraph.llm import get_model_for_phase
 
         model = get_model_for_phase("monthly-digest")
-        assert model == "xai/grok-4-3", (
-            f"monthly-digest should be pinned to xai/grok-4-3, got {model!r}"
+        assert model == "xai/grok-4.3", (
+            f"monthly-digest should be pinned to xai/grok-4.3, got {model!r}"
         )
 
     def test_phase_slug_not_none(self) -> None:
@@ -148,6 +148,6 @@ class TestMonthlyNodePassesPhaseSlug:
             assert "kimi" not in m.lower(), (
                 f"kimi-k2-thinking must not be selected in best mode; got {m!r}"
             )
-        assert all(m == "xai/grok-4-3" for m in called_models), (
-            f"Expected the pinned xai/grok-4-3 model via phase_slug; got {called_models}"
+        assert all(m == "xai/grok-4.3" for m in called_models), (
+            f"Expected the pinned xai/grok-4.3 model via phase_slug; got {called_models}"
         )


### PR DESCRIPTION
Two fixes surfaced by the first real Grok baseline seed run (which failed at preflight, not the pipeline). Refs #624, #627.

## 1. Wrong xAI model id
The live xAI API rejected `grok-4-3` with `400 Model not found`. The flagship's actual id uses a **dot**: `grok-4.3` (older slugs redirect to it). Corrected in `config/model_modes.yaml`, `validate-providers.py`, workflow comments, docs, and the monthly test. **Confirmed working** — the live xAI preflight now passes (`PASS xAI grok-4.3`).

## 2. Preflight hard-failed on a fresh DB
After the fresh-start wipe, `daily_snapshots` is empty, so the "Prior baseline exists" check failed and gated the seed. But a *baseline* run creates the first snapshot — only *delta* `--auto-baseline` needs a prior one. Demoted to an informational SKIP.

## Verification
- Dry-run workflow on this branch (live xAI preflight + graph compile): **green** — `PASS xAI grok-4.3`, `PASS Supabase reachable`, preflight success, baseline (dry-run) success.
- 20 atlas unit tests pass; `make score` 10/10; ruff clean.

After merge, the real baseline seed runs from develop on Grok.