### PR TITLE
fix(atlas): restore Hermes analyst fan-out + deterministic market-context injection + cost-rate fix (#694)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -6,6 +6,7 @@ not full history. Selected technical columns only — the model gets signal, not
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from typing import Any  # noqa  # scored-lint suppression: duck-typed Supabase client + rows
 
 # Indicator columns surfaced to the agent (trend / momentum / regime). Not all 30+.
@@ -56,4 +57,61 @@ def get_macro_series(*, client: Any, series_ids: list[str], lookback: int = 6) -
         )
         rows = getattr(resp, "data", None) or []
         out[sid] = {"latest": rows[0] if rows else {}, "window": rows}
+    return out
+
+
+def get_market_context(
+    *,
+    client: Any,
+    tickers: list[str] | tuple[str, ...],
+    series_ids: list[str] | tuple[str, ...],
+    run_date: date,
+    price_window_days: int = 7,
+) -> dict[str, Any]:
+    """Compact latest-values block for the run-wide shared context (#694).
+
+    Returns ``{"as_of", "price_technicals": {ticker: {…latest row…}},
+    "macro_series": {series_id: {date, value, prev_value, unit}}}``.
+
+    - Technicals: one bulk query over ``tickers`` for the trailing
+      ``price_window_days``; the newest row per ticker wins. Tickers absent
+      from ``price_technicals`` are simply omitted.
+    - Macro: re-uses :func:`get_macro_series` (per-series latest two
+      observations — series cadences are mixed, so a bulk newest-first query
+      would starve monthly series behind daily ones).
+    """
+    out: dict[str, Any] = {
+        "as_of": run_date.isoformat(),
+        "price_technicals": {},
+        "macro_series": {},
+    }
+    if tickers:
+        since = (run_date - timedelta(days=price_window_days)).isoformat()
+        resp = (
+            client.table("price_technicals")
+            .select(",".join(("ticker", *TECHNICAL_COLUMNS)))
+            .in_("ticker", list(tickers))
+            .gte("date", since)
+            .order("date", desc=True)
+            .limit(len(tickers) * price_window_days)
+            .execute()
+        )
+        for row in getattr(resp, "data", None) or []:
+            ticker = row.get("ticker")
+            if ticker and ticker not in out["price_technicals"]:
+                out["price_technicals"][ticker] = {k: row.get(k) for k in TECHNICAL_COLUMNS}
+    if series_ids:
+        macro = get_macro_series(client=client, series_ids=list(series_ids), lookback=2)
+        for sid, payload in macro.items():
+            window = payload.get("window") or []
+            if not window:
+                continue
+            latest = window[0]
+            prev = window[1] if len(window) > 1 else {}
+            out["macro_series"][sid] = {
+                "date": latest.get("obs_date"),
+                "value": latest.get("value"),
+                "prev_value": prev.get("value"),
+                "unit": latest.get("unit"),
+            }
     return out

--- a/digiquant/src/digiquant/olympus/atlas/diagnostics.py
+++ b/digiquant/src/digiquant/olympus/atlas/diagnostics.py
@@ -15,9 +15,12 @@ from digigraph import usage
 
 logger = logging.getLogger(__name__)
 
-# ROUGH rates — TUNE from console.x.ai billing. grok-4.3 generation + Live Search per
-# source. est_cost_usd is explicitly an estimate, not a billed figure.
-_PRICING = {"input_per_mtok": 3.0, "output_per_mtok": 15.0, "per_source": 0.025}
+# grok-4.3 list prices (docs.x.ai, 2026-06): $1.25/$2.50 per 1M in/out tokens.
+# Agent tools (web_search/x_search) bill $5 per 1k SERVER-SIDE tool invocations;
+# invocations aren't visible client-side, but sources are — the 2026-06-12 run
+# showed ~1.5 invocations/source, so per_source ≈ 1.5 × $0.005 = $0.0075.
+# est_cost_usd is explicitly an estimate, not a billed figure (#694).
+_PRICING = {"input_per_mtok": 1.25, "output_per_mtok": 2.50, "per_source": 0.0075}
 
 # State containers holding SegmentSlots (dict slug->slot) + the scalar macro slot.
 _DICT_OUTPUT_FIELDS = (

--- a/digiquant/src/digiquant/olympus/atlas/docs/agentic/ARCHITECTURE.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/agentic/ARCHITECTURE.md
@@ -91,7 +91,16 @@ Before any phase executes, the agent performs a structured context load:
 2. **Load config** — `config/watchlist.md`, `config/preferences.md`
 3. **Load prior context from Supabase** — query `daily_snapshots` and `documents` for recent dates
 4. **Load yesterday's snapshot from Supabase** — establishes continuity baseline for today's changes
-5. **Announce**: `"Context loaded. Starting Phase 1 of 9."`
+5. **Inject market context (#694)** — preflight queries `price_technicals`
+   (core + sector ETFs, latest row each) and `macro_series_observations`
+   (latest + previous value per configured series) into
+   `DataLayerSnapshot.market_context`, which `_shared_context` serializes into
+   every phase call. Agents get real quantitative values deterministically —
+   the Supabase data tools remain available for follow-up queries but are no
+   longer the only path to price/macro data (they were never invoked under
+   `tool_choice="auto"`). Fail-soft: a data-layer error logs a warning and
+   phases run without injected values.
+6. **Announce**: `"Context loaded. Starting Phase 1 of 9."`
 
 ---
 
@@ -604,6 +613,16 @@ Phase 7C spawns one LLM node per ticker in the watchlist (up to 98). The `ATLAS_
 | `25` (CI default) | Capped at 25 tickers; logged at INFO level |
 
 This keeps Phase 7C within Groq's free-tier concurrency limits during scheduled CI runs. Production / local runs can set `ATLAS_MAX_ANALYSTS=0` to use the full watchlist.
+
+**Watchlist resolution (#694):** when the CLI is invoked without `--watchlist`
+(every scheduled workflow), `resolve_cli_inputs` falls back to
+`config/watchlist.md` — both the Atlas graph and the Hermes 7C/7CD fan-out are
+compiled from `AtlasInput.watchlist`, and an empty tuple silently skipped every
+analyst/debate node. An explicit `--watchlist` still overrides the file, and an
+empty file still disables the fan-out. Cost note: with the fallback active, a
+delta run adds `min(len(watchlist), ATLAS_MAX_ANALYSTS) × 4` analyst calls plus
+the debate/risk rounds — tune `ATLAS_MAX_ANALYSTS` in the workflow envs to
+bound spend.
 
 ### Fallback behaviour
 

--- a/digiquant/src/digiquant/olympus/atlas/graph.py
+++ b/digiquant/src/digiquant/olympus/atlas/graph.py
@@ -401,11 +401,19 @@ def _auto_resolve_baseline(run_date: date) -> date | None:
 def resolve_cli_inputs(args) -> dict:
     """Translate argparse Namespace → AtlasInput kwargs.
 
-    Pure apart from the optional Supabase call behind ``--auto-baseline``;
-    ``tests/test_cli.py`` covers both the explicit and auto-baseline
+    Pure apart from the optional Supabase call behind ``--auto-baseline`` and
+    the ``config/watchlist.md`` read on the no-flag fallback;
+    ``tests/dq/atlas/test_cli.py`` covers the explicit and auto-baseline
     paths by stubbing that call.
     """
     watchlist = tuple(t.strip() for t in args.watchlist.split(",") if t.strip())
+    if not watchlist:
+        # Scheduled/CI runs pass no --watchlist. Fall back to config/watchlist.md
+        # so the Hermes 7C/7CD per-ticker fan-out actually runs (#694) — the
+        # graphs are compiled from AtlasInput.watchlist, and an empty tuple
+        # silently skipped every analyst/debate node on scheduled runs.
+        # ATLAS_MAX_ANALYSTS still caps the fan-out at phase-build time.
+        watchlist = tuple(_parse_watchlist_md())
     baseline_date = args.baseline_date
 
     if args.auto_baseline:

--- a/digiquant/src/digiquant/olympus/atlas/graph.py
+++ b/digiquant/src/digiquant/olympus/atlas/graph.py
@@ -344,7 +344,10 @@ def build_cli_parser():
     parser.add_argument(
         "--watchlist",
         default="",
-        help="Comma-separated ticker list. Empty means Phase 7C fan-out is skipped.",
+        help=(
+            "Comma-separated ticker list. Empty falls back to config/watchlist.md "
+            "(#694); pass 'none' to skip the Phase 7C fan-out entirely."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -406,14 +409,20 @@ def resolve_cli_inputs(args) -> dict:
     ``tests/dq/atlas/test_cli.py`` covers the explicit and auto-baseline
     paths by stubbing that call.
     """
-    watchlist = tuple(t.strip() for t in args.watchlist.split(",") if t.strip())
-    if not watchlist:
-        # Scheduled/CI runs pass no --watchlist. Fall back to config/watchlist.md
-        # so the Hermes 7C/7CD per-ticker fan-out actually runs (#694) — the
-        # graphs are compiled from AtlasInput.watchlist, and an empty tuple
-        # silently skipped every analyst/debate node on scheduled runs.
-        # ATLAS_MAX_ANALYSTS still caps the fan-out at phase-build time.
-        watchlist = tuple(_parse_watchlist_md())
+    raw_watchlist = args.watchlist.strip()
+    if raw_watchlist.lower() == "none":
+        # Explicit opt-out: compile zero 7C/7CD nodes (the pre-#694 empty
+        # behavior, now opt-in instead of the accidental default).
+        watchlist: tuple[str, ...] = ()
+    else:
+        watchlist = tuple(t.strip() for t in raw_watchlist.split(",") if t.strip())
+        if not watchlist:
+            # Scheduled/CI runs pass no --watchlist. Fall back to config/watchlist.md
+            # so the Hermes 7C/7CD per-ticker fan-out actually runs (#694) — the
+            # graphs are compiled from AtlasInput.watchlist, and an empty tuple
+            # silently skipped every analyst/debate node on scheduled runs.
+            # ATLAS_MAX_ANALYSTS still caps the fan-out at phase-build time.
+            watchlist = tuple(_parse_watchlist_md())
     baseline_date = args.baseline_date
 
     if args.auto_baseline:

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-update dict shape
 
+import yaml
+
 from digiquant.olympus.atlas.data.queries import get_market_context
 from digiquant.olympus.atlas.decision_log import (
     ReflectorOutput,
@@ -79,7 +81,7 @@ def _market_context_tickers() -> list[str]:
             etfs = getattr(sector, "etfs", None) or []
             if etfs and etfs[0] not in tickers:
                 tickers.append(etfs[0])
-    except (OSError, ValueError):
+    except (OSError, ValueError, yaml.YAMLError):
         # sectors.yaml missing/malformed → core set still ships.
         pass
     return tickers

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -6,15 +6,18 @@ See ``atlas/docs/agentic/ARCHITECTURE.md`` Pre-Flight Protocol.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import date
 from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-update dict shape
 
+from digiquant.olympus.atlas.data.queries import get_market_context
 from digiquant.olympus.atlas.decision_log import (
     ReflectorOutput,
     fetch_recent_lessons,
     resolve_pending,
 )
+from digiquant.olympus.atlas.sectors_config import load_sectors
 from digiquant.olympus.atlas.state import (
     AtlasConfigBundle,
     AtlasResearchState,
@@ -31,6 +34,8 @@ from digiquant.olympus.atlas.supabase_io import (
 # decision_log may be empty or not yet migrated — do not fail the rest of preflight.
 _SUPABASE_READ_ERRORS = (OSError, RuntimeError, ValueError, TypeError, KeyError)
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class PreflightDeps:
@@ -43,7 +48,46 @@ class PreflightDeps:
     price_staleness_days: int = 3
 
 
-def _data_layer_snapshot(deps: PreflightDeps, run_date: date) -> DataLayerSnapshot:
+# Broad-market ETFs (+ BTC/ETH) always present in the injected market context.
+# Sector ETFs are appended from config/sectors.yaml at preflight time.
+_CORE_MARKET_TICKERS: tuple[str, ...] = (
+    "SPY",
+    "QQQ",
+    "IWM",
+    "DIA",
+    "TLT",
+    "IEF",
+    "HYG",
+    "LQD",
+    "GLD",
+    "SLV",
+    "USO",
+    "UUP",
+    "EFA",
+    "EEM",
+    "FXI",
+    "BTC-USD",
+    "ETH-USD",
+)
+
+
+def _market_context_tickers() -> list[str]:
+    """Core ETF set + the headline ETF of each configured sector (deduped)."""
+    tickers = list(_CORE_MARKET_TICKERS)
+    try:
+        for sector in load_sectors():
+            etfs = getattr(sector, "etfs", None) or []
+            if etfs and etfs[0] not in tickers:
+                tickers.append(etfs[0])
+    except (OSError, ValueError):
+        # sectors.yaml missing/malformed → core set still ships.
+        pass
+    return tickers
+
+
+def _data_layer_snapshot(
+    deps: PreflightDeps, run_date: date, config: AtlasConfigBundle
+) -> DataLayerSnapshot:
     """Probe price_technicals + macro_series freshness; empty tables are valid."""
     latest_tech, ticker_count = query_price_technicals_freshness(client=deps.client)
     macro_latest = query_macro_series_freshness(client=deps.client)
@@ -59,11 +103,25 @@ def _data_layer_snapshot(deps: PreflightDeps, run_date: date) -> DataLayerSnapsh
         if latest_tech < stale_cutoff:
             fallback = "scripts"
 
+    # Deterministic market values for every phase's shared context (#694).
+    # Fail-soft: research must proceed (ungrounded) on a data-layer hiccup.
+    market_context: dict[str, Any] = {}
+    try:
+        market_context = get_market_context(
+            client=deps.client,
+            tickers=_market_context_tickers(),
+            series_ids=list(config.macro_series),
+            run_date=run_date,
+        )
+    except _SUPABASE_READ_ERRORS as exc:
+        logger.warning("market_context unavailable (%s); phases run without injected values", exc)
+
     return DataLayerSnapshot(
         price_technicals_latest=latest_tech,
         price_technicals_ticker_count=ticker_count,
         macro_series_latest=macro_latest,
         fallback_used=fallback,  # type: ignore[arg-type]
+        market_context=market_context,
     )
 
 
@@ -86,7 +144,7 @@ def build_preflight_node(deps: PreflightDeps) -> Callable[[AtlasResearchState], 
 
         config = deps.config_loader()
         prior_context = load_prior_context(client=deps.client, run_date=state.run_date)
-        data_layer = _data_layer_snapshot(deps, state.run_date)
+        data_layer = _data_layer_snapshot(deps, state.run_date, config)
 
         # Hydrate ``decision_lessons`` from ``decision_log`` so the PM (Phase 7D)
         # sees prior reflections this run. The fetch is bounded:

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -180,12 +180,17 @@ class PriorContext(BaseModel):
 
 
 class DataLayerSnapshot(BaseModel):
-    """Freshness probe for price/macro data. Populated in pre-flight."""
+    """Freshness probe + compact market values for price/macro data. Populated in pre-flight."""
 
     price_technicals_latest: date | None = None
     price_technicals_ticker_count: int = 0
     macro_series_latest: date | None = None
     fallback_used: Literal["supabase", "scripts", "mcp", "none"] = "none"
+    # Deterministic quantitative context injected into every phase's shared
+    # context (#694): latest technicals for the core/sector ETF set plus the
+    # latest macro series values. Agents were expected to pull these via the
+    # data tools but never call them (tool_choice=auto) — inject instead.
+    market_context: dict[str, Any] = Field(default_factory=dict)
 
 
 class Phase6BiasRow(TypedDict, total=False):

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -217,7 +217,10 @@ def _build_cli_parser():
     parser.add_argument(
         "--watchlist",
         default="",
-        help="Comma-separated ticker list. Empty means Phase 7C fan-out is skipped.",
+        help=(
+            "Comma-separated ticker list. Empty falls back to config/watchlist.md "
+            "(#694); pass 'none' to skip the Phase 7C fan-out entirely."
+        ),
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/dq/atlas/test_cli.py
+++ b/tests/dq/atlas/test_cli.py
@@ -27,7 +27,17 @@ def test_baseline_minimal():
     assert kwargs["run_type"] == "baseline"
     assert kwargs["run_date"] == date(2026, 4, 20)
     assert kwargs["baseline_date"] is None
-    assert kwargs["watchlist"] == ()
+    # No --watchlist falls back to config/watchlist.md so the Hermes 7C/7CD
+    # fan-out runs on scheduled jobs (#694). SPY is a permanent member.
+    assert "SPY" in kwargs["watchlist"]
+
+
+def test_explicit_watchlist_overrides_md_fallback():
+    args = _parse(
+        "--run-type", "baseline", "--run-date", "2026-04-20", "--watchlist", "AAPL"
+    )
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["watchlist"] == ("AAPL",)
 
 
 def test_delta_with_explicit_baseline():

--- a/tests/dq/atlas/test_cli.py
+++ b/tests/dq/atlas/test_cli.py
@@ -33,9 +33,7 @@ def test_baseline_minimal():
 
 
 def test_explicit_watchlist_overrides_md_fallback():
-    args = _parse(
-        "--run-type", "baseline", "--run-date", "2026-04-20", "--watchlist", "AAPL"
-    )
+    args = _parse("--run-type", "baseline", "--run-date", "2026-04-20", "--watchlist", "AAPL")
     kwargs = resolve_cli_inputs(args)
     assert kwargs["watchlist"] == ("AAPL",)
 

--- a/tests/dq/atlas/test_cli.py
+++ b/tests/dq/atlas/test_cli.py
@@ -38,6 +38,12 @@ def test_explicit_watchlist_overrides_md_fallback():
     assert kwargs["watchlist"] == ("AAPL",)
 
 
+def test_watchlist_none_disables_fanout():
+    args = _parse("--run-type", "baseline", "--run-date", "2026-04-20", "--watchlist", "none")
+    kwargs = resolve_cli_inputs(args)
+    assert kwargs["watchlist"] == ()
+
+
 def test_delta_with_explicit_baseline():
     args = _parse(
         "--run-type",

--- a/tests/dq/atlas/test_market_context.py
+++ b/tests/dq/atlas/test_market_context.py
@@ -1,0 +1,139 @@
+"""Unit tests for the deterministic market-context injection (#694).
+
+Research agents never invoke the Supabase data tools (tool_choice=auto), so
+preflight injects a compact latest-values block into ``DataLayerSnapshot``,
+which ``_shared_context`` already serializes into every phase call.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.data.queries import get_market_context
+from digiquant.olympus.atlas.phases.preflight import (
+    PreflightDeps,
+    _market_context_tickers,
+    build_preflight_node,
+)
+from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+pytestmark = pytest.mark.unit
+
+RUN_DATE = date(2026, 6, 12)
+
+
+def _client(price_rows=None, macro_rows=None) -> FakeSupabaseClient:
+    return FakeSupabaseClient(
+        canned_reads={
+            "daily_snapshots": [],
+            "documents": [],
+            "price_technicals": price_rows
+            or [
+                {"date": "2026-06-11", "ticker": "SPY", "rsi_14": 61.2, "pct_vs_sma50": 2.1},
+                {"date": "2026-06-10", "ticker": "SPY", "rsi_14": 58.0, "pct_vs_sma50": 1.7},
+                {"date": "2026-06-11", "ticker": "TLT", "rsi_14": 44.5, "pct_vs_sma50": -0.8},
+            ],
+            "macro_series_observations": macro_rows
+            or [
+                {"series_id": "DGS10", "obs_date": "2026-06-11", "value": 4.21, "unit": "pct"},
+                {"series_id": "DGS10", "obs_date": "2026-06-10", "value": 4.18, "unit": "pct"},
+            ],
+        }
+    )
+
+
+class TestGetMarketContext:
+    def test_latest_row_per_ticker_wins(self) -> None:
+        ctx = get_market_context(
+            client=_client(),
+            tickers=["SPY", "TLT", "MISSING"],
+            series_ids=[],
+            run_date=RUN_DATE,
+        )
+        assert ctx["as_of"] == "2026-06-12"
+        assert ctx["price_technicals"]["SPY"]["rsi_14"] == 61.2
+        assert ctx["price_technicals"]["SPY"]["date"] == "2026-06-11"
+        assert ctx["price_technicals"]["TLT"]["rsi_14"] == 44.5
+        # Tickers absent from the table are omitted, not nulled.
+        assert "MISSING" not in ctx["price_technicals"]
+
+    def test_macro_series_latest_and_prev(self) -> None:
+        ctx = get_market_context(
+            client=_client(),
+            tickers=[],
+            series_ids=["DGS10"],
+            run_date=RUN_DATE,
+        )
+        dgs10 = ctx["macro_series"]["DGS10"]
+        assert dgs10["value"] == 4.21
+        assert dgs10["prev_value"] == 4.18
+        assert dgs10["date"] == "2026-06-11"
+
+    def test_empty_inputs_yield_empty_blocks(self) -> None:
+        ctx = get_market_context(client=_client(), tickers=[], series_ids=[], run_date=RUN_DATE)
+        assert ctx["price_technicals"] == {}
+        assert ctx["macro_series"] == {}
+
+
+class TestMarketContextTickers:
+    def test_includes_core_set_and_sector_etfs(self) -> None:
+        tickers = _market_context_tickers()
+        assert "SPY" in tickers
+        assert "TLT" in tickers
+        # Sector headline ETFs come from config/sectors.yaml.
+        assert "XLK" in tickers
+        # No duplicates.
+        assert len(tickers) == len(set(tickers))
+
+
+class TestPreflightInjection:
+    def test_preflight_populates_market_context(self) -> None:
+        deps = PreflightDeps(
+            client=_client(),
+            config_loader=lambda: AtlasConfigBundle(watchlist=["SPY"], macro_series=["DGS10"]),
+        )
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=RUN_DATE)
+
+        out = node(state)
+
+        mc = out["data_layer"].market_context
+        assert mc["price_technicals"]["SPY"]["rsi_14"] == 61.2
+        assert mc["macro_series"]["DGS10"]["value"] == 4.21
+
+    def test_preflight_fails_soft_when_market_context_query_raises(self) -> None:
+        # Explode only on the per-series `.eq("series_id", …)` filter, which is
+        # unique to get_market_context's macro path — the freshness probes
+        # (no eq) must keep working.
+        class _ExplodingClient(FakeSupabaseClient):
+            def table(self, name: str):  # noqa: ANN201 — duck-typed fake
+                query = super().table(name)
+                if name == "macro_series_observations":
+
+                    def _boom(_col: str, _val: object) -> None:
+                        raise RuntimeError("boom")
+
+                    query.eq = _boom  # type: ignore[method-assign]
+                return query
+
+        deps = PreflightDeps(
+            client=_ExplodingClient(
+                canned_reads={
+                    "daily_snapshots": [],
+                    "documents": [],
+                    "price_technicals": [{"date": "2026-06-11", "ticker": "SPY"}],
+                    "macro_series_observations": [{"obs_date": "2026-06-11"}],
+                }
+            ),
+            config_loader=lambda: AtlasConfigBundle(macro_series=["DGS10"]),
+        )
+        node = build_preflight_node(deps)
+        out = node(AtlasResearchState(run_type="baseline", run_date=RUN_DATE))
+
+        # Freshness metadata survives; market_context degrades to empty.
+        assert out["data_layer"].price_technicals_latest == date(2026, 6, 11)
+        assert out["data_layer"].market_context == {}

--- a/tests/dq/atlas/test_market_context.py
+++ b/tests/dq/atlas/test_market_context.py
@@ -26,22 +26,25 @@ pytestmark = pytest.mark.unit
 RUN_DATE = date(2026, 6, 12)
 
 
+_DEFAULT_PRICE_ROWS = [
+    {"date": "2026-06-11", "ticker": "SPY", "rsi_14": 61.2, "pct_vs_sma50": 2.1},
+    {"date": "2026-06-10", "ticker": "SPY", "rsi_14": 58.0, "pct_vs_sma50": 1.7},
+    {"date": "2026-06-11", "ticker": "TLT", "rsi_14": 44.5, "pct_vs_sma50": -0.8},
+]
+_DEFAULT_MACRO_ROWS = [
+    {"series_id": "DGS10", "obs_date": "2026-06-11", "value": 4.21, "unit": "pct"},
+    {"series_id": "DGS10", "obs_date": "2026-06-10", "value": 4.18, "unit": "pct"},
+]
+
+
 def _client(price_rows=None, macro_rows=None) -> FakeSupabaseClient:
     return FakeSupabaseClient(
         canned_reads={
             "daily_snapshots": [],
             "documents": [],
-            "price_technicals": price_rows
-            or [
-                {"date": "2026-06-11", "ticker": "SPY", "rsi_14": 61.2, "pct_vs_sma50": 2.1},
-                {"date": "2026-06-10", "ticker": "SPY", "rsi_14": 58.0, "pct_vs_sma50": 1.7},
-                {"date": "2026-06-11", "ticker": "TLT", "rsi_14": 44.5, "pct_vs_sma50": -0.8},
-            ],
-            "macro_series_observations": macro_rows
-            or [
-                {"series_id": "DGS10", "obs_date": "2026-06-11", "value": 4.21, "unit": "pct"},
-                {"series_id": "DGS10", "obs_date": "2026-06-10", "value": 4.18, "unit": "pct"},
-            ],
+            # `is None` (not `or`) so tests can pass [] for no-rows scenarios.
+            "price_technicals": _DEFAULT_PRICE_ROWS if price_rows is None else price_rows,
+            "macro_series_observations": _DEFAULT_MACRO_ROWS if macro_rows is None else macro_rows,
         }
     )
 


### PR DESCRIPTION
Fixes #694

## What was broken (confirmed on the 2026-06-12 production runs)

Three defects left green runs hollow:

1. **Hermes 7C/7CD fan-out compiled with an empty watchlist on every scheduled run.** The graphs are built from `AtlasInput.watchlist`, which only the `--watchlist` CLI flag populated — the workflows never pass it. The `config/watchlist.md` fallback lived only in the Atlas config loader. Result: zero analyst documents, zero debates, PM rebalance with empty `analyst_payloads` recommending nothing. (`ATLAS_MAX_ANALYSTS=25` in CI shows the fan-out was always intended to run.)
2. **No quantitative data reached the research agents.** `DataLayerSnapshot` carried freshness metadata only; actual values were supposed to come from model-initiated data-tool calls — which never happen (run 27416738693: 29 chat calls = exactly one per node, zero tool rounds, `tool_choice="auto"`). Digests shipped "no price, spread or trend data retrieved" while `price_technicals`/`macro_series_observations` were fresh.
3. **Cost estimator miscalibrated** — grok-4 legacy token rates ($3/$15 vs grok-4.3's $1.25/$2.50) and the retired per-source Live Search price; reported $9.56 vs ~$4 billed.

## Fix

- `atlas/graph.py resolve_cli_inputs` — no `--watchlist` falls back to `config/watchlist.md`; explicit flag still overrides; empty file still disables the fan-out. One resolution point feeds the Atlas graph, Hermes graph, config loader, and run summary.
- `atlas/data/queries.py get_market_context` (new) — one bulk `price_technicals` query (latest row per core/sector ETF) + per-series latest/prev macro values (per-series to avoid daily-cadence series starving monthly ones in a newest-first bulk query).
- `atlas/phases/preflight.py` — builds `DataLayerSnapshot.market_context` (core ETF set + headline sector ETFs from `config/sectors.yaml` + configured macro series); fail-soft (warning + empty block) so a data hiccup can't kill the run. `_shared_context` already serializes `data_layer` into every phase call — no per-phase wiring needed.
- `atlas/diagnostics.py` — pricing updated to grok-4.3 list rates + agent-tools billing ($5/1k server-side invocations, ≈1.5 invocations/source observed → per_source $0.0075).
- Docs: agentic ARCHITECTURE (pre-flight protocol + watchlist resolution/cost note).

## Cost impact (heads-up)

With the fan-out restored, a delta run adds up to `ATLAS_MAX_ANALYSTS (25) × 4` analyst calls plus debate/risk rounds — expect roughly $5–15/day on grok-4.3 versus ~$4 today. Tune `ATLAS_MAX_ANALYSTS` in the workflow envs to bound spend.

## Verification

- `tests/dq/atlas` green locally (incl. 6 new market-context tests + updated CLI contract tests: fallback active, explicit flag overrides)
- `make score`: Security 10 · Quality 10 · Optimization 10 · Accuracy 10; `make doc-check` OK
- Post-merge: dispatch an atlas-delta run and confirm `analyst/{ticker}` documents land and the digest stops claiming missing price data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
