### PR TITLE
fix(olympus): render pipeline payloads — research library showed 'No content available' for every document

### DIFF
--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -127,6 +127,32 @@ The Overview page renders a typed `SnapshotEnvelope` panel above the KPI strip
   loading skeleton, error banner (with Retry button), stale banner, and empty
   state.
 
+## Pipeline payload rendering
+
+The Atlas pipeline (SIMP-013) writes validated Pydantic payloads into
+`documents.payload` and the digest into `daily_snapshots.snapshot`; the legacy
+`documents.content` and `daily_snapshots.regime` / `actionable` / `risks` /
+`market_data` / `segment_biases` columns stay null. The frontend therefore
+renders from the payloads:
+
+- `lib/render-pipeline-payloads.ts` — markdown renderers + shape sniffers for
+  the three pipeline payload shapes: segment reports (`macro`, `bonds`,
+  `equity`, `sector-*`, `alt-*`, `inst-*`, …), the Phase-7 master digest
+  (`digest-delta` / `digest-baseline` and the snapshot jsonb), and the Hermes
+  `pm-rebalance` decision. Segment-specific metric fields render generically so
+  new segments display without frontend changes.
+- `lib/render-document-from-payload.ts` — routes payloads by shape first, then
+  by the legacy `doc_type` / `document_key` conventions; unknown object
+  payloads fall back to a JSON code block instead of "_No content available._".
+- `lib/queries.ts` — the Overview strategy panel falls back to the snapshot
+  jsonb (`market_regime_snapshot`, `bias`, `headline`, `actionable_summary`,
+  `risk_radar`, narrative summaries) when the legacy columns are null.
+
+`positions` / `theses` / `nav_history` / `portfolio_metrics` are written by the
+operator portfolio flow (`materialize_snapshot.py` → `run_db_first.py`), not by
+the scheduled research pipeline — portfolio panels stay in their empty states
+until that flow has run.
+
 ## Token collision notes
 
 Atlas declares its own Tailwind v4 `@theme` palette

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -26,7 +26,11 @@ import type {
 import { renderDigestMarkdownFromSnapshot, type DigestSnapshot } from './render-digest-from-snapshot';
 import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
 import { DASHBOARD_BENCHMARK_TICKERS, sortTickerUniverse } from './benchmark-tickers';
-import { extractSnapshotContextBullets } from './snapshot-context';
+import {
+  digestItemsToStrings,
+  extractDigestContextBullets,
+  extractSnapshotContextBullets,
+} from './snapshot-context';
 import { MACRO_PREVIEW_SERIES_IDS } from './macro-curated';
 import { getDocLibraryTier } from './library-doc-tier';
 
@@ -501,6 +505,12 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       ? (rawRegime as Record<string, unknown>)
       : {};
 
+  // The Atlas pipeline (SIMP-013) writes the digest into the `snapshot` JSONB
+  // and leaves the legacy `regime`/`actionable`/`risks`/`market_data`/
+  // `segment_biases` columns null — fall back to the digest for the strategy
+  // panel when the legacy columns are absent.
+  const digest = (snapshotJson ?? {}) as Record<string, unknown>;
+
   // Build benchmark map
   const benchmarks: BenchmarkHistoryMap = {};
   for (const row of benchRows) {
@@ -755,10 +765,13 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     return { ticker: p.ticker, current_pct: curr, recommended_pct: rec, action };
   });
 
-  const snapshot_context_bullets = extractSnapshotContextBullets(
+  const legacyContextBullets = extractSnapshotContextBullets(
     snapshot.segment_biases,
     snapshot.market_data
   );
+  const snapshot_context_bullets = legacyContextBullets.length
+    ? legacyContextBullets
+    : extractDigestContextBullets(digest);
 
   const runTypeRaw = String(snapshot.run_type || '').toLowerCase();
   const latest_snapshot_run_type: 'baseline' | 'delta' | null =
@@ -851,11 +864,13 @@ export async function getFullDashboardData(): Promise<DashboardData> {
         invested_pct: h.invested_pct != null ? Number(h.invested_pct) : null,
       })),
       strategy: {
-        regime: String(regime.label ?? regime.regime ?? 'Unknown'),
-        regime_label: String(regime.bias ?? regime.regime_label ?? 'neutral'),
-        summary: String(regime.summary ?? ''),
-        actionable: (snapshot.actionable ?? []) as string[],
-        risks: (snapshot.risks ?? []) as string[],
+        regime: String(
+          regime.label ?? regime.regime ?? digest.market_regime_snapshot ?? 'Unknown'
+        ),
+        regime_label: String(regime.bias ?? regime.regime_label ?? digest.bias ?? 'neutral'),
+        summary: String(regime.summary ?? digest.headline ?? ''),
+        actionable: snapshot.actionable ?? digestItemsToStrings(digest.actionable_summary),
+        risks: snapshot.risks ?? digestItemsToStrings(digest.risk_radar),
         theses,
         next_review: 'Daily',
       },

--- a/frontend/olympus/lib/render-digest-from-snapshot.ts
+++ b/frontend/olympus/lib/render-digest-from-snapshot.ts
@@ -2,6 +2,7 @@
  * Client-side markdown compiled from a digest snapshot JSON (v1).
  * Kept in sync with scripts/materialize_snapshot.py `render_digest_markdown`.
  */
+import { isMasterDigestPayload, renderMasterDigestMarkdown } from './render-pipeline-payloads';
 
 export type DigestSnapshot = {
   date?: string;
@@ -18,6 +19,13 @@ function str(v: unknown): string {
 }
 
 export function renderDigestMarkdownFromSnapshot(snapshot: DigestSnapshot): string {
+  // The Atlas pipeline publishes the master-digest shape (DigestPayload) into
+  // `daily_snapshots.snapshot`; the v1 operator schema below has `regime` /
+  // `portfolio` / `sector_scorecard` instead. Route by shape.
+  if (isMasterDigestPayload(snapshot)) {
+    return renderMasterDigestMarkdown(snapshot);
+  }
+
   const date = str(snapshot.date);
   const regime = (snapshot.regime || {}) as Record<string, unknown>;
   const lines: string[] = [];

--- a/frontend/olympus/lib/render-document-from-payload.ts
+++ b/frontend/olympus/lib/render-document-from-payload.ts
@@ -1,4 +1,12 @@
 import { renderDigestMarkdownFromSnapshot, type DigestSnapshot } from './render-digest-from-snapshot';
+import {
+  isMasterDigestPayload,
+  isRebalancePayload,
+  isSegmentReportPayload,
+  renderMasterDigestMarkdown,
+  renderRebalanceMarkdown,
+  renderSegmentReportMarkdown,
+} from './render-pipeline-payloads';
 
 function s(v: unknown): string {
   return v == null ? '' : String(v);
@@ -16,6 +24,17 @@ function pushBulletBlock(target: string[], heading: string, items: unknown[] | u
   target.push('');
 }
 
+function renderPayloadJsonFallback(payload: unknown, documentKey?: string): string {
+  const lines: string[] = [`# ${documentKey || 'Document'}`, '', '## Payload'];
+  try {
+    lines.push('```json', JSON.stringify(payload, null, 2), '```');
+  } catch {
+    lines.push('_Unable to render payload._');
+  }
+  lines.push('');
+  return `${lines.join('\n').trim()}\n`;
+}
+
 export function renderDocumentMarkdownFromPayload(payload: unknown, documentKey?: string): string | null {
   const p = asObj(payload);
   if (!p) return null;
@@ -29,6 +48,13 @@ export function renderDocumentMarkdownFromPayload(payload: unknown, documentKey?
     }
   }
 
+  // Pipeline payloads (SIMP-013): the publisher writes validated Pydantic
+  // payloads with no doc_type and segment-slug document keys — sniff the
+  // shape before the legacy doc_type routing below.
+  if (isMasterDigestPayload(p)) return renderMasterDigestMarkdown(p);
+  if (isRebalancePayload(p, documentKey)) return renderRebalanceMarkdown(p);
+  if (isSegmentReportPayload(p)) return renderSegmentReportMarkdown(p);
+
   // Infer doc_type from document_key when it is missing (legacy/transitional payloads).
   let docType = s(p.doc_type);
   if (!docType && documentKey) {
@@ -40,7 +66,13 @@ export function renderDocumentMarkdownFromPayload(payload: unknown, documentKey?
     else if (dk.startsWith('asset-recommendations/')) docType = 'asset_recommendation';
     else if (dk.startsWith('opportunity-screen/')) docType = 'opportunity_screen';
   }
-  if (!docType) return null;
+  if (!docType) {
+    // `digest`-keyed documents return null so the caller can fall back to the
+    // richer daily_snapshots.snapshot render. Every other unknown shape gets a
+    // JSON dump — debuggable beats "_No content available._".
+    if (documentKey === 'digest') return null;
+    return renderPayloadJsonFallback(payload, documentKey);
+  }
 
   const dateStr = s(p.date);
 

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import { fixtureDigest } from './__fixtures__/snapshot-fixture';
+import { renderDigestMarkdownFromSnapshot } from './render-digest-from-snapshot';
+import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
+import {
+  isMasterDigestPayload,
+  isRebalancePayload,
+  isSegmentReportPayload,
+  renderMasterDigestMarkdown,
+  renderRebalanceMarkdown,
+  renderSegmentReportMarkdown,
+} from './render-pipeline-payloads';
+import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
+
+/** Trimmed copy of the production `documents.payload` for `bonds` (2026-06-12). */
+const BONDS_PAYLOAD = {
+  segment: 'bonds',
+  date: '2026-06-12',
+  bias: 'neutral',
+  headline: 'Curve steepens as front-end yields ease on rate-cut repricing.',
+  material_findings: [
+    {
+      label: 'CTAs short USTs',
+      summary: 'Systematic funds hold short duration into supply week.',
+      source_ids: ['1'],
+    },
+  ],
+  sources: [{ id: '1', title: 'Rates wrap', url: 'https://example.com/rates' }],
+  notes: 'No spread data retrieved.',
+  yield_curve_shape: 'steepening',
+  two_ten_spread_bps: null,
+  credit_ig_spread_bps: null,
+  credit_hy_spread_bps: null,
+};
+
+/** Trimmed copy of the production `pm-rebalance` payload (2026-06-12 — empty run). */
+const REBALANCE_EMPTY = {
+  notes: 'Data gaps prevent any rebalance.',
+  actions: [],
+  recommended_portfolio: [],
+};
+
+const REBALANCE_POPULATED = {
+  notes: 'Trim tech overweight.',
+  actions: [{ ticker: 'NVDA', action: 'TRIM', current_pct: 12, recommended_pct: 8 }],
+  recommended_portfolio: [{ ticker: 'NVDA', weight_pct: 8 }],
+};
+
+/** Legacy v1 operator snapshot shape — must keep rendering via the old path. */
+const V1_SNAPSHOT = {
+  date: '2026-04-27',
+  regime: { bias: 'bullish', label: 'Risk-on', conviction: 'high', summary: 'Breadth healthy.' },
+  actionable: ['Add semis exposure'],
+  risks: ['CPI surprise'],
+  sector_scorecard: [
+    { sector: 'Technology', etf: 'XLK', bias: 'bullish', confidence: 'high', key_driver: 'AI capex' },
+  ],
+};
+
+describe('shape sniffers', () => {
+  it('classifies the master digest payload', () => {
+    expect(isMasterDigestPayload(fixtureDigest())).toBe(true);
+    expect(isMasterDigestPayload(BONDS_PAYLOAD)).toBe(false);
+    expect(isMasterDigestPayload(V1_SNAPSHOT)).toBe(false);
+  });
+
+  it('classifies segment reports', () => {
+    expect(isSegmentReportPayload(BONDS_PAYLOAD)).toBe(true);
+    expect(isSegmentReportPayload(REBALANCE_EMPTY)).toBe(false);
+  });
+
+  it('classifies rebalance payloads by shape and by document key', () => {
+    expect(isRebalancePayload(REBALANCE_EMPTY)).toBe(true);
+    expect(isRebalancePayload(BONDS_PAYLOAD, 'pm-rebalance')).toBe(true);
+    expect(isRebalancePayload(BONDS_PAYLOAD)).toBe(false);
+  });
+});
+
+describe('renderSegmentReportMarkdown', () => {
+  it('renders headline, bias, findings, signals, notes and sources', () => {
+    const md = renderSegmentReportMarkdown(BONDS_PAYLOAD);
+    expect(md).toContain('# Bonds — 2026-06-12');
+    expect(md).toContain('**Bias:** neutral');
+    expect(md).toContain('Curve steepens');
+    expect(md).toContain('**CTAs short USTs** — Systematic funds hold short duration');
+    expect(md).toContain('**Yield Curve Shape:** steepening');
+    expect(md).toContain('No spread data retrieved.');
+    expect(md).toContain('[Rates wrap](https://example.com/rates)');
+  });
+
+  it('omits null metric fields instead of rendering empty rows', () => {
+    const md = renderSegmentReportMarkdown(BONDS_PAYLOAD);
+    expect(md).not.toContain('Two Ten Spread Bps');
+  });
+});
+
+describe('renderMasterDigestMarkdown', () => {
+  it('renders regime, headline, narrative sections and freshness', () => {
+    const md = renderMasterDigestMarkdown(fixtureDigest());
+    expect(md).toContain('# Daily Digest — 2026-04-27');
+    expect(md).toContain('Risk-on regime confirmed');
+    expect(md).toContain('**Overall bias:** bullish');
+    expect(md).toContain('Tech rally extends as macro stress eases');
+    expect(md).toContain('**NVDA breaks resistance**');
+    expect(md).toContain('## Alt-Data Dashboard');
+  });
+});
+
+describe('renderRebalanceMarkdown', () => {
+  it('states explicitly when no changes were recommended', () => {
+    const md = renderRebalanceMarkdown(REBALANCE_EMPTY);
+    expect(md).toContain('_No allocation changes were recommended for this run._');
+    expect(md).toContain('Data gaps prevent any rebalance.');
+  });
+
+  it('renders actions and recommended portfolio tables when present', () => {
+    const md = renderRebalanceMarkdown(REBALANCE_POPULATED);
+    expect(md).toContain('## Actions');
+    expect(md).toContain('| NVDA | TRIM | 12 | 8 |');
+    expect(md).toContain('## Recommended portfolio');
+  });
+});
+
+describe('renderDocumentMarkdownFromPayload routing', () => {
+  it('renders pipeline segment documents instead of returning null (#690 follow-up)', () => {
+    const md = renderDocumentMarkdownFromPayload(BONDS_PAYLOAD, 'bonds');
+    expect(md).not.toBeNull();
+    expect(md).toContain('# Bonds — 2026-06-12');
+  });
+
+  it('renders digest-delta documents with the master digest renderer', () => {
+    const md = renderDocumentMarkdownFromPayload(fixtureDigest(), 'digest-delta');
+    expect(md).toContain('# Daily Digest — 2026-04-27');
+  });
+
+  it('renders pm-rebalance documents', () => {
+    const md = renderDocumentMarkdownFromPayload(REBALANCE_EMPTY, 'pm-rebalance');
+    expect(md).toContain('# Rebalance Decision');
+  });
+
+  it('still renders the legacy v1 snapshot payload through the v1 path', () => {
+    const md = renderDocumentMarkdownFromPayload(V1_SNAPSHOT, 'digest');
+    expect(md).toContain('## Market Regime Snapshot');
+    expect(md).toContain('| Technology | XLK | bullish | high | AI capex |');
+  });
+
+  it('renders unknown shapes as a JSON dump instead of null', () => {
+    const md = renderDocumentMarkdownFromPayload({ mystery: true }, 'future-doc-kind');
+    expect(md).toContain('# future-doc-kind');
+    expect(md).toContain('"mystery": true');
+  });
+
+  it('returns null for unknown digest-keyed payloads so the snapshot fallback applies', () => {
+    expect(renderDocumentMarkdownFromPayload({ mystery: true }, 'digest')).toBeNull();
+  });
+});
+
+describe('renderDigestMarkdownFromSnapshot shape routing', () => {
+  it('delegates the pipeline digest shape to the master renderer', () => {
+    const md = renderDigestMarkdownFromSnapshot(fixtureDigest() as never);
+    expect(md).toContain('# Daily Digest — 2026-04-27');
+  });
+
+  it('keeps rendering the v1 operator shape', () => {
+    const md = renderDigestMarkdownFromSnapshot(V1_SNAPSHOT as never);
+    expect(md).toContain('# DIGEST — 2026-04-27');
+    expect(md).toContain('## Sector Scorecard');
+  });
+});
+
+describe('snapshot-context digest helpers', () => {
+  it('normalizes ActionableItem / RiskItem entries to display strings', () => {
+    expect(
+      digestItemsToStrings([
+        { priority: 1, label: 'Trim tech', rationale: 'Crowded positioning' },
+        { horizon_hours: 48, label: 'CPI print', trigger: 'Hot core MoM' },
+        'plain string',
+      ])
+    ).toEqual(['Trim tech — Crowded positioning', 'CPI print — Hot core MoM', 'plain string']);
+    expect(digestItemsToStrings(null)).toEqual([]);
+  });
+
+  it('builds context bullets from digest narrative sections', () => {
+    const bullets = extractDigestContextBullets(fixtureDigest());
+    expect(bullets.length).toBeGreaterThan(0);
+    expect(bullets[0]).toMatch(/^US equities: /);
+  });
+});

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -69,6 +69,10 @@ describe('shape sniffers', () => {
     expect(isSegmentReportPayload(REBALANCE_EMPTY)).toBe(false);
   });
 
+  it('sniffers are standalone-correct: the master digest is not a segment report', () => {
+    expect(isSegmentReportPayload(fixtureDigest())).toBe(false);
+  });
+
   it('classifies rebalance payloads by shape and by document key', () => {
     expect(isRebalancePayload(REBALANCE_EMPTY)).toBe(true);
     expect(isRebalancePayload(BONDS_PAYLOAD, 'pm-rebalance')).toBe(true);
@@ -95,6 +99,18 @@ describe('renderSegmentReportMarkdown', () => {
 });
 
 describe('renderMasterDigestMarkdown', () => {
+  it('renders defensively when actionable/risk entries have blank labels', () => {
+    const digest = {
+      ...fixtureDigest(),
+      actionable_summary: [{ priority: 1, label: '', rationale: '' }],
+      risk_radar: [{ horizon_hours: 24, label: '', trigger: 'VIX spike' }],
+    };
+    const md = renderMasterDigestMarkdown(digest);
+    expect(md).not.toContain('****');
+    expect(md).toContain('- **P1** **Item**');
+    expect(md).toContain('- **Risk** — VIX spike');
+  });
+
   it('renders regime, headline, narrative sections and freshness', () => {
     const md = renderMasterDigestMarkdown(fixtureDigest());
     expect(md).toContain('# Daily Digest — 2026-04-27');

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -1,0 +1,328 @@
+/**
+ * Markdown renderers for the payload shapes the Atlas/Hermes pipeline publishes
+ * to Supabase (`documents.payload`, `daily_snapshots.snapshot`).
+ *
+ * The pipeline writes validated Pydantic payloads (SIMP-013) and leaves
+ * `documents.content` empty, so the Research Library renders markdown from the
+ * payload itself. Three shapes cover every pipeline document:
+ *
+ * - **Segment report** (`macro`, `bonds`, `equity`, `sector-*`, `alt-*`,
+ *   `inst-*`, …): SegmentReport core (`segment`, `date`, `bias`, `headline`,
+ *   `material_findings`, `sources`, `notes`) plus per-segment metric fields.
+ * - **Master digest** (`digest-delta` / `digest-baseline` documents and the
+ *   `daily_snapshots.snapshot` jsonb): {@link DigestPayload} shape.
+ * - **PM rebalance** (`pm-rebalance`): `{ notes, actions, recommended_portfolio }`.
+ *
+ * All renderers are defensive: they tolerate missing/extra keys and never
+ * throw on malformed payloads (worst case they render fewer sections).
+ */
+
+function s(v: unknown): string {
+  return v == null ? '' : String(v);
+}
+
+function asObj(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+/** "alt-cta-positioning" → "Alt CTA Positioning"-ish humanized heading. */
+function humanize(slug: string): string {
+  return slug
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\bCta\b/g, 'CTA')
+    .replace(/\bVix\b/g, 'VIX')
+    .replace(/\bEtf\b/g, 'ETF')
+    .replace(/\bPm\b/g, 'PM')
+    .replace(/\bUs\b/g, 'US')
+    .replace(/\bAi\b/g, 'AI');
+}
+
+function escapeTableCell(v: unknown): string {
+  return s(v).replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+}
+
+/** Render an array of similarly-shaped objects as a compact markdown table. */
+function objectArrayTable(rows: Record<string, unknown>[], maxCols = 7): string[] {
+  const cols: string[] = [];
+  for (const row of rows) {
+    for (const k of Object.keys(row)) {
+      if (!cols.includes(k)) cols.push(k);
+      if (cols.length >= maxCols) break;
+    }
+    if (cols.length >= maxCols) break;
+  }
+  if (!cols.length) return [];
+  const out: string[] = [];
+  out.push(`| ${cols.map(humanize).join(' | ')} |`);
+  out.push(`|${cols.map(() => '---').join('|')}|`);
+  for (const row of rows) {
+    out.push(`| ${cols.map((c) => escapeTableCell(row[c])).join(' | ')} |`);
+  }
+  out.push('');
+  return out;
+}
+
+function pushFindings(out: string[], findings: unknown): void {
+  if (!Array.isArray(findings) || !findings.length) return;
+  out.push('## Material findings', '');
+  for (const f of findings) {
+    const o = asObj(f);
+    if (!o) continue;
+    const label = s(o.label).trim();
+    const summary = s(o.summary).trim();
+    if (!label && !summary) continue;
+    out.push(`- **${label || 'Finding'}** — ${summary}`);
+  }
+  out.push('');
+}
+
+function pushSources(out: string[], sources: unknown): void {
+  if (!Array.isArray(sources) || !sources.length) return;
+  out.push('## Sources', '');
+  for (const src of sources) {
+    const o = asObj(src);
+    if (!o) continue;
+    const title = s(o.title).trim() || s(o.id).trim() || 'source';
+    const url = s(o.url).trim();
+    out.push(url ? `- [${title}](${url})` : `- ${title}`);
+  }
+  out.push('');
+}
+
+function pushNotes(out: string[], notes: unknown): void {
+  const n = s(notes).trim();
+  if (!n) return;
+  out.push('## Notes', '', n, '');
+}
+
+/* ── Master digest ───────────────────────────────────────────────────────── */
+
+/** SegmentReport-core keys handled explicitly by every renderer below. */
+const CORE_KEYS = new Set([
+  'segment',
+  'date',
+  'bias',
+  'headline',
+  'material_findings',
+  'sources',
+  'notes',
+  'doc_type',
+  'schema_version',
+]);
+
+const DIGEST_NARRATIVE_SECTIONS: Array<[key: string, heading: string]> = [
+  ['us_equities_summary', 'US Equities'],
+  ['asset_classes_summary', 'Asset Classes'],
+  ['institutional_summary', 'Institutional'],
+  ['alt_data_dashboard', 'Alt-Data Dashboard'],
+  ['thesis_tracker', 'Thesis Tracker'],
+  ['portfolio_recommendations', 'Portfolio Recommendations'],
+];
+
+/** True when a payload looks like the Phase-7 master digest (DigestPayload). */
+export function isMasterDigestPayload(payload: unknown): boolean {
+  const p = asObj(payload);
+  if (!p) return false;
+  if (typeof p.market_regime_snapshot === 'string') return true;
+  if (asObj(p.segment_freshness)) return true;
+  return s(p.segment) === 'master-digest' && typeof p.headline === 'string';
+}
+
+/** Markdown for the master-digest payload (documents and `daily_snapshots.snapshot`). */
+export function renderMasterDigestMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const out: string[] = [];
+  const date = s(p.date).trim();
+  out.push(`# Daily Digest${date ? ` — ${date}` : ''}`, '');
+
+  const regime = s(p.market_regime_snapshot).trim();
+  const bias = s(p.bias).trim();
+  if (regime || bias) {
+    out.push('## Market regime', '');
+    if (regime) out.push(regime, '');
+    if (bias) out.push(`**Overall bias:** ${bias}`, '');
+  }
+
+  const headline = s(p.headline).trim();
+  if (headline) out.push('## Headline', '', headline, '');
+
+  const actionable = Array.isArray(p.actionable_summary) ? p.actionable_summary : [];
+  if (actionable.length) {
+    out.push('## Actionable summary', '');
+    for (const a of actionable) {
+      const o = asObj(a);
+      if (o) {
+        const pri = s(o.priority).trim();
+        out.push(`- ${pri ? `**P${pri}** ` : ''}**${s(o.label).trim()}** — ${s(o.rationale).trim()}`);
+      } else if (s(a).trim()) {
+        out.push(`- ${s(a).trim()}`);
+      }
+    }
+    out.push('');
+  }
+
+  const risks = Array.isArray(p.risk_radar) ? p.risk_radar : [];
+  if (risks.length) {
+    out.push('## Risk radar', '');
+    for (const r of risks) {
+      const o = asObj(r);
+      if (o) {
+        const horizon = s(o.horizon_hours).trim();
+        const trigger = s(o.trigger).trim();
+        out.push(
+          `- **${s(o.label).trim()}**${trigger ? ` — ${trigger}` : ''}${horizon ? ` _(≤${horizon}h)_` : ''}`
+        );
+      } else if (s(r).trim()) {
+        out.push(`- ${s(r).trim()}`);
+      }
+    }
+    out.push('');
+  }
+
+  pushFindings(out, p.material_findings);
+
+  for (const [key, heading] of DIGEST_NARRATIVE_SECTIONS) {
+    const text = s(p[key]).trim();
+    if (!text) continue;
+    out.push(`## ${heading}`, '', text, '');
+  }
+
+  const freshness = asObj(p.segment_freshness);
+  if (freshness && Object.keys(freshness).length) {
+    out.push('## Segment freshness', '');
+    out.push('| Segment | Source | As of |');
+    out.push('|---|---|---|');
+    for (const [seg, val] of Object.entries(freshness).sort(([a], [b]) => a.localeCompare(b))) {
+      const o = asObj(val) ?? {};
+      out.push(`| ${seg} | ${s(o.source)} | ${s(o.as_of)} |`);
+    }
+    out.push('');
+  }
+
+  pushNotes(out, p.notes);
+  pushSources(out, p.sources);
+  return `${out.join('\n').trim()}\n`;
+}
+
+/* ── PM rebalance ────────────────────────────────────────────────────────── */
+
+/** True for the Hermes `pm-rebalance` payload (`{notes, actions, recommended_portfolio}`). */
+export function isRebalancePayload(payload: unknown, documentKey?: string): boolean {
+  if (documentKey === 'pm-rebalance') return true;
+  const p = asObj(payload);
+  if (!p) return false;
+  return Array.isArray(p.actions) && Array.isArray(p.recommended_portfolio);
+}
+
+/** Markdown for the PM rebalance decision payload. */
+export function renderRebalanceMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const out: string[] = ['# Rebalance Decision', ''];
+
+  const actions = Array.isArray(p.actions)
+    ? (p.actions.map(asObj).filter(Boolean) as Record<string, unknown>[])
+    : [];
+  if (actions.length) {
+    out.push('## Actions', '', ...objectArrayTable(actions));
+  }
+
+  const rec = Array.isArray(p.recommended_portfolio)
+    ? (p.recommended_portfolio.map(asObj).filter(Boolean) as Record<string, unknown>[])
+    : [];
+  if (rec.length) {
+    out.push('## Recommended portfolio', '', ...objectArrayTable(rec));
+  }
+
+  if (!actions.length && !rec.length) {
+    out.push('_No allocation changes were recommended for this run._', '');
+  }
+
+  pushNotes(out, p.notes);
+  return `${out.join('\n').trim()}\n`;
+}
+
+/* ── Segment reports ─────────────────────────────────────────────────────── */
+
+/** True for SegmentReport-shaped payloads (every Phase 1–6 research document). */
+export function isSegmentReportPayload(payload: unknown): boolean {
+  const p = asObj(payload);
+  if (!p) return false;
+  if (typeof p.segment !== 'string' || !p.segment) return false;
+  return (
+    typeof p.headline === 'string' ||
+    typeof p.bias === 'string' ||
+    Array.isArray(p.material_findings)
+  );
+}
+
+/**
+ * Markdown for a segment research report. Core narrative sections are rendered
+ * explicitly; the segment-specific metric fields (e.g. `vix_level`,
+ * `spy_trend`, `yield_curve_shape`) are rendered generically so new segments
+ * display without frontend changes.
+ */
+export function renderSegmentReportMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const out: string[] = [];
+  const date = s(p.date).trim();
+  const segment = s(p.segment).trim();
+  out.push(`# ${humanize(segment || 'Research Report')}${date ? ` — ${date}` : ''}`, '');
+
+  const bias = s(p.bias).trim();
+  if (bias) out.push(`**Bias:** ${bias}`, '');
+
+  const headline = s(p.headline).trim();
+  if (headline) out.push(headline, '');
+
+  pushFindings(out, p.material_findings);
+
+  // Generic rendering for segment-specific fields, grouped by value shape.
+  const scalarLines: string[] = [];
+  const extras = Object.entries(p)
+    .filter(([k]) => !CORE_KEYS.has(k))
+    .sort(([a], [b]) => a.localeCompare(b));
+  for (const [key, value] of extras) {
+    if (value == null) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      const text = s(value).trim();
+      if (text) scalarLines.push(`- **${humanize(key)}:** ${text}`);
+    }
+  }
+  if (scalarLines.length) {
+    out.push('## Signals', '', ...scalarLines, '');
+  }
+
+  for (const [key, value] of extras) {
+    if (Array.isArray(value) && value.length) {
+      const objRows = value.map(asObj).filter(Boolean) as Record<string, unknown>[];
+      out.push(`## ${humanize(key)}`, '');
+      if (objRows.length === value.length) {
+        out.push(...objectArrayTable(objRows));
+      } else {
+        for (const item of value) {
+          const text = s(item).trim();
+          if (text) out.push(`- ${text}`);
+        }
+        out.push('');
+      }
+      continue;
+    }
+    const o = asObj(value);
+    if (o && Object.keys(o).length) {
+      out.push(`## ${humanize(key)}`, '');
+      for (const [ik, iv] of Object.entries(o)) {
+        const text =
+          typeof iv === 'string' || typeof iv === 'number' || typeof iv === 'boolean'
+            ? s(iv).trim()
+            : JSON.stringify(iv);
+        if (text) out.push(`- **${humanize(ik)}:** ${text}`);
+      }
+      out.push('');
+    }
+  }
+
+  pushNotes(out, p.notes);
+  pushSources(out, p.sources);
+  return `${out.join('\n').trim()}\n`;
+}

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -154,7 +154,9 @@ export function renderMasterDigestMarkdown(payload: unknown): string {
       const o = asObj(a);
       if (o) {
         const pri = s(o.priority).trim();
-        out.push(`- ${pri ? `**P${pri}** ` : ''}**${s(o.label).trim()}** — ${s(o.rationale).trim()}`);
+        const label = s(o.label).trim() || 'Item';
+        const rationale = s(o.rationale).trim();
+        out.push(`- ${pri ? `**P${pri}** ` : ''}**${label}**${rationale ? ` — ${rationale}` : ''}`);
       } else if (s(a).trim()) {
         out.push(`- ${s(a).trim()}`);
       }
@@ -170,8 +172,9 @@ export function renderMasterDigestMarkdown(payload: unknown): string {
       if (o) {
         const horizon = s(o.horizon_hours).trim();
         const trigger = s(o.trigger).trim();
+        const label = s(o.label).trim() || 'Risk';
         out.push(
-          `- **${s(o.label).trim()}**${trigger ? ` — ${trigger}` : ''}${horizon ? ` _(≤${horizon}h)_` : ''}`
+          `- **${label}**${trigger ? ` — ${trigger}` : ''}${horizon ? ` _(≤${horizon}h)_` : ''}`
         );
       } else if (s(r).trim()) {
         out.push(`- ${s(r).trim()}`);
@@ -248,6 +251,9 @@ export function renderRebalanceMarkdown(payload: unknown): string {
 export function isSegmentReportPayload(payload: unknown): boolean {
   const p = asObj(payload);
   if (!p) return false;
+  // The master digest extends the SegmentReport core — exclude it so each
+  // sniffer is standalone-correct regardless of call order.
+  if (isMasterDigestPayload(p)) return false;
   if (typeof p.segment !== 'string' || !p.segment) return false;
   return (
     typeof p.headline === 'string' ||

--- a/frontend/olympus/lib/snapshot-context.ts
+++ b/frontend/olympus/lib/snapshot-context.ts
@@ -62,3 +62,58 @@ export function extractSnapshotContextBullets(
 
   return out.slice(0, max);
 }
+
+/** Narrative sections of the pipeline digest payload used as Overview context bullets. */
+const DIGEST_BULLET_SECTIONS: Array<[key: string, label: string]> = [
+  ['us_equities_summary', 'US equities'],
+  ['asset_classes_summary', 'Asset classes'],
+  ['institutional_summary', 'Institutional'],
+  ['alt_data_dashboard', 'Alt-data'],
+];
+
+/**
+ * Context bullets from the pipeline digest (`daily_snapshots.snapshot` JSONB)
+ * for snapshots where the legacy `segment_biases` / `market_data` columns are
+ * null (every SIMP-013 pipeline row).
+ */
+export function extractDigestContextBullets(digest: unknown, max = 5): string[] {
+  const out: string[] = [];
+  if (!digest || typeof digest !== 'object' || Array.isArray(digest)) return out;
+  const d = digest as Record<string, unknown>;
+  for (const [key, label] of DIGEST_BULLET_SECTIONS) {
+    if (out.length >= max) break;
+    const v = d[key];
+    if (typeof v === 'string' && v.trim()) pushUnique(out, `${label}: ${v.trim()}`, max);
+  }
+  return out.slice(0, max);
+}
+
+/**
+ * Normalize digest list entries (`actionable_summary` ActionableItem[] /
+ * `risk_radar` RiskItem[], or plain strings) to display strings.
+ */
+export function digestItemsToStrings(items: unknown): string[] {
+  if (!Array.isArray(items)) return [];
+  const out: string[] = [];
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (item.trim()) out.push(item.trim());
+      continue;
+    }
+    if (item && typeof item === 'object' && !Array.isArray(item)) {
+      const o = item as Record<string, unknown>;
+      const label = typeof o.label === 'string' ? o.label.trim() : '';
+      const detail =
+        typeof o.rationale === 'string'
+          ? o.rationale.trim()
+          : typeof o.trigger === 'string'
+            ? o.trigger.trim()
+            : typeof o.summary === 'string'
+              ? o.summary.trim()
+              : '';
+      const text = [label, detail].filter(Boolean).join(' — ');
+      if (text) out.push(text);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Fixes #693

## Problem

Every research file on digiquant.io/olympus renders "_No content available._" and the Overview strategy panel is empty ("Unknown" regime, no actionables/risks) — even though the 2026-06-12 production run published 28 fully-populated documents and a complete digest to Supabase.

## Root cause

Frontend↔publisher contract drift. The Atlas pipeline (SIMP-013) writes validated Pydantic payloads into `documents.payload` and the digest into `daily_snapshots.snapshot`, leaving `documents.content` and the legacy snapshot columns (`regime`/`actionable`/`risks`/`market_data`/`segment_biases`) null. The frontend rendered only the legacy surfaces:

1. `render-document-from-payload.ts` required `payload.doc_type` or an old `document_key` prefix — the pipeline's keys (`macro`, `bonds`, `equity`, `sector-*`, `alt-*`, `inst-*`, `digest-delta`, `pm-rebalance`) matched neither → `return null` for every document.
2. `render-digest-from-snapshot.ts` only knew the operator-flow v1 schema (`regime`/`portfolio`/`sector_scorecard`), not the master-digest shape the pipeline publishes.
3. The Overview strategy panel read the null legacy columns.

## Fix (frontend-only; retroactively fixes all already-published rows)

- **`lib/render-pipeline-payloads.ts` (new)** — markdown renderers + shape sniffers for the three pipeline shapes. Segment-specific metric fields render generically (Signals list / tables), so future segments display without frontend changes.
- **`lib/render-document-from-payload.ts`** — shape-based routing before the legacy `doc_type` conventions; unknown shapes render a JSON dump instead of returning null (kills the blank-page failure mode for good; `digest`-keyed docs keep the richer snapshot fallback).
- **`lib/render-digest-from-snapshot.ts`** — routes by shape; v1 operator schema unchanged (regression-tested).
- **`lib/queries.ts` + `lib/snapshot-context.ts`** — strategy panel and context bullets fall back to the snapshot JSONB (`market_regime_snapshot`, `bias`, `headline`, `actionable_summary`, `risk_radar`, narrative summaries).
- **README** — documented the payload-rendering contract and why portfolio panels are empty (operator flow `materialize_snapshot.py` → `run_db_first.py` has never run in production; 0 rows in `positions`/`theses`/`nav_history`/`portfolio_metrics` — separate, human-gated concern).

## Verification

- 58/58 olympus vitest (18 new cases with production-shaped fixtures: bonds segment, master digest, empty + populated pm-rebalance, v1 regression, unknown-shape fallback, digest-key null contract)
- `tsc --noEmit` introduces no new errors; eslint clean; `next build` static export green
- `make score`: Security 10 · Quality 10 · Optimization 10 · Accuracy 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)