### PR TITLE
fix(llm): fail soft on xAI Live Search 410 deprecation (#650)

### DIFF
--- a/digigraph/src/digigraph/llm.py
+++ b/digigraph/src/digigraph/llm.py
@@ -600,7 +600,20 @@ def chat_completion(
         kwargs["extra_body"] = {"search_parameters": search_parameters}
     elif search_parameters is not None:
         logger.debug("search_parameters ignored for non-xAI model %s", effective_model)
-    r = _create_with_retry(client, **kwargs)
+    try:
+        r = _create_with_retry(client, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        # xAI deprecated Live Search (HTTP 410) in favour of the Agent Tools API (#650).
+        # Fail soft: drop the deprecated search_parameters and retry once ungrounded so
+        # the phase/pipeline keeps producing instead of crashing on every soft segment.
+        if getattr(exc, "status_code", None) == 410 and "extra_body" in kwargs:
+            logger.warning(
+                "xAI rejected search_parameters (410 deprecated); retrying without Live Search"
+            )
+            kwargs.pop("extra_body", None)
+            r = _create_with_retry(client, **kwargs)
+        else:
+            raise
     if not r.choices:
         return "" if not tools else ("", None)
     msg = r.choices[0].message

--- a/tests/dg/test_llm_search_params.py
+++ b/tests/dg/test_llm_search_params.py
@@ -24,6 +24,38 @@ def _mock_client() -> MagicMock:
 
 
 @pytest.mark.unit
+def test_live_search_410_deprecation_fails_soft(monkeypatch: pytest.MonkeyPatch) -> None:
+    # xAI deprecated Live Search (HTTP 410). The search path must drop extra_body and
+    # retry ungrounded rather than crash the phase (#650).
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    calls: list[dict] = []
+
+    class _Gone(Exception):
+        status_code = 410
+
+    def create(**kwargs):
+        calls.append(kwargs)
+        if "extra_body" in kwargs:
+            raise _Gone("Live search is deprecated. Please switch to the Agent Tools API")
+        m = MagicMock()
+        m.choices = [MagicMock(message=MagicMock(content="ungrounded-ok", tool_calls=None))]
+        return m
+
+    client = MagicMock()
+    client.chat.completions.create = create
+    with patch("digigraph.llm.get_client_for_model", return_value=client):
+        out = chat_completion(
+            "xai/grok-4.3",
+            [{"role": "user", "content": "410-failsoft-probe"}],
+            search_parameters=SEARCH_PARAMS,
+        )
+    assert out == "ungrounded-ok"
+    assert len(calls) == 2
+    assert "extra_body" in calls[0]
+    assert "extra_body" not in calls[1]
+
+
+@pytest.mark.unit
 def test_search_params_forwarded_via_extra_body_for_xai(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes the urgent half of #650.

## Why
xAI **deprecated Live Search** (`search_parameters`/`extra_body`) → **HTTP 410**, surfaced by the #566 baseline live run. Every `live_search=True` phase (alt-*, inst-*, macro, international) crashes, and the daily `atlas-delta` cron (~12:00 UTC) would open a failure issue every day.

## What
`chat_completion` now catches a 410 when `extra_body` (Live Search) is present, drops it, and retries once **ungrounded** — so the phase and pipeline keep producing on the data-tools core instead of crashing. Covers both the tool-loop (macro/international) and tool-free (alt/inst) search paths, since both route through `chat_completion`.

## Scope
Interim safety net only. The full migration to xAI's **Agent Tools API** (web_search via the Responses API, as a decoupled grounding pre-pass) is the rest of #650.

Tests: new `test_live_search_410_deprecation_fails_soft` (asserts retry drops extra_body and succeeds); 45 llm unit tests pass; ruff clean; score 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)