### PR TITLE
fix(digiquant): intraday technicals — bump fetch period to 1y (200-bar warmup)

### DIFF
--- a/.github/workflows/digiquant-prices-backfill.yml
+++ b/.github/workflows/digiquant-prices-backfill.yml
@@ -83,9 +83,12 @@ jobs:
       - name: Step 2 — Compute technicals (full history)
         if: ${{ inputs.dry_run == false }}
         run: |
+          # No --date: compute over the FULL cache. (--date is an *upper* bound
+          # "slice output to <= DATE"; the old --date 1990-01-01 sliced to
+          # <=1990, which a recent cache has none of → 0 rows. --days 99999
+          # keeps all computed rows.)
           python -m digiquant prices compute-technicals \
             --cache-dir data/price-history \
-            --date 1990-01-01 \
             --days 99999 \
             --supabase
 

--- a/.github/workflows/digiquant-prices.yml
+++ b/.github/workflows/digiquant-prices.yml
@@ -69,6 +69,7 @@ jobs:
           python -m digiquant prices fetch-quotes \
             --watchlist digiquant/src/digiquant/olympus/atlas/config/watchlist.md \
             --cache-dir data/price-history \
+            --period 1y \
             --supabase
       - name: Compute technicals -> upsert price_technicals
         run: |

--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -27,12 +27,19 @@ def prices() -> None:
 # ─── Trading-calendar helpers ─────────────────────────────────────────────
 
 
-def _fetch_trading_days(client: Any, venue: str, *, page_size: int = 5000) -> pl.Series | None:
+def _fetch_trading_days(client: Any, venue: str, *, page_size: int = 1000) -> pl.Series | None:
     """Fetch all trading days for ``venue`` from the ``trading_calendar`` table.
 
     Returns a :class:`polars.Series` of :class:`datetime.date` values for rows
     where ``is_trading_day=True``, or ``None`` on error.  Paginates automatically
     so callers are not limited by Supabase's default 1 000-row cap.
+
+    ``page_size`` must be <= PostgREST's max-rows cap (1 000). A larger value
+    silently returns only the first 1 000 rows, so ``len(batch) < page_size``
+    is true on page 1 and pagination stops after one page — which previously
+    yielded only the *oldest* 1 000 days and dropped every recent session from
+    the technicals trading-day filter. ``.order("date")`` makes paging
+    deterministic.
     """
     all_dates: list[date] = []
     offset = 0
@@ -43,6 +50,7 @@ def _fetch_trading_days(client: Any, venue: str, *, page_size: int = 5000) -> pl
                 .select("date")
                 .eq("venue", venue)
                 .eq("is_trading_day", True)
+                .order("date")
                 .range(offset, offset + page_size - 1)
                 .execute()
             )

--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -212,7 +212,10 @@ def compute_technicals_cmd(
             click.echo(f"  skip {ticker:6s} (insufficient cache)")
             continue
         if target_date:
-            df = df.filter(df["timestamp"] <= date.fromisoformat(target_date))
+            # ``timestamp`` is often Datetime('μs') from the CSV cache; Polars no
+            # longer coerces Datetime vs a python ``date``, so cast to Date for the
+            # boundary comparison (sibling of the #608 is_in dtype fix).
+            df = df.filter(df["timestamp"].cast(pl.Date) <= date.fromisoformat(target_date))
 
         # Resolve trading-days filter. Filter df *before* compute_indicators so
         # ind.height == df.height holds after the call (see assertion below).


### PR DESCRIPTION
After #608 fixed the compute-technicals crash, the intraday job still upserted **0** technicals rows: the ephemeral CI cache held only `fetch-quotes`' default **3mo (~60 bars)**, but the indicators use a **200-bar** SMA/zscore window → all long-window values null → 0 rows → `price_technicals` frozen → Atlas research empty.

**Fix:** add `--period 1y` (~252 bars) to the intraday fetch-quotes step so the cache covers the 200-bar warmup.

The existing 2026-05-01→present gap is repopulated separately via the full-history backfill workflow (`digiquant-prices-backfill.yml`, running now).

**Follow-up (noted, not in this PR):** persist the `data/price-history` cache across runs so the intraday job doesn't re-fetch 1y for every ticker every 15 min — otherwise this trades the empty-output bug for yfinance rate-limit pressure (cf. #465/#563).

Refs #465.