### PR TITLE
feat(atlas): enable LangSmith tracing on baseline/delta/monthly (#687)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -93,6 +93,12 @@ jobs:
           DIGI_CHECKPOINTER: postgres
           DIGI_CHECKPOINTER_POSTGRES_URI: ${{ secrets.DIGI_CHECKPOINTER_POSTGRES_URI }}
           RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+          # LangSmith tracing via digismith — 1 trace per graph, 3 per run (#687).
+          # The flag is required: the key alone yields zero traces (verified).
+          # Fail-soft: a missing/invalid key just skips ingest, never breaks the run.
+          LANGSMITH_TRACING: "true"
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGSMITH_PROJECT: atlas-baseline
         run: |
           mkdir -p artifacts
           set -o pipefail

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -89,6 +89,12 @@ jobs:
           DIGI_CHECKPOINTER: postgres
           DIGI_CHECKPOINTER_POSTGRES_URI: ${{ secrets.DIGI_CHECKPOINTER_POSTGRES_URI }}
           RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+          # LangSmith tracing via digismith — 1 trace per graph, 3 per run (#687).
+          # The flag is required: the key alone yields zero traces (verified).
+          # Fail-soft: a missing/invalid key just skips ingest, never breaks the run.
+          LANGSMITH_TRACING: "true"
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGSMITH_PROJECT: atlas-delta
         run: |
           mkdir -p artifacts
           set -o pipefail

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -145,6 +145,12 @@ jobs:
           DIGI_CHECKPOINTER: postgres
           DIGI_CHECKPOINTER_POSTGRES_URI: ${{ secrets.DIGI_CHECKPOINTER_POSTGRES_URI }}
           RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+          # LangSmith tracing via digismith — 1 trace per graph, 3 per run (#687).
+          # The flag is required: the key alone yields zero traces (verified).
+          # Fail-soft: a missing/invalid key just skips ingest, never breaks the run.
+          LANGSMITH_TRACING: "true"
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          LANGSMITH_PROJECT: atlas-monthly
         run: |
           mkdir -p artifacts
           set -o pipefail


### PR DESCRIPTION
Enables LangSmith tracing on the three atlas workflows — the final step of #687.

## What
Adds to each run step:
```yaml
LANGSMITH_TRACING: "true"
LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
LANGSMITH_PROJECT: atlas-{baseline,delta,monthly}
```
Each pipeline emits **1 trace per graph → 3 per run** into digismith's LangSmith workspace; per-workflow project keeps the three separable.

## Validation (readiness smoke, #687)
- **AUTH OK** on US with a workspace-scoped PAT (`lsv2_pt_…`).
- **NESTING OK** — `@traceable` calls nest under the LangGraph root across parallel node threads (`nested=3`, 1 trace/invoke). Confirms 3 traces/run with no code change.
- The `LANGSMITH_TRACING=true` flag is **required** — the key alone yields zero traces (empirically verified).
- Tracing is **fail-soft**: a missing/invalid key just skips ingest, never breaks a run.

## Prerequisite
The `LANGSMITH_API_KEY` repo secret must hold a **workspace-scoped** key (PAT or workspace service key). An **organization-scoped** service key 403s on `/sessions` and `/runs/multipart` without `X-Tenant-Id` — that was the original failure.

Closes #687