### PR TITLE
feat(website): digiquant.io de-slop + redesign — honest data, real CTAs, working tabs

### DIFF
--- a/frontend/digiquant/README.md
+++ b/frontend/digiquant/README.md
@@ -9,16 +9,23 @@ are loaded from `../design/` so there is a single source of truth.
 
 ## Files
 
-| File          | Purpose                                                |
-| ------------- | ------------------------------------------------------ |
-| `index.html`  | DigiQuant landing — hero, product family, chat embed   |
-| `atlas.html`  | Stub reserving `/atlas` for Phase 4                    |
-| `main.js`     | Composes quant-native ticker, diagram, scroll-trigger  |
-| `CNAME`       | GitHub Pages custom domain (`digiquant.io`)            |
+| File          | Purpose                                                        |
+| ------------- | -------------------------------------------------------------- |
+| `index.html`  | DigiQuant landing — hero, acts, deployment tabs, get-started   |
+| `atlas.html`  | Atlas marketing page — cycles, ten-phase pipeline, data sources |
+| `atlas-main.js` | Atlas page module — counters + draw-ins                      |
+| `main.js`     | Landing module — diagram, counters, Act V tabs                 |
+| `style.css`   | Page styles on top of the shared design tokens                 |
+| `_headers`    | Cloudflare Pages security headers (root-level, see #674)       |
+| `CNAME`       | Legacy GitHub Pages domain marker (`digiquant.io`)             |
+
+All charts and figures on these pages are illustrative and labeled as such
+in the markup; the live data surface is the Olympus dashboard at
+[`/olympus/`](https://digiquant.io/olympus/).
 
 ## Design system
 
-No CSS or JS lives in this directory beyond `main.js`. Styles come from
+Page CSS lives in `style.css`; shared styles come from
 `../design/tokens.css` and `../design/components.css`; the
 full reference is [`../design/README.md`](../design/README.md).
 

--- a/frontend/digiquant/atlas-main.js
+++ b/frontend/digiquant/atlas-main.js
@@ -1,99 +1,12 @@
 /**
  * atlas.html — page entry module.
  *
- * Lightweight compared to digiquant main.js:
- *   - Hero equity-curve draw-in animation
- *   - Counter animations for metric cards
- *   - No ticker, no living-architecture diagram
+ * Lightweight compared to digiquant main.js: hero curve draw-in + metric
+ * counters, both from the shared page-motion module.
  */
+import { initCounters, initDrawIn } from './page-motion.js';
 
-// --- Counter animation (shared with digiquant main.js) -------------------
-function formatCount(value, decimals, suffix) {
-    const n = decimals > 0 ? value.toFixed(decimals) : String(Math.round(value));
-    return suffix ? `${n}${suffix}` : n;
-}
-
-function animateCounter(el) {
-    if (el.dataset.countDone === '1') return;
-    el.dataset.countDone = '1';
-    const target = parseFloat(el.dataset.countTo);
-    const decimals = parseInt(el.dataset.countDecimals || '0', 10);
-    const suffix = el.dataset.countSuffix || '';
-    if (!Number.isFinite(target)) return;
-
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReduced) {
-        el.textContent = formatCount(target, decimals, suffix);
-        return;
-    }
-
-    const duration = 900;
-    const start = performance.now();
-    let finalized = false;
-
-    function step(now) {
-        if (finalized) return;
-        const t = Math.min(1, (now - start) / duration);
-        const k = 1 - Math.pow(1 - t, 3);
-        el.textContent = formatCount(target * k, decimals, suffix);
-        if (t < 1) {
-            requestAnimationFrame(step);
-        } else {
-            finalized = true;
-            el.textContent = formatCount(target, decimals, suffix);
-        }
-    }
-    requestAnimationFrame(step);
-    setTimeout(() => {
-        if (finalized) return;
-        finalized = true;
-        el.textContent = formatCount(target, decimals, suffix);
-    }, duration + 200);
-}
-
-function initCounters() {
-    const counters = document.querySelectorAll('[data-count-to]');
-    if (counters.length === 0) return;
-    if (!('IntersectionObserver' in window)) {
-        counters.forEach(animateCounter);
-        return;
-    }
-    const io = new IntersectionObserver((entries) => {
-        for (const entry of entries) {
-            if (entry.isIntersecting) {
-                animateCounter(entry.target);
-                io.unobserve(entry.target);
-            }
-        }
-    }, { threshold: [0, 0.15], rootMargin: '0px 0px -8% 0px' });
-    counters.forEach((el) => io.observe(el));
-}
-
-// --- Hero curve draw-in --------------------------------------------------
-function initDrawIn() {
-    const path = document.querySelector('.atl-draw-in');
-    if (!path) return;
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const length = path.getTotalLength ? path.getTotalLength() : 2200;
-    path.style.strokeDasharray = String(length);
-    if (prefersReduced) {
-        path.style.strokeDashoffset = '0';
-        return;
-    }
-    path.style.strokeDashoffset = String(length);
-    requestAnimationFrame(() => {
-        path.style.transition = 'stroke-dashoffset 2200ms cubic-bezier(0.2, 0.8, 0.2, 1)';
-        path.style.strokeDashoffset = '0';
-    });
-    setTimeout(() => {
-        if (path.style.strokeDashoffset !== '0') {
-            path.style.strokeDashoffset = '0';
-        }
-    }, 2400);
-}
-
-// --- Boot ----------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', () => {
-    initDrawIn();
-    initCounters();
+  initDrawIn('.atl-draw-in', { duration: 2200 });
+  initCounters({ duration: 900 });
 });

--- a/frontend/digiquant/atlas.html
+++ b/frontend/digiquant/atlas.html
@@ -319,6 +319,7 @@
                 <span class="logo-text">atlas</span>
             </div>
             <div class="nav-links">
+                <a href="./olympus/" class="nav-link">Olympus</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
                 <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>

--- a/frontend/digiquant/atlas.html
+++ b/frontend/digiquant/atlas.html
@@ -347,13 +347,13 @@
                 <div class="atl-badge qn-metric">ATLAS · DIGIQUANT RESEARCH ENGINE</div>
                 <h1 class="atl-hero-title">Research that<br>runs on schedule.</h1>
                 <p class="atl-hero-sub">
-                    Nine-phase macro research pipeline. Structured JSON artifacts persisted to
+                    Ten-phase macro research pipeline. Structured JSON artifacts persisted to
                     Supabase daily. Consumes free data sources — FRED, Treasury, price technicals,
-                    crypto sentiment. Feeds Hermes portfolio deliberation and Kairos strategy exploration.
+                    crypto sentiment. Feeds Hermes portfolio deliberation.
                 </p>
                 <div class="atl-hero-meta">
                     <div class="atl-hero-stat">
-                        <span class="atl-hero-stat-value qn-metric" data-count-to="9">0</span>
+                        <span class="atl-hero-stat-value qn-metric" data-count-to="10">0</span>
                         <span class="atl-hero-stat-label">pipeline phases</span>
                     </div>
                     <div class="atl-hero-stat">
@@ -408,12 +408,12 @@
                     <span class="atl-cycle-freq qn-metric">WEEKLY · SUNDAY</span>
                     <h3 class="atl-cycle-title">Full baseline</h3>
                     <p class="atl-cycle-desc">
-                        All 9 phases run in full. Research templates are regenerated
+                        All 10 phases run in full. Research templates are regenerated
                         from their YAML specs. Sets the week's anchor for downstream delta chains.
                         More expensive, more thorough — run once per week.
                     </p>
                     <div class="atl-cycle-tags">
-                        <span class="atl-tag">9 phases</span>
+                        <span class="atl-tag">10 phases</span>
                         <span class="atl-tag">run_type=baseline</span>
                         <span class="atl-tag">weekly anchor</span>
                         <span class="atl-tag">full regen</span>
@@ -444,11 +444,13 @@
         <section class="dq-act" id="pipeline">
             <div class="dq-act-head">
                 <span class="dq-act-kicker qn-metric">ACT II · PIPELINE</span>
-                <h2 class="dq-act-title">Nine phases. Parallel where it counts.</h2>
+                <h2 class="dq-act-title">Ten phases. Parallel where it counts.</h2>
                 <p class="dq-act-lede">
                     Baseline runs execute all phases in sequence — with Phase 1 running
                     parallel sub-nodes across alt data sources. Each phase node returns a
                     structured Pydantic output. No free-form text leaves the pipeline.
+                    Numbering is historical: phase 7 split into 7 / 7C / 7D and phase 8
+                    folded into them, so the ten phases you see are the ten that run.
                 </p>
             </div>
 
@@ -611,11 +613,11 @@
             <div class="dq-metric-row" style="margin-top: var(--space-5)">
                 <div class="dq-metric-card">
                     <span class="dq-metric-label">FRED series configured</span>
-                    <span class="dq-metric-value qn-metric" data-count-to="42">0</span>
+                    <span class="dq-metric-value qn-metric" data-count-to="25">0</span>
                 </div>
                 <div class="dq-metric-card">
                     <span class="dq-metric-label">Watchlist tickers</span>
-                    <span class="dq-metric-value qn-metric" data-count-to="65">0</span>
+                    <span class="dq-metric-value qn-metric" data-count-to="90" data-count-suffix="+">0</span>
                 </div>
                 <div class="dq-metric-card">
                     <span class="dq-metric-label">Paid APIs required</span>

--- a/frontend/digiquant/index.html
+++ b/frontend/digiquant/index.html
@@ -334,7 +334,7 @@
             <div class="dq-composite-panel" id="panel-mcp" role="tabpanel" aria-labelledby="tab-mcp" hidden>
                 <div class="qn-chart-frame dq-code-frame">
                     <span class="dq-widget-label qn-metric">MCP TOOLS · FROM THE ACTUAL SERVER</span>
-                    <pre class="dq-code"><code>$ digiquant mcp serve
+                    <pre class="dq-code"><code>$ python -m digiquant.mcp_server
 
 tools:
   digiquant_list_strategies        # registry inventory

--- a/frontend/digiquant/index.html
+++ b/frontend/digiquant/index.html
@@ -24,8 +24,9 @@
                 <span class="logo-text">digiquant</span>
             </div>
             <div class="nav-links">
+                <a href="./atlas.html" class="nav-link">Atlas</a>
+                <a href="./olympus/" class="nav-link">Olympus</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
-                <a href="https://digithings.ai/chat.html" class="nav-link">DigiChat</a>
                 <a href="https://github.com/digithings-ai" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
@@ -391,6 +392,8 @@
         <div class="dq-footer-inner">
             <div class="dq-footer-col">
                 <span class="dq-footer-title qn-metric">DIGIQUANT</span>
+                <a href="./atlas.html" class="nav-link">Atlas — macro research</a>
+                <a href="./olympus/" class="nav-link">Olympus — live dashboard</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
                 <a href="https://digithings.ai/chat.html" class="nav-link">DigiChat</a>
                 <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/frontend/digiquant/index.html
+++ b/frontend/digiquant/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DigiQuant | Quant-native AI, on infrastructure you own</title>
-    <meta name="description" content="DigiQuant — backtest, optimize, and deploy on infrastructure you own. Atlas research, Hermes delivery, Kairos execution, powered by NautilusTrader.">
+    <meta name="description" content="DigiQuant — backtest and optimize on NautilusTrader, with Atlas scheduled macro research and Hermes signal deliberation. MIT open core, self-hosted.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200..700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -45,11 +45,15 @@
             <div class="dq-hero-inner">
                 <h1 class="dq-hero-title tws-weight-shift"
                     data-weight-from="200" data-weight-to="600">
-                    Backtest, optimize, and deploy — on infrastructure you own.
+                    Backtest, optimize, and research — on infrastructure you own.
                 </h1>
                 <p class="dq-hero-sub qn-metric">
-                    NautilusTrader execution &nbsp;·&nbsp; human-gated live orders &nbsp;·&nbsp; open-core
+                    NautilusTrader backtesting &nbsp;·&nbsp; scheduled macro research &nbsp;·&nbsp; MIT open core
                 </p>
+                <div class="dq-hero-cta-row">
+                    <a href="./olympus/" class="dq-cta-primary">Open the live dashboard <span aria-hidden="true">&rarr;</span></a>
+                    <a href="https://github.com/digithings-ai/digithings#readme" class="dq-cta-ghost" target="_blank" rel="noopener noreferrer">Quickstart on GitHub <span aria-hidden="true">&rarr;</span></a>
+                </div>
             </div>
         </header>
 
@@ -59,11 +63,12 @@
         <section class="dq-act" id="act-overview">
             <div class="dq-act-head">
                 <span class="dq-act-kicker qn-metric">ACT I · OVERVIEW</span>
-                <h2 class="dq-act-title">One pipeline. Three specialists.</h2>
+                <h2 class="dq-act-title">One pipeline. Two specialists. One planned.</h2>
                 <p class="dq-act-lede">
-                    Atlas researches. Hermes deliberates. Kairos executes. Every
-                    run lands in NautilusTrader — deterministic, reproducible,
-                    yours.
+                    Atlas researches on schedule. Hermes deliberates and turns the
+                    digest into signals. Kairos — the execution layer — is on the
+                    roadmap. Every backtest runs on NautilusTrader: deterministic,
+                    reproducible, yours.
                 </p>
             </div>
 
@@ -73,16 +78,16 @@
 
             <div class="dq-metric-row">
                 <div class="dq-metric-card">
-                    <span class="dq-metric-label">Backtest runtime</span>
-                    <span class="dq-metric-value qn-metric">12<span class="dq-metric-unit">ms/candle</span></span>
+                    <span class="dq-metric-label">Execution engine</span>
+                    <span class="dq-metric-value qn-metric dq-metric-small">NautilusTrader</span>
                 </div>
                 <div class="dq-metric-card">
-                    <span class="dq-metric-label">Strategies registered</span>
-                    <span class="dq-metric-value qn-metric" data-count-to="14">0</span>
+                    <span class="dq-metric-label">Strategies in the registry</span>
+                    <span class="dq-metric-value qn-metric" data-count-to="6">0</span>
                 </div>
                 <div class="dq-metric-card">
                     <span class="dq-metric-label">Asset coverage</span>
-                    <span class="dq-metric-value qn-metric dq-metric-small">equities / crypto / futures</span>
+                    <span class="dq-metric-value qn-metric dq-metric-small">equities / crypto</span>
                 </div>
             </div>
         </section>
@@ -90,13 +95,14 @@
         <!-- ================================================================
              3. Act II — Atlas (research): candle chart + metric counters
              ================================================================ -->
-        <section class="dq-act accent-atlas" id="act-atlas">
+        <section class="dq-act dq-act--rail accent-atlas" id="act-atlas">
             <div class="dq-act-head">
                 <span class="dq-act-kicker qn-metric">ACT II · ATLAS</span>
                 <h2 class="dq-act-title">Research, persisted.</h2>
                 <p class="dq-act-lede">
                     Scheduled research cycles produce structured views — not prose.
-                    Outputs land in a shared store, re-used by Hermes and Kairos.
+                    Outputs land in a shared store, re-used by Hermes and rendered
+                    live in the Olympus dashboard.
                 </p>
             </div>
 
@@ -109,24 +115,23 @@
                             <line x1="0" y1="100" x2="480" y2="100"/>
                             <line x1="0" y1="150" x2="480" y2="150"/>
                         </g>
-                        <!-- Candles (synthesized OHLC) -->
+                        <!-- Candles (illustrative shapes only) -->
                         <g class="dq-candle-group">
-                            <!-- Each candle: wick (line) + body (rect) -->
-                            <g data-ohlc="110,120,102,115"><line x1="20" y1="95" x2="20" y2="138" /><rect x="14" y="105" width="12" height="10" class="qn-up"/></g>
-                            <g data-ohlc="115,118,108,112"><line x1="50" y1="98" x2="50" y2="132" /><rect x="44" y="110" width="12" height="6"  class="qn-down"/></g>
-                            <g data-ohlc="112,122,110,121"><line x1="80" y1="90"  x2="80" y2="130" /><rect x="74" y="100" width="12" height="14" class="qn-up"/></g>
-                            <g data-ohlc="121,124,117,118"><line x1="110" y1="88" x2="110" y2="123"/><rect x="104" y="100" width="12" height="8"  class="qn-down"/></g>
-                            <g data-ohlc="118,128,117,126"><line x1="140" y1="82" x2="140" y2="123"/><rect x="134" y="92"  width="12" height="14" class="qn-up"/></g>
-                            <g data-ohlc="126,130,120,122"><line x1="170" y1="80" x2="170" y2="120"/><rect x="164" y="90"  width="12" height="10" class="qn-down"/></g>
-                            <g data-ohlc="122,134,121,132"><line x1="200" y1="76" x2="200" y2="119"/><rect x="194" y="82"  width="12" height="16" class="qn-up"/></g>
-                            <g data-ohlc="132,138,128,130"><line x1="230" y1="72" x2="230" y2="112"/><rect x="224" y="82"  width="12" height="10" class="qn-down"/></g>
-                            <g data-ohlc="130,142,129,141"><line x1="260" y1="68" x2="260" y2="111"/><rect x="254" y="73"  width="12" height="17" class="qn-up"/></g>
-                            <g data-ohlc="141,146,136,138"><line x1="290" y1="64" x2="290" y2="104"/><rect x="284" y="74"  width="12" height="10" class="qn-down"/></g>
-                            <g data-ohlc="138,150,137,149" class="dq-candle-highlight"><line x1="320" y1="60" x2="320" y2="103"/><rect x="314" y="66" width="12" height="17" class="qn-up"/></g>
-                            <g data-ohlc="149,154,144,146"><line x1="350" y1="56" x2="350" y2="96"/><rect x="344" y="66"  width="12" height="10" class="qn-down"/></g>
-                            <g data-ohlc="146,158,145,157"><line x1="380" y1="52" x2="380" y2="95"/><rect x="374" y="58"  width="12" height="17" class="qn-up"/></g>
-                            <g data-ohlc="157,162,153,155"><line x1="410" y1="48" x2="410" y2="87"/><rect x="404" y="58"  width="12" height="10" class="qn-down"/></g>
-                            <g data-ohlc="155,166,154,164"><line x1="440" y1="44" x2="440" y2="86"/><rect x="434" y="50"  width="12" height="16" class="qn-up"/></g>
+                            <g><line x1="20" y1="95" x2="20" y2="138" /><rect x="14" y="105" width="12" height="10" class="qn-up"/></g>
+                            <g><line x1="50" y1="98" x2="50" y2="132" /><rect x="44" y="110" width="12" height="6"  class="qn-down"/></g>
+                            <g><line x1="80" y1="90"  x2="80" y2="130" /><rect x="74" y="100" width="12" height="14" class="qn-up"/></g>
+                            <g><line x1="110" y1="88" x2="110" y2="123"/><rect x="104" y="100" width="12" height="8"  class="qn-down"/></g>
+                            <g><line x1="140" y1="82" x2="140" y2="123"/><rect x="134" y="92"  width="12" height="14" class="qn-up"/></g>
+                            <g><line x1="170" y1="80" x2="170" y2="120"/><rect x="164" y="90"  width="12" height="10" class="qn-down"/></g>
+                            <g><line x1="200" y1="76" x2="200" y2="119"/><rect x="194" y="82"  width="12" height="16" class="qn-up"/></g>
+                            <g><line x1="230" y1="72" x2="230" y2="112"/><rect x="224" y="82"  width="12" height="10" class="qn-down"/></g>
+                            <g><line x1="260" y1="68" x2="260" y2="111"/><rect x="254" y="73"  width="12" height="17" class="qn-up"/></g>
+                            <g><line x1="290" y1="64" x2="290" y2="104"/><rect x="284" y="74"  width="12" height="10" class="qn-down"/></g>
+                            <g class="dq-candle-highlight"><line x1="320" y1="60" x2="320" y2="103"/><rect x="314" y="66" width="12" height="17" class="qn-up"/></g>
+                            <g><line x1="350" y1="56" x2="350" y2="96"/><rect x="344" y="66"  width="12" height="10" class="qn-down"/></g>
+                            <g><line x1="380" y1="52" x2="380" y2="95"/><rect x="374" y="58"  width="12" height="17" class="qn-up"/></g>
+                            <g><line x1="410" y1="48" x2="410" y2="87"/><rect x="404" y="58"  width="12" height="10" class="qn-down"/></g>
+                            <g><line x1="440" y1="44" x2="440" y2="86"/><rect x="434" y="50"  width="12" height="16" class="qn-up"/></g>
                         </g>
                     </svg>
                 </div>
@@ -146,88 +151,92 @@
                     </div>
                 </div>
             </div>
+            <p class="dq-caption qn-metric">// illustrative chart and example tear-sheet figures — every number above comes from a reference backtest, not live trading</p>
 
-            <a href="https://github.com/digithings-ai/digithings" class="dq-passthrough" target="_blank" rel="noopener noreferrer">Atlas on GitHub &rarr;</a>
+            <a href="./atlas.html" class="dq-passthrough">Atlas in depth &rarr;</a>
         </section>
 
         <!-- ================================================================
-             4. Act III — Hermes (delivery / signals)
+             4. Act III — Hermes (deliberation → signals)
              ================================================================ -->
         <section class="dq-act accent-hermes" id="act-hermes">
             <div class="dq-act-head">
                 <span class="dq-act-kicker qn-metric">ACT III · HERMES</span>
-                <h2 class="dq-act-title">Delivery, not deliberation theatre.</h2>
+                <h2 class="dq-act-title">Deliberation you can replay.</h2>
                 <p class="dq-act-lede">
-                    Hermes translates research into allocations. Every signal is
-                    timestamped, attributed, and reviewable — auditors, risk
-                    teams, and your future self can replay any decision.
+                    Hermes takes the Atlas digest through analyst debate — bull,
+                    bear, risk — and lands timestamped, attributed allocations.
+                    Auditors, risk reviewers, and your future self can replay any
+                    decision.
                 </p>
             </div>
 
-            <p class="dq-timeline-note qn-metric">// Example signal log — live stream requires a running Atlas instance</p>
+            <p class="dq-timeline-note qn-metric">// example signal log — the format a Hermes run produces; strategy names from the actual registry</p>
             <ol class="dq-timeline" aria-label="Example signal log">
                 <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+00:00:00</span>
-                    <span class="dq-sig">mean-reversion-stat-arb · portfolio-A</span>
-                    <span class="dq-chip qn-up">+ rebalance</span>
-                </li>
-                <li class="dq-timeline-row">
-                    <span class="dq-ts qn-metric">T+00:33:34</span>
-                    <span class="dq-sig">trend-follow-futures · portfolio-A</span>
+                    <span class="dq-sig">ema-cross-trailing · BTC</span>
                     <span class="dq-chip qn-up">+ enter</span>
                 </li>
                 <li class="dq-timeline-row">
+                    <span class="dq-ts qn-metric">T+00:33:34</span>
+                    <span class="dq-sig">macd-trend · ETH</span>
+                    <span class="dq-chip qn-up">+ rebalance</span>
+                </li>
+                <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+01:45:52</span>
-                    <span class="dq-sig">vol-carry · portfolio-B</span>
+                    <span class="dq-sig">rsi-momentum · SPY</span>
                     <span class="dq-chip qn-down">&minus; trim</span>
                 </li>
                 <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+04:09:17</span>
-                    <span class="dq-sig">pairs-mean-reversion · portfolio-A</span>
+                    <span class="dq-sig">bollinger-mr · QQQ</span>
                     <span class="dq-chip qn-up">+ open</span>
                 </li>
                 <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+04:50:48</span>
-                    <span class="dq-sig">breakout-swing · portfolio-C</span>
+                    <span class="dq-sig">ema-cross-long · SOL</span>
                     <span class="dq-chip qn-down">&minus; exit</span>
                 </li>
                 <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+05:35:01</span>
-                    <span class="dq-sig">carry-roll · portfolio-B</span>
+                    <span class="dq-sig">ema-cross · BTC</span>
                     <span class="dq-chip qn-up">+ hold</span>
                 </li>
                 <li class="dq-timeline-row">
                     <span class="dq-ts qn-metric">T+06:26:53</span>
-                    <span class="dq-sig">risk-off-overlay · all</span>
+                    <span class="dq-sig">risk-off review · all</span>
                     <span class="dq-chip qn-down">&minus; reduce</span>
                 </li>
             </ol>
         </section>
 
         <!-- ================================================================
-             5. Act IV — Kairos (execution)
+             5. Act IV — Kairos (execution — planned)
              ================================================================ -->
-        <section class="dq-act accent-kairos" id="act-kairos">
+        <section class="dq-act dq-act--rail-right accent-kairos" id="act-kairos">
             <div class="dq-act-head">
-                <span class="dq-act-kicker qn-metric">ACT IV · KAIROS</span>
-                <h2 class="dq-act-title">Execution, gated.</h2>
+                <span class="dq-act-kicker qn-metric">ACT IV · KAIROS <span class="dq-planned-chip">PLANNED</span></span>
+                <h2 class="dq-act-title">Execution, gated — by design.</h2>
                 <p class="dq-act-lede">
-                    Strategies climb a ladder — backtest, paper, loopback, live.
-                    Each rung is a human gate.
+                    Kairos is the planned execution layer. Strategies climb a
+                    ladder — backtest, paper, loopback, live — and every rung
+                    above backtest is a human gate. Today the ladder ends at
+                    backtest; the live rungs ship with Kairos, never before.
                 </p>
             </div>
 
-            <div class="qn-chart-frame dq-ladder" aria-label="Execution ladder — loopback-only by default">
+            <div class="qn-chart-frame dq-ladder" aria-label="Execution ladder — backtest shipped, live rungs planned">
                 <svg viewBox="0 0 600 240" preserveAspectRatio="xMidYMid meet">
                     <g stroke="currentColor" stroke-opacity="0.15" stroke-width="1" fill="none">
                         <line x1="0" y1="220" x2="600" y2="220"/>
                     </g>
-                    <!-- Staircase: 5 steps -->
+                    <!-- Staircase: 5 steps — solid = shipped, dashed = planned -->
                     <g class="dq-ladder-steps" fill="none" stroke="currentColor" stroke-width="1.5">
-                        <rect x="40"  y="180" width="90" height="40" opacity="0.55"/>
-                        <rect x="150" y="140" width="90" height="80" opacity="0.65"/>
-                        <rect x="260" y="100" width="90" height="120" opacity="0.75" class="dq-ladder-active" stroke="var(--accent-kairos)" />
-                        <rect x="370" y="70"  width="90" height="150" opacity="0.35" stroke-dasharray="4 6"/>
+                        <rect x="40"  y="180" width="90" height="40" opacity="0.9" class="dq-ladder-active" stroke="var(--accent-kairos)"/>
+                        <rect x="150" y="140" width="90" height="80" opacity="0.4" stroke-dasharray="4 6"/>
+                        <rect x="260" y="100" width="90" height="120" opacity="0.35" stroke-dasharray="4 6"/>
+                        <rect x="370" y="70"  width="90" height="150" opacity="0.3" stroke-dasharray="4 6"/>
                         <rect x="480" y="40"  width="90" height="180" opacity="0.25" stroke-dasharray="4 6"/>
                     </g>
                     <g class="dq-ladder-labels" font-family="JetBrains Mono, monospace" font-size="10" fill="currentColor" text-anchor="middle" opacity="0.7">
@@ -245,95 +254,127 @@
                 </svg>
             </div>
             <p class="dq-caption qn-metric">
-                // loopback-only by default · human-gated transitions for anything consequential
+                // backtest rung shipped today · everything to its right lands with Kairos — human-gated, always
             </p>
         </section>
 
         <!-- ================================================================
-             6. Act V — Composite dashboard
+             6. Act V — Run it your way (real tabs, real content)
              ================================================================ -->
         <section class="dq-act" id="act-composite">
             <div class="dq-act-head">
-                <span class="dq-act-kicker qn-metric">ACT V · COMPOSITE</span>
+                <span class="dq-act-kicker qn-metric">ACT V · RUN IT</span>
                 <h2 class="dq-act-title">Ship it — your way.</h2>
                 <p class="dq-act-lede">
-                    Run DigiQuant as a service, expose it over MCP, or ship it as a
-                    Docker image inside your stack. Same pipeline. Different edges.
+                    Watch it in the Olympus dashboard, expose it to your agents
+                    over MCP, or ship it as Docker inside your stack. Same
+                    pipeline. Different edges.
                 </p>
             </div>
 
-            <div class="dq-toggle-row" role="tablist">
-                <button class="dq-toggle is-on"  data-mode="plug"   type="button">Plug in</button>
-                <button class="dq-toggle"        data-mode="mcp"    type="button">Expose as MCP</button>
-                <button class="dq-toggle"        data-mode="docker" type="button">Ship as Docker</button>
+            <div class="dq-toggle-row" role="tablist" aria-label="Deployment modes">
+                <button class="dq-toggle is-on" id="tab-dash"   role="tab" aria-selected="true"  aria-controls="panel-dash"   data-mode="dash"   type="button">Dashboard</button>
+                <button class="dq-toggle"       id="tab-mcp"    role="tab" aria-selected="false" aria-controls="panel-mcp"    data-mode="mcp"    type="button">Expose as MCP</button>
+                <button class="dq-toggle"       id="tab-docker" role="tab" aria-selected="false" aria-controls="panel-docker" data-mode="docker" type="button">Ship as Docker</button>
             </div>
 
-            <div class="dq-composite" data-composite-mode="plug">
-                <!-- Equity sparkline -->
-                <div class="qn-chart-frame dq-widget">
-                    <span class="dq-widget-label qn-metric">EQUITY · 30D</span>
-                    <svg viewBox="0 0 240 80" preserveAspectRatio="none">
-                        <path d="M 0 66 L 20 64 L 40 60 L 60 58 L 80 54 L 100 55 L 120 48 L 140 44 L 160 40 L 180 36 L 200 32 L 220 28 L 240 26"
-                              fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.85"/>
-                    </svg>
+            <div class="dq-composite-panel" id="panel-dash" role="tabpanel" aria-labelledby="tab-dash">
+                <div class="dq-composite">
+                    <!-- Equity sparkline -->
+                    <div class="qn-chart-frame dq-widget">
+                        <span class="dq-widget-label qn-metric">EQUITY · EXAMPLE</span>
+                        <svg viewBox="0 0 240 80" preserveAspectRatio="none">
+                            <path d="M 0 66 L 20 64 L 40 60 L 60 58 L 80 54 L 100 55 L 120 48 L 140 44 L 160 40 L 180 36 L 200 32 L 220 28 L 240 26"
+                                  fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.85"/>
+                        </svg>
+                    </div>
+                    <!-- Candle mini -->
+                    <div class="qn-chart-frame dq-widget">
+                        <span class="dq-widget-label qn-metric">CANDLES · EXAMPLE</span>
+                        <svg viewBox="0 0 240 80" preserveAspectRatio="none">
+                            <g>
+                                <rect x="10" y="42" width="8" height="14" class="qn-up"/>
+                                <rect x="28" y="38" width="8" height="10" class="qn-down"/>
+                                <rect x="46" y="32" width="8" height="18" class="qn-up"/>
+                                <rect x="64" y="34" width="8" height="12" class="qn-down"/>
+                                <rect x="82" y="26" width="8" height="20" class="qn-up"/>
+                                <rect x="100" y="28" width="8" height="14" class="qn-up"/>
+                                <rect x="118" y="32" width="8" height="12" class="qn-down"/>
+                                <rect x="136" y="22" width="8" height="22" class="qn-up"/>
+                                <rect x="154" y="24" width="8" height="14" class="qn-down"/>
+                                <rect x="172" y="18" width="8" height="22" class="qn-up"/>
+                                <rect x="190" y="22" width="8" height="10" class="qn-down"/>
+                                <rect x="208" y="14" width="8" height="24" class="qn-up"/>
+                            </g>
+                        </svg>
+                    </div>
+                    <!-- Dashboard pointer -->
+                    <div class="qn-chart-frame dq-widget dq-widget-list">
+                        <span class="dq-widget-label qn-metric">OLYMPUS · LIVE DASHBOARD</span>
+                        <p class="dq-widget-copy">The real thing — daily snapshots, positions, theses, and
+                        research documents straight from the pipeline's Supabase store.</p>
+                        <a href="./olympus/" class="dq-passthrough">Open Olympus &rarr;</a>
+                    </div>
+                    <!-- Ladder mini -->
+                    <div class="qn-chart-frame dq-widget">
+                        <span class="dq-widget-label qn-metric">LADDER</span>
+                        <svg viewBox="0 0 240 80" preserveAspectRatio="xMidYMid meet">
+                            <g fill="none" stroke="currentColor" stroke-width="1.2">
+                                <rect x="10"  y="56" width="40" height="18" opacity="0.9" stroke="var(--accent-kairos)"/>
+                                <rect x="58"  y="42" width="40" height="32" opacity="0.35" stroke-dasharray="3 5"/>
+                                <rect x="106" y="28" width="40" height="46" opacity="0.3" stroke-dasharray="3 5"/>
+                                <rect x="154" y="18" width="40" height="56" opacity="0.28" stroke-dasharray="3 5"/>
+                                <rect x="202" y="8"  width="30" height="66" opacity="0.25" stroke-dasharray="3 5"/>
+                            </g>
+                        </svg>
+                    </div>
                 </div>
-                <!-- Candle mini -->
-                <div class="qn-chart-frame dq-widget">
-                    <span class="dq-widget-label qn-metric">CANDLES · 1H</span>
-                    <svg viewBox="0 0 240 80" preserveAspectRatio="none">
-                        <g>
-                            <rect x="10" y="42" width="8" height="14" class="qn-up"/>
-                            <rect x="28" y="38" width="8" height="10" class="qn-down"/>
-                            <rect x="46" y="32" width="8" height="18" class="qn-up"/>
-                            <rect x="64" y="34" width="8" height="12" class="qn-down"/>
-                            <rect x="82" y="26" width="8" height="20" class="qn-up"/>
-                            <rect x="100" y="28" width="8" height="14" class="qn-up"/>
-                            <rect x="118" y="32" width="8" height="12" class="qn-down"/>
-                            <rect x="136" y="22" width="8" height="22" class="qn-up"/>
-                            <rect x="154" y="24" width="8" height="14" class="qn-down"/>
-                            <rect x="172" y="18" width="8" height="22" class="qn-up"/>
-                            <rect x="190" y="22" width="8" height="10" class="qn-down"/>
-                            <rect x="208" y="14" width="8" height="24" class="qn-up"/>
-                        </g>
-                    </svg>
+            </div>
+
+            <div class="dq-composite-panel" id="panel-mcp" role="tabpanel" aria-labelledby="tab-mcp" hidden>
+                <div class="qn-chart-frame dq-code-frame">
+                    <span class="dq-widget-label qn-metric">MCP TOOLS · FROM THE ACTUAL SERVER</span>
+                    <pre class="dq-code"><code>$ digiquant mcp serve
+
+tools:
+  digiquant_list_strategies        # registry inventory
+  digiquant_run_backtest           # NautilusTrader run for one strategy
+  digiquant_run_optimize           # parameter sweep / Bayesian search
+  digiquant_run_pipeline           # backtest -&gt; optimize -&gt; export
+  digiquant_export                 # tear sheets + artifacts
+  digiquant_get_price_technicals   # indicator snapshot per ticker
+  digiquant_get_macro_series       # FRED-backed macro series</code></pre>
+                    <p class="dq-widget-copy">Every capability is a discoverable MCP tool — point Claude,
+                    Cursor, or any MCP client at the server and ask for a backtest.</p>
                 </div>
-                <!-- Signal list mini -->
-                <div class="qn-chart-frame dq-widget dq-widget-list">
-                    <span class="dq-widget-label qn-metric">SIGNALS · LIVE</span>
-                    <ul>
-                        <li><span class="qn-metric">09:32</span> <span>DIGI/QNT1</span> <span class="qn-up">+</span></li>
-                        <li><span class="qn-metric">10:05</span> <span>ATL</span> <span class="qn-up">+</span></li>
-                        <li><span class="qn-metric">11:18</span> <span>KRS</span> <span class="qn-down">&minus;</span></li>
-                        <li><span class="qn-metric">13:41</span> <span>HRM</span> <span class="qn-up">+</span></li>
-                    </ul>
-                </div>
-                <!-- Ladder mini -->
-                <div class="qn-chart-frame dq-widget">
-                    <span class="dq-widget-label qn-metric">LADDER</span>
-                    <svg viewBox="0 0 240 80" preserveAspectRatio="xMidYMid meet">
-                        <g fill="none" stroke="currentColor" stroke-width="1.2">
-                            <rect x="10"  y="56" width="40" height="18" opacity="0.55"/>
-                            <rect x="58"  y="42" width="40" height="32" opacity="0.65"/>
-                            <rect x="106" y="28" width="40" height="46" opacity="0.9" stroke="var(--accent-kairos)"/>
-                            <rect x="154" y="18" width="40" height="56" opacity="0.35" stroke-dasharray="3 5"/>
-                            <rect x="202" y="8"  width="30" height="66" opacity="0.25" stroke-dasharray="3 5"/>
-                        </g>
-                    </svg>
+            </div>
+
+            <div class="dq-composite-panel" id="panel-docker" role="tabpanel" aria-labelledby="tab-docker" hidden>
+                <div class="qn-chart-frame dq-code-frame">
+                    <span class="dq-widget-label qn-metric">DOCKER · QUICKSTART</span>
+                    <pre class="dq-code"><code>$ git clone https://github.com/digithings-ai/digithings
+$ cd digithings
+$ cp .env.example .env
+$ docker compose up digiquant
+
+# DigiQuant API on :8001 — backtests, optimization, research</code></pre>
+                    <p class="dq-widget-copy">The whole stack is compose-first. One service or all of them —
+                    your laptop is the data center.</p>
                 </div>
             </div>
         </section>
 
         <!-- ================================================================
-             7. Pricing / CTA
+             7. Get started (open core, honestly)
              ================================================================ -->
         <section class="dq-act accent-digiquant" id="act-pricing">
             <div class="dq-act-head">
-                <span class="dq-act-kicker qn-metric">PRICING</span>
-                <h2 class="dq-act-title">Open core. Managed tier for Atlas.</h2>
+                <span class="dq-act-kicker qn-metric">GET STARTED</span>
+                <h2 class="dq-act-title">Open core. No gate, no tier, no call.</h2>
                 <p class="dq-act-lede">
-                    Self-host the full stack at no cost. The managed Atlas tier
-                    layers on SLAs, custom strategy onboarding, and operational
-                    support for teams that want a partner instead of an oncall rota.
+                    The full stack is MIT-licensed and self-hosted at no cost.
+                    A managed Atlas tier is something we're exploring — if you'd
+                    pay for one, that's useful signal.
                 </p>
             </div>
 
@@ -342,45 +383,32 @@
                     <h3>Open core</h3>
                     <p class="dq-price qn-metric">self-host · free</p>
                     <ul class="dq-pricing-list">
-                        <li>Full stack, MIT / Apache-licensed modules</li>
-                        <li>NautilusTrader execution engine</li>
-                        <li>Atlas, Hermes, Kairos reference pipelines</li>
+                        <li>Full stack, MIT-licensed</li>
+                        <li>NautilusTrader backtesting + optimization</li>
+                        <li>Atlas research + Hermes deliberation pipelines</li>
+                        <li>Olympus dashboard + MCP tool surface</li>
                         <li>Community support on GitHub</li>
                     </ul>
                     <a href="https://github.com/digithings-ai/digithings" class="dq-cta-ghost" target="_blank" rel="noopener noreferrer">View on GitHub &rarr;</a>
                 </article>
 
-                <article class="dq-pricing-card dq-pricing-card-accent">
-                    <h3>Managed Atlas</h3>
-                    <p class="dq-price qn-metric">contact</p>
+                <article class="dq-pricing-card">
+                    <h3>Managed Atlas <span class="dq-planned-chip">PLANNED</span></h3>
+                    <p class="dq-price qn-metric">not yet available</p>
                     <ul class="dq-pricing-list">
-                        <li>Managed Atlas runner with SLA</li>
-                        <li>Custom strategy onboarding</li>
-                        <li>Priority fixes + roadmap input</li>
-                        <li>Optional on-prem deployment</li>
+                        <li>Hosted Atlas runner on a schedule you set</li>
+                        <li>Your data store, our operations</li>
+                        <li>Interested? Tell us — it shapes the roadmap</li>
                     </ul>
-                    <a href="mailto:hello@digithings.ai" class="dq-cta-ghost">Get in touch &rarr;</a>
+                    <a href="mailto:hello@digithings.ai?subject=Managed%20Atlas%20interest" class="dq-cta-ghost">Register interest &rarr;</a>
                 </article>
             </div>
 
             <div class="dq-chat-block">
-                <h3 class="dq-chat-title">Try it conversationally</h3>
-                <p class="dq-chat-lede">Pose a quant question — DigiChat will scaffold the research, propose a backtest plan, and hand you to Kairos.</p>
-                <div class="dq-chat-chips">
-                    <span class="dq-chip qn-metric">Build me a mean-reversion stat-arb on tech</span>
-                    <span class="dq-chip qn-metric">Screen momentum in futures, last 90d</span>
-                    <span class="dq-chip qn-metric">Compare vol-carry vs trend-follow in crypto</span>
-                </div>
-                <div class="dq-chat-slot dq-chat-slot-pending" aria-hidden="true">
-                    <span class="dq-chat-status-dot"></span>
-                    <div class="dq-chat-status-text">
-                        <p class="qn-metric">// chat.digithings.ai &mdash; deploying</p>
-                        <p>The hosted chat is being rolled out. Self-host the
-                        full stack today via the GitHub repo — same UI, same
-                        BYOK flow, runs on your laptop.</p>
-                    </div>
-                </div>
-                <a href="https://digithings.ai/chat.html" class="dq-cta-ghost">Learn about DigiChat &rarr;</a>
+                <h3 class="dq-chat-title">Prefer to talk to your stack?</h3>
+                <p class="dq-chat-lede">DigiChat is the conversational front door — BYOK, self-hosted,
+                and wired to DigiQuant's tools through DigiGraph. It runs on your laptop today.</p>
+                <a href="https://digithings.ai/chat.html" class="dq-cta-ghost">About DigiChat &rarr;</a>
             </div>
         </section>
     </main>
@@ -399,14 +427,9 @@
                 <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
                 <a href="https://github.com/digithings-ai/digithings#readme" class="nav-link" target="_blank" rel="noopener noreferrer">Docs</a>
             </div>
-            <p class="dq-footer-meta qn-metric">&copy; 2026 digithings AI · open core</p>
+            <p class="dq-footer-meta qn-metric">&copy; 2026 digithings AI · open core · no live data on this page — the dashboard has the real thing</p>
         </div>
     </footer>
-
-    <!-- ====================================================================
-         Ticker ribbon — pinned to viewport bottom
-         ==================================================================== -->
-    <div id="dq-ticker" class="dq-ticker-pinned" aria-label="Synthesized symbol ticker"></div>
 
     <script type="module" src="main.js"></script>
 </body>

--- a/frontend/digiquant/main.js
+++ b/frontend/digiquant/main.js
@@ -1,39 +1,26 @@
 /**
  * digiquant.io — quant-native entry module.
  *
- * Composes primitives from the design:
- *   - quant-native/ticker        → bottom-pinned symbol ribbon
+ * Composes primitives from the design package:
  *   - typography-motion          → hero title variable-weight scroll shift
  *   - living-architecture        → Act I DigiQuant subsystem diagram
- *   - scroll-trigger             → drives counter animations + draw-ins
  *
- * No real market data. All symbols, prices, signals, and metrics are
- * synthesized for illustration only.
+ * Charts and metrics on this page are illustrative and labeled as such in
+ * the markup; nothing here claims to be live data. The live surface is the
+ * Olympus dashboard at /olympus/.
  */
-import { initTicker } from '../design/quant-native/ticker.js';
 import { initTypographyMotion } from '../design/typography-motion/index.js';
 import { initDiagram } from '../design/living-architecture/index.js';
-import { initScrollTrigger } from '../design/scroll-trigger.js';
-
-// --- Ticker symbols (synthesized; no real tickers) -----------------------
-const TICKER_SYMBOLS = [
-  { sym: 'DIGI', price: '128.4', delta: '+0.8%' },
-  { sym: 'QNT1', price: '22.11', delta: '-0.2%' },
-  { sym: 'ATL',  price: '3.42',  delta: '+1.1%' },
-  { sym: 'KRS',  price: '0.88',  delta: '-0.4%' },
-  { sym: 'HRM',  price: '17.5',  delta: '+0.3%' },
-  { sym: 'GRFX', price: '94.2',  delta: '+0.9%' },
-  { sym: 'SRCH', price: '55.0',  delta: '+0.0%' },
-];
+import { initCounters, initDrawIn } from './page-motion.js';
 
 // --- Living-architecture nodes for Act I ---------------------------------
-// DigiQuant root + Atlas / Hermes / Kairos children + NautilusTrader callout.
+// DigiQuant root + Atlas / Hermes children + planned Kairos + NautilusTrader.
 const ARCH_NODES = [
-  { id: 'dq',       label: 'DigiQuant',     x: 500, y: 110, accentVar: '--accent-digiquant', group: 'core' },
-  { id: 'atlas',    label: 'Atlas',         x: 230, y: 290, accentVar: '--accent-atlas' },
-  { id: 'hermes',   label: 'Hermes',        x: 500, y: 320, accentVar: '--accent-hermes' },
-  { id: 'kairos',   label: 'Kairos',        x: 770, y: 290, accentVar: '--accent-kairos' },
-  { id: 'nautilus', label: 'NautilusTrader', x: 500, y: 460, accentVar: '--accent-digiquant' },
+  { id: 'dq',       label: 'DigiQuant',        x: 500, y: 110, accentVar: '--accent-digiquant', group: 'core' },
+  { id: 'atlas',    label: 'Atlas',            x: 230, y: 290, accentVar: '--accent-atlas' },
+  { id: 'hermes',   label: 'Hermes',           x: 500, y: 320, accentVar: '--accent-hermes' },
+  { id: 'kairos',   label: 'Kairos · planned', x: 770, y: 290, accentVar: '--accent-kairos' },
+  { id: 'nautilus', label: 'NautilusTrader',   x: 500, y: 460, accentVar: '--accent-digiquant' },
 ];
 const ARCH_EDGES = [
   { source: 'dq',      target: 'atlas' },
@@ -45,110 +32,33 @@ const ARCH_EDGES = [
   { source: 'hermes',  target: 'nautilus' },
 ];
 
-// --- Counter animation ---------------------------------------------------
-function formatCount(value, decimals, suffix) {
-  const n = decimals > 0 ? value.toFixed(decimals) : String(Math.round(value));
-  return suffix ? `${n}${suffix}` : n;
-}
+// --- Act V tabs: real tab semantics, real panel switching -----------------
+function initModeTabs() {
+  const tabs = Array.from(document.querySelectorAll('.dq-toggle[role="tab"]'));
+  const panels = Array.from(document.querySelectorAll('.dq-composite-panel[role="tabpanel"]'));
+  if (tabs.length === 0 || panels.length === 0) return;
 
-function animateCounter(el) {
-  if (el.dataset.countDone === '1') return;
-  el.dataset.countDone = '1';
-  const target   = parseFloat(el.dataset.countTo);
-  const decimals = parseInt(el.dataset.countDecimals || '0', 10);
-  const suffix   = el.dataset.countSuffix || '';
-  if (!Number.isFinite(target)) return;
-
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (prefersReduced) {
-    el.textContent = formatCount(target, decimals, suffix);
-    return;
+  function select(tab) {
+    tabs.forEach((t) => {
+      const on = t === tab;
+      t.classList.toggle('is-on', on);
+      t.setAttribute('aria-selected', String(on));
+      t.tabIndex = on ? 0 : -1;
+    });
+    panels.forEach((p) => {
+      p.hidden = p.id !== tab.getAttribute('aria-controls');
+    });
   }
 
-  const duration = 1100;
-  const start = performance.now();
-  const finalize = () => {
-    el.textContent = formatCount(target, decimals, suffix);
-  };
-  let finalized = false;
-  function step(now) {
-    if (finalized) return;
-    const t = Math.min(1, (now - start) / duration);
-    const k = 1 - Math.pow(1 - t, 3); // easeOutCubic
-    el.textContent = formatCount(target * k, decimals, suffix);
-    if (t < 1) {
-      requestAnimationFrame(step);
-    } else {
-      finalized = true;
-      finalize();
-    }
-  }
-  requestAnimationFrame(step);
-  // Belt-and-suspenders: if the tab was hidden when init fired, rAF is
-  // throttled and the chain above may never run a single frame. The
-  // setTimeout below guarantees the final value lands either way.
-  // (Real animation still wins when the tab is foreground because rAF
-  // ticks well before this fires.)
-  setTimeout(() => {
-    if (finalized) return;
-    finalized = true;
-    finalize();
-  }, duration + 200);
-}
-
-function initCounters() {
-  const counters = document.querySelectorAll('[data-count-to]');
-  if (counters.length === 0) return;
-  if (!('IntersectionObserver' in window)) {
-    counters.forEach(animateCounter);
-    return;
-  }
-  const io = new IntersectionObserver((entries) => {
-    for (const entry of entries) {
-      if (entry.isIntersecting && entry.intersectionRatio > 0) {
-        animateCounter(entry.target);
-        io.unobserve(entry.target);
-      }
-    }
-  }, {
-    // Lower threshold + bottom rootMargin: fires reliably even when the
-    // metric row is short (threshold: 0.4 missed it on screens where the
-    // row is more than 40% tall vs the viewport).
-    threshold: [0, 0.15],
-    rootMargin: '0px 0px -8% 0px',
-  });
-  counters.forEach((el) => io.observe(el));
-}
-
-// --- Draw-in on scroll for the hero equity curve -------------------------
-function initDrawIn() {
-  const path = document.querySelector('.dq-draw-in');
-  if (!path) return;
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const length = path.getTotalLength ? path.getTotalLength() : 2000;
-  path.style.strokeDasharray = String(length);
-  if (prefersReduced) {
-    path.style.strokeDashoffset = '0';
-    return;
-  }
-  path.style.strokeDashoffset = String(length);
-  // Kick off shortly after load for a dignified reveal.
-  requestAnimationFrame(() => {
-    path.style.transition = 'stroke-dashoffset 2400ms cubic-bezier(0.2, 0.8, 0.2, 1)';
-    path.style.strokeDashoffset = '0';
-  });
-}
-
-// --- Composite toggles (Act V) -------------------------------------------
-function initCompositeToggles() {
-  const toggles = document.querySelectorAll('.dq-toggle');
-  const composite = document.querySelector('.dq-composite');
-  if (!composite || toggles.length === 0) return;
-  toggles.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      toggles.forEach((b) => b.classList.remove('is-on'));
-      btn.classList.add('is-on');
-      composite.setAttribute('data-composite-mode', btn.dataset.mode || 'plug');
+  tabs.forEach((tab, i) => {
+    tab.addEventListener('click', () => select(tab));
+    tab.addEventListener('keydown', (e) => {
+      const dir = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+      if (!dir) return;
+      e.preventDefault();
+      const next = tabs[(i + dir + tabs.length) % tabs.length];
+      next.focus();
+      select(next);
     });
   });
 }
@@ -163,11 +73,6 @@ function initCandleHover() {
 
 // --- Boot ----------------------------------------------------------------
 document.addEventListener('DOMContentLoaded', () => {
-  // Ticker — pinned ribbon.
-  try {
-    initTicker({ elementId: 'dq-ticker', symbols: TICKER_SYMBOLS, cadence: 40 });
-  } catch (err) { console.warn('[digiquant] ticker init failed', err); }
-
   // Typography motion — hero weight shift on scroll.
   try { initTypographyMotion(); } catch (err) { console.warn('[digiquant] typo-motion failed', err); }
 
@@ -181,11 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   } catch (err) { console.warn('[digiquant] arch init failed', err); }
 
-  // Scroll-trigger — powers reveal progress vars.
-  try { initScrollTrigger({ selector: '.scroll-trigger' }); } catch (_) { /* optional */ }
-
-  initDrawIn();
+  initDrawIn('.dq-draw-in');
   initCounters();
-  initCompositeToggles();
+  initModeTabs();
   initCandleHover();
 });

--- a/frontend/digiquant/main.js
+++ b/frontend/digiquant/main.js
@@ -61,6 +61,10 @@ function initModeTabs() {
       select(next);
     });
   });
+
+  // Roving tabindex from first paint, not just after the first interaction.
+  const initial = tabs.find((t) => t.getAttribute('aria-selected') === 'true') || tabs[0];
+  select(initial);
 }
 
 // --- Candle hover highlight (Act II) -------------------------------------

--- a/frontend/digiquant/page-motion.js
+++ b/frontend/digiquant/page-motion.js
@@ -1,0 +1,98 @@
+/**
+ * Shared page-motion primitives for the digiquant.io static pages.
+ * One implementation for counters and the hero-curve draw-in — main.js and
+ * atlas-main.js previously carried drifting copies of this code.
+ */
+
+function formatCount(value, decimals, suffix) {
+  const n = decimals > 0 ? value.toFixed(decimals) : String(Math.round(value));
+  return suffix ? `${n}${suffix}` : n;
+}
+
+function animateCounter(el, duration) {
+  if (el.dataset.countDone === '1') return;
+  el.dataset.countDone = '1';
+  const target   = parseFloat(el.dataset.countTo);
+  const decimals = parseInt(el.dataset.countDecimals || '0', 10);
+  const suffix   = el.dataset.countSuffix || '';
+  if (!Number.isFinite(target)) return;
+
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const finalize = () => {
+    el.textContent = formatCount(target, decimals, suffix);
+  };
+  if (prefersReduced) {
+    finalize();
+    return;
+  }
+
+  const start = performance.now();
+  let finalized = false;
+  function step(now) {
+    if (finalized) return;
+    const t = Math.min(1, (now - start) / duration);
+    const k = 1 - Math.pow(1 - t, 3); // easeOutCubic
+    el.textContent = formatCount(target * k, decimals, suffix);
+    if (t < 1) {
+      requestAnimationFrame(step);
+    } else {
+      finalized = true;
+      finalize();
+    }
+  }
+  requestAnimationFrame(step);
+  // If the tab is hidden, rAF is throttled and may never tick — make sure
+  // the final value lands either way.
+  setTimeout(() => {
+    if (finalized) return;
+    finalized = true;
+    finalize();
+  }, duration + 200);
+}
+
+/** Animate every [data-count-to] element when it scrolls into view. */
+export function initCounters({ duration = 1100 } = {}) {
+  const counters = document.querySelectorAll('[data-count-to]');
+  if (counters.length === 0) return;
+  if (!('IntersectionObserver' in window)) {
+    counters.forEach((el) => animateCounter(el, duration));
+    return;
+  }
+  const io = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting && entry.intersectionRatio > 0) {
+        animateCounter(entry.target, duration);
+        io.unobserve(entry.target);
+      }
+    }
+  }, {
+    // Lower threshold + bottom rootMargin: fires reliably even when the
+    // metric row is taller than 40% of a small viewport.
+    threshold: [0, 0.15],
+    rootMargin: '0px 0px -8% 0px',
+  });
+  counters.forEach((el) => io.observe(el));
+}
+
+/** Stroke draw-in for a hero SVG path. */
+export function initDrawIn(selector, { duration = 2400 } = {}) {
+  const path = document.querySelector(selector);
+  if (!path) return;
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const length = path.getTotalLength ? path.getTotalLength() : 2000;
+  path.style.strokeDasharray = String(length);
+  if (prefersReduced) {
+    path.style.strokeDashoffset = '0';
+    return;
+  }
+  path.style.strokeDashoffset = String(length);
+  requestAnimationFrame(() => {
+    path.style.transition = `stroke-dashoffset ${duration}ms cubic-bezier(0.2, 0.8, 0.2, 1)`;
+    path.style.strokeDashoffset = '0';
+  });
+  setTimeout(() => {
+    if (path.style.strokeDashoffset !== '0') {
+      path.style.strokeDashoffset = '0';
+    }
+  }, duration + 200);
+}

--- a/frontend/digiquant/style.css
+++ b/frontend/digiquant/style.css
@@ -10,8 +10,6 @@
 body {
   background: var(--bg-secondary);
   min-height: 100vh;
-  /* Reserve space so the pinned ticker never overlaps content. */
-  padding-bottom: 48px;
 }
 
 main {
@@ -297,10 +295,7 @@ main {
   max-width: 960px;
   margin: 0 auto;
   position: relative;
-  transition: outline 0.25s, box-shadow 0.25s;
 }
-.dq-composite[data-composite-mode="mcp"]    { outline: 1px dashed var(--accent-digigraph); outline-offset: 8px; }
-.dq-composite[data-composite-mode="docker"] { outline: 1px dashed var(--accent-digichat); outline-offset: 8px; }
 
 .dq-widget {
   color: var(--text-primary);
@@ -412,31 +407,6 @@ main {
   margin: 0;
   max-width: 52ch;
 }
-.dq-chat-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  justify-content: center;
-}
-.dq-chat-chips .dq-chip {
-  color: var(--text-secondary);
-  border-color: var(--border-color);
-  background: rgba(10, 10, 10, 0.45);
-}
-.dq-chat-slot {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  background: rgba(10, 10, 10, 0.6);
-}
-.dq-chat-slot iframe {
-  width: 100%;
-  height: 100%;
-  border: 0;
-  display: block;
-}
 
 /* --- Footer -------------------------------------------------------------- */
 .dq-footer {
@@ -469,18 +439,6 @@ main {
   color: var(--text-secondary);
 }
 
-/* --- Ticker ribbon (pinned) --------------------------------------------- */
-.dq-ticker-pinned {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 40;
-  background: rgba(10, 10, 10, 0.9);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-
 /* --- Responsive --------------------------------------------------------- */
 @media (max-width: 900px) {
   .dq-split {
@@ -506,7 +464,6 @@ main {
   .dq-hero-title { font-size: clamp(1.6rem, 8vw, 2.4rem); }
   .dq-hero-sub { font-size: 0.78rem; }
   .dq-pricing-card { padding: 1.5rem 1.25rem; }
-  .dq-chat-slot-pending { flex-direction: column; gap: 0.6rem; align-items: flex-start; }
   .nav-link { min-height: 44px; display: flex; align-items: center; }
   .dq-metric-row {
     grid-template-columns: 1fr;
@@ -516,12 +473,10 @@ main {
     gap: var(--space-1);
   }
   .dq-ts { font-size: 0.75rem; }
-  .dq-ticker-pinned { font-size: 10px; }
   .dq-hero {
     min-height: 50vh;
     padding: var(--space-6) 0;
   }
-  body { padding-bottom: 40px; }
 }
 
 /* --- Honesty helpers ---------------------------------------------------- */
@@ -533,43 +488,98 @@ main {
   opacity: 0.65;
 }
 
-.dq-chat-slot-pending {
+
+/* --- Hero CTAs ------------------------------------------------------------ */
+.dq-hero-cta-row {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 0.85rem;
-  min-height: 0;
-  padding: 1rem 1.1rem;
-  border: 1px solid color-mix(in srgb, var(--accent-digiquant) 25%, var(--border-color));
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--accent-digiquant) 6%, var(--bg-secondary));
+  gap: var(--space-3);
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: var(--space-4);
+}
+.dq-cta-primary {
+  display: inline-block;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--accent-digiquant);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent-digiquant) 14%, transparent);
+  color: var(--text-primary);
+  font-family: var(--font-family-mono);
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+}
+.dq-cta-primary:hover {
+  background: color-mix(in srgb, var(--accent-digiquant) 28%, transparent);
+}
+
+/* --- Planned chip ---------------------------------------------------------- */
+.dq-planned-chip {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5em;
+  padding: 0.1em 0.55em;
+  border: 1px dashed var(--accent-kairos, var(--border-color));
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+  font-size: 0.62em;
+  letter-spacing: 0.14em;
+  color: var(--text-secondary);
+  background: transparent;
+}
+
+/* --- Act composition variants (break the all-centered monotony) ----------- */
+.dq-act--rail .dq-act-head,
+.dq-act--rail-right .dq-act-head {
+  margin-left: 0;
+  margin-right: auto;
+  text-align: left;
+  max-width: 56ch;
+}
+.dq-act--rail-right .dq-act-head {
+  margin-left: auto;
+  margin-right: 0;
+  text-align: right;
+}
+.dq-act--rail-right .dq-act-head .dq-act-lede { margin-left: auto; }
+
+/* --- Act V panels + code frames ------------------------------------------- */
+.dq-composite-panel { max-width: 960px; margin: 0 auto; }
+.dq-composite-panel[hidden] { display: none; }
+.dq-code-frame {
+  padding: var(--space-4);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.dq-code {
+  margin: 0;
+  overflow-x: auto;
+  font-family: var(--font-family-mono);
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+.dq-code code { font-family: inherit; }
+.dq-widget-copy {
+  margin: 0;
   color: var(--text-secondary);
   font-size: 0.9rem;
   text-align: left;
 }
-.dq-chat-slot-pending .dq-chat-status-dot {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  margin-top: 0.55rem;
-  border-radius: 50%;
-  background: var(--accent-digiquant);
-  box-shadow: 0 0 10px color-mix(in srgb, var(--accent-digiquant) 60%, transparent);
-  animation: dqChatPendingPulse 2s ease-in-out infinite;
+
+/* --- Keyboard affordance --------------------------------------------------- */
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent-digiquant);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
 }
-.dq-chat-status-text { flex: 1 1 auto; }
-.dq-chat-status-text p { margin: 0 0 0.35rem; }
-.dq-chat-status-text p:last-child { margin-bottom: 0; }
-.dq-chat-status-text .qn-metric {
-  font-size: 0.78rem;
-  letter-spacing: 0.06em;
-  color: var(--accent-digiquant);
-  opacity: 0.95;
-}
-@keyframes dqChatPendingPulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50%      { opacity: 0.5; transform: scale(1.25); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .dq-chat-slot-pending .dq-chat-status-dot { animation: none; }
+
+/* --- Architecture diagram: keep labels legible on small screens ------------ */
+@media (max-width: 640px) {
+  .dq-arch { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .dq-arch svg { min-width: 640px; }
 }

--- a/frontend/digithings/index.html
+++ b/frontend/digithings/index.html
@@ -234,35 +234,35 @@
          straight into digigraph.
          ================================================================ -->
     <main class="dt-scroll-track" id="scroll-track">
-        <section class="dt-act" data-act="digigraph" data-accent="digigraph">
+        <section class="dt-act" id="digigraph" data-act="digigraph" data-accent="digigraph">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act I</p>
                 <h2>DigiGraph</h2>
                 <p>The supervisor that picks the right specialist for every request.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digiquant" data-accent="digiquant">
+        <section class="dt-act" id="digiquant" data-act="digiquant" data-accent="digiquant">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act II</p>
                 <h2>DigiQuant</h2>
                 <p>Research → signals → execution. Every step audited, live trades human-gated.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digisearch" data-accent="digisearch">
+        <section class="dt-act" id="digisearch" data-act="digisearch" data-accent="digisearch">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act III</p>
                 <h2>DigiSearch</h2>
                 <p>Backend-neutral RAG. Swap your vector DB without touching business code.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digichat" data-accent="digichat">
+        <section class="dt-act" id="digichat" data-act="digichat" data-accent="digichat">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act IV</p>
                 <h2>DigiChat</h2>
                 <p>Conversational front door. BYOK every request — keys never stored.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="ecosystem" data-accent="digigraph">
+        <section class="dt-act" id="ecosystem" data-act="ecosystem" data-accent="digigraph">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act V</p>
                 <h2>Ecosystem</h2>


### PR DESCRIPTION
Fixes #680

The audit's verdict on digiquant.io was that the *styling* is fine but the *substance* is slop: every dynamic-looking element was fabricated, some claimed to be live, and every CTA dead-ended. This PR fixes the substance and tightens the composition.

## Honesty
- **Fake ticker + "SIGNALS · LIVE" widget removed.** Footer now states the page has no live data and points to Olympus.
- **All four fabricated counters corrected against the repo**: strategies 14 → **6** (`strategies/` registry), FRED 42 → **25** (`macro_series.yaml`), tickers 65 → **90+** (`watchlist.md`), invented "12 ms/candle" removed. Futures claim dropped (no futures support exists).
- **Kairos = PLANNED everywhere** (diagram node, act kicker chip, ladder shows only backtest solid). Hero no longer claims human-gated live orders.
- **"Managed Atlas" tier** → explicit PLANNED + register-interest (it sold SLAs for a product that cannot be bought).
- **Dead chat embed removed** (hardcoded "deploying" for ~7 weeks).
- **Hermes copy matches ADR-0015** (deliberation → signals); example log uses real registry strategy names.
- **atlas.html**: nine → ten phases (matching the ten rendered cards) + numbering footnote, MIT-only license, README table refreshed.

## Design / function
- Hero CTAs: **Open the live dashboard** (/olympus/) + GitHub quickstart.
- Act V is real tabs now — three honest panels (dashboard widgets · the actual MCP tool listing from `mcp_server.py` · docker quickstart) with correct ARIA tab semantics and arrow-key support. Previously clicking changed an outline color.
- Varied act compositions (left/right rails) break the identical-centered-section monotony; `:focus-visible` styles; mobile diagram horizontal-scrolls at a legible width.
- Dead code removed; counter/draw-in deduped into `page-motion.js`.

## Verification
Real-browser check (Playwright, local server): **0 console errors** on both pages, tab switching verified via a11y snapshot, full-page screenshot reviewed. `make score` 10/10/10/10.

Stacked on #676 (`task/673-site-wiring`) — merge that first; this branch contains its nav-link commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)