### PR TITLE
chore(atlas): standardize Supabase key env var → SUPABASE_SERVICE_ROLE_KEY (#647)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Validate providers (preflight)
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
@@ -75,7 +75,7 @@ jobs:
         id: run
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           # Replaces the Gemini free tier whose rate limits broke daily runs (#569/#570/#572).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Validate providers (preflight)
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
@@ -72,7 +72,7 @@ jobs:
       - name: Run delta
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           # Replaces the Gemini free tier whose rate limits broke daily runs (#569/#570/#572).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run monthly
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases run on xAI Grok (config/model_modes.yaml -> xai/grok-4.3).
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/digiquant-prices.yml
+++ b/.github/workflows/digiquant-prices.yml
@@ -136,7 +136,6 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-      SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/digibase/ARCHITECTURE.md
+++ b/digibase/ARCHITECTURE.md
@@ -306,7 +306,7 @@ class SupabaseConnector:
 
     @classmethod
     def from_env(
-        cls, *, url_var: str = "SUPABASE_URL", key_var: str = "SUPABASE_SERVICE_KEY"
+        cls, *, url_var: str = "SUPABASE_URL", key_var: str = "SUPABASE_SERVICE_ROLE_KEY"
     ) -> SupabaseConnector: ...
 
     @property
@@ -337,7 +337,7 @@ class SupabaseConnector:
     ) -> SupabaseReadResult: ...
 ```
 
-`from_env` resolves `SUPABASE_URL` + the service-role key (`SUPABASE_SERVICE_KEY`
+`from_env` resolves `SUPABASE_URL` + the service-role key (`SUPABASE_SERVICE_ROLE_KEY`
 by default; both overridable), raising `SupabaseNotConfiguredError` when either
 is unset/blank — this guard runs *before* the deferred `create_client` import,
 so a missing-config error never requires the optional dependency. Construct with

--- a/digibase/src/digibase/connectors/supabase.py
+++ b/digibase/src/digibase/connectors/supabase.py
@@ -48,7 +48,7 @@ class SupabaseClient(Protocol):
 
 
 class SupabaseNotConfiguredError(RuntimeError):
-    """Raised when ``SUPABASE_URL`` / ``SUPABASE_SERVICE_KEY`` are missing."""
+    """Raised when ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY`` are missing."""
 
 
 @dataclass
@@ -97,11 +97,11 @@ class SupabaseConnector:
         cls,
         *,
         url_var: str = "SUPABASE_URL",
-        key_var: str = "SUPABASE_SERVICE_KEY",
+        key_var: str = "SUPABASE_SERVICE_ROLE_KEY",
     ) -> SupabaseConnector:
         """Build a connector from environment variables.
 
-        Resolves ``SUPABASE_URL`` and the service-role key (``SUPABASE_SERVICE_KEY``
+        Resolves ``SUPABASE_URL`` and the service-role key (``SUPABASE_SERVICE_ROLE_KEY``
         by default), then constructs a live client. The ``supabase`` package is
         an optional extra, so its import is deferred to here — importing this
         module never requires the dependency.

--- a/digiquant/scripts/atlas/audit_activity_coverage_api.py
+++ b/digiquant/scripts/atlas/audit_activity_coverage_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Same checks as scripts/sql/audit_activity_coverage.sql using the Supabase REST client
-(SUPABASE_URL + SUPABASE_SERVICE_KEY — no Postgres URI required).
+(SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY — no Postgres URI required).
 
 Usage:
   python3 scripts/audit_activity_coverage_api.py
@@ -39,9 +39,9 @@ def _max_date(sb, table: str, col: str = "date"):
 
 def main() -> int:
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        print("SUPABASE_URL and SUPABASE_SERVICE_KEY required", file=sys.stderr)
+        print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required", file=sys.stderr)
         return 1
     sb = create_client(url, key)
     pe = _max_date(sb, "position_events")

--- a/digiquant/scripts/atlas/backfill-historical-daily-to-supabase.sh
+++ b/digiquant/scripts/atlas/backfill-historical-daily-to-supabase.sh
@@ -7,7 +7,7 @@
 #   SKIP_COPY=1 ./scripts/backfill-historical-daily-to-supabase.sh   # data/agent-cache/daily already filled
 #
 # Prerequisites:
-#   - config/supabase.env with SUPABASE_URL + SUPABASE_SERVICE_KEY
+#   - config/supabase.env with SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY
 #   - pip install -r requirements.txt
 #   - Unless SKIP_COPY=1: LEGACY_ROOT must be a directory whose children include YYYY-MM-DD folders to copy
 #

--- a/digiquant/scripts/atlas/backfill-supabase.py
+++ b/digiquant/scripts/atlas/backfill-supabase.py
@@ -3,7 +3,7 @@
 
 Usage:
   export SUPABASE_URL=https://xxx.supabase.co
-  export SUPABASE_SERVICE_KEY=eyJ...
+  export SUPABASE_SERVICE_ROLE_KEY=eyJ...
   python scripts/backfill-supabase.py
 """
 import argparse
@@ -18,7 +18,7 @@ import update_tearsheet as mod
 def main():
     parser = argparse.ArgumentParser(
         description="backfill-supabase.py — One-time backfill of all daily data to Supabase",
-        epilog="Requires SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables."
+        epilog="Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables."
     )
     parser.add_argument(
         "--dry-run", action="store_true",
@@ -27,7 +27,7 @@ def main():
     cli_args = parser.parse_args()
 
     if not mod.supabase_configured():
-        print("❌ Supabase not configured. Set SUPABASE_URL and SUPABASE_SERVICE_KEY env vars.")
+        print("❌ Supabase not configured. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars.")
         sys.exit(1)
 
     print("📊 Backfilling Supabase from digest files found under data/agent-cache/daily/ (recovery path)...")

--- a/digiquant/scripts/atlas/backfill_context.py
+++ b/digiquant/scripts/atlas/backfill_context.py
@@ -52,9 +52,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/backfill_execution_prices.py
+++ b/digiquant/scripts/atlas/backfill_execution_prices.py
@@ -7,7 +7,7 @@ after the session (or after price sync), run this script for that date.
 
 Usage:
   python3 scripts/backfill_execution_prices.py [--date YYYY-MM-DD]
-Environment: SUPABASE_URL, SUPABASE_SERVICE_KEY
+Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 """
 
 from __future__ import annotations
@@ -39,9 +39,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/backfill_export_state.py
+++ b/digiquant/scripts/atlas/backfill_export_state.py
@@ -42,9 +42,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/backfill_normalize_schemas.py
+++ b/digiquant/scripts/atlas/backfill_normalize_schemas.py
@@ -92,9 +92,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/backfill_pm_rebalance_and_activity.py
+++ b/digiquant/scripts/atlas/backfill_pm_rebalance_and_activity.py
@@ -20,7 +20,7 @@ Backfill canonical PM output + Activity ledger for a date range.
 3) Optionally run **`backfill_execution_prices.py`** per day when new rows have
    null opens.
 
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY (see config/supabase.env).
+Requires: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env).
 
 Examples:
 

--- a/digiquant/scripts/atlas/backfill_position_events.py
+++ b/digiquant/scripts/atlas/backfill_position_events.py
@@ -4,7 +4,7 @@ Backfill missing position_events by running the same logic as execute_at_open.py
 for each trading day from --from through --through (inclusive).
 
 Default --from: the calendar day after max(position_events.date) in Supabase.
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY, rebalance_decision.json per day (or
+Requires: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, rebalance_decision.json per day (or
 prior-trading-day mode when same-day doc is missing).
 
 After inserts with possible null opens, runs backfill_execution_prices.py for that date.
@@ -43,9 +43,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/backfill_positions_entry_from_events.py
+++ b/digiquant/scripts/atlas/backfill_positions_entry_from_events.py
@@ -9,7 +9,7 @@ Usage:
   python3 scripts/backfill_positions_entry_from_events.py --recent-days 60
   python3 scripts/backfill_positions_entry_from_events.py --recent-days 120 --dry-run
 
-Environment: SUPABASE_URL, SUPABASE_SERVICE_KEY (see config/supabase.env)
+Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env)
 """
 
 from __future__ import annotations
@@ -42,9 +42,9 @@ def _sb() -> Any:
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/compute-technicals.py
+++ b/digiquant/scripts/atlas/compute-technicals.py
@@ -222,9 +222,9 @@ def get_supabase_client():
     except ImportError:
         pass
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        print("  ⚠️  SUPABASE_URL / SUPABASE_SERVICE_KEY not set — skipping upsert")
+        print("  ⚠️  SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — skipping upsert")
         return None
     return create_client(url, key)
 

--- a/digiquant/scripts/atlas/ensure_position_activity_through_today.py
+++ b/digiquant/scripts/atlas/ensure_position_activity_through_today.py
@@ -12,7 +12,7 @@ ledger rows. This script chains the recommended repair:
   3. `reconcile_position_events_from_positions.py` — inserts HOLD only where a ticker
      on `positions` still has no `(date,ticker)` row.
 
-Usage (repo root, SUPABASE_URL + SUPABASE_SERVICE_KEY set):
+Usage (repo root, SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY set):
 
   python3 scripts/ensure_position_activity_through_today.py
   python3 scripts/ensure_position_activity_through_today.py --through 2026-04-15
@@ -52,9 +52,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/execute_at_open.py
+++ b/digiquant/scripts/atlas/execute_at_open.py
@@ -29,9 +29,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/fetch_research_library.py
+++ b/digiquant/scripts/atlas/fetch_research_library.py
@@ -48,9 +48,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/fill-entry-prices.py
+++ b/digiquant/scripts/atlas/fill-entry-prices.py
@@ -10,7 +10,7 @@ Usage:
     python3 scripts/fill-entry-prices.py --ticker IAU  # fill a single ticker only
 
 Requires:
-    SUPABASE_URL and SUPABASE_SERVICE_KEY env vars (or config/supabase.env)
+    SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars (or config/supabase.env)
 """
 
 import argparse
@@ -37,12 +37,12 @@ except ImportError:
 
 def get_supabase_client():
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not _HAS_SUPABASE:
         print("❌ supabase-py not installed — pip install supabase", file=sys.stderr)
         sys.exit(1)
     if not url or not key:
-        print("❌ SUPABASE_URL and SUPABASE_SERVICE_KEY must be set", file=sys.stderr)
+        print("❌ SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set", file=sys.stderr)
         sys.exit(1)
     return create_client(url, key)
 
@@ -65,7 +65,7 @@ def lookup_close(sb, ticker: str, entry_date: str) -> float | None:
 def main():
     parser = argparse.ArgumentParser(
         description="fill-entry-prices.py — Back-fill entry_price_usd from Supabase price_history",
-        epilog="Requires SUPABASE_URL and SUPABASE_SERVICE_KEY env vars."
+        epilog="Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY env vars."
     )
     parser.add_argument(
         "--dry-run", action="store_true",

--- a/digiquant/scripts/atlas/fold_document_deltas.py
+++ b/digiquant/scripts/atlas/fold_document_deltas.py
@@ -51,9 +51,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/format_deliberation_transcripts_chat.py
+++ b/digiquant/scripts/atlas/format_deliberation_transcripts_chat.py
@@ -17,7 +17,7 @@ Usage:
   python3 scripts/format_deliberation_transcripts_chat.py --start YYYY-MM-DD --end YYYY-MM-DD --apply
   python3 scripts/format_deliberation_transcripts_chat.py --start YYYY-MM-DD --end YYYY-MM-DD --dry-run
 
-Env: SUPABASE_URL, SUPABASE_SERVICE_KEY (config/supabase.env)
+Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (config/supabase.env)
 """
 
 from __future__ import annotations
@@ -46,9 +46,9 @@ except ImportError:
 
 def _sb():
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/ingest_fred.py
+++ b/digiquant/scripts/atlas/ingest_fred.py
@@ -4,7 +4,7 @@
 ingest_fred.py — Fetch FRED series observations into macro_series_observations.
 
 Requires: FRED_API_KEY (free from https://fred.stlouisfed.org/docs/api/api_key.html), or set in config/mcp.secrets.env
-Env: SUPABASE_URL, SUPABASE_SERVICE_KEY for --supabase
+Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY for --supabase
 
 Usage:
   python3 scripts/ingest_fred.py --dry-run
@@ -149,7 +149,7 @@ def main() -> int:
 
     sb = connect_supabase() if args.supabase else None
     if args.supabase and not sb:
-        print("Supabase not configured (SUPABASE_URL + SUPABASE_SERVICE_KEY)", file=sys.stderr)
+        print("Supabase not configured (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY)", file=sys.stderr)
         return 1
 
     all_rows: list[dict] = []

--- a/digiquant/scripts/atlas/lib/macro_ingest.py
+++ b/digiquant/scripts/atlas/lib/macro_ingest.py
@@ -53,7 +53,7 @@ def connect_supabase():
         return None
     load_config_env()
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
         return None
     return create_client(url, key)

--- a/digiquant/scripts/atlas/materialize_snapshot.py
+++ b/digiquant/scripts/atlas/materialize_snapshot.py
@@ -55,13 +55,13 @@ _SUPABASE_UPSERT_ERRORS = (OSError, ValueError, TypeError, KeyError, RuntimeErro
 def _require_supabase() -> None:
     if not _HAS_SUPABASE:
         raise RuntimeError("Supabase SDK not installed. Run: pip install supabase")
-    if not os.environ.get("SUPABASE_URL") or not os.environ.get("SUPABASE_SERVICE_KEY"):
-        raise RuntimeError("Missing SUPABASE_URL and/or SUPABASE_SERVICE_KEY in environment.")
+    if not os.environ.get("SUPABASE_URL") or not os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
+        raise RuntimeError("Missing SUPABASE_URL and/or SUPABASE_SERVICE_ROLE_KEY in environment.")
 
 
 def _sb():
     _require_supabase()
-    return create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_KEY"])
+    return create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_ROLE_KEY"])
 
 
 def _safe_upsert(table: str, row: Dict[str, Any], on_conflict: str) -> None:

--- a/digiquant/scripts/atlas/normalize_supabase_documents.py
+++ b/digiquant/scripts/atlas/normalize_supabase_documents.py
@@ -11,7 +11,7 @@ Legacy markdown-first rows (e.g. deliberation.md) are wrapped into valid JSON wi
 provenance in meta/footer_notes; structured semantics may still need human review.
 
 Requires: pip install jsonschema supabase python-dotenv
-Env: SUPABASE_URL, SUPABASE_SERVICE_KEY (e.g. config/supabase.env)
+Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (e.g. config/supabase.env)
 """
 
 from __future__ import annotations
@@ -96,9 +96,9 @@ def _sb():
         load_dotenv(ROOT / "config" / "supabase.env")
         load_dotenv()
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/pipeline_meta_review.py
+++ b/digiquant/scripts/atlas/pipeline_meta_review.py
@@ -37,9 +37,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/pipeline_review_to_github.py
+++ b/digiquant/scripts/atlas/pipeline_review_to_github.py
@@ -4,7 +4,7 @@ Create GitHub Issues from a published `pipeline_review` document in Supabase `do
 
 Requires:
   - `gh` CLI installed and authenticated (`gh auth login`).
-  - SUPABASE_URL + SUPABASE_SERVICE_KEY (see config/supabase.env).
+  - SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env).
 
 Document keys (canonical):
   - pipeline-review/research/{YYYY-MM-DD}.json
@@ -70,9 +70,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/preload-history.py
+++ b/digiquant/scripts/atlas/preload-history.py
@@ -136,7 +136,7 @@ def upsert_to_supabase(ticker: str, df: pd.DataFrame) -> int:
     """Upsert OHLCV rows for a single ticker into the Supabase price_history table.
 
     Returns the number of rows upserted, or 0 on error.
-    Requires SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables.
+    Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables.
     """
     try:
         from supabase import create_client
@@ -153,9 +153,9 @@ def upsert_to_supabase(ticker: str, df: pd.DataFrame) -> int:
         pass
 
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        print("    ⚠️  SUPABASE_URL / SUPABASE_SERVICE_KEY not set — skipping Supabase upsert")
+        print("    ⚠️  SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — skipping Supabase upsert")
         return 0
 
     sb = create_client(url, key)
@@ -337,9 +337,9 @@ def _get_supabase_client():
     except ImportError:
         pass
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        print("  ⚠️  SUPABASE_URL / SUPABASE_SERVICE_KEY not set")
+        print("  ⚠️  SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set")
         return None
     return create_client(url, key)
 

--- a/digiquant/scripts/atlas/publish_document.py
+++ b/digiquant/scripts/atlas/publish_document.py
@@ -39,9 +39,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/publish_research.py
+++ b/digiquant/scripts/atlas/publish_research.py
@@ -58,9 +58,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/reconcile_position_events_from_positions.py
+++ b/digiquant/scripts/atlas/reconcile_position_events_from_positions.py
@@ -7,7 +7,7 @@ events (OPEN/TRIM/ADD/EXIT/HOLD).
 Use when `rebalance_table` omitted tickers that still appear in `positions`, or after
 repairing historical data.
 
-Requires: SUPABASE_URL, SUPABASE_SERVICE_KEY
+Requires: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 
 Usage:
   python3 scripts/reconcile_position_events_from_positions.py --from 2026-01-02 --through 2026-04-15

--- a/digiquant/scripts/atlas/refresh_performance_metrics.py
+++ b/digiquant/scripts/atlas/refresh_performance_metrics.py
@@ -25,7 +25,7 @@ Usage:
   python3 scripts/refresh_performance_metrics.py --supabase
   python3 scripts/refresh_performance_metrics.py --supabase --date YYYY-MM-DD
   python3 scripts/refresh_performance_metrics.py --supabase --fill-calendar-through YYYY-MM-DD
-Environment: SUPABASE_URL, SUPABASE_SERVICE_KEY (see config/supabase.env)
+Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env)
 """
 
 from __future__ import annotations
@@ -68,9 +68,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/regen_research_deltas.py
+++ b/digiquant/scripts/atlas/regen_research_deltas.py
@@ -2124,7 +2124,7 @@ def main():
             sys.exit(1)
         sb = create_client(
             os.environ["SUPABASE_URL"],
-            os.environ["SUPABASE_SERVICE_KEY"],
+            os.environ["SUPABASE_SERVICE_ROLE_KEY"],
         )
     else:
         sb = None

--- a/digiquant/scripts/atlas/repair_supabase_portfolio_data.py
+++ b/digiquant/scripts/atlas/repair_supabase_portfolio_data.py
@@ -9,7 +9,7 @@ and upserts from local digests.
 Usage:
   python3 scripts/repair_supabase_portfolio_data.py [--dry-run]
 
-Environment: SUPABASE_URL, SUPABASE_SERVICE_KEY (see config/supabase.env)
+Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env)
 """
 
 from __future__ import annotations
@@ -42,9 +42,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/run_db_first.py
+++ b/digiquant/scripts/atlas/run_db_first.py
@@ -32,9 +32,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/sync_positions_from_rebalance.py
+++ b/digiquant/scripts/atlas/sync_positions_from_rebalance.py
@@ -17,7 +17,7 @@ Intended to run from ``run_db_first.py`` before ``refresh_performance_metrics.py
 
 Usage:
   python3 scripts/sync_positions_from_rebalance.py --date YYYY-MM-DD
-Environment: SUPABASE_URL, SUPABASE_SERVICE_KEY (see config/supabase.env)
+Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env)
 """
 
 from __future__ import annotations
@@ -50,9 +50,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/update_tearsheet.py
+++ b/digiquant/scripts/atlas/update_tearsheet.py
@@ -501,7 +501,7 @@ def compute_fx_impact(pj_positions, investor_currency):
 def supabase_configured():
     """Check if Supabase credentials are available in environment."""
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     return bool(_HAS_SUPABASE and url and key)
 
 
@@ -510,7 +510,7 @@ def _get_supabase_client():
     from supabase import create_client
 
     url = os.environ["SUPABASE_URL"]
-    key = os.environ["SUPABASE_SERVICE_KEY"]
+    key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
     return create_client(url, key)
 
 
@@ -876,7 +876,7 @@ def main():
     else:
         print("   ❌ Supabase not configured — data will NOT be available to the frontend!")
         if _HAS_SUPABASE:
-            print("      Set SUPABASE_URL and SUPABASE_SERVICE_KEY in config/supabase.env")
+            print("      Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in config/supabase.env")
         else:
             print("      Install SDK: pip install supabase")
 

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -94,7 +94,7 @@ def check_env_vars() -> bool:
     print(_bold("\n1. Environment variables"))
     required = {
         "SUPABASE_URL": "Supabase project URL",
-        "SUPABASE_SERVICE_KEY": "Supabase service-role key",
+        "SUPABASE_SERVICE_ROLE_KEY": "Supabase service-role key",
         "XAI_API_KEY": "xAI API key (all phases run on Grok — see config/model_modes.yaml)",
     }
     all_ok = True
@@ -150,9 +150,9 @@ def check_xai(model: str = "grok-4.3") -> bool:
 def check_supabase() -> bool:
     print(_bold("\n4. Supabase connectivity + baseline row"))
     url = os.environ.get("SUPABASE_URL", "").strip()
-    key = os.environ.get("SUPABASE_SERVICE_KEY", "").strip()
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
     if not url or not key:
-        check("Supabase ping", False, "SUPABASE_URL / SUPABASE_SERVICE_KEY not set — skipping")
+        check("Supabase ping", False, "SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — skipping")
         return False
     try:
         _ensure_importable()

--- a/digiquant/scripts/atlas/validate_db_first.py
+++ b/digiquant/scripts/atlas/validate_db_first.py
@@ -28,9 +28,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/validate_pipeline_step.py
+++ b/digiquant/scripts/atlas/validate_pipeline_step.py
@@ -3,7 +3,7 @@
 Validate Supabase after discrete pipeline steps (research close-out, Track B phases).
 
 Requires: pip install jsonschema supabase python-dotenv
-Env: SUPABASE_URL, SUPABASE_SERVICE_KEY (e.g. config/supabase.env)
+Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (e.g. config/supabase.env)
 
 Examples:
   python3 scripts/validate_pipeline_step.py --date 2026-04-11 --step research_closeout
@@ -77,9 +77,9 @@ def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_KEY required")
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/verify_supabase_canonical.py
+++ b/digiquant/scripts/atlas/verify_supabase_canonical.py
@@ -5,7 +5,7 @@ Read-only checks before deleting any local `outputs/` tree:
 1. No `documents.document_key` still contains the legacy `outputs/` path prefix.
 2. Optional: given --date (repeatable), a `daily_snapshots` row exists for that date.
 
-Requires SUPABASE_URL + SUPABASE_SERVICE_KEY (e.g. config/supabase.env).
+Requires SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (e.g. config/supabase.env).
 
 Exit 0 if all checks pass; non-zero if legacy keys remain or a requested date is missing.
 """
@@ -48,9 +48,9 @@ def main() -> int:
         return 2
 
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
-        print("❌ SUPABASE_URL and SUPABASE_SERVICE_KEY required (see config/supabase.env)", file=sys.stderr)
+        print("❌ SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required (see config/supabase.env)", file=sys.stderr)
         return 2
 
     sb = create_client(url, key)

--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -121,7 +121,7 @@ def fetch_quotes_cmd(
     if supabase and not dry_run:
         client = build_supabase_client(
             os.environ.get("SUPABASE_URL"),
-            os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"),
+            os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
         )
         if client is None:
             raise click.ClickException("Supabase credentials not set.")
@@ -188,7 +188,7 @@ def compute_technicals_cmd(
     if supabase and not dry_run:
         client = build_supabase_client(
             os.environ.get("SUPABASE_URL"),
-            os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"),
+            os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
         )
         if client is None:
             raise click.ClickException("Supabase credentials not set.")
@@ -375,7 +375,7 @@ def fetch_macro_cmd(
 
     client = build_supabase_client(
         os.environ.get("SUPABASE_URL"),
-        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"),
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
     )
     if client is None:
         raise click.ClickException("Supabase credentials not set.")
@@ -456,7 +456,7 @@ def sync_calendar_cmd(venues: str, start: str, end: str, dry_run: bool, supabase
 
     client = build_supabase_client(
         os.environ.get("SUPABASE_URL"),
-        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"),
+        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
     )
     if client is None:
         raise click.ClickException("Supabase credentials not set.")

--- a/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
@@ -178,7 +178,7 @@ pip install -r requirements.txt
 
 3. Supabase credentials (service role required for publishing):
 - `SUPABASE_URL`
-- `SUPABASE_SERVICE_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
 
 4. **FRED API key** (free): [`FRED_API_KEY`](https://fred.stlouisfed.org/docs/api/api_key.html) — required for `ingest_fred.py` and for the GitHub **Daily Price Update** job to load FRED series. If unset in Actions, FRED is skipped with a warning; Frankfurter and Fear & Greed still run.
 
@@ -256,7 +256,7 @@ If you have a **local** tree under `data/agent-cache/daily/` (gitignored), you c
 1. **Markdown-era exports:** populate `data/agent-cache/daily/` (manually or by setting **`LEGACY_ROOT`** to a directory that contains `YYYY-MM-DD/` folders when you run the copy step), then materialize and refresh documents/metrics:
    - [`scripts/backfill-historical-daily-to-supabase.sh`](scripts/backfill-historical-daily-to-supabase.sh) — copies from **`LEGACY_ROOT`** unless **`SKIP_COPY=1`**, then runs [`scripts/backfill-db-first-digest.sh`](scripts/backfill-db-first-digest.sh), then `update_tearsheet.py`.
    - Override **`BASELINE_DATE`**, **`LAST_DATE`**, or use **`SKIP_COPY=1`** if `data/agent-cache/daily/` is already populated.
-2. **Requires** `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` (e.g. `config/supabase.env`).
+2. **Requires** `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (e.g. `config/supabase.env`).
 3. Afterward: `python3 scripts/validate_db_first.py --mode full`.
 
 **Note:** `delta-request.json` is applied to the **previous calendar day’s** row in `daily_snapshots` (`--baseline-date`); ops must match that chain. Stub `snapshot.json` files are ignored when a rich `delta-request.json` exists (see backfill script).

--- a/digiquant/src/digiquant/olympus/atlas/docs/agentic/EVOLUTION_GITHUB_IMPLEMENTATION_PLAN.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/agentic/EVOLUTION_GITHUB_IMPLEMENTATION_PLAN.md
@@ -190,7 +190,7 @@ Each file should:
 
 **Workflow:** [`.github/workflows/pipeline-meta-review.yml`](../../.github/workflows/pipeline-meta-review.yml) — `workflow_dispatch` + weekly cron (`0 8 * * 1` UTC). Runs [`scripts/pipeline_meta_review.py`](../../scripts/pipeline_meta_review.py) (`--days 21`) to **list** recent `pipeline_review` rows; does not open Issues yet (extend for weekly digest).
 
-**Secrets (same pattern as daily price job):** `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_KEY` or equivalent repo secrets.
+**Secrets (same pattern as daily price job):** `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` or equivalent repo secrets.
 
 ---
 

--- a/digiquant/src/digiquant/olympus/atlas/docs/ops/DIGITHINGS-WAVE2-GRAPH-SKETCH.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/ops/DIGITHINGS-WAVE2-GRAPH-SKETCH.md
@@ -65,7 +65,7 @@ Avoid reimplementing SQL writes in TypeScript for Wave 2; keep Python authoritat
 
 Mirror today’s operator machine; inject from DigiThings env or secrets store:
 
-- `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` (or name used in Atlas scripts)
+- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (or name used in Atlas scripts)
 - `CRON_SECRET` or internal auth for **trigger** endpoints only
 - Provider keys for LLM nodes (LiteLLM in DigiThings or BYOK later)
 - `ATLAS_ROOT` or monorepo path to **`scripts/`** if subprocess uses relative imports

--- a/digiquant/src/digiquant/olympus/atlas/graph.py
+++ b/digiquant/src/digiquant/olympus/atlas/graph.py
@@ -371,7 +371,7 @@ def _auto_resolve_baseline(run_date: date) -> date | None:
     """
     import os
 
-    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_KEY"):
+    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_ROLE_KEY"):
         return None
 
     from digiquant.olympus.atlas.supabase_io import SupabaseConfig, build_client
@@ -414,7 +414,7 @@ def resolve_cli_inputs(args) -> dict:
         if resolved is None and not args.dry_run:
             raise SystemExit(
                 "--auto-baseline could not resolve a baseline date; "
-                "is SUPABASE_URL/SUPABASE_SERVICE_KEY set and does "
+                "is SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY set and does "
                 "daily_snapshots contain a prior baseline run?"
             )
         baseline_date = resolved

--- a/digiquant/src/digiquant/olympus/atlas/skills/github-workflow/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/github-workflow/SKILL.md
@@ -37,5 +37,5 @@ See [`docs/ops/GITHUB_PIPELINE_LABELS.md`](../../docs/ops/GITHUB_PIPELINE_LABELS
 
 ## Guardrails
 
-- Do not put secrets or `SUPABASE_SERVICE_KEY` in issue or PR bodies.
+- Do not put secrets or `SUPABASE_SERVICE_ROLE_KEY` in issue or PR bodies.
 - Do not enable auto-merge unless the repo owner requests it; default is human review.

--- a/digiquant/src/digiquant/olympus/atlas/skills/orchestrator/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/orchestrator/SKILL.md
@@ -449,7 +449,7 @@ After `materialize_snapshot.py` / `publish_document.py` have run, execute:
 `python3 scripts/run_db_first.py`  
 This refreshes performance metrics, runs `execute_at_open.py` when appropriate, and `validate_db_first.py`.
 
-The frontend reads from Supabase at runtime. If validation fails, check `SUPABASE_URL` / `SUPABASE_SERVICE_KEY` and that today’s snapshot row exists in `daily_snapshots`.
+The frontend reads from Supabase at runtime. If validation fails, check `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` and that today’s snapshot row exists in `daily_snapshots`.
 
 ### 8C: Commit and push
 Run: `./scripts/git-commit.sh` to commit **config / docs** changes only. Digest data is already in Supabase.

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -137,7 +137,7 @@ class SupabaseClient(Protocol):
 
 
 class SupabaseNotConfiguredError(RuntimeError):
-    """Raised when SUPABASE_URL / SUPABASE_SERVICE_KEY are missing at runtime."""
+    """Raised when SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are missing at runtime."""
 
 
 @dataclass(frozen=True)
@@ -150,12 +150,12 @@ class SupabaseConfig:
     @classmethod
     def from_env(cls) -> "SupabaseConfig":
         url = os.environ.get("SUPABASE_URL", "").strip()
-        key = os.environ.get("SUPABASE_SERVICE_KEY", "").strip()
+        key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
         missing: list[str] = []
         if not url:
             missing.append("SUPABASE_URL")
         if not key:
-            missing.append("SUPABASE_SERVICE_KEY")
+            missing.append("SUPABASE_SERVICE_ROLE_KEY")
         if missing:
             raise SupabaseNotConfiguredError(f"missing required env var(s): {', '.join(missing)}")
         return cls(url=url, service_key=key)

--- a/scripts/preload-history.py
+++ b/scripts/preload-history.py
@@ -122,10 +122,10 @@ def upsert_to_supabase(ticker: str, df: pl.DataFrame) -> int:
     required environment variables or the ``supabase`` package are missing.
     """
     url = os.environ.get("SUPABASE_URL", "")
-    key = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
     if not url or not key:
         raise RuntimeError(
-            "SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables must be set"
+            "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables must be set"
         )
 
     try:

--- a/tests/db/connectors/test_supabase_connector.py
+++ b/tests/db/connectors/test_supabase_connector.py
@@ -149,18 +149,18 @@ class FakeSupabaseClient:
 class TestFromEnv:
     def test_missing_both_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SUPABASE_URL", raising=False)
-        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
         with pytest.raises(SupabaseNotConfiguredError) as exc:
             SupabaseConnector.from_env()
         assert "SUPABASE_URL" in str(exc.value)
-        assert "SUPABASE_SERVICE_KEY" in str(exc.value)
+        assert "SUPABASE_SERVICE_ROLE_KEY" in str(exc.value)
 
     def test_missing_key_only_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
-        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
         with pytest.raises(SupabaseNotConfiguredError) as exc:
             SupabaseConnector.from_env()
-        assert "SUPABASE_SERVICE_KEY" in str(exc.value)
+        assert "SUPABASE_SERVICE_ROLE_KEY" in str(exc.value)
         assert "SUPABASE_URL" not in str(exc.value)
 
     def test_calls_create_client_with_resolved_creds(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -184,7 +184,7 @@ class TestFromEnv:
         fake_module.create_client = _create_client  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "supabase", fake_module)
         monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
-        monkeypatch.setenv("SUPABASE_SERVICE_KEY", "sk-123")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "sk-123")
 
         connector = SupabaseConnector.from_env()
         assert captured == {"url": "https://x.supabase.co", "key": "sk-123"}

--- a/tests/dq/atlas/test_cli.py
+++ b/tests/dq/atlas/test_cli.py
@@ -140,7 +140,7 @@ def test_auto_resolve_baseline_queries_daily_snapshots(monkeypatch):
             return FakeQuery()
 
     monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
-    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "fake-key")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "fake-key")
 
     import digiquant.olympus.atlas.supabase_io as sio
 

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -148,14 +148,14 @@ class FakeSupabaseClient:
 class TestSupabaseConfig:
     def test_from_env_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SUPABASE_URL", "https://x.supabase.co")
-        monkeypatch.setenv("SUPABASE_SERVICE_KEY", "sk-123")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "sk-123")
         cfg = SupabaseConfig.from_env()
         assert cfg.url == "https://x.supabase.co"
         assert cfg.service_key == "sk-123"
 
     def test_from_env_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SUPABASE_URL", raising=False)
-        monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+        monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
         with pytest.raises(SupabaseNotConfiguredError):
             SupabaseConfig.from_env()
 


### PR DESCRIPTION
Fixes #647.

Eliminates the dual naming surfaced during #566 live validation: the app read env var `SUPABASE_SERVICE_KEY` while the GitHub secret is `SUPABASE_SERVICE_ROLE_KEY`, bridged per-workflow. Now standardized on `SUPABASE_SERVICE_ROLE_KEY` everywhere so secret name == env var name == code.

- **127 occurrences across 55 files** renamed (code, workflows, tests, docs).
- Workflows set `SUPABASE_SERVICE_ROLE_KEY` directly from the like-named secret; removed the now-duplicate env key in `digiquant-prices.yml`.
- `prices.py` reads `SUPABASE_SERVICE_ROLE_KEY` only (dropped the `SUPABASE_SERVICE_KEY` fallback).
- `digibase` connector default `key_var` → `SUPABASE_SERVICE_ROLE_KEY`.

Verification: `git grep SUPABASE_SERVICE_KEY` returns nothing; ruff clean; doc-links OK; 363 unit tests pass (db + dq/atlas); `make score` 10/10.

> Note: anyone with a local `config/supabase.env` or `.env` must rename their `SUPABASE_SERVICE_KEY` entry to `SUPABASE_SERVICE_ROLE_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)