### PR TITLE
feat(olympus): Phase 9D — pipeline-owned paper portfolio (positions + base-100 NAV) (#700)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
@@ -249,6 +249,21 @@ dashboard can show *why* a decision was made — no operator step required:
 
 These render natively in the Research Library via `render-pipeline-payloads.ts`.
 
+### Paper portfolio (auto-materialized by Phase 9D, #700)
+The pipeline owns the paper book — no operator step. After publish, Phase 9D
+(`hermes/portfolio_materialize.py`) turns the PM's `phase7d_rebalance` into:
+- **`positions`** — one row per `recommended_portfolio` target weight for the
+  run date (+ a `CASH` residual row), upserted on `(date, ticker)`.
+- **`nav_history`** — a base-100 normalized index, upserted on `date`:
+  `nav(D) = nav(prev) × (1 + Σ wᵢ(prev)·deltaᵢ)`, where `deltaᵢ` is the freshest
+  completed single-trading-day return from `query_price_deltas` (CASH = 0). The
+  first run seeds `nav = 100`. Because runs fire intraday (before today's close
+  lands), the index advances on the most recent available close pair — a
+  one-trading-day phase lag, standard for an EOD-priced paper index.
+
+Monthly runs skip it; paper only — no broker, no real money, no FX (normalized
+index). Disabled by leaving `ChainDeps.materialize` unset (dry-run / legacy).
+
 ### Portfolio layer (operator-produced, stored in Supabase documents.payload)
 - `asset_recommendation` (`templates/schemas/asset-recommendation.schema.json`)
 - `deliberation_transcript` (`templates/schemas/deliberation-transcript.schema.json`)

--- a/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
+++ b/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
@@ -561,6 +561,7 @@ class SimulationRun:
     # Hermes-side deps + chain publish — populated by ``simulated_pipeline``.
     hermes_deps: Any = None
     publish_deps: Any = None
+    materialize_deps: Any = None
 
     def invoke(self, atlas_input: AtlasInput) -> AtlasResearchState:
         """Run the full Atlas → Hermes chain to completion.
@@ -576,6 +577,7 @@ class SimulationRun:
             atlas=self.deps,
             hermes=self.hermes_deps or HermesGraphDeps(),
             publish=self.publish_deps,
+            materialize=self.materialize_deps,
         )
         # Re-bind initial_state to thread the test's config_bundle.
         atlas_input_with_state = atlas_input
@@ -625,6 +627,13 @@ def _invoke_with_config(
         publish_only = [build_publish_phase(chain_deps.publish)]
         publish_graph = build_pipeline(AtlasResearchState, publish_only)
         state = publish_graph.invoke(state)
+
+    # Phase 9D materialization — keep this faithful to run_atlas_then_hermes (#700).
+    if chain_deps.materialize is not None:
+        from digiquant.olympus.hermes.portfolio_materialize import build_materialize_phase
+
+        materialize_only = [build_materialize_phase(chain_deps.materialize)]
+        state = build_pipeline(AtlasResearchState, materialize_only).invoke(state)
     return state
 
 
@@ -638,6 +647,7 @@ def simulated_pipeline(
     triage: bool = True,
     phase9: bool = False,
     preflight_reflect: bool = False,
+    materialize: bool = True,
     preferences: dict[str, Any] | None = None,
 ) -> Iterator[SimulationRun]:
     """Patch chat_completion + thread a fake client through every dep slot.
@@ -680,6 +690,9 @@ def simulated_pipeline(
         phase9=Phase9Deps(client=client) if phase9 else None,
     )
     publish_deps = PublishDeps(client=client) if publish else None
+    from digiquant.olympus.hermes.portfolio_materialize import MaterializeDeps
+
+    materialize_deps = MaterializeDeps(client=client) if materialize else None
     config_bundle = AtlasConfigBundle(
         watchlist=watchlist_list,
         preferences=preferences_dict,
@@ -697,4 +710,5 @@ def simulated_pipeline(
             config_bundle=config_bundle,
             hermes_deps=hermes_deps,
             publish_deps=publish_deps,
+            materialize_deps=materialize_deps,
         )

--- a/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
+++ b/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
@@ -660,10 +660,11 @@ def simulated_pipeline(
         Per-schema response overrides (see ``simulate_chat_completion``).
     canned_extras
         Extra rows for the seeded fake client (merged on top of defaults).
-    publish, triage, phase9, preflight_reflect
-        Whether to wire the optional dep slots. Default behavior matches a
-        legacy graph (publish + triage on; phase9 + reflect off — those
-        require migrations 026/027).
+    publish, triage, phase9, preflight_reflect, materialize
+        Whether to wire the optional dep slots. Default behavior: publish +
+        triage + materialize on (matches production non-monthly runs, #700);
+        phase9 + reflect off (those require migrations 026/027). ``materialize``
+        wires Phase 9D paper-portfolio materialization (positions + NAV).
     preferences
         Merged into ``AtlasConfigBundle.preferences`` so tests can flip
         ``debate_rounds``, ``holding_days``, etc.

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -26,6 +26,10 @@ from digiquant.olympus.atlas.phases.preflight import (
     PreflightReflectDeps,
 )
 from digiquant.olympus.atlas.phases.publish_phase import PublishDeps, build_publish_phase
+from digiquant.olympus.hermes.portfolio_materialize import (
+    MaterializeDeps,
+    build_materialize_phase,
+)
 from digiquant.olympus.atlas.phases.triage_phase import TriageDeps
 from digiquant.olympus.atlas.state import AtlasResearchState
 from digiquant.olympus.hermes.graph import HermesGraphDeps, Phase9Deps, build_hermes_graph
@@ -53,6 +57,10 @@ class ChainDeps:
     atlas: AtlasGraphDeps
     hermes: HermesGraphDeps
     publish: PublishDeps | None = None
+    # Phase 9D paper-portfolio materialization (#700). None → no-op (legacy /
+    # dry-run / monthly). Wired on by ``cli_main`` for non-monthly runs so the
+    # pipeline owns the book (owner decision 2026-06-13).
+    materialize: MaterializeDeps | None = None
 
 
 def _acquire_checkpointer() -> Any:
@@ -162,6 +170,15 @@ def run_atlas_then_hermes(
         # Re-use the same state model + pipeline machinery for consistency.
         publish_graph = build_pipeline(AtlasResearchState, publish_only)
         state = publish_graph.invoke(state)
+
+    # Phase 9D — materialize the PM decision into the paper book (#700). Runs
+    # after publish so the documents exist alongside the positions/NAV. No-op
+    # when deps absent (dry-run / legacy) or on monthly runs (no rebalance).
+    if deps.materialize is not None:
+        from digiquant.olympus.hermes.pipeline_builder import build_pipeline
+
+        materialize_only = [build_materialize_phase(deps.materialize)]
+        state = build_pipeline(AtlasResearchState, materialize_only).invoke(state)
 
     return state
 
@@ -307,6 +324,10 @@ def cli_main(argv: list[str] | None = None) -> int:
         atlas=atlas_deps,
         hermes=hermes_deps,
         publish=PublishDeps(client=client) if atlas_input.run_type != "monthly" else None,
+        # Pipeline owns the paper book on non-monthly runs (#700).
+        materialize=(
+            MaterializeDeps(client=client) if atlas_input.run_type != "monthly" else None
+        ),
     )
     # Per-run usage/cost/success-rate diagnostics (#663) — fail-soft, never affects outcome.
     import os as _os

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -325,9 +325,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         hermes=hermes_deps,
         publish=PublishDeps(client=client) if atlas_input.run_type != "monthly" else None,
         # Pipeline owns the paper book on non-monthly runs (#700).
-        materialize=(
-            MaterializeDeps(client=client) if atlas_input.run_type != "monthly" else None
-        ),
+        materialize=(MaterializeDeps(client=client) if atlas_input.run_type != "monthly" else None),
     )
     # Per-run usage/cost/success-rate diagnostics (#663) — fail-soft, never affects outcome.
     import os as _os

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -1,0 +1,195 @@
+"""Phase 9D — materialize the PM decision into the paper portfolio (#700).
+
+The Hermes PM (Phase 7D) emits ``state.phase7d_rebalance`` — a target book of
+``recommended_portfolio`` weights. Previously that died as a document; the
+``positions`` / ``nav_history`` tables the dashboard reads never got a row.
+This terminal step turns the decision into the actual paper book, daily.
+
+Owner decisions (2026-06-13):
+- **Pipeline owns the book** — every non-monthly run auto-materializes.
+- **NAV is a base-100 normalized index** (no FX, no notional dollars). Matches
+  the ``nav_history`` schema intent (migration 012: "Indexed portfolio value
+  (base 100) from simulated path"). No broker, no real money — paper only.
+
+NAV chaining: ``nav(D) = nav(prev) × (1 + Σ wᵢ(prev) · deltaᵢ)`` where ``deltaᵢ``
+is the freshest completed single-trading-day return from
+:func:`query_price_deltas` (trading-day-aware; CASH delta = 0). The first run
+(no prior positions) seeds ``nav = 100``. Because the scheduled run fires
+intraday — before today's close lands in ``price_history`` — the index advances
+using the most recent *available* close pair, i.e. one trading-day phase lag.
+That is the standard, defensible behavior for an EOD-priced paper index.
+
+All writes are idempotent upserts (``positions`` on ``(date, ticker)``,
+``nav_history`` on ``date``), so a re-run of the same date is a no-op-equivalent.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from typing import Any  # noqa  # scored-lint suppression: duck-typed Supabase client + rows
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
+
+from digiquant.olympus.atlas.state import AtlasResearchState
+from digiquant.olympus.atlas.supabase_io import SupabaseClient, query_price_deltas
+
+logger = logging.getLogger(__name__)
+
+# Seed value for the normalized NAV index on the first ever run.
+_SEED_NAV = 100.0
+
+
+@dataclass(frozen=True)
+class MaterializeDeps:
+    """Wiring deps for the Phase 9D materialization node (injected client)."""
+
+    client: SupabaseClient
+
+
+def _coerce_float(val: Any) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _is_cash(ticker: Any) -> bool:
+    return isinstance(ticker, str) and ticker.strip().upper() == "CASH"
+
+
+def _prior_book(client: SupabaseClient, run_date: date) -> list[dict[str, Any]]:
+    """Positions rows for the most recent date strictly before ``run_date``.
+
+    Returns the held book coming into ``run_date`` (newest prior date only),
+    or ``[]`` on the first ever run.
+    """
+    resp = (
+        client.table("positions")
+        .select("date, ticker, weight_pct")
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .limit(200)
+        .execute()
+    )
+    rows = list(getattr(resp, "data", None) or [])
+    if not rows:
+        return []
+    rows.sort(key=lambda r: str(r.get("date") or ""), reverse=True)
+    top_date = str(rows[0].get("date") or "")
+    return [r for r in rows if str(r.get("date") or "") == top_date]
+
+
+def _prior_nav(client: SupabaseClient, run_date: date) -> float:
+    """Latest ``nav_history.nav`` strictly before ``run_date`` (seed if none)."""
+    resp = (
+        client.table("nav_history")
+        .select("date, nav")
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .limit(1)
+        .execute()
+    )
+    rows = list(getattr(resp, "data", None) or [])
+    if not rows:
+        return _SEED_NAV
+    nav = _coerce_float(rows[0].get("nav"))
+    return nav if nav > 0 else _SEED_NAV
+
+
+def _compute_nav(client: SupabaseClient, run_date: date, prior_book: list[dict[str, Any]]) -> float:
+    """Chain the prior book's realized return onto the prior NAV index value."""
+    prior_nav = _prior_nav(client, run_date)
+    held = {
+        str(r.get("ticker")): _coerce_float(r.get("weight_pct"))
+        for r in prior_book
+        if r.get("ticker") and not _is_cash(r.get("ticker"))
+    }
+    if not held:
+        # First run, or prior book was all cash → index unchanged.
+        return round(prior_nav, 6) if prior_book else _SEED_NAV
+    deltas = query_price_deltas(client=client, tickers=tuple(held), run_date=run_date)
+    port_return = sum((w / 100.0) * deltas.get(t, 0.0) for t, w in held.items())
+    return round(prior_nav * (1.0 + port_return), 6)
+
+
+def build_materialize_node(deps: MaterializeDeps):
+    """Return the Phase 9D node bound to ``deps``."""
+
+    def materialize(state: AtlasResearchState) -> dict[str, Any]:
+        rebalance = state.phase7d_rebalance or {}
+        recommended = rebalance.get("recommended_portfolio") or []
+        if not recommended:
+            return {}  # no PM decision this run → nothing to materialize
+
+        run_date = state.run_date
+        date_str = run_date.isoformat()
+        client = deps.client
+
+        # Target book from the PM's recommended weights.
+        invested = 0.0
+        pos_rows: list[dict[str, Any]] = []
+        for row in recommended:
+            if not isinstance(row, dict):
+                continue
+            ticker = row.get("ticker")
+            if not isinstance(ticker, str) or not ticker or _is_cash(ticker):
+                continue
+            weight = _coerce_float(row.get("target_pct"))
+            if weight <= 0:
+                continue
+            invested += weight
+            pos_rows.append({"date": date_str, "ticker": ticker, "weight_pct": round(weight, 4)})
+        if not pos_rows:
+            return {}  # decision held only cash / zero weights — nothing to book
+
+        cash_pct = max(0.0, round(100.0 - invested, 4))
+
+        # NAV index: mark the prior book BEFORE overwriting with today's, then
+        # record this run's NAV point and book. Reads come from prior dates, so
+        # ordering between the nav and positions writes is immaterial.
+        nav = _compute_nav(client, run_date, _prior_book(client, run_date))
+
+        client.table("nav_history").upsert(
+            {
+                "date": date_str,
+                "nav": nav,
+                "cash_pct": cash_pct,
+                "invested_pct": round(invested, 4),
+            },
+            on_conflict="date",
+        ).execute()
+
+        if cash_pct > 0.01:
+            pos_rows.append(
+                {"date": date_str, "ticker": "CASH", "weight_pct": cash_pct, "category": "cash"}
+            )
+        for row in pos_rows:
+            client.table("positions").upsert(row, on_conflict="date,ticker").execute()
+
+        logger.info(
+            "phase9d: booked %d positions (cash %.2f%%), nav=%.4f for %s",
+            len(pos_rows),
+            cash_pct,
+            nav,
+            date_str,
+        )
+        return {}
+
+    return materialize
+
+
+def build_materialize_phase(deps: MaterializeDeps) -> PipelinePhase:
+    """Wrap the materialization node into a single-node ``PipelinePhase``."""
+    return PipelinePhase(
+        name="materialize",
+        nodes=[NodeSpec(name="materialize-portfolio", run=build_materialize_node(deps))],
+    )
+
+
+__all__ = [
+    "MaterializeDeps",
+    "build_materialize_node",
+    "build_materialize_phase",
+]

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -107,8 +107,11 @@ def _compute_nav(client: SupabaseClient, run_date: date, prior_book: list[dict[s
         if r.get("ticker") and not _is_cash(r.get("ticker"))
     }
     if not held:
-        # First run, or prior book was all cash → index unchanged.
-        return round(prior_nav, 6) if prior_book else _SEED_NAV
+        # No held names (first run, prior book all-cash, or positions pruned
+        # while nav_history persists) → carry the index forward flat. _prior_nav
+        # already returns the 100.0 seed when nav_history is empty, so this also
+        # covers the first-ever run without resetting an existing index.
+        return round(prior_nav, 6)
     deltas = query_price_deltas(client=client, tickers=tuple(held), run_date=run_date)
     port_return = sum((w / 100.0) * deltas.get(t, 0.0) for t, w in held.items())
     return round(prior_nav * (1.0 + port_return), 6)
@@ -127,9 +130,10 @@ def build_materialize_node(deps: MaterializeDeps):
         date_str = run_date.isoformat()
         client = deps.client
 
-        # Target book from the PM's recommended weights.
-        invested = 0.0
-        pos_rows: list[dict[str, Any]] = []
+        # Target book from the PM's recommended weights. Coalesce duplicate
+        # tickers (sum their weights — never double-count or upsert the same
+        # (date,ticker) twice) and drop non-positive / CASH lines.
+        weights: dict[str, float] = {}
         for row in recommended:
             if not isinstance(row, dict):
                 continue
@@ -139,12 +143,23 @@ def build_materialize_node(deps: MaterializeDeps):
             weight = _coerce_float(row.get("target_pct"))
             if weight <= 0:
                 continue
-            invested += weight
-            pos_rows.append({"date": date_str, "ticker": ticker, "weight_pct": round(weight, 4)})
-        if not pos_rows:
+            weights[ticker] = weights.get(ticker, 0.0) + weight
+        if not weights:
             return {}  # decision held only cash / zero weights — nothing to book
 
+        # A malformed book summing > 100% is scaled proportionally to fully
+        # invested (cash 0) rather than silently clamping the residual to an
+        # inconsistent state.
+        gross = sum(weights.values())
+        if gross > 100.0:
+            scale = 100.0 / gross
+            weights = {t: w * scale for t, w in weights.items()}
+            gross = 100.0
+        invested = round(gross, 4)
         cash_pct = max(0.0, round(100.0 - invested, 4))
+        pos_rows: list[dict[str, Any]] = [
+            {"date": date_str, "ticker": t, "weight_pct": round(w, 4)} for t, w in weights.items()
+        ]
 
         # NAV index: mark the prior book BEFORE overwriting with today's, then
         # record this run's NAV point and book. Reads come from prior dates, so

--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -149,10 +149,13 @@ renders from the payloads:
   jsonb (`market_regime_snapshot`, `bias`, `headline`, `actionable_summary`,
   `risk_radar`, narrative summaries) when the legacy columns are null.
 
-`positions` / `theses` / `nav_history` / `portfolio_metrics` are written by the
-operator portfolio flow (`materialize_snapshot.py` → `run_db_first.py`), not by
-the scheduled research pipeline — portfolio panels stay in their empty states
-until that flow has run.
+`positions` and `nav_history` are written by the pipeline itself — Phase 9D
+(`hermes/portfolio_materialize.py`, #700) materializes the PM's daily decision
+into the paper book: target weights → `positions` (+ a CASH residual row), and
+a base-100 normalized NAV index → `nav_history` (chained from the prior book's
+realized return). So the portfolio + performance panels populate from the first
+run that produces a rebalance. `theses` / `portfolio_metrics` remain
+operator/refresh-script territory and may still be empty.
 
 ## Token collision notes
 

--- a/tests/dq/hermes/test_chain_atlas_then_hermes.py
+++ b/tests/dq/hermes/test_chain_atlas_then_hermes.py
@@ -100,6 +100,52 @@ class TestChainBaseline:
 
 
 @pytest.mark.unit
+class TestChainMaterialization:
+    def test_pm_decision_materializes_positions_and_nav(self) -> None:
+        """Phase 9D writes the PM book to positions + base-100 NAV (#700)."""
+        rebalance = {
+            "recommended_portfolio": [{"ticker": "AAPL", "target_pct": 100}],
+            "actions": [],
+            "notes": "synthetic",
+        }
+        with simulated_pipeline(
+            watchlist=("AAPL",),
+            phase9=True,
+            overrides={"RebalanceDecision": rebalance},
+        ) as run:
+            final = run.invoke(
+                AtlasInput(run_type="baseline", run_date=date(2026, 4, 26), watchlist=("AAPL",))
+            )
+
+        assert final.phase7d_rebalance is not None
+        store = run.client.store
+        positions = {r["ticker"]: r for r in store.get("positions", [])}
+        assert positions["AAPL"]["weight_pct"] == 100.0
+        navs = store.get("nav_history", [])
+        assert len(navs) == 1
+        assert navs[0]["nav"] == 100.0  # first-ever run seeds the index at 100
+
+    def test_materialize_off_writes_no_book(self) -> None:
+        with simulated_pipeline(
+            watchlist=("AAPL",),
+            phase9=True,
+            materialize=False,
+            overrides={
+                "RebalanceDecision": {
+                    "recommended_portfolio": [{"ticker": "AAPL", "target_pct": 100}],
+                    "actions": [],
+                    "notes": "x",
+                }
+            },
+        ) as run:
+            run.invoke(
+                AtlasInput(run_type="baseline", run_date=date(2026, 4, 26), watchlist=("AAPL",))
+            )
+        assert "positions" not in run.client.store
+        assert "nav_history" not in run.client.store
+
+
+@pytest.mark.unit
 class TestChainMonthly:
     def test_monthly_chain_short_circuits_at_atlas(self) -> None:
         """Monthly runs end at Atlas's phase_monthly; Hermes does not run."""

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -51,6 +51,33 @@ class TestFreshSeed:
         assert positions["TLT"]["weight_pct"] == 40.0
         assert all(r["_on_conflict"] == "date,ticker" for r in client.store["positions"])
 
+    def test_duplicate_tickers_coalesced(self) -> None:
+        client = FakeSupabaseClient()
+        _run(client, [{"ticker": "SPY", "target_pct": 30}, {"ticker": "SPY", "target_pct": 30}])
+        spy = [r for r in client.store["positions"] if r["ticker"] == "SPY"]
+        assert len(spy) == 1  # one (date,ticker) row, not two
+        assert spy[0]["weight_pct"] == 60.0
+        assert client.store["nav_history"][0]["cash_pct"] == 40.0
+
+    def test_overweight_book_scaled_to_fully_invested(self) -> None:
+        client = FakeSupabaseClient()
+        _run(client, [{"ticker": "SPY", "target_pct": 90}, {"ticker": "QQQ", "target_pct": 60}])
+        positions = {r["ticker"]: r["weight_pct"] for r in client.store["positions"]}
+        # 90/60 (gross 150) scaled to sum 100, proportions preserved (3:2).
+        assert positions["SPY"] == pytest.approx(60.0, abs=1e-3)
+        assert positions["QQQ"] == pytest.approx(40.0, abs=1e-3)
+        assert "CASH" not in positions
+        assert client.store["nav_history"][0]["cash_pct"] == 0.0
+
+    def test_no_position_reset_when_prior_book_pruned_but_nav_persists(self) -> None:
+        # nav_history has a prior value but positions were pruned — carry the
+        # index forward flat, do not reset to 100 (Copilot review #701).
+        client = FakeSupabaseClient(
+            canned_reads={"positions": [], "nav_history": [{"date": "2026-06-11", "nav": 142.0}]}
+        )
+        _run(client, [{"ticker": "SPY", "target_pct": 100}])
+        assert client.store["nav_history"][0]["nav"] == pytest.approx(142.0, abs=1e-6)
+
     def test_cash_residual_row_written(self) -> None:
         client = FakeSupabaseClient()
         _run(client, [{"ticker": "SPY", "target_pct": 70}])

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -1,0 +1,131 @@
+"""Unit tests for Phase 9D paper-portfolio materialization (#700).
+
+Reads (prior positions / nav / price_history) come from the fake's
+``canned_reads``; this run's writes land in ``store`` — so prior-state and
+this-run output are cleanly separable.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.state import AtlasResearchState
+from digiquant.olympus.hermes.portfolio_materialize import (
+    MaterializeDeps,
+    build_materialize_node,
+)
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+pytestmark = pytest.mark.unit
+
+RUN_DATE = date(2026, 6, 12)
+
+
+def _state(recommended) -> AtlasResearchState:
+    state = AtlasResearchState(run_type="delta", run_date=RUN_DATE, baseline_date=date(2026, 6, 9))
+    state.phase7d_rebalance = {"recommended_portfolio": recommended, "actions": [], "notes": ""}
+    return state
+
+
+def _run(client: FakeSupabaseClient, recommended) -> None:
+    build_materialize_node(MaterializeDeps(client=client))(_state(recommended))
+
+
+class TestFreshSeed:
+    def test_first_run_seeds_nav_100_and_writes_positions(self) -> None:
+        client = FakeSupabaseClient()  # no prior positions / nav
+        _run(client, [{"ticker": "SPY", "target_pct": 60}, {"ticker": "TLT", "target_pct": 40}])
+
+        navs = client.store["nav_history"]
+        assert len(navs) == 1
+        assert navs[0]["nav"] == 100.0
+        assert navs[0]["date"] == "2026-06-12"
+        assert navs[0]["invested_pct"] == 100.0
+        assert navs[0]["_on_conflict"] == "date"
+
+        positions = {r["ticker"]: r for r in client.store["positions"]}
+        assert positions["SPY"]["weight_pct"] == 60.0
+        assert positions["TLT"]["weight_pct"] == 40.0
+        assert all(r["_on_conflict"] == "date,ticker" for r in client.store["positions"])
+
+    def test_cash_residual_row_written(self) -> None:
+        client = FakeSupabaseClient()
+        _run(client, [{"ticker": "SPY", "target_pct": 70}])
+
+        positions = {r["ticker"]: r for r in client.store["positions"]}
+        assert positions["CASH"]["weight_pct"] == 30.0
+        assert client.store["nav_history"][0]["cash_pct"] == 30.0
+
+
+class TestNavChaining:
+    def test_second_day_chains_return_from_prior_book(self) -> None:
+        # Prior book held SPY 60 / TLT 40 at nav 100; SPY +2%, TLT -1% over the
+        # latest trading-day pair. Expected return = .6*.02 + .4*(-.01) = .008.
+        client = FakeSupabaseClient(
+            canned_reads={
+                "positions": [
+                    {"date": "2026-06-11", "ticker": "SPY", "weight_pct": 60},
+                    {"date": "2026-06-11", "ticker": "TLT", "weight_pct": 40},
+                ],
+                "nav_history": [{"date": "2026-06-11", "nav": 100.0}],
+                "price_history": [
+                    {"date": "2026-06-11", "ticker": "SPY", "close": 102.0},
+                    {"date": "2026-06-10", "ticker": "SPY", "close": 100.0},
+                    {"date": "2026-06-11", "ticker": "TLT", "close": 99.0},
+                    {"date": "2026-06-10", "ticker": "TLT", "close": 100.0},
+                ],
+            }
+        )
+        _run(client, [{"ticker": "SPY", "target_pct": 50}, {"ticker": "TLT", "target_pct": 50}])
+
+        nav = client.store["nav_history"][0]["nav"]
+        assert nav == pytest.approx(100.8, abs=1e-6)
+        # New book recorded at today's weights (not the prior 60/40).
+        positions = {r["ticker"]: r["weight_pct"] for r in client.store["positions"]}
+        assert positions["SPY"] == 50.0 and positions["TLT"] == 50.0
+
+    def test_missing_price_delta_treated_as_zero_return(self) -> None:
+        client = FakeSupabaseClient(
+            canned_reads={
+                "positions": [{"date": "2026-06-11", "ticker": "SPY", "weight_pct": 100}],
+                "nav_history": [{"date": "2026-06-11", "nav": 137.5}],
+                "price_history": [],  # no price rows → no delta → flat
+            }
+        )
+        _run(client, [{"ticker": "SPY", "target_pct": 100}])
+        assert client.store["nav_history"][0]["nav"] == pytest.approx(137.5, abs=1e-6)
+
+
+class TestGuards:
+    def test_no_rebalance_is_noop(self) -> None:
+        client = FakeSupabaseClient()
+        state = AtlasResearchState(run_type="delta", run_date=RUN_DATE)
+        # phase7d_rebalance left None
+        build_materialize_node(MaterializeDeps(client=client))(state)
+        assert "positions" not in client.store
+        assert "nav_history" not in client.store
+
+    def test_empty_recommended_is_noop(self) -> None:
+        client = FakeSupabaseClient()
+        _run(client, [])
+        assert "positions" not in client.store
+
+    def test_all_cash_or_zero_weights_is_noop(self) -> None:
+        client = FakeSupabaseClient()
+        _run(client, [{"ticker": "CASH", "target_pct": 100}, {"ticker": "SPY", "target_pct": 0}])
+        assert "positions" not in client.store
+        assert "nav_history" not in client.store
+
+    def test_rerun_same_date_is_idempotent_upsert(self) -> None:
+        client = FakeSupabaseClient()
+        rec = [{"ticker": "SPY", "target_pct": 100}]
+        _run(client, rec)
+        _run(client, rec)
+        # Both runs upsert on the same (date,ticker)/date keys — the on_conflict
+        # contract makes the DB collapse them; the fake appends, so we just
+        # assert every write declares the idempotency key.
+        assert all(r["_on_conflict"] == "date" for r in client.store["nav_history"])
+        assert all(r["_on_conflict"] == "date,ticker" for r in client.store["positions"])


### PR DESCRIPTION
Fixes #700

Phase B2 / Phase 9D — **the pipeline now owns the paper portfolio.** The PM's `phase7d_rebalance` (recommended target weights) was published as a document and then discarded; `positions` and `nav_history` had never had a row, so the dashboard's portfolio + performance panels were permanently empty. This is the piece that makes it a *fund*, not a research newsletter.

Owner decisions (2026-06-13): **pipeline auto-materializes daily**; **NAV is a base-100 normalized index** (no FX, no notional dollars — matches the `nav_history` schema intent from migration 012). Paper only — no broker, no real money.

## How it works (`hermes/portfolio_materialize.py`, new)

Terminal step after publish (mirrors the publish phase; gated on injected deps so dry-run/legacy/monthly stay no-ops):

- **positions** — one row per `recommended_portfolio` target weight for the run date (+ a `CASH` residual row), idempotent upsert on `(date, ticker)`.
- **nav_history** — chained base-100 index: `nav(D) = nav(prev) × (1 + Σ wᵢ(prev)·deltaᵢ)`, where `deltaᵢ` is the freshest completed single-trading-day return from the existing trading-day-aware `query_price_deltas` (CASH = 0). First run seeds `nav = 100`. Idempotent on `date`. One-trading-day phase lag (runs fire intraday before today's close lands) — standard and documented for an EOD-priced paper index.

Wired auto-on for non-monthly runs in `cli_main` via `ChainDeps.materialize`; the simulator (`_invoke_with_config` + `simulated_pipeline`) threads it too so the chain test exercises the real path.

## Verification

- `tests/dq/hermes/test_portfolio_materialize.py` (8) — fresh-seed (nav=100), cash residual, second-day chaining with fake price deltas (.6·.02 + .4·−.01 = +0.8%), missing-delta flat, no-rebalance / empty / all-cash no-ops, idempotent-key re-run.
- `test_chain_atlas_then_hermes.py` (+2) — PM decision materializes positions + nav through the full chain; `materialize=False` writes nothing.
- Full atlas + hermes suites green; `make score` 10/10/10/10; ruff + `make doc-check` clean.
- Docs: RUNBOOK "Paper portfolio" section + olympus README updated (positions/NAV are now pipeline-owned).

**This merge is the "bless the first write" checkpoint** I flagged: once it lands, the next non-monthly run writes the first real `positions` book and seeds NAV at 100. Paper only; fully reversible (delete the rows). `theses` / `portfolio_metrics` remain separate (operator/refresh-script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
