### PR TITLE
feat(website): digithings.ai honesty pass — real capabilities, planned labels, working CTAs

### DIFF
--- a/frontend/digiquant/atlas.html
+++ b/frontend/digiquant/atlas.html
@@ -319,6 +319,7 @@
                 <span class="logo-text">atlas</span>
             </div>
             <div class="nav-links">
+                <a href="./olympus/" class="nav-link">Olympus</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
                 <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>

--- a/frontend/digiquant/index.html
+++ b/frontend/digiquant/index.html
@@ -24,8 +24,9 @@
                 <span class="logo-text">digiquant</span>
             </div>
             <div class="nav-links">
+                <a href="./atlas.html" class="nav-link">Atlas</a>
+                <a href="./olympus/" class="nav-link">Olympus</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
-                <a href="https://digithings.ai/chat.html" class="nav-link">DigiChat</a>
                 <a href="https://github.com/digithings-ai" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
@@ -391,6 +392,8 @@
         <div class="dq-footer-inner">
             <div class="dq-footer-col">
                 <span class="dq-footer-title qn-metric">DIGIQUANT</span>
+                <a href="./atlas.html" class="nav-link">Atlas — macro research</a>
+                <a href="./olympus/" class="nav-link">Olympus — live dashboard</a>
                 <a href="https://digithings.ai" class="nav-link">digithings.ai</a>
                 <a href="https://digithings.ai/chat.html" class="nav-link">DigiChat</a>
                 <a href="https://github.com/digithings-ai/digithings" class="nav-link" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/frontend/digithings/chat.css
+++ b/frontend/digithings/chat.css
@@ -49,7 +49,7 @@
     padding: 0.5rem 0.95rem;
     border: 1px solid color-mix(in srgb, var(--accent-digiquant) 30%, var(--border-color));
     background: color-mix(in srgb, var(--accent-digiquant) 8%, var(--bg-secondary));
-    border-radius: var(--radius-full, 999px);
+    border-radius: 999px;
     font-family: var(--font-family-mono);
     font-size: 0.8rem;
     letter-spacing: 0.04em;
@@ -160,7 +160,7 @@
     font-size: 0.68rem;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-muted, var(--text-secondary));
+    color: var(--text-secondary);
     margin: 0 0 1rem;
 }
 

--- a/frontend/digithings/chat.html
+++ b/frontend/digithings/chat.html
@@ -63,7 +63,7 @@
 
             <div class="dc-status-badge">
                 <span class="dc-status-dot"></span>
-                <span>deploying &rarr; <a href="https://chat.digithings.ai">chat.digithings.ai</a></span>
+                <span>hosted instance on the roadmap &middot; self-host it today</span>
             </div>
 
             <div class="dc-actions">
@@ -90,7 +90,7 @@
             <div class="dc-feature-card">
                 <p class="dc-feature-label">Audit on by default</p>
                 <h3><span class="dc-icon" aria-hidden="true">log</span>Immutable logs, zero raw PII</h3>
-                <p>DigiSmith correlation IDs on every span. PII redacted before logs hit disk. Compliance-ready from day one.</p>
+                <p>DigiSmith correlation IDs on every span. PII redacted before logs hit disk.</p>
             </div>
             <div class="dc-feature-card">
                 <p class="dc-feature-label">Self-hosted</p>
@@ -135,12 +135,12 @@ make up-digichat      # starts DigiGraph + DigiChat on port 3005
             { kind: 'comment', text: '// Example session — illustrative only, numbers are not real data' },
             { kind: 'prompt', text: 'Build me a mean-reversion stat-arb on tech' },
             { kind: 'output', text: '→ routing to DigiQuant + DigiSearch' },
-            { kind: 'comment', text: 'Atlas: researching momentum factors (NASDAQ tech, 90d)' },
+            { kind: 'comment', text: 'Atlas: researching mean-reversion candidates (NASDAQ tech, 90d)' },
             { kind: 'output', text: '→ strategy scaffold: pairs-mean-reversion · sector=tech' },
-            { kind: 'comment', text: 'Hermes: signal ready · Kairos: loopback only (human gate required for live)' },
-            { kind: 'output', text: '→ backtest queued · est. 2 min · results to DigiStore' },
+            { kind: 'comment', text: 'Hermes: signal ready · execution: backtest only (live rungs land with Kairos, planned)' },
+            { kind: 'output', text: '→ backtest queued · est. 2 min · tear sheet on completion' },
             { kind: 'prompt', text: 'Show me the Sharpe by year' },
-            { kind: 'output', text: '→ querying DigiStore · example: 2021: 1.12  2022: 0.87  2023: 1.44  2024: 1.31' },
+            { kind: 'output', text: '→ reading run artifacts · example: 2021: 1.12  2022: 0.87  2023: 1.44  2024: 1.31' },
         ];
 
         document.addEventListener('DOMContentLoaded', () => {

--- a/frontend/digithings/chat.html
+++ b/frontend/digithings/chat.html
@@ -137,7 +137,7 @@ make up-digichat      # starts DigiGraph + DigiChat on port 3005
             { kind: 'output', text: '→ routing to DigiQuant + DigiSearch' },
             { kind: 'comment', text: 'Atlas: researching mean-reversion candidates (NASDAQ tech, 90d)' },
             { kind: 'output', text: '→ strategy scaffold: pairs-mean-reversion · sector=tech' },
-            { kind: 'comment', text: 'Hermes: signal ready · execution: backtest only (live rungs land with Kairos, planned)' },
+            { kind: 'comment', text: 'Hermes: signal ready · execution: backtest only (live execution lands with Kairos, planned)' },
             { kind: 'output', text: '→ backtest queued · est. 2 min · tear sheet on completion' },
             { kind: 'prompt', text: 'Show me the Sharpe by year' },
             { kind: 'output', text: '→ reading run artifacts · example: 2021: 1.12  2022: 0.87  2023: 1.44  2024: 1.31' },

--- a/frontend/digithings/index.html
+++ b/frontend/digithings/index.html
@@ -136,7 +136,7 @@
                     <p class="one-liner">Production RAG without a stack rewrite when you switch vector DB.</p>
                     <p class="body">
                         One <code>DigiSearch</code> client with the vector backend behind a registry
-                        (Chroma today, more engines planned) &mdash; backend-neutral <code>Document</code>,
+                        (Azure AI Search or Chroma today, more planned) &mdash; backend-neutral <code>Document</code>,
                         <code>Chunk</code>, <code>Query</code>, and <code>Result</code> entities mean swapping
                         engines never touches business code.
                     </p>
@@ -374,7 +374,7 @@
             </div>
             <div class="dt-diff-card">
                 <h3>Backend-swappable</h3>
-                <p>DigiSearch keeps its vector backend behind a registry (Chroma today). The same interface-first rule applies across the stack: pick what you can operate, change later without rewriting business code.</p>
+                <p>DigiSearch keeps its vector backend behind a registry (Azure AI Search or Chroma today). The same interface-first rule applies across the stack: pick what you can operate, change later without rewriting business code.</p>
             </div>
         </div>
     </section>
@@ -383,7 +383,7 @@
         <ul>
             <li data-module-id="digikey"><strong>DigiKey</strong> — auth + identity, RS256 JWTs, JWKS.</li>
             <li data-module-id="digismith"><strong>DigiSmith</strong> — observability, correlation IDs, PII redaction.</li>
-            <li data-module-id="digiclaw"><strong>DigiClaw</strong> — always-on agent runtime, immutable audit.</li>
+            <li data-module-id="digiclaw"><strong>DigiClaw</strong> — heartbeat runner, drift checks, immutable JSONL audit.</li>
             <li data-module-id="digibase"><strong>DigiBase</strong> — shared HTTP + audit Python library.</li>
             <li data-module-id="digistore"><strong>DigiStore</strong> — planned storage facade (interfaces first).</li>
             <li data-module-id="digilink"><strong>DigiLink</strong> — planned MCP bridge for non-native transports.</li>

--- a/frontend/digithings/index.html
+++ b/frontend/digithings/index.html
@@ -10,13 +10,13 @@
     <link rel="alternate icon" href="../design/assets/favicon.ico">
 
     <meta property="og:title" content="DigiThings — An open-core agentic stack">
-    <meta property="og:description" content="Ten composable modules. One stack. Architecture-native, open core.">
+    <meta property="og:description" content="Eight composable modules, two on the roadmap. One open-core stack.">
     <meta property="og:image" content="https://digithings.ai/design/assets/og.png">
     <meta property="og:url" content="https://digithings.ai">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="DigiThings — An open-core agentic stack">
-    <meta name="twitter:description" content="Ten composable modules. One stack.">
+    <meta name="twitter:description" content="Eight composable modules, two on the roadmap. One stack.">
     <meta name="twitter:image" content="https://digithings.ai/design/assets/og.png">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -86,7 +86,7 @@
                 <div id="hero-term" class="term-host term-hero" data-title="digithings"></div>
                 <p class="hero-hint" aria-hidden="true">Scroll to walk the stack &darr;</p>
                 <div class="dt-hero-status" aria-hidden="true">
-                    <span><span class="dt-hero-status-dot"></span>10 modules online</span>
+                    <span><span class="dt-hero-status-dot"></span>8 modules shipping &middot; 2 planned</span>
                     <span>v0.1 · open-core</span>
                 </div>
             </div>
@@ -119,9 +119,10 @@
                     <p class="one-liner">Strategy research that ends in an order, not a markdown file.</p>
                     <p class="body">
                         Atlas runs scheduled research cycles, Hermes turns the output into signals,
-                        Kairos executes them on a NautilusTrader core. Every step writes to an
-                        immutable audit trail; live trading stays loopback-only until a human flips
-                        the gate. No black-box cloud platform. No vendor-priced data feed required.
+                        and every backtest runs on a NautilusTrader core. Kairos &mdash; the
+                        execution layer &mdash; is on the roadmap, and nothing will ever trade
+                        live without a human gate. No black-box cloud platform. No vendor-priced
+                        data feed required.
                     </p>
                     <p class="body">
                         <a class="pass-through" href="https://digiquant.io" target="_blank" rel="noopener noreferrer">Open digiquant.io <span aria-hidden="true">&rarr;</span></a>
@@ -134,9 +135,10 @@
                     <h2 class="detail-title">DigiSearch</h2>
                     <p class="one-liner">Production RAG without a stack rewrite when you switch vector DB.</p>
                     <p class="body">
-                        One <code>DigiSearch</code> client over Chroma, pgvector, Qdrant, or in-memory &mdash;
-                        backend-neutral <code>Document</code>, <code>Chunk</code>, <code>Query</code>, and <code>Result</code>
-                        entities mean you swap engines without touching business code.
+                        One <code>DigiSearch</code> client with the vector backend behind a registry
+                        (Chroma today, more engines planned) &mdash; backend-neutral <code>Document</code>,
+                        <code>Chunk</code>, <code>Query</code>, and <code>Result</code> entities mean swapping
+                        engines never touches business code.
                     </p>
                     <p class="body">
                         Dense, sparse, and hybrid retrieval are first-class &mdash; pick per query, not
@@ -157,7 +159,7 @@
                         service calls, so a single deployment serves humans and agents.
                     </p>
                     <p class="body">
-                        <a class="pass-through" href="https://chat.digithings.ai" target="_blank" rel="noopener noreferrer">Open DigiChat <span aria-hidden="true">&rarr;</span></a>
+                        <a class="pass-through" href="chat.html">About DigiChat <span aria-hidden="true">&rarr;</span></a>
                     </p>
                     <div id="term-digichat" class="term-host" data-title="digichat/app/api/chat/route.ts"></div>
                 </div>
@@ -279,10 +281,10 @@
     <section class="dt-stack-grid" id="stack">
         <div class="dt-stack-grid-header">
             <span class="dt-stack-grid-label">// the full stack</span>
-            <h2 class="dt-stack-grid-title">Ten modules. One stack.</h2>
+            <h2 class="dt-stack-grid-title">One stack. Eight modules shipping, two planned.</h2>
             <p class="dt-stack-grid-lede">
-                Four core verticals, six support modules. Drop the ones you don't need —
-                every interface stays the same.
+                Four core verticals, four support modules — plus two on the roadmap,
+                interfaces first. Drop the ones you don't need; every interface stays the same.
             </p>
         </div>
         <div class="dt-stack-grid-tiles">
@@ -334,17 +336,17 @@
                 <p class="dt-tile-role">Shared HTTP + audit primitives</p>
                 <code class="dt-tile-api">from digibase.audit import redact_mapping</code>
             </article>
-            <article class="dt-module-tile accent-digistore">
-                <span class="dt-tile-status" aria-hidden="true">●</span>
-                <h3 class="dt-tile-name">DigiStore</h3>
-                <p class="dt-tile-role">Storage · S3 · MinIO · Postgres · SQLite</p>
-                <code class="dt-tile-api">DigiStore.configure(backend="s3")</code>
+            <article class="dt-module-tile dt-module-tile--planned accent-digistore">
+                <span class="dt-tile-status" aria-hidden="true">◌</span>
+                <h3 class="dt-tile-name">DigiStore <span class="dt-tile-planned">planned</span></h3>
+                <p class="dt-tile-role">Storage facade · interfaces first</p>
+                <code class="dt-tile-api"># roadmap — one typed API over object stores + DBs</code>
             </article>
-            <article class="dt-module-tile accent-digilink">
-                <span class="dt-tile-status" aria-hidden="true">●</span>
-                <h3 class="dt-tile-name">DigiLink</h3>
+            <article class="dt-module-tile dt-module-tile--planned accent-digilink">
+                <span class="dt-tile-status" aria-hidden="true">◌</span>
+                <h3 class="dt-tile-name">DigiLink <span class="dt-tile-planned">planned</span></h3>
                 <p class="dt-tile-role">MCP protocol bridge · adapters</p>
-                <code class="dt-tile-api">digilink.register_adapter("rest", ...)</code>
+                <code class="dt-tile-api"># roadmap — adapt legacy REST/webhooks into MCP</code>
             </article>
         </div>
     </section>
@@ -364,15 +366,15 @@
             </div>
             <div class="dt-diff-card">
                 <h3>BYOK, every request</h3>
-                <p>Anthropic, OpenAI, or any LiteLLM-compatible key. Forwarded per-request to DigiGraph; never persisted, never logged, never seen by anyone except you.</p>
+                <p>Anthropic, OpenAI, or any LiteLLM-compatible key. Forwarded per-request to DigiGraph; never persisted, never logged.</p>
             </div>
             <div class="dt-diff-card">
                 <h3>Audit-on-by-default</h3>
-                <p>Immutable JSONL audit, correlation IDs across every span, PII redacted before logs hit disk. Compliance posture out of the box.</p>
+                <p>Immutable JSONL audit, correlation IDs across every span, PII redacted before logs hit disk &mdash; the evidence trail is there when someone asks.</p>
             </div>
             <div class="dt-diff-card">
                 <h3>Backend-swappable</h3>
-                <p>DigiSearch over Chroma / pgvector / Qdrant. DigiStore over S3 / MinIO / Postgres / SQLite. Pick what you can operate; change later without rewriting business code.</p>
+                <p>DigiSearch keeps its vector backend behind a registry (Chroma today). The same interface-first rule applies across the stack: pick what you can operate, change later without rewriting business code.</p>
             </div>
         </div>
     </section>
@@ -383,8 +385,8 @@
             <li data-module-id="digismith"><strong>DigiSmith</strong> — observability, correlation IDs, PII redaction.</li>
             <li data-module-id="digiclaw"><strong>DigiClaw</strong> — always-on agent runtime, immutable audit.</li>
             <li data-module-id="digibase"><strong>DigiBase</strong> — shared HTTP + audit Python library.</li>
-            <li data-module-id="digistore"><strong>DigiStore</strong> — one API over S3, MinIO, Postgres, SQLite.</li>
-            <li data-module-id="digilink"><strong>DigiLink</strong> — MCP protocol bridge for non-native transports.</li>
+            <li data-module-id="digistore"><strong>DigiStore</strong> — planned storage facade (interfaces first).</li>
+            <li data-module-id="digilink"><strong>DigiLink</strong> — planned MCP bridge for non-native transports.</li>
         </ul>
     </aside>
 

--- a/frontend/digithings/index.html
+++ b/frontend/digithings/index.html
@@ -234,35 +234,35 @@
          straight into digigraph.
          ================================================================ -->
     <main class="dt-scroll-track" id="scroll-track">
-        <section class="dt-act" data-act="digigraph" data-accent="digigraph">
+        <section class="dt-act" id="digigraph" data-act="digigraph" data-accent="digigraph">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act I</p>
                 <h2>DigiGraph</h2>
                 <p>The supervisor that picks the right specialist for every request.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digiquant" data-accent="digiquant">
+        <section class="dt-act" id="digiquant" data-act="digiquant" data-accent="digiquant">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act II</p>
                 <h2>DigiQuant</h2>
                 <p>Research → signals → execution. Every step audited, live trades human-gated.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digisearch" data-accent="digisearch">
+        <section class="dt-act" id="digisearch" data-act="digisearch" data-accent="digisearch">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act III</p>
                 <h2>DigiSearch</h2>
                 <p>Backend-neutral RAG. Swap your vector DB without touching business code.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="digichat" data-accent="digichat">
+        <section class="dt-act" id="digichat" data-act="digichat" data-accent="digichat">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act IV</p>
                 <h2>DigiChat</h2>
                 <p>Conversational front door. BYOK every request — keys never stored.</p>
             </div>
         </section>
-        <section class="dt-act" data-act="ecosystem" data-accent="digigraph">
+        <section class="dt-act" id="ecosystem" data-act="ecosystem" data-accent="digigraph">
             <div class="dt-act-anchor">
                 <p class="act-tag">Act V</p>
                 <h2>Ecosystem</h2>

--- a/frontend/digithings/main.js
+++ b/frontend/digithings/main.js
@@ -55,7 +55,7 @@ const SUPPORT = {
     digikey: {
         title: 'DigiKey', kicker: 'Support · Auth',
         role: 'Auth + identity plane.',
-        body: 'RS256 JWTs with a JWKS endpoint, scoped API keys, SSO federation, org + project membership, and row-level resource access baked straight into the issued tokens.',
+        body: 'RS256 JWTs with a JWKS endpoint, scoped API keys, and service-to-service token exchange. SSO federation and org/project membership are on the roadmap.',
         code: 'DIGIKEY_ISSUER=https://digikey.example.com',
     },
     digismith: {
@@ -67,7 +67,7 @@ const SUPPORT = {
     digiclaw: {
         title: 'DigiClaw', kicker: 'Support · Runtime',
         role: 'Always-on runtime + audit.',
-        body: 'Heartbeat, immutable JSONL audit, and MCP skill surface for long-running autonomous work. Atlas runner scheduling and drift detection live here.',
+        body: 'Heartbeat and immutable JSONL audit for long-running autonomous work. Scheduler and drift detection are on the roadmap.',
         code: 'python -m digiclaw',
     },
     digibase: {
@@ -77,16 +77,16 @@ const SUPPORT = {
         code: 'from digibase.audit import redact_mapping',
     },
     digistore: {
-        title: 'DigiStore', kicker: 'Support · Storage',
-        role: 'One API over S3, MinIO, Postgres, SQLite.',
-        body: 'A typed storage facade. Strategy artifacts, research outputs, and vector payloads travel the same path no matter where they land. Swap backends without touching business code.',
-        code: 'store = DigiStore.configure(backend="s3", bucket="digi-artifacts")',
+        title: 'DigiStore', kicker: 'Support · Storage · planned',
+        role: 'Planned storage facade — interfaces first.',
+        body: 'Not shipped yet. The plan: one typed API so strategy artifacts, research outputs, and vector payloads travel the same path no matter where they land.',
+        code: '# roadmap — typed storage facade over object stores + databases',
     },
     digilink: {
-        title: 'DigiLink', kicker: 'Support · Protocol',
-        role: 'MCP protocol bridge.',
-        body: 'When an external system speaks something DigiGraph does not — proprietary broker feeds, legacy REST surfaces, odd webhooks — DigiLink adapts it into MCP tool calls.',
-        code: 'digilink.register_adapter("legacy-rest", RestToMcpAdapter(...))',
+        title: 'DigiLink', kicker: 'Support · Protocol · planned',
+        role: 'Planned MCP protocol bridge.',
+        body: 'Not shipped yet. The plan: when an external system speaks something DigiGraph does not — legacy REST surfaces, odd webhooks — DigiLink adapts it into MCP tool calls.',
+        code: '# roadmap — adapter registry for non-MCP transports',
     },
 };
 
@@ -109,7 +109,7 @@ async function loadSnippet(path, lang) {
 }
 
 const HERO_LINES = [
-    { kind: 'prompt', text: 'digithings ask "where does this request go?"' },
+    { kind: 'prompt', text: 'digi ask "where does this request go?"' },
     { kind: 'output', text: '→ digigraph routes: digisearch + digiquant' },
     { kind: 'tool-call', text: 'digigraph.route ✓ 12ms' },
     { kind: 'comment', text: 'BYOK · audit on · self-hosted' },

--- a/frontend/digithings/main.js
+++ b/frontend/digithings/main.js
@@ -55,7 +55,7 @@ const SUPPORT = {
     digikey: {
         title: 'DigiKey', kicker: 'Support · Auth',
         role: 'Auth + identity plane.',
-        body: 'RS256 JWTs with a JWKS endpoint, scoped API keys, and service-to-service token exchange. SSO federation and org/project membership are on the roadmap.',
+        body: 'RS256 JWTs with a JWKS endpoint, scoped API keys, and JWT issuance via token exchange (API-key and BFF-session grants). SSO federation and org/project membership are on the roadmap.',
         code: 'DIGIKEY_ISSUER=https://digikey.example.com',
     },
     digismith: {
@@ -67,7 +67,7 @@ const SUPPORT = {
     digiclaw: {
         title: 'DigiClaw', kicker: 'Support · Runtime',
         role: 'Always-on runtime + audit.',
-        body: 'Heartbeat and immutable JSONL audit for long-running autonomous work. Scheduler and drift detection are on the roadmap.',
+        body: 'Heartbeat, immutable JSONL audit, and drift checks that trigger DigiQuant re-optimization when a strategy decays. A full agent gateway and skill surface are on the roadmap.',
         code: 'python -m digiclaw',
     },
     digibase: {

--- a/frontend/digithings/style.css
+++ b/frontend/digithings/style.css
@@ -859,6 +859,6 @@ body.dt-page {
 /* --- Keyboard affordance ----------------------------------------------------- */
 a:focus-visible,
 button:focus-visible {
-    outline: 2px solid var(--accent-digigraph, currentColor);
+    outline: 2px solid var(--accent, var(--accent-digigraph, currentColor));
     outline-offset: 3px;
 }

--- a/frontend/digithings/style.css
+++ b/frontend/digithings/style.css
@@ -649,12 +649,16 @@ body.dt-page {
 }
 
 @media (max-width: 640px) {
-    /* Flatten: stage stays at top but shorter, acts stack normally below. */
-    .dt-stage { position: relative; height: 60vh; }
+    /* Flatten: stage sizes to its content (min 60vh) so the hero card can
+       never be clipped by a fixed height on short viewports; the card flows
+       in-document while the diagram stays as backdrop. */
+    .dt-stage { position: relative; height: auto; min-height: 60vh; overflow: visible; }
     .dt-hero-card {
+        position: relative;
         max-width: calc(100vw - 1.5rem);
-        left: 0.75rem;
-        top: calc(var(--dt-nav-height) + 0.6rem);
+        left: auto;
+        top: auto;
+        margin: calc(var(--dt-nav-height) + 0.6rem) 0.75rem 1rem;
         padding: 1rem 1.1rem 0;
     }
     .dt-hero-card .editorial-title { font-size: clamp(1.5rem, 7vw, 2rem); }
@@ -830,4 +834,31 @@ body.dt-page {
     color: var(--text-secondary);
     font-size: 0.92rem;
     line-height: 1.55;
+}
+
+/* --- Planned module tiles --------------------------------------------------- */
+.dt-module-tile--planned {
+    border-style: dashed;
+    opacity: 0.85;
+}
+.dt-module-tile--planned .dt-tile-status { opacity: 0.5; }
+.dt-tile-planned {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 0.4em;
+    padding: 0.08em 0.5em;
+    border: 1px dashed var(--border-color);
+    border-radius: 4px;
+    font-family: var(--font-family-mono);
+    font-size: 0.55em;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+/* --- Keyboard affordance ----------------------------------------------------- */
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent-digigraph, currentColor);
+    outline-offset: 3px;
 }


### PR DESCRIPTION
Fixes #682

The audit found digithings.ai sells several things that don't exist. This PR makes every claim verifiable against the repo while keeping the design language intact:

- **DigiStore / DigiLink** → explicit PLANNED tiles (dashed border, roadmap copy); fabricated API snippets removed from tiles, detail panels, and the support-modules aside
- **DigiSearch** → "Chroma today, registry for more" (pgvector/Qdrant/in-memory don't exist)
- **DigiKey** → real capabilities (RS256 JWTs, JWKS, scoped API keys); SSO/org-membership → roadmap
- **DigiClaw** → heartbeat + JSONL audit (real); invented skill surface/scheduling removed
- **Kairos** → roadmap, everywhere
- **Module count** → "8 modules shipping · 2 planned" (hero pill, grid title, og/twitter meta)
- **Dead CTA** → `chat.digithings.ai` (refuses connections, no deploy workflow exists) no longer linked anywhere; DigiChat CTA goes to the about page
- **Demo coherence** → mean-reversion ask now gets mean-reversion research; hero terminal uses the real `digi` CLI
- **Unfalsifiable claims trimmed** (BYOK "never seen by anyone except you", compliance-ready)
- **Design**: mobile hero un-clipped (stage sizes to content <640px — verified at 375px), `:focus-visible` styles, chat.css token cleanup

**Verification:** real-browser check — 0 console errors, desktop + 375px screenshots reviewed; HTML parses; `make score` 10/10/10/10.

Stacked on #676 (`task/673-site-wiring`) — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)