### PR TITLE
feat(atlas): dispatch-only LangSmith readiness smoke (#687)

### DIFF
--- a/.github/workflows/langsmith-smoke.yml
+++ b/.github/workflows/langsmith-smoke.yml
@@ -1,0 +1,46 @@
+name: langsmith smoke
+
+# Dispatch-only readiness check (#687): does the LANGSMITH_API_KEY secret
+# authenticate, and do @traceable calls nest under the LangGraph root across
+# parallel node threads (the basis for "1 trace per graph, 3 per run")?
+# Run this once before enabling LANGSMITH_TRACING on the atlas workflows.
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: langsmith-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            digiquant/pyproject.toml
+
+      - name: Install Atlas + langsmith
+        run: |
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
+
+      - name: Run LangSmith smoke
+        env:
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          # Key alone yields zero traces — the flag is required (empirically verified).
+          LANGSMITH_TRACING: "true"
+          LANGSMITH_PROJECT: atlas-langsmith-smoke
+        run: |
+          python digiquant/scripts/atlas/smoke_langsmith.py

--- a/digiquant/scripts/atlas/smoke_langsmith.py
+++ b/digiquant/scripts/atlas/smoke_langsmith.py
@@ -1,0 +1,116 @@
+"""LangSmith readiness smoke (#687): validate the LANGSMITH_API_KEY secret + tracing.
+
+Three checks, from the actual CI environment:
+  1. AUTH — the key authenticates (no 403/401).
+  2. TRACING — LANGSMITH_TRACING actually produces run trees (key alone does not).
+  3. NESTING — @traceable calls nest under the LangGraph root across parallel node
+     threads → one trace per graph invoke (the basis for "3 traces/run", free tier).
+
+Never prints the API key. Dispatch-only; not imported by runtime code.
+"""
+
+from __future__ import annotations
+
+import operator
+import os
+from typing import Annotated, Any, TypedDict
+
+
+class S(TypedDict, total=False):
+    results: Annotated[list, operator.add]
+
+
+_RECORDS: list[dict[str, Any]] = []
+
+
+def _auth_ok() -> bool:
+    try:
+        from langsmith import Client
+
+        list(Client(api_key=os.environ["LANGSMITH_API_KEY"]).list_projects(limit=1))
+        print("AUTH: OK — key accepted")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"AUTH: FAIL — {type(exc).__name__}: {str(exc)[:140]}")
+        return False
+
+
+def _nesting_ok() -> bool:
+    from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase, build_pipeline
+    from digismith.trace import LANGSMITH_SDK_AVAILABLE, traceable
+
+    if not LANGSMITH_SDK_AVAILABLE:
+        print("NESTING: FAIL — langsmith SDK not importable")
+        return False
+    try:
+        from langsmith.run_helpers import get_current_run_tree
+    except ImportError:
+        from langsmith.run_trees import get_current_run_tree  # type: ignore
+
+    @traceable("inner_llm_call")
+    def inner(tag: str) -> str:
+        rt = get_current_run_tree()
+        _RECORDS.append(
+            {
+                "has_parent": bool(getattr(rt, "parent_run_id", None)) if rt else False,
+                "trace_id": str(getattr(rt, "trace_id", None)) if rt else None,
+                "rt_seen": rt is not None,
+            }
+        )
+        return tag
+
+    def make_node(name: str):
+        def _n(_state: S) -> dict[str, Any]:
+            inner(name)
+            return {"results": [name]}
+
+        return _n
+
+    phase = PipelinePhase(
+        name="fan", nodes=[NodeSpec(name=f"n{i}", run=make_node(f"n{i}")) for i in range(3)]
+    )
+    g = build_pipeline(S, [phase])
+
+    spans: list[set] = []
+    for _ in range(2):
+        b = len(_RECORDS)
+        g.invoke({"results": []})
+        recs = _RECORDS[b:]
+        nested = sum(1 for r in recs if r["has_parent"])
+        tids = {r["trace_id"] for r in recs}
+        print(
+            f"  invoke: inner={len(recs)} rt_seen={sum(r['rt_seen'] for r in recs)} "
+            f"nested={nested} trace_ids={len(tids)}"
+        )
+        spans.append(tids)
+    try:
+        from langchain_core.tracers.langchain import wait_for_all_tracers
+
+        wait_for_all_tracers()
+    except Exception:  # noqa: BLE001
+        pass
+
+    all_nested = all(r["has_parent"] for r in _RECORDS) and len(_RECORDS) > 0
+    one_per_invoke = all(len(t) == 1 for t in spans) and spans[0] != spans[1]
+    ok = all_nested and one_per_invoke
+    print(
+        f"NESTING: {'OK — 1 trace per invoke, no orphaning' if ok else 'FAIL — orphaning/no tracing'}"
+    )
+    return ok
+
+
+def main() -> int:
+    if not os.environ.get("LANGSMITH_API_KEY"):
+        print("FAIL: LANGSMITH_API_KEY not set (secret missing)")
+        return 1
+    os.environ.setdefault("LANGSMITH_PROJECT", "atlas-langsmith-smoke")
+    auth = _auth_ok()
+    nesting = _nesting_ok()
+    print(
+        f"\nVERDICT: {'READY — enable LANGSMITH_TRACING on the workflows' if (auth and nesting) else 'NOT READY — fix the above before enabling'}"
+    )
+    return 0 if (auth and nesting) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Dispatch-only CI smoke that validates the `LANGSMITH_API_KEY` secret and tracing **before** we enable it on the atlas workflows.

Three checks, run from the real CI environment:
- **AUTH** — the key authenticates (no 403/401). The secret was rotated; this confirms the live value works (local `.env` has the old one).
- **TRACING** — `LANGSMITH_TRACING=true` actually produces run trees (key alone yields zero traces — empirically verified).
- **NESTING** — `@traceable` calls nest under the LangGraph root across **parallel** node threads → 1 trace per graph invoke (the basis for "3 traces/run", free tier).

## Why

Per #687, gate the rollout: confirm the rotated secret authenticates and traces nest as expected, then enable `LANGSMITH_TRACING=true` + `LANGSMITH_API_KEY` on `atlas-baseline`/`delta`/`monthly` in a follow-up.

## Notes

- `workflow_dispatch`-only; nothing scheduled. The script never prints the key.
- Local run confirms the nesting logic (`nested=3`, 1 trace/invoke); AUTH passes only with the rotated secret in CI.

Part of #687