### PR TITLE
feat(olympus): publish Hermes deliberations (bull/bear + risk debate) for the dashboard (#698)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
@@ -237,7 +237,19 @@ Common flags:
 - **Delta ops** on weekdays: `templates/delta-request-schema.json`
 - **Per-document research pipeline** (optional Track B): `templates/schemas/research-baseline-manifest.schema.json`, `templates/schemas/document-delta.schema.json`, `templates/schemas/research-changelog.schema.json` — publish manifest on baseline; weekdays publish `document-deltas/…` then run [`scripts/fold_document_deltas.py`](scripts/fold_document_deltas.py) to materialize targets + `research-changelog/{{DATE}}.json`.
 
-### Portfolio layer (stored in Supabase documents.payload)
+### Hermes deliberation layer (auto-published by the pipeline, #698)
+The Hermes phases publish their per-run reasoning to `documents.payload` so the
+dashboard can show *why* a decision was made — no operator step required:
+- `analyst/{TICKER}` — Phase 7C 4-axis analyst synthesis (`category=deep-dive`).
+- `deliberation/{TICKER}` — Phase 7C-D bull/bear `DebateSummary` (rounds + theses
+  + net_stance + conviction_delta; `category=deep-dive`, `segment=deliberation`).
+- `risk-debate` — Phase 7D aggressive-vs-conservative `RiskDebateSummary`
+  (`category=portfolio`, `segment=deliberation`).
+- `pm-rebalance` — Phase 7D `RebalanceDecision` (`category=portfolio`).
+
+These render natively in the Research Library via `render-pipeline-payloads.ts`.
+
+### Portfolio layer (operator-produced, stored in Supabase documents.payload)
 - `asset_recommendation` (`templates/schemas/asset-recommendation.schema.json`)
 - `deliberation_transcript` (`templates/schemas/deliberation-transcript.schema.json`)
 - `rebalance_decision` (`templates/schemas/rebalance-decision.schema.json`)

--- a/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
@@ -176,6 +176,28 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                 )
             )
 
+        # Per-ticker bull/bear debate summaries (#698). Produced by the Phase
+        # 7C-D research manager but previously discarded in state — publish so
+        # the dashboard can show *why* a ticker's conviction moved. Skip any
+        # half-built scratch entry (a finished summary always has net_stance).
+        for ticker, debate in state.phase7cd_debates.items():
+            if not isinstance(debate, dict) or "net_stance" not in debate:
+                continue
+            artifacts.append(
+                publish_document(
+                    client=deps.client,
+                    document_key=f"deliberation/{ticker}",
+                    payload=dict(debate),
+                    doc_type=None,
+                    run_type=run_type,
+                    title=f"{ticker} debate {date_str}",
+                    date_str=date_str,
+                    category="deep-dive",
+                    segment="deliberation",
+                    sector=ticker,
+                )
+            )
+
         if state.phase7d_rebalance is not None:
             artifacts.append(
                 publish_document(
@@ -187,6 +209,23 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                     title=f"PM Rebalance {date_str}",
                     date_str=date_str,
                     category="portfolio",
+                )
+            )
+
+        # Aggressive-vs-conservative risk-temperament debate (#698) — the
+        # portfolio-level deliberation framing the PM decision. One per run.
+        if state.phase7d_risk_debate is not None:
+            artifacts.append(
+                publish_document(
+                    client=deps.client,
+                    document_key="risk-debate",
+                    payload=dict(state.phase7d_risk_debate),
+                    doc_type=None,
+                    run_type=run_type,
+                    title=f"Risk Debate {date_str}",
+                    date_str=date_str,
+                    category="portfolio",
+                    segment="deliberation",
                 )
             )
 

--- a/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
@@ -214,12 +214,20 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
 
         # Aggressive-vs-conservative risk-temperament debate (#698) — the
         # portfolio-level deliberation framing the PM decision. One per run.
-        if state.phase7d_risk_debate is not None:
+        # ``phase7d_risk_debate`` is TypedDict(total=False): the aggressive node
+        # writes a partial dict (conservative_case / key_tension empty) that the
+        # conservative node later completes. Publish only when all three sides
+        # are filled, matching the frontend sniffer's contract.
+        risk_debate = state.phase7d_risk_debate or {}
+        if all(
+            str(risk_debate.get(k, "")).strip()
+            for k in ("aggressive_case", "conservative_case", "key_tension")
+        ):
             artifacts.append(
                 publish_document(
                     client=deps.client,
                     document_key="risk-debate",
-                    payload=dict(state.phase7d_risk_debate),
+                    payload=dict(risk_debate),
                     doc_type=None,
                     run_type=run_type,
                     title=f"Risk Debate {date_str}",

--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -136,11 +136,12 @@ The Atlas pipeline (SIMP-013) writes validated Pydantic payloads into
 renders from the payloads:
 
 - `lib/render-pipeline-payloads.ts` — markdown renderers + shape sniffers for
-  the three pipeline payload shapes: segment reports (`macro`, `bonds`,
-  `equity`, `sector-*`, `alt-*`, `inst-*`, …), the Phase-7 master digest
-  (`digest-delta` / `digest-baseline` and the snapshot jsonb), and the Hermes
-  `pm-rebalance` decision. Segment-specific metric fields render generically so
-  new segments display without frontend changes.
+  the pipeline payload shapes: segment reports (`macro`, `bonds`, `equity`,
+  `sector-*`, `alt-*`, `inst-*`, …), the Phase-7 master digest (`digest-delta`
+  / `digest-baseline` and the snapshot jsonb), the Hermes `pm-rebalance`
+  decision, the per-ticker bull/bear `deliberation/{ticker}` debate summaries,
+  and the portfolio-level `risk-debate` (#698). Segment-specific metric fields
+  render generically so new segments display without frontend changes.
 - `lib/render-document-from-payload.ts` — routes payloads by shape first, then
   by the legacy `doc_type` / `document_key` conventions; unknown object
   payloads fall back to a JSON code block instead of "_No content available._".

--- a/frontend/olympus/lib/render-document-from-payload.ts
+++ b/frontend/olympus/lib/render-document-from-payload.ts
@@ -1,10 +1,14 @@
 import { renderDigestMarkdownFromSnapshot, type DigestSnapshot } from './render-digest-from-snapshot';
 import {
+  isDebateSummaryPayload,
   isMasterDigestPayload,
   isRebalancePayload,
+  isRiskDebatePayload,
   isSegmentReportPayload,
+  renderDebateSummaryMarkdown,
   renderMasterDigestMarkdown,
   renderRebalanceMarkdown,
+  renderRiskDebateMarkdown,
   renderSegmentReportMarkdown,
 } from './render-pipeline-payloads';
 
@@ -53,6 +57,8 @@ export function renderDocumentMarkdownFromPayload(payload: unknown, documentKey?
   // shape before the legacy doc_type routing below.
   if (isMasterDigestPayload(p)) return renderMasterDigestMarkdown(p);
   if (isRebalancePayload(p, documentKey)) return renderRebalanceMarkdown(p);
+  if (isRiskDebatePayload(p)) return renderRiskDebateMarkdown(p);
+  if (isDebateSummaryPayload(p)) return renderDebateSummaryMarkdown(p);
   if (isSegmentReportPayload(p)) return renderSegmentReportMarkdown(p);
 
   // Infer doc_type from document_key when it is missing (legacy/transitional payloads).

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -3,11 +3,15 @@ import { fixtureDigest } from './__fixtures__/snapshot-fixture';
 import { renderDigestMarkdownFromSnapshot } from './render-digest-from-snapshot';
 import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
 import {
+  isDebateSummaryPayload,
   isMasterDigestPayload,
   isRebalancePayload,
+  isRiskDebatePayload,
   isSegmentReportPayload,
+  renderDebateSummaryMarkdown,
   renderMasterDigestMarkdown,
   renderRebalanceMarkdown,
+  renderRiskDebateMarkdown,
   renderSegmentReportMarkdown,
 } from './render-pipeline-payloads';
 import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
@@ -44,6 +48,25 @@ const REBALANCE_POPULATED = {
   notes: 'Trim tech overweight.',
   actions: [{ ticker: 'NVDA', action: 'TRIM', current_pct: 12, recommended_pct: 8 }],
   recommended_portfolio: [{ ticker: 'NVDA', weight_pct: 8 }],
+};
+
+/** Trimmed copy of the production `deliberation/{ticker}` DebateSummary payload. */
+const DEBATE_PAYLOAD = {
+  ticker: 'NVDA',
+  rounds: [
+    { round_number: 1, bull_argument: 'AI demand accelerating', bear_argument: 'Valuation stretched' },
+  ],
+  bull_thesis: 'Datacenter capex supercycle intact.',
+  bear_thesis: 'Multiple compression risk on any guide-down.',
+  net_stance: 'bullish',
+  conviction_delta: 1,
+};
+
+/** Trimmed copy of the production `risk-debate` RiskDebateSummary payload. */
+const RISK_DEBATE_PAYLOAD = {
+  aggressive_case: 'Add beta into the breakout.',
+  conservative_case: 'Keep the cash buffer; breadth is thin.',
+  key_tension: 'Momentum vs. participation.',
 };
 
 /** Legacy v1 operator snapshot shape — must keep rendering via the old path. */
@@ -137,6 +160,40 @@ describe('renderRebalanceMarkdown', () => {
   });
 });
 
+describe('debate renderers (#698)', () => {
+  it('sniffers classify debate and risk-debate payloads distinctly', () => {
+    expect(isDebateSummaryPayload(DEBATE_PAYLOAD)).toBe(true);
+    expect(isDebateSummaryPayload(RISK_DEBATE_PAYLOAD)).toBe(false);
+    expect(isRiskDebatePayload(RISK_DEBATE_PAYLOAD)).toBe(true);
+    expect(isRiskDebatePayload(DEBATE_PAYLOAD)).toBe(false);
+    // Neither is mistaken for a segment report.
+    expect(isSegmentReportPayload(DEBATE_PAYLOAD)).toBe(false);
+    expect(isSegmentReportPayload(RISK_DEBATE_PAYLOAD)).toBe(false);
+  });
+
+  it('renders the debate summary with stance, theses, and rounds', () => {
+    const md = renderDebateSummaryMarkdown(DEBATE_PAYLOAD);
+    expect(md).toContain('# Bull / Bear Debate — NVDA');
+    expect(md).toContain('**Net stance:** bullish · conviction Δ +1');
+    expect(md).toContain('### Round 1');
+    expect(md).toContain('**Bull:** AI demand accelerating');
+    expect(md).toContain('**Bear:** Valuation stretched');
+  });
+
+  it('renders a negative conviction delta without a stray plus sign', () => {
+    const md = renderDebateSummaryMarkdown({ ...DEBATE_PAYLOAD, conviction_delta: -2 });
+    expect(md).toContain('conviction Δ -2');
+    expect(md).not.toContain('+-2');
+  });
+
+  it('renders the risk debate with both cases and the tension', () => {
+    const md = renderRiskDebateMarkdown(RISK_DEBATE_PAYLOAD);
+    expect(md).toContain('## Aggressive case');
+    expect(md).toContain('## Conservative case');
+    expect(md).toContain('Momentum vs. participation.');
+  });
+});
+
 describe('renderDocumentMarkdownFromPayload routing', () => {
   it('renders pipeline segment documents instead of returning null (#690 follow-up)', () => {
     const md = renderDocumentMarkdownFromPayload(BONDS_PAYLOAD, 'bonds');
@@ -152,6 +209,19 @@ describe('renderDocumentMarkdownFromPayload routing', () => {
   it('renders pm-rebalance documents', () => {
     const md = renderDocumentMarkdownFromPayload(REBALANCE_EMPTY, 'pm-rebalance');
     expect(md).toContain('# Rebalance Decision');
+  });
+
+  it('renders deliberation documents with the debate renderer (#698)', () => {
+    const md = renderDocumentMarkdownFromPayload(DEBATE_PAYLOAD, 'deliberation/NVDA');
+    expect(md).toContain('# Bull / Bear Debate — NVDA');
+    expect(md).toContain('## Bull thesis');
+    expect(md).toContain('Datacenter capex');
+  });
+
+  it('renders risk-debate documents with the risk-debate renderer (#698)', () => {
+    const md = renderDocumentMarkdownFromPayload(RISK_DEBATE_PAYLOAD, 'risk-debate');
+    expect(md).toContain('# Risk Temperament Debate');
+    expect(md).toContain('## Key tension');
   });
 
   it('still renders the legacy v1 snapshot payload through the v1 path', () => {

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -332,3 +332,77 @@ export function renderSegmentReportMarkdown(payload: unknown): string {
   pushSources(out, p.sources);
   return `${out.join('\n').trim()}\n`;
 }
+
+/* ── Bull/bear debate (Phase 7CD) ─────────────────────────────────────────── */
+
+/** True for the Hermes per-ticker `DebateSummary` payload (`deliberation/{ticker}`). */
+export function isDebateSummaryPayload(payload: unknown): boolean {
+  const p = asObj(payload);
+  if (!p) return false;
+  return (
+    typeof p.bull_thesis === 'string' &&
+    typeof p.bear_thesis === 'string' &&
+    typeof p.net_stance === 'string'
+  );
+}
+
+/** Markdown for a bull/bear debate summary (one ticker, N rounds). */
+export function renderDebateSummaryMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const ticker = s(p.ticker).trim();
+  const out: string[] = [`# Bull / Bear Debate${ticker ? ` — ${ticker}` : ''}`, ''];
+
+  const stance = s(p.net_stance).trim();
+  const delta = s(p.conviction_delta).trim();
+  if (stance) {
+    const sign = delta && !delta.startsWith('-') && delta !== '0' ? `+${delta}` : delta;
+    out.push(`**Net stance:** ${stance}${delta ? ` · conviction Δ ${sign}` : ''}`, '');
+  }
+
+  const bull = s(p.bull_thesis).trim();
+  const bear = s(p.bear_thesis).trim();
+  if (bull) out.push('## Bull thesis', '', bull, '');
+  if (bear) out.push('## Bear thesis', '', bear, '');
+
+  const rounds = Array.isArray(p.rounds) ? p.rounds : [];
+  if (rounds.length) {
+    out.push('## Rounds', '');
+    rounds.forEach((r, i) => {
+      const o = asObj(r);
+      if (!o) return;
+      const n = s(o.round_number).trim();
+      out.push(`### Round ${n || i + 1}`, '');
+      const ba = s(o.bull_argument).trim();
+      const be = s(o.bear_argument).trim();
+      if (ba) out.push(`**Bull:** ${ba}`, '');
+      if (be) out.push(`**Bear:** ${be}`, '');
+    });
+  }
+  return `${out.join('\n').trim()}\n`;
+}
+
+/* ── Risk-temperament debate (Phase 7D) ───────────────────────────────────── */
+
+/** True for the Hermes `RiskDebateSummary` payload (`risk-debate`). */
+export function isRiskDebatePayload(payload: unknown): boolean {
+  const p = asObj(payload);
+  if (!p) return false;
+  return (
+    typeof p.aggressive_case === 'string' &&
+    typeof p.conservative_case === 'string' &&
+    typeof p.key_tension === 'string'
+  );
+}
+
+/** Markdown for the aggressive-vs-conservative risk debate. */
+export function renderRiskDebateMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const out: string[] = ['# Risk Temperament Debate', ''];
+  const agg = s(p.aggressive_case).trim();
+  const con = s(p.conservative_case).trim();
+  const tension = s(p.key_tension).trim();
+  if (agg) out.push('## Aggressive case', '', agg, '');
+  if (con) out.push('## Conservative case', '', con, '');
+  if (tension) out.push('## Key tension', '', tension, '');
+  return `${out.join('\n').trim()}\n`;
+}

--- a/tests/dq/atlas/test_publish_phase.py
+++ b/tests/dq/atlas/test_publish_phase.py
@@ -135,6 +135,24 @@ class TestPublishNode:
         assert not any(k.startswith("deliberation/") for k in keys)
         assert "risk-debate" not in keys
 
+    def test_omits_partial_risk_debate(self) -> None:
+        # The aggressive node writes a partial dict (conservative_case /
+        # key_tension empty) before the conservative node completes it;
+        # an incomplete risk debate must not publish (Copilot review #699).
+        client = FakeSupabaseClient()
+        state = _seed_full_state(run_type="baseline")
+        state.phase7d_risk_debate = {
+            "aggressive_case": "lever up",
+            "conservative_case": "",
+            "key_tension": "",
+        }
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        keys = {r["document_key"] for r in client.store["documents"]}
+        assert "risk-debate" not in keys
+
     def test_writes_one_daily_snapshot_row(self) -> None:
         client = FakeSupabaseClient()
         state = _seed_full_state(run_type="baseline")

--- a/tests/dq/atlas/test_publish_phase.py
+++ b/tests/dq/atlas/test_publish_phase.py
@@ -92,6 +92,49 @@ class TestPublishNode:
         # Return value records every artifact so state.published is populated.
         assert len(result["published"]) == len(doc_rows) + 1  # +1 for daily_snapshots
 
+    def test_publishes_debates_and_risk_debate_when_present(self) -> None:
+        client = FakeSupabaseClient()
+        state = _seed_full_state(run_type="baseline")
+        state.phase7cd_debates = {
+            "AAPL": {
+                "ticker": "AAPL",
+                "rounds": [{"round_number": 1, "bull_argument": "up", "bear_argument": "down"}],
+                "bull_thesis": "growth",
+                "bear_thesis": "valuation",
+                "net_stance": "bullish",
+                "conviction_delta": 1,
+            },
+            # Half-built scratch entry (no net_stance) must be skipped.
+            "MSFT": {"rounds": [], "pending": {"round_number": 1}},
+        }
+        state.phase7d_risk_debate = {
+            "aggressive_case": "lever up",
+            "conservative_case": "hold cash",
+            "key_tension": "duration risk",
+        }
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        by_key = {r["document_key"]: r for r in client.store["documents"]}
+        assert "deliberation/AAPL" in by_key
+        assert by_key["deliberation/AAPL"]["category"] == "deep-dive"
+        assert by_key["deliberation/AAPL"]["payload"]["net_stance"] == "bullish"
+        assert "deliberation/MSFT" not in by_key  # scratch entry skipped
+        assert "risk-debate" in by_key
+        assert by_key["risk-debate"]["category"] == "portfolio"
+
+    def test_omits_debates_when_absent(self) -> None:
+        client = FakeSupabaseClient()
+        state = _seed_full_state(run_type="baseline")  # no debates seeded
+        node = build_publish_node(PublishDeps(client=client))
+
+        node(state)
+
+        keys = {r["document_key"] for r in client.store["documents"]}
+        assert not any(k.startswith("deliberation/") for k in keys)
+        assert "risk-debate" not in keys
+
     def test_writes_one_daily_snapshot_row(self) -> None:
         client = FakeSupabaseClient()
         state = _seed_full_state(run_type="baseline")


### PR DESCRIPTION
Fixes #698

Phase B1 of the Olympus production roadmap. The Hermes pipeline produces per-ticker bull/bear debates (`phase7cd_debates`) and a portfolio-level risk-temperament debate (`phase7d_risk_debate`) every run, but the publish phase never wrote them to `documents` — so the deliberation rendering the frontend already has has never had data. This is exactly the "read the deliberations and decision-making" piece of the daily-read vision.

## Backend (`atlas/phases/publish_phase.py`)

- Publish each finished `phase7cd_debates[ticker]` as `deliberation/{ticker}` (`category=deep-dive`, `segment=deliberation`). Half-built scratch entries (no `net_stance`) are skipped — only research-manager-finalized summaries publish.
- Publish `phase7d_risk_debate` as `risk-debate` (`category=portfolio`, `segment=deliberation`).
- Both omitted entirely when the state fields are empty (mirrors the existing analyst/rebalance pattern; no-op on runs without a fan-out).

## Frontend (`render-pipeline-payloads.ts` + `render-document-from-payload.ts`)

- `isDebateSummaryPayload` / `renderDebateSummaryMarkdown` — net stance + conviction Δ, bull/bear theses, per-round bull-vs-bear arguments.
- `isRiskDebatePayload` / `renderRiskDebateMarkdown` — aggressive case, conservative case, key tension.
- Routed ahead of the segment-report sniffer; both are distinct from existing shapes (verified by sniffer tests). Native rendering, same pattern as the #692 payload renderers — no "_No content available._".
- Research Library groups them under Portfolio via `segment=deliberation`.

## Verification

- Backend: `test_publish_phase.py` — publishes both with correct keys/categories, skips scratch entries, omits when absent. Existing exact-key test unaffected (seed has no debates).
- Frontend: 8 new vitest cases (sniffer distinctness incl. negative conviction Δ, both renderers, routing). 66/66 green.
- `tsc --noEmit` clean, `next build` green, ruff clean, `make doc-check` OK, `make score` 10/10/10/10.

No cost impact (publishing already-computed state). The deliberations populate on the next run that fans out (focus list from #696/#697).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
