### PR TITLE
fix(website): un-nest design package in site builds — restore digithings.ai styling

### DIFF
--- a/.github/workflows/site-smoke.yml
+++ b/.github/workflows/site-smoke.yml
@@ -1,0 +1,76 @@
+name: site-smoke
+
+# Post-deploy smoke check for the static sites (#671). The /design/design/
+# nesting regression shipped because nothing ever fetched a /design/ asset
+# from production: the SPA fallback turned every missing path into a
+# soft-200 text/html response that MIME-blocked all CSS/JS.
+#
+# Verdicts per URL:
+#   200 + expected content-type  -> pass
+#   200 + text/html              -> FAIL (SPA fallback is masking a missing asset)
+#   404 / 5xx                    -> FAIL
+#   403 / 429                    -> warn only (Cloudflare bot challenge; inconclusive from CI IPs)
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe design assets and homepages
+        id: probe
+        run: |
+          set -uo pipefail
+          fail=0
+          probe() {
+            local url="$1" want_type="$2"
+            local status ctype
+            read -r status ctype < <(curl -sL -o /dev/null --max-time 20 \
+              -A "digithings-site-smoke/1.0 (+https://github.com/digithings-ai/digithings)" \
+              -w "%{http_code} %{content_type}\n" "$url" || echo "000 none")
+            case "$status" in
+              200)
+                if [[ "$ctype" == *"$want_type"* ]]; then
+                  echo "PASS  $url ($ctype)"
+                elif [[ "$ctype" == *text/html* && "$want_type" != text/html ]]; then
+                  echo "FAIL  $url returned text/html — SPA fallback is masking a missing asset"
+                  fail=1
+                else
+                  echo "FAIL  $url returned unexpected content-type '$ctype' (wanted $want_type)"
+                  fail=1
+                fi ;;
+              403|429)
+                echo "WARN  $url -> $status (bot challenge; inconclusive from CI)" ;;
+              *)
+                echo "FAIL  $url -> HTTP $status"
+                fail=1 ;;
+            esac
+          }
+          probe "https://digithings.ai/" "text/html"
+          probe "https://digithings.ai/design/tokens.css" "text/css"
+          probe "https://digithings.ai/design/components.css" "text/css"
+          probe "https://digithings.ai/design/terminal/index.js" "javascript"
+          probe "https://digiquant.io/" "text/html"
+          probe "https://digiquant.io/design/tokens.css" "text/css"
+          probe "https://digiquant.io/olympus/" "text/html"
+          exit "$fail"
+
+      - name: Open issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="[site-smoke] production design assets failing"
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title $TITLE" --json number --jq '.[0].number // empty')
+          BODY="Scheduled smoke check found broken design-asset paths in production. See run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID — likely the /design/ assembly regressed (#671)."
+          if [[ -n "$EXISTING" ]]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --label agent-task --label "component:website" --body "$BODY"
+          fi

--- a/scripts/build-digiquant.sh
+++ b/scripts/build-digiquant.sh
@@ -8,9 +8,16 @@
 set -euo pipefail
 
 # 1. Static landing pages (digiquant.io root + atlas.html marketing page).
-mkdir -p dist
+# Clean slate: with a stale dist/ from a previous run, the bare-directory form
+# `cp -r frontend/design dist/design` would nest the package at dist/design/design/.
+rm -rf dist
+mkdir -p dist/design
 cp -r frontend/digiquant/. dist/
-cp -r frontend/design dist/design
+cp -r frontend/design/. dist/design/
+
+# Fail the deploy if the design package didn't land where the pages reference it.
+[ -f dist/design/tokens.css ] || { echo "ERROR: dist/design/tokens.css missing — design package not assembled" >&2; exit 1; }
+[ ! -e dist/design/design ] || { echo "ERROR: design package nested at dist/design/design/" >&2; exit 1; }
 
 # 2. Olympus dashboard. Cloudflare Pages provisions Node + npm; the workspace
 # install is required so @digithings/design symlinks into Olympus's

--- a/scripts/build-digiquant.sh
+++ b/scripts/build-digiquant.sh
@@ -7,6 +7,9 @@
 #                              basePath /olympus → served at digiquant.io/olympus/)
 set -euo pipefail
 
+# Anchor to the repo root so the rm/cp below never touch another cwd's dist/.
+cd "$(dirname "$0")/.."
+
 # 1. Static landing pages (digiquant.io root + atlas.html marketing page).
 # Clean slate: with a stale dist/ from a previous run, the bare-directory form
 # `cp -r frontend/design dist/design` would nest the package at dist/design/design/.

--- a/scripts/build-digithings.sh
+++ b/scripts/build-digithings.sh
@@ -2,6 +2,9 @@
 # Build script for digithings.ai — run by Cloudflare Pages on every push.
 set -euo pipefail
 
+# Anchor to the repo root so the rm/cp below never touch another cwd's dist/.
+cd "$(dirname "$0")/.."
+
 # Clean slate: a stale dist/ from a previous run would re-nest the design copy below.
 rm -rf dist
 mkdir -p dist/design/assets

--- a/scripts/build-digithings.sh
+++ b/scripts/build-digithings.sh
@@ -2,13 +2,22 @@
 # Build script for digithings.ai — run by Cloudflare Pages on every push.
 set -euo pipefail
 
+# Clean slate: a stale dist/ from a previous run would re-nest the design copy below.
+rm -rf dist
 mkdir -p dist/design/assets
 cp -r frontend/digithings/. dist/
-cp -r frontend/design dist/design
+# Copy CONTENTS (trailing /.): `cp -r frontend/design dist/design` nests the package
+# at dist/design/design/ because dist/design already exists (mkdir above), which
+# 404s every stylesheet and ES module the pages reference via ../design/.
+cp -r frontend/design/. dist/design/
 # REM-083: ship OG asset at stable absolute URL path
 if [ -f frontend/digithings/public/og.png ]; then
   cp frontend/digithings/public/og.png dist/design/assets/og.png
 fi
+
+# Fail the deploy if the design package didn't land where the pages reference it.
+[ -f dist/design/tokens.css ] || { echo "ERROR: dist/design/tokens.css missing — design package not assembled" >&2; exit 1; }
+[ ! -e dist/design/design ] || { echo "ERROR: design package nested at dist/design/design/" >&2; exit 1; }
 
 echo "--- dist/ contents ---"
 ls -la dist/


### PR DESCRIPTION
Fixes #671

## What broke

digithings.ai renders completely unstyled in production (Times New Roman, no JS, no diagram/terminals). Verified live with a real browser: every `/design/*` stylesheet and ES module returns the SPA fallback (`index.html`, `text/html`) and gets MIME-blocked — 8 console errors. The design tree is actually deployed at `/design/design/` (live-verified: `/design/design/tokens.css` → 200 `text/css`).

Root cause: 513680aa changed `mkdir -p dist` → `mkdir -p dist/design/assets` in `scripts/build-digithings.sh`. Because `dist/design` now pre-exists, `cp -r frontend/design dist/design` copies the directory *into* it instead of *as* it.

## Fix

- Copy package **contents** (`cp -r frontend/design/. dist/design/`) so a pre-existing destination is fine
- `rm -rf dist` first — local re-runs previously accumulated stale/nested layouts
- Build-time guards: assert `dist/design/tokens.css` exists and `dist/design/design` does not, so a wrong layout fails the Cloudflare Pages build instead of deploying silently (there is no post-deploy smoke check for `/design/` paths)
- Same hardening in `scripts/build-digiquant.sh`, where the identical bug was latent (any second local run re-nested the package)

## Verification

- `scripts/build-digithings.sh` run twice in a row: `dist/design/tokens.css` ✓, no `dist/design/design` ✓, `dist/design/assets/og.png` (REM-083) ✓, terminal/typography-motion assets ✓
- digiquant landing-assembly section run twice: same checks pass
- Guard trips on a reproduction of the old nested layout
- `make score`: Security 10, Quality 10, Optimization 10, Accuracy 10

## Note for reviewers

This PR targets `develop` directly rather than `module/website`: that module branch is 349 commits behind develop and predates the existence of `scripts/build-digithings.sh`, while production builds from develop-lineage content. Flagging the stale `module/website` branch separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
