### PR TITLE
fix(atlas): route alt-ai-portfolios to xai/grok-4.3 — fixes the daily delta 401 (#678)

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -33,11 +33,12 @@
 phase_models:
 
   # ── Phase 1 — Alt-data extraction ──────────────────────────────────────────
-  # [tier: extraction] ~500 tokens each, 4 parallel segments.
+  # [tier: extraction] ~500 tokens each, 5 parallel segments.
   alt-sentiment-news:      "xai/grok-4.3"
   alt-cta-positioning:     "xai/grok-4.3"
   alt-options-derivatives: "xai/grok-4.3"
   alt-politician-signals:  "xai/grok-4.3"
+  alt-ai-portfolios:       "xai/grok-4.3"
 
   # ── Phase 2 — Institutional flow extraction ────────────────────────────────
   # [tier: extraction] ~800 tokens each, 2 segments.

--- a/scripts/validate_model_routing.py
+++ b/scripts/validate_model_routing.py
@@ -66,6 +66,7 @@ ALL_SLUGS: list[tuple[str, str]] = [
     ("alt-cta-positioning",      "Phase 1B — CTA positioning"),
     ("alt-options-derivatives",  "Phase 1C — GEX/VIX/dealer"),
     ("alt-politician-signals",   "Phase 1D — STOCK Act signals"),
+    ("alt-ai-portfolios",        "Phase 1E — AI-portfolio x_search"),
     # Phase 2 — institutional flows
     ("inst-institutional-flows", "Phase 2A — ETF flows / 13D-G"),
     ("inst-hedge-fund-intel",    "Phase 2B — 13F / fund signals"),

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import digigraph.model_config as model_config
 from digigraph.model_config import get_model_for_phase
 from digiquant.olympus.atlas.phases.phase1_altdata import _SPECS as ALT_SPECS
 from digiquant.olympus.atlas.phases.phase2_institutional import _SPECS as INST_SPECS
@@ -61,6 +62,10 @@ def _all_slugs() -> list[str]:
 @pytest.mark.unit
 def test_every_phase_slug_has_model_routing(monkeypatch):
     monkeypatch.setenv("DIGI_CONFIG_PATH", _REPO_CONFIG)
+    # The model-modes cache is keyed by mtime only (not path); reset it so an
+    # earlier test that loaded a different model_modes file can't leak in here.
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    load_sectors.cache_clear()
     missing = sorted(slug for slug in _all_slugs() if get_model_for_phase(slug) is None)
     assert not missing, (
         f"phase slugs missing from config/model_modes.yaml phase_models: {missing} — "

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -1,0 +1,69 @@
+"""Model-routing coverage: every phase slug must resolve via model_modes.yaml.
+
+A slug without a ``phase_models`` entry silently falls back through
+``get_model_for_mode()`` to the hard-coded ``gpt-4o-mini`` last resort, which
+digillm routes to the default OpenAI client — unauthenticated in the Atlas CI
+workflows, where only ``XAI_API_KEY`` is provided. That is exactly how the
+``alt-ai-portfolios`` segment 401'd every scheduled delta run (#678). Segment
+slugs are derived from the phase specs themselves so a new segment cannot ship
+without a routing entry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digigraph.model_config import get_model_for_phase
+from digiquant.olympus.atlas.phases.phase1_altdata import _SPECS as ALT_SPECS
+from digiquant.olympus.atlas.phases.phase2_institutional import _SPECS as INST_SPECS
+from digiquant.olympus.atlas.phases.phase3_macro import _SPEC as MACRO_SPEC
+from digiquant.olympus.atlas.phases.phase4_assetclass import _SPECS as ASSET_SPECS
+from digiquant.olympus.atlas.sectors_config import load_sectors
+
+_REPO_CONFIG = str(Path(__file__).parents[3] / "config")
+
+# Static phase_slug literals passed to run_research_agent outside the
+# SegmentNodeSpec fan-outs (regenerate with: git grep -h 'phase_slug="'
+# -- digiquant/src/digiquant/olympus).
+_STATIC_PHASE_SLUGS = (
+    "equity",
+    "master-digest",
+    "monthly-digest",
+    "pm-rebalance",
+    "risk-aggressive",
+    "risk-conservative",
+    "phase9-evolution",
+    "decision-reflector",
+)
+
+# Dynamic per-ticker slugs, prefix-matched in model_modes.yaml ("<prefix>-").
+_DYNAMIC_SLUG_EXAMPLES = (
+    "technical-analyst-AAPL",
+    "sentiment-analyst-AAPL",
+    "news-analyst-AAPL",
+    "fundamental-analyst-AAPL",
+    "bull-researcher-AAPL",
+    "bear-researcher-AAPL",
+    "research-manager-AAPL",
+)
+
+
+def _all_slugs() -> list[str]:
+    specs = (*ALT_SPECS, *INST_SPECS, MACRO_SPEC, *ASSET_SPECS)
+    slugs = [spec.segment_slug for spec in specs]
+    slugs += [sector.slug for sector in load_sectors()]
+    slugs += [*_STATIC_PHASE_SLUGS, *_DYNAMIC_SLUG_EXAMPLES]
+    return slugs
+
+
+@pytest.mark.unit
+def test_every_phase_slug_has_model_routing(monkeypatch):
+    monkeypatch.setenv("DIGI_CONFIG_PATH", _REPO_CONFIG)
+    missing = sorted(slug for slug in _all_slugs() if get_model_for_phase(slug) is None)
+    assert not missing, (
+        f"phase slugs missing from config/model_modes.yaml phase_models: {missing} — "
+        "without an entry they fall back to the unauthenticated gpt-4o-mini "
+        "default and 401 in CI (#678)"
+    )

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pytest
 
 import digigraph.model_config as model_config
-from digigraph.model_config import get_model_for_phase
 from digiquant.olympus.atlas.phases.phase1_altdata import _SPECS as ALT_SPECS
 from digiquant.olympus.atlas.phases.phase2_institutional import _SPECS as INST_SPECS
 from digiquant.olympus.atlas.phases.phase3_macro import _SPEC as MACRO_SPEC
@@ -66,7 +65,9 @@ def test_every_phase_slug_has_model_routing(monkeypatch):
     # earlier test that loaded a different model_modes file can't leak in here.
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     load_sectors.cache_clear()
-    missing = sorted(slug for slug in _all_slugs() if get_model_for_phase(slug) is None)
+    missing = sorted(
+        slug for slug in _all_slugs() if model_config.get_model_for_phase(slug) is None
+    )
     assert not missing, (
         f"phase slugs missing from config/model_modes.yaml phase_models: {missing} — "
         "without an entry they fall back to the unauthenticated gpt-4o-mini "


### PR DESCRIPTION
Fixes #678

## Root cause

`.github/workflows/atlas-delta.yml` has failed every scheduled run since the xAI cutover. Each attempt died with:

```
openai.AuthenticationError: Error code: 401 - Incorrect API key provided: not-set
During task with name 'alt-ai-portfolios'
```

The `alt-ai-portfolios` segment (added as the fifth Phase-1 segment in #658) was never registered in `config/model_modes.yaml` `phase_models`. The resolution chain then does:

1. `get_model_for_phase("alt-ai-portfolios")` → `None` (no entry, no matching prefix)
2. → `get_model_for_mode()` → yaml has no `default_model`/`defaults` → hard-coded last resort **`gpt-4o-mini`**
3. Bare model string, no `xai/` prefix → digillm's **default OpenAI client** → `OPENAI_API_KEY` is not set in the post-cutover workflow (only `XAI_API_KEY` is) → api key `"not-set"` → 401 from api.openai.com

Every other phase has an explicit `xai/grok-4.3` entry and succeeded (their outputs were checkpointed across retry attempts); the preflight xAI ping passed on every failing run — key and credits are fine. Only the unrouted slug failed, and it failed the whole pipeline on all 3 outer attempts, every day.

`scripts/validate_model_routing.py` didn't catch it because its hand-maintained `ALL_SLUGS` inventory predates #658 and was missing the same slug.

## Fix

- `config/model_modes.yaml` — add `alt-ai-portfolios: "xai/grok-4.3"` (extraction tier, same as its four Phase-1 siblings); comment updated 4 → 5 segments
- `scripts/validate_model_routing.py` — add the slug to the routing inventory (Phase 1E)
- `tests/dq/atlas/test_model_routing_coverage.py` — **new regression test** that derives segment slugs from the phase `_SPECS` themselves (plus the static/dynamic `phase_slug` literals) and asserts every one resolves via `phase_models`. A future segment added without a routing entry now fails unit tests instead of 401-ing in production. Red before the fix (`['alt-ai-portfolios']`), green after.

## Verification

- `pytest tests/dq/atlas` green locally
- `python3 scripts/validate_model_routing.py --routing` → 39 phases, 1 distinct model (`xai/grok-4.3`), no `defaults[...]` fallback rows
- After merge: today's scheduled delta run (or a manual dispatch) should complete and land a fresh `daily_snapshots` row — will verify per the issue's acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)
