### PR TITLE
chore(docs): refresh agent backlog snapshot

### DIFF
--- a/docs/agent-backlog/generated-snapshot.md
+++ b/docs/agent-backlog/generated-snapshot.md
@@ -1,5 +1,5 @@
 # Agent backlog snapshot
 
-This file is **optional output** from `.github/workflows/agent-backlog-snapshot.yml` when the workflow runs (scheduled or manual). Until then, it is a placeholder so links from [README.md](README.md) stay valid.
+**Generated:** 2026-06-08 11:01 UTC · **repo:** `digithings-ai/digithings` · **label:** `agent-task`
 
-Open issues labeled `agent-task` will be listed here automatically when the snapshot job is enabled and `GITHUB_TOKEN` can read issues.
+*No open issues with label `agent-task`.*


### PR DESCRIPTION
Auto-generated weekly refresh of `docs/agent-backlog/generated-snapshot.md`.

Triggered by the [Agent backlog snapshot](../actions/workflows/agent-backlog-snapshot.yml) scheduled workflow.