### PR TITLE
fix(atlas): make checkpointer acquisition best-effort (#667)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -7,6 +7,7 @@ Cron entry point: ``python -m digiquant.olympus.hermes.chain``.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import date
 from typing import Any  # noqa  # scored-lint suppression: opaque LangGraph checkpointer/graph
@@ -52,6 +53,24 @@ class ChainDeps:
     atlas: AtlasGraphDeps
     hermes: HermesGraphDeps
     publish: PublishDeps | None = None
+
+
+def _acquire_checkpointer() -> Any:
+    """Return a checkpointer when ``DIGI_CHECKPOINTER`` is set, else ``None``.
+
+    Best-effort: checkpointing is an optimization, never a hard dependency. A missing
+    package, bad ``DIGI_CHECKPOINTER_POSTGRES_URI``, or unreachable Postgres degrades to
+    ``None`` (a normal, uncheckpointed run) with a warning — it must not crash the run.
+    """
+    if not os.environ.get("DIGI_CHECKPOINTER", "").strip():
+        return None
+    try:
+        from digigraph.graph.graph import get_checkpointer
+
+        return get_checkpointer()
+    except Exception as exc:  # noqa: BLE001 — checkpointing is best-effort; never crash the run
+        _logger.warning("checkpointer unavailable (%s); running without resume", exc)
+        return None
 
 
 def _invoke_resumable(
@@ -296,12 +315,9 @@ def cli_main(argv: list[str] | None = None) -> int:
     )
     # Checkpoint/resume (#665): durable per-graph threads when DIGI_CHECKPOINTER is set
     # (DIGI_CHECKPOINTER=postgres + DIGI_CHECKPOINTER_POSTGRES_URI in prod). thread_base is
-    # the run to resume (--resume-run-id) or this run's id for a fresh start.
-    _checkpointer = None
-    if _os.environ.get("DIGI_CHECKPOINTER", "").strip():
-        from digigraph.graph.graph import get_checkpointer
-
-        _checkpointer = get_checkpointer()
+    # the run to resume (--resume-run-id) or this run's id for a fresh start. Best-effort:
+    # a bad URI / unreachable Postgres degrades to an uncheckpointed run (#667).
+    _checkpointer = _acquire_checkpointer()
     _thread_base = getattr(args, "resume_run_id", None) or _run_id
     _final_state = None
     _status = "success"

--- a/tests/dq/hermes/test_chain_checkpointer.py
+++ b/tests/dq/hermes/test_chain_checkpointer.py
@@ -1,0 +1,36 @@
+"""Checkpointer acquisition is best-effort (#667) — a bad URI must not crash the run."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("openai")  # chain -> atlas.graph -> digigraph.llm needs openai
+
+from digiquant.olympus.hermes import chain  # noqa: E402
+
+
+@pytest.mark.unit
+def test_acquire_none_when_env_unset(monkeypatch):
+    monkeypatch.delenv("DIGI_CHECKPOINTER", raising=False)
+    assert chain._acquire_checkpointer() is None
+
+
+@pytest.mark.unit
+def test_acquire_returns_saver_when_available(monkeypatch):
+    monkeypatch.setenv("DIGI_CHECKPOINTER", "postgres")
+    sentinel = object()
+    with patch("digigraph.graph.graph.get_checkpointer", return_value=sentinel):
+        assert chain._acquire_checkpointer() is sentinel
+
+
+@pytest.mark.unit
+def test_acquire_degrades_to_none_on_init_failure(monkeypatch):
+    # Bad URI / unreachable Postgres → setup() raises → must degrade to None, not crash.
+    monkeypatch.setenv("DIGI_CHECKPOINTER", "postgres")
+    with patch(
+        "digigraph.graph.graph.get_checkpointer",
+        side_effect=RuntimeError("could not connect to server"),
+    ):
+        assert chain._acquire_checkpointer() is None


### PR DESCRIPTION
Fixes #667 (follow-up to #665). Hardens checkpointer init before the `DIGI_CHECKPOINTER_POSTGRES_URI` secret is wired.

`get_checkpointer()`'s postgres branch only catches `ImportError`; a bad URI or unreachable Postgres makes `PostgresSaver.setup()` raise, and the chain called it unguarded → **the whole run crashed**. `_acquire_checkpointer()` now degrades a missing-package / bad-URI / connection failure to an **uncheckpointed run with a warning** — checkpointing is an optimization, never a hard dependency.

Tests: `test_chain_checkpointer` (3) — None when unset, returns saver when available, degrades to None on init failure. 68 unit tests green; ruff clean; score 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)