### PR TITLE
fix(atlas): cap web_search allowed_domains at xAI 5-domain limit (#654)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/config/search_domains.yaml
+++ b/digiquant/src/digiquant/olympus/atlas/config/search_domains.yaml
@@ -1,16 +1,21 @@
 # Curated allowlist for the xAI Agent Tools `web_search` grounding pre-pass
 # (web_grounding.py) — maps to web_search `filters.allowed_domains`. Keeps the
 # day-to-day search flow consistent and high-signal. Edit to tune sources.
+#
+# NOTE: xAI caps allowed_domains at 5 per request (HTTP 400 otherwise). Only the
+# FIRST 5 entries below are sent — keep the highest-signal, broadest general
+# sources at the top. Later entries are reference/aspirational (e.g. for a future
+# per-phase domain map: capitoltrades for politician trades, cftc for COT).
 web_allowed_websites:
-  - reuters.com
-  - apnews.com
-  - sec.gov
-  - federalreserve.gov
-  - cftc.gov
-  - treasury.gov
-  - bls.gov
-  - finance.yahoo.com
-  - capitoltrades.com
-# News + X sources are enabled without a domain restriction.
+  - reuters.com         # broad market/financial news
+  - apnews.com          # broad newswire
+  - sec.gov             # filings (13F, 8-K, etc.)
+  - federalreserve.gov  # Fed policy / statements
+  - bls.gov             # CPI, jobs, official econ data
+  # --- below here NOT sent (exceeds the xAI 5-domain cap) ---
+  - cftc.gov            # COT positioning (alt-cta)
+  - treasury.gov        # issuance / fiscal
+  - finance.yahoo.com   # quotes / market pages
+  - capitoltrades.com   # politician trades (alt-politician)
 recency_days: 7
 max_search_results: 8

--- a/digiquant/src/digiquant/olympus/atlas/data/web_grounding.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/web_grounding.py
@@ -20,6 +20,9 @@ from digigraph.llm import web_search
 
 _CONFIG = Path(__file__).resolve().parent.parent / "config" / "search_domains.yaml"
 
+# xAI web_search rejects (HTTP 400) more than 5 allowed_domains per request.
+_MAX_ALLOWED_DOMAINS = 5
+
 
 @lru_cache(maxsize=1)
 def _config() -> dict[str, Any]:
@@ -53,7 +56,8 @@ def fetch_web_grounding(
     the caller then proceeds with data-tool-only (ungrounded) research.
     """
     cfg = _config()
-    allowed = list(cfg.get("web_allowed_websites", [])) or None
+    # xAI caps allowed_domains at 5 — send the highest-priority slice (allowlist order).
+    allowed = list(cfg.get("web_allowed_websites", []))[:_MAX_ALLOWED_DOMAINS] or None
     max_results = int(cfg.get("max_search_results", 8))
     result = web_search(
         model,

--- a/tests/dq/atlas/data/test_web_grounding.py
+++ b/tests/dq/atlas/data/test_web_grounding.py
@@ -24,9 +24,10 @@ def test_fetch_web_grounding_returns_summary_and_sources():
     assert out["summary"].startswith("- CPI")
     assert out["sources"] == ["https://u"]
     assert out["as_of"] == "2026-06-09"
-    # allowlist forwarded from search_domains.yaml
+    # allowlist forwarded from search_domains.yaml, capped at the xAI 5-domain limit
     kwargs = ws.call_args[1]
     assert "reuters.com" in kwargs["allowed_domains"]
+    assert len(kwargs["allowed_domains"]) <= 5
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #654. Follow-up to #650 caught by the validation baseline (run 27199717966).

The baseline ran green (no 410) but **all 8 `live_search` phases fell back to ungrounded** with `web_search 400 — A maximum of 5 domains can be allowed, but 9 were provided`. xAI `web_search` `filters.allowed_domains` caps at 5 (the deprecated Live Search capped too; lost in the migration, and the #650 smoke used 0–1 domains so didn't surface it).

- `web_grounding.fetch_web_grounding` now sends only the first 5 allowlist entries.
- `search_domains.yaml` reordered so the 5 highest-signal general domains lead (reuters, apnews, sec.gov, federalreserve.gov, bls.gov); the rest kept as reference for a future per-phase domain map.
- Test asserts ≤5 domains forwarded.

score 10/10; ruff clean; tests pass. Will re-validate with a baseline after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)