### PR TITLE
fix(digichat): workspace Docker build, ship migrations, fix NaN rate-limit window

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,11 @@
-# Root build context is used by frontend/digichat/Dockerfile (npm workspace build).
-# Keep the context small: exclude everything Docker never needs.
+# Root build context is shared by every service compose builds with `context: .`
+# (digikey, digigraph, digiquant, digismith, digiclaw, digichat). Their
+# Dockerfiles COPY the service source dirs, so exclude only what no image needs.
 .git
 .github
 .worktrees
 .claude
+.playwright-mcp
 node_modules
 **/node_modules
 **/.next
@@ -16,15 +18,6 @@ openspec
 tests
 scripts
 agents
-digibase
-digiclaw
-digidev
-digigraph
-digikey
-digillm
-digiquant
-digisearch
-digismith
 frontend/digithings
 frontend/digiquant
 **/*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Root build context is used by frontend/digichat/Dockerfile (npm workspace build).
+# Keep the context small: exclude everything Docker never needs.
+.git
+.github
+.worktrees
+.claude
+node_modules
+**/node_modules
+**/.next
+**/out
+dist
+data
+docs
+projects
+openspec
+tests
+scripts
+agents
+digibase
+digiclaw
+digidev
+digigraph
+digikey
+digillm
+digiquant
+digisearch
+digismith
+frontend/digithings
+frontend/digiquant
+**/*.log
+.env
+.env.*
+!.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,8 +322,10 @@ services:
 
   digichat:
     build:
-      context: ./digichat
-      dockerfile: Dockerfile
+      # Repo-root context: digichat is an npm workspace member; its lockfile and
+      # the private @digithings/design package only exist at the root (#675).
+      context: .
+      dockerfile: frontend/digichat/Dockerfile
     image: digi-digichat:latest
     container_name: digi-digichat
     profiles:

--- a/frontend/digichat/Dockerfile
+++ b/frontend/digichat/Dockerfile
@@ -1,16 +1,23 @@
-# DigiChat — Next.js standalone (build from ./digichat)
+# DigiChat — Next.js standalone.
+# Build from the REPO ROOT (compose: context '.', dockerfile frontend/digichat/Dockerfile):
+# the app is an npm workspace member whose lockfile lives at the repo root and whose
+# private @digithings/design dependency only resolves through the workspace link.
 FROM node:22-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache libc6-compat
 COPY package.json package-lock.json ./
-RUN npm ci
+COPY frontend/digichat/package.json frontend/digichat/
+COPY frontend/design/package.json frontend/design/
+COPY frontend/olympus/package.json frontend/olympus/
+RUN npm ci --workspace frontend/digichat --include-workspace-root
 
 FROM node:22-alpine AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
-RUN npm run build
+COPY --from=deps /app ./
+COPY frontend/design ./frontend/design
+COPY frontend/digichat ./frontend/digichat
+RUN npm run build --workspace frontend/digichat
 
 FROM node:22-alpine AS runner
 WORKDIR /app
@@ -18,11 +25,17 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN apk add --no-cache curl
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
-COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# Workspace standalone output mirrors the monorepo: server.js lives at
+# frontend/digichat/server.js inside the standalone tree.
+COPY --from=builder --chown=nextjs:nodejs /app/frontend/digichat/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/frontend/digichat/.next/static ./frontend/digichat/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/frontend/digichat/public ./frontend/digichat/public
+# Drizzle migrations: the standalone server.js chdir()s to its own directory,
+# so runMigrate() resolves process.cwd()/drizzle = frontend/digichat/drizzle.
+# Compose sets DIGICHAT_AUTO_MIGRATE=1, so the folder MUST ship in the image.
+COPY --from=builder --chown=nextjs:nodejs /app/frontend/digichat/drizzle ./frontend/digichat/drizzle
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
-CMD ["node", "server.js"]
+CMD ["node", "frontend/digichat/server.js"]

--- a/frontend/digichat/OPERATIONS.md
+++ b/frontend/digichat/OPERATIONS.md
@@ -53,7 +53,7 @@ Trace payloads from DigiGraph may include **`service`** (`digigraph` \| `digisea
 
 Machine API keys persist under owner key `machine:<tenantSlug>`.
 
-Apply new tables with `cd digichat && npm run db:migrate` (see [drizzle/0001_conversations.sql](digichat/drizzle/0001_conversations.sql), [drizzle/0002_quant_runs.sql](digichat/drizzle/0002_quant_runs.sql) for quant run storage).
+Apply new tables with `cd frontend/digichat && npm run db:migrate` (see [drizzle/0001_conversations.sql](drizzle/0001_conversations.sql), [drizzle/0002_quant_runs.sql](drizzle/0002_quant_runs.sql) for quant run storage).
 
 ## Local dev (fast iteration — no DigiChat Docker image)
 
@@ -70,7 +70,7 @@ Use the **Next.js dev server** for hot reload. For the fastest loop, run **all b
 
    Stop: `make stack-local-stop`. Details, Ollama, and **`litellm_proxy_api_key`**: **[../docs/LOCAL_STACK.md](../docs/LOCAL_STACK.md)**.
 
-3. **DigiChat env** — `cd digichat && cp -n .env.example .env.local`, then set at least:
+3. **DigiChat env** — `cd frontend/digichat && cp -n .env.example .env.local`, then set at least:
 
    - `AUTH_SECRET` — use the **same** value as repo-root `.env` if you already use Auth.js elsewhere, **or** `openssl rand -base64 32`. Set **`NEXTAUTH_SECRET`** to the same string to avoid decrypt errors.
    - **`AUTH_URL`** and **`NEXTAUTH_URL`** — must match the origin you open in the browser. **`npm run dev`** serves **`http://127.0.0.1:3000`** by default (don’t mix `localhost` vs `127.0.0.1` for cookies). If repo-root `.env` uses **`AUTH_URL=...:3005`** for Docker DigiChat, your **host** `.env.local` should still use **:3000** when using `make digichat-dev`, unless you change the Next port.
@@ -94,7 +94,7 @@ Use the **Next.js dev server** for hot reload. For the fastest loop, run **all b
    make up-digichat-db
    ```
 
-   Then in `digichat/.env.local` set `DIGICHAT_DATABASE_URL=postgresql://digichat:digichat@127.0.0.1:5433/digichat`, run `cd digichat && npm run db:migrate`, and restart DigiChat. The **Ecosystem** sheet shows when server DB is configured vs skipped. **Strategic direction:** platform data (chat DB, checkpoints, cache creds, etc.) should eventually route through a **DigiBase** data-plane service so secrets and policy live in one place — see [digibase/ARCHITECTURE.md](../digibase/ARCHITECTURE.md). **v1** remains a normal Postgres URL per environment.
+   Then in `frontend/digichat/.env.local` set `DIGICHAT_DATABASE_URL=postgresql://digichat:digichat@127.0.0.1:5433/digichat`, run `cd frontend/digichat && npm run db:migrate`, and restart DigiChat. The **Ecosystem** sheet shows when server DB is configured vs skipped. **Strategic direction:** platform data (chat DB, checkpoints, cache creds, etc.) should eventually route through a **DigiBase** data-plane service so secrets and policy live in one place — see [digibase/ARCHITECTURE.md](../digibase/ARCHITECTURE.md). **v1** remains a normal Postgres URL per environment.
 
 Older two-service-only script (DigiQuant + DigiGraph on **18001** / **18000**): [`scripts/run_local.sh`](scripts/run_local.sh).
 
@@ -109,7 +109,7 @@ Older two-service-only script (DigiQuant + DigiGraph on **18001** / **18000**): 
 2. Configure and run DigiChat:
 
    ```bash
-   cd digichat
+   cd frontend/digichat
    cp -n .env.example .env.local
    ```
 
@@ -140,7 +140,7 @@ Older two-service-only script (DigiQuant + DigiGraph on **18001** / **18000**): 
 From repo root:
 
 ```bash
-cd digichat
+cd frontend/digichat
 cp .env.example .env.local
 # Set AUTH_SECRET, DIGIGRAPH_INTERNAL_URL, optional AUTH_OIDC_* , DIGICHAT_DATABASE_URL
 npm install
@@ -193,7 +193,7 @@ docker compose --profile digichat up -d --build
 After first boot with Postgres:
 
 ```bash
-cd digichat && DIGICHAT_DATABASE_URL=postgresql://digichat:digichat@127.0.0.1:5433/digichat npm run db:seed
+cd frontend/digichat && DIGICHAT_DATABASE_URL=postgresql://digichat:digichat@127.0.0.1:5433/digichat npm run db:seed
 npm run db:create-key -- default automation
 ```
 
@@ -219,7 +219,7 @@ See [digichat/.env.example](digichat/.env.example). Critical variables:
 
 ## Chat troubleshooting
 
-- **`upstream_auth` / missing JWT:** If `DIGIKEY_URL` points at DigiKey, **`DIGIKEY_BFF_TOKEN` must match** the secret on the DigiKey process (same value in root `.env` / compose and `digichat/.env.local`). Restart DigiChat after changing env. See [../docs/LOCAL_STACK.md](../docs/LOCAL_STACK.md) for the full matrix. Alternatives: call the BFF with **`Authorization: Bearer dgk_live_…`**, or set **`DIGIGRAPH_UPSTREAM_API_KEY`** for a static upstream Bearer.
+- **`upstream_auth` / missing JWT:** If `DIGIKEY_URL` points at DigiKey, **`DIGIKEY_BFF_TOKEN` must match** the secret on the DigiKey process (same value in root `.env` / compose and `frontend/digichat/.env.local`). Restart DigiChat after changing env. See [../docs/LOCAL_STACK.md](../docs/LOCAL_STACK.md) for the full matrix. Alternatives: call the BFF with **`Authorization: Bearer dgk_live_…`**, or set **`DIGIGRAPH_UPSTREAM_API_KEY`** for a static upstream Bearer.
 - **DigiGraph** accepts both string `content` and OpenAI/AI-SDK **part lists** (`[{ "type": "text", "text": "..." }]`) on `/v1/chat/completions`. The **trace** BFF path normalizes AI SDK `ModelMessage` payloads to plain `{ "role", "content" }` strings before `POST /v1/chat/completions`, matching DigiGraph’s `ChatMessage` model and avoiding `422` from strict body validation. If a call still fails, the assistant bubble includes the **upstream response body** (e.g. FastAPI `detail`) after the status line.
 - **Auth:** In production Docker you must **sign in** at `/login` (or use a machine `Authorization: Bearer …` key). `DIGICHAT_DEV_AUTH=1` enables the dev password provider; set **`AUTH_URL`** to the exact origin users use (e.g. `http://127.0.0.1:3005`) so the session cookie is issued correctly.
 
@@ -231,4 +231,4 @@ See [digichat/.env.example](digichat/.env.example). Critical variables:
 
 ## Legacy static UI
 
-The `website/digichat/` zero-dependency demo was removed. Use **`digichat/`** for all production deployments.
+The `website/digichat/` zero-dependency demo was removed. Use **`frontend/digichat/`** for all production deployments.

--- a/frontend/digichat/next.config.ts
+++ b/frontend/digichat/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 import {
   DIGICHAT_APP_SECURITY_HEADERS,
@@ -6,6 +7,14 @@ import {
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Pin the tracing root to the monorepo root so the standalone tree is always
+  // .next/standalone/frontend/digichat/server.js — without this Next infers the
+  // root from surrounding lockfiles, which breaks in git worktrees and would
+  // silently move server.js out from under the Dockerfile's COPY paths (#675).
+  outputFileTracingRoot: path.join(__dirname, "../.."),
+  turbopack: {
+    root: path.join(__dirname, "../.."),
+  },
   async headers() {
     return [
       {

--- a/frontend/digichat/src/lib/bff-rate-limit.test.ts
+++ b/frontend/digichat/src/lib/bff-rate-limit.test.ts
@@ -20,4 +20,19 @@ describe("checkBffRateLimit", () => {
       expect(blocked.retryAfterSec).toBeGreaterThan(0);
     }
   });
+
+  it("still limits under the module defaults (regression: NaN window from '60_000')", () => {
+    // Before #675 the default window parsed as NaN ("60_000" → Number → NaN,
+    // numeric separators are literal-only syntax), the cutoff filter emptied
+    // the history on every call, and the limiter never tripped at any volume.
+    const key = `defaults-${Date.now()}`;
+    let blocked = false;
+    for (let i = 0; i < 100; i++) {
+      if (!checkBffRateLimit(key).allowed) {
+        blocked = true;
+        break;
+      }
+    }
+    expect(blocked).toBe(true);
+  });
 });

--- a/frontend/digichat/src/lib/bff-rate-limit.ts
+++ b/frontend/digichat/src/lib/bff-rate-limit.ts
@@ -7,8 +7,24 @@ type Window = { timestamps: number[] };
 const MAX_RATE_LIMIT_KEYS = 10_000;
 const windows = new BoundedTTLMap<string, Window>(MAX_RATE_LIMIT_KEYS, 60 * 60_000);
 
-const DEFAULT_MAX = Number(process.env.DIGICHAT_CHAT_RATE_LIMIT_MAX ?? "30");
-const DEFAULT_WINDOW_MS = Number(process.env.DIGICHAT_CHAT_RATE_LIMIT_WINDOW_MS ?? "60_000");
+/**
+ * Parse a positive integer from the environment. `Number("60_000")` is NaN —
+ * numeric separators are a literal-only syntax — and a NaN window made the
+ * cutoff filter drop every timestamp, silently disabling the limiter (#675).
+ */
+function envPositiveInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`bff-rate-limit: ignoring invalid ${name}=${JSON.stringify(raw)}; using ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+const DEFAULT_MAX = envPositiveInt("DIGICHAT_CHAT_RATE_LIMIT_MAX", 30);
+const DEFAULT_WINDOW_MS = envPositiveInt("DIGICHAT_CHAT_RATE_LIMIT_WINDOW_MS", 60_000);
 
 export function checkBffRateLimit(
   key: string,

--- a/frontend/digichat/src/lib/bff-rate-limit.ts
+++ b/frontend/digichat/src/lib/bff-rate-limit.ts
@@ -16,7 +16,7 @@ function envPositiveInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     console.warn(`bff-rate-limit: ignoring invalid ${name}=${JSON.stringify(raw)}; using ${fallback}`);
     return fallback;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,7 @@
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.3.0",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0",
-        "zod": "^4.3.6"
+        "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Fixes #675

Makes `make up-digichat` actually able to build and boot, and makes the chat rate limiter actually limit:

1. **Compose context** `./digichat` → repo root (the directory no longer exists; the app is an npm workspace member at `frontend/digichat` whose lockfile and private `@digithings/design` dep only exist at the root).
2. **Workspace Dockerfile**: deps stage seeds workspace `package.json`s and runs `npm ci --workspace frontend/digichat --include-workspace-root`; runner copies the standalone tree at monorepo-mirrored paths and **ships `drizzle/`** — compose hardcodes `DIGICHAT_AUTO_MIGRATE=1`, and `runMigrate()` resolves `process.cwd()/drizzle` after the standalone `server.js` `chdir`s to its own dir (verified in the generated server.js).
3. **`outputFileTracingRoot` pinned** to the repo root: Next otherwise *infers* the workspace root from surrounding lockfiles — in a git worktree it picked the parent repo and produced `standalone/.worktrees/<name>/frontend/digichat/server.js`, which would silently break the image's COPY paths depending on where you build.
4. **NaN rate limiter**: `Number("60_000")` → NaN (numeric separators are literal-only syntax) → the cutoff filter emptied the history every call → the limiter never tripped at any volume. Now parsed via `envPositiveInt()` (warn + fallback on junk). New regression test exercises the module **defaults** — the existing tests passed explicit numbers, which is exactly how this slipped through.
5. Root `.dockerignore` (new root context), OPERATIONS.md pre-move path fixes, stale `zod` lockfile entry dropped.

**Verification:** 82/82 digichat vitest; standalone layout matches COPY paths after the pin; `docker compose --profile digichat config -q` valid; `make doc-check` OK; `make score` 10/10/10/10. ⚠️ No docker daemon in my environment — the full `docker build` should be exercised in CI or by a reviewer before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)