### PR TITLE
chore(atlas): Postgres checkpointer connectivity smoke (#665)

### DIFF
--- a/.github/workflows/checkpointer-conn-smoke.yml
+++ b/.github/workflows/checkpointer-conn-smoke.yml
@@ -1,0 +1,26 @@
+name: checkpointer conn smoke (#665)
+
+# One-off manual check that DIGI_CHECKPOINTER_POSTGRES_URI is valid and reachable
+# from GitHub Actions (IPv4), connecting exactly as the chain does. No xAI calls.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      DIGI_CHECKPOINTER_POSTGRES_URI: ${{ secrets.DIGI_CHECKPOINTER_POSTGRES_URI }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install checkpointer
+        run: python -m pip install -U pip "langgraph-checkpoint-postgres>=2.0"
+      - name: Probe Postgres checkpointer connectivity
+        run: python digiquant/scripts/atlas/smoke_checkpointer_conn.py

--- a/digiquant/scripts/atlas/smoke_checkpointer_conn.py
+++ b/digiquant/scripts/atlas/smoke_checkpointer_conn.py
@@ -12,7 +12,6 @@ Dispatch-only; not imported by runtime code.
 from __future__ import annotations
 
 import os
-import sys
 
 
 def main() -> int:

--- a/digiquant/scripts/atlas/smoke_checkpointer_conn.py
+++ b/digiquant/scripts/atlas/smoke_checkpointer_conn.py
@@ -1,0 +1,58 @@
+"""Connectivity smoke for the LangGraph Postgres checkpointer (#665/#667).
+
+Validates DIGI_CHECKPOINTER_POSTGRES_URI exactly as the chain uses it:
+PostgresSaver.from_conn_string(uri) -> setup() (DDL: catches transaction-pooler / no
+prepared statements / missing perms) -> get_tuple() (a read). Reachability is implicitly
+tested (GitHub Actions is IPv4 — the session pooler must be used, not the direct host).
+
+NEVER prints the URI (it embeds the password) — only an ok/fail verdict + error class.
+Dispatch-only; not imported by runtime code.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    uri = os.environ.get("DIGI_CHECKPOINTER_POSTGRES_URI", "").strip()
+    if not uri:
+        print("FAIL: DIGI_CHECKPOINTER_POSTGRES_URI not set (add the secret first)")
+        return 1
+    # Surface only the host:port/user shape (no password) for a sanity hint.
+    try:
+        after_at = uri.split("@", 1)[1]
+        print(f"target: …@{after_at}")  # host:port/db — no credentials
+    except IndexError:
+        print("target: <unparseable uri shape>")
+
+    try:
+        from langgraph.checkpoint.postgres import PostgresSaver
+    except ImportError as exc:
+        print(f"FAIL: langgraph-checkpoint-postgres not installed: {exc}")
+        return 1
+
+    try:
+        cm = PostgresSaver.from_conn_string(uri)
+        saver = cm.__enter__()
+        try:
+            saver.setup()  # DDL — fails on transaction pooler / no prepared stmts / no perms
+            saver.get_tuple({"configurable": {"thread_id": "__conn_smoke__", "checkpoint_ns": ""}})
+        finally:
+            cm.__exit__(None, None, None)
+    except Exception as exc:  # noqa: BLE001 — report the verdict, never leak the URI
+        print(f"FAIL: {type(exc).__name__}: {str(exc)[:400]}")
+        print(
+            "Hints: use the SESSION pooler (port 5432, host …pooler.supabase.com), NOT the "
+            "transaction pooler (6543) or the IPv6 direct host; URL-encode special chars in "
+            "the password."
+        )
+        return 1
+
+    print("OK: PostgresSaver connected, setup() + get_tuple() succeeded — checkpointer ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Dispatch-only workflow + script to verify `DIGI_CHECKPOINTER_POSTGRES_URI` from GitHub Actions (IPv4) — connects via PostgresSaver exactly as the chain does (`from_conn_string` → `setup()` → `get_tuple`), so it catches the wrong pooler (6543), bad password, or missing perms before a full baseline. Redacts the URI (prints only host:port/db). Relates #665/#667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)