### PR TITLE
feat(olympus): Morning Read — reshape Overview into a daily decision document (#702)

### DIFF
--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -110,6 +110,33 @@ present at build time the real ids are fetched from the `theses` table; without 
 only the `_unlinked` fallback is exported. Theses created after a deploy 404 on
 direct load until the next deploy.
 
+## Morning Read (Overview)
+
+`app/page.tsx` is the daily decision document — top to bottom it reads
+regime → KPIs → what to do → why → where to read more. The panels under
+`components/overview/` wire data that the dashboard query already loads:
+
+- **Today's Actions** (`today-actions-panel.tsx`) — `portfolio_management.rebalance_actions`
+  (computed in `queries.ts`, surfaced from #702). EXIT→OPEN→TRIM→ADD→HOLD sort;
+  HOLDs collapse; explicit "no changes proposed" state.
+- **Morning Brief** (`morning-brief-panel.tsx`) — the digest, tabbed
+  (Market / Equities / Risk / Actions). Shares the snapshot fetch via the
+  exported `useLatestSnapshot()` hook and reuses the snapshot panel's section
+  renderers; it replaces the single long scroll on the Overview.
+- **Deliberations** (`deliberations-strip.tsx`) — bull/bear `DebateSummary`
+  cards from `pipeline_observability.deliberation_transcripts` (#699 publishes
+  them; full payloads are already in context). Expand-in-place via
+  `renderDebateSummaryMarkdown`. Renders null when no deliberations ran.
+- **Decision Trail** (`decision-trail-panel.tsx`) — navigable rows into the
+  day's artifacts (deliberations, PM memo, digest); honest empty state.
+- **AsOfBadge** (`as-of-badge.tsx`) — freshness pill in the hero; amber when the
+  run date is older than yesterday (UTC).
+
+> **Sharing:** the static export embeds the Supabase anon key and every table
+> has `anon` RLS `USING (true)`, so the dashboard URL is world-readable. Do not
+> share it until the auth gate (Cloudflare Access) + column scrub land in the
+> separate human-gated auth PR.
+
 ## Daily snapshot envelope
 
 The Overview page renders a typed `SnapshotEnvelope` panel above the KPI strip

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -283,7 +283,12 @@ export default function OverviewPage() {
 
   // Morning-read data surfaces (#702) — all already in the dashboard payload.
   const pipe = data.pipeline_observability;
-  const deliberations = pipe?.deliberation_transcripts ?? [];
+  // Only bull/bear debate docs (have net_stance) — analyst-only / other
+  // bundled docs must not inflate the deliberation count or surface a trail
+  // row the strip would render null for.
+  const deliberations = (pipe?.deliberation_transcripts ?? []).filter(
+    (d) => d?.payload && typeof d.payload.net_stance === 'string'
+  );
   const hasPmMemo = pipe?.pm_allocation_memo != null;
   const rebalanceActions = data.portfolio_management?.rebalance_actions ?? [];
 

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -11,11 +11,8 @@ import {
   DollarSign,
   PieChart,
   Activity,
-  AlertTriangle,
-  ArrowUpRight,
   Target,
   Shield,
-  Zap,
   Minus,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -27,7 +24,11 @@ import {
   YAxis,
 } from 'recharts';
 import TopAssetsPulse from '@/components/overview/top-assets-pulse';
-import { DailySnapshotPanel } from '@/components/overview/daily-snapshot-panel';
+import { MorningBriefPanel } from '@/components/overview/morning-brief-panel';
+import { TodayActionsPanel } from '@/components/overview/today-actions-panel';
+import { DeliberationsStrip } from '@/components/overview/deliberations-strip';
+import { DecisionTrailPanel } from '@/components/overview/decision-trail-panel';
+import { AsOfBadge } from '@/components/overview/as-of-badge';
 import AtlasLoader from '@/components/AtlasLoader';
 import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
 
@@ -277,16 +278,14 @@ export default function OverviewPage() {
   const latestDate = portfolio.meta.last_updated || null;
   const latestRunDocs = latestDate ? docs.filter((d) => d.date === latestDate) : [];
   const latestRunDocByKey = new Map(latestRunDocs.map((d) => [d.path, d]));
-  const researchQuickLinks = [{ label: 'Digest', docKey: 'digest' }].filter(
-    (x) => latestRunDocByKey.has(x.docKey)
-  );
-  const pmQuickLinks = [
-    { label: 'Deliberation', keys: ['deliberation.md', 'deliberation.json'] as const },
-    { label: 'Rebalance', keys: ['rebalance-decision.json'] as const },
-  ].flatMap((c) => {
-    const docKey = c.keys.find((k) => latestRunDocByKey.has(k));
-    return docKey ? [{ label: c.label, docKey }] : [];
-  });
+  const hasDigest = latestRunDocByKey.has('digest');
+  const runTypeLabel = portfolio.meta.latest_snapshot_run_type ?? null;
+
+  // Morning-read data surfaces (#702) — all already in the dashboard payload.
+  const pipe = data.pipeline_observability;
+  const deliberations = pipe?.deliberation_transcripts ?? [];
+  const hasPmMemo = pipe?.pm_allocation_memo != null;
+  const rebalanceActions = data.portfolio_management?.rebalance_actions ?? [];
 
   // NAV sparkline — last N points for the P&L stat card
   const navSnaps = portfolio.snapshots ?? [];
@@ -329,23 +328,22 @@ export default function OverviewPage() {
               </span>
             </div>
             <div className="flex items-center gap-2 flex-wrap">
-              {latestDate && (
-                <span className="text-[10px] text-text-muted font-mono">
-                  as of {latestDate}
-                </span>
+              <AsOfBadge date={latestDate} />
+              {runTypeLabel && (
+                <Badge variant="default" className="uppercase tracking-wider">
+                  {runTypeLabel}
+                </Badge>
               )}
-              <Badge variant={regimeBadgeVariant}>
-                Next review: {strategy.next_review}
-              </Badge>
+              <Badge variant={regimeBadgeVariant}>{regimeLabel}</Badge>
             </div>
           </div>
 
           {/* Regime name */}
-          <h2 className={`text-3xl sm:text-4xl font-black tracking-tight mb-3 ${regimeLabelColor}`}>
+          <h2 className={`text-3xl sm:text-4xl font-black tracking-tight mb-2 ${regimeLabelColor}`}>
             {strategy.regime}
           </h2>
 
-          {/* Summary */}
+          {/* Digest headline — the one-line "what matters now" */}
           <p className="text-text-secondary leading-relaxed text-sm sm:text-base max-w-3xl">
             {strategy.summary}
           </p>
@@ -366,9 +364,6 @@ export default function OverviewPage() {
           )}
         </div>
       </div>
-
-      {/* ── Daily snapshot envelope (live read from daily_snapshots) ───────── */}
-      <DailySnapshotPanel />
 
       {/* ── KPI Stat Strip ─────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -419,8 +414,11 @@ export default function OverviewPage() {
         />
       </div>
 
-      {/* ── Top assets (quick up/down) ─────────────────────────────────────── */}
-      {hasTopAssets && <TopAssetsPulse benchmarks={data.benchmarks ?? {}} />}
+      {/* ── Today's Actions — the decision spine ───────────────────────────── */}
+      <TodayActionsPanel actions={rebalanceActions} />
+
+      {/* ── Morning Brief — the digest, tabbed for a scannable read ────────── */}
+      <MorningBriefPanel />
 
       {benchmarkBlurb && (
         <div className="glass-card px-5 py-3.5 border border-border-subtle/90">
@@ -444,11 +442,11 @@ export default function OverviewPage() {
         </div>
       )}
 
-      {/* ── Main Grid: Positions | Actions+Risk ───────────────────────────── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+      {/* ── Positions | Market pulse ───────────────────────────────────────── */}
+      <div className={`grid grid-cols-1 gap-5 ${hasTopAssets ? 'lg:grid-cols-2' : ''}`}>
 
         {/* Left: Positions table */}
-        <div className="glass-card p-0 overflow-hidden lg:col-span-1">
+        <div className="glass-card p-0 overflow-hidden">
           <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Target size={15} className="text-fin-blue" />
@@ -492,7 +490,7 @@ export default function OverviewPage() {
             ))}
             {positions.length === 0 && (
               <p className="text-center py-10 text-text-muted text-sm">
-                No active positions
+                No active positions yet — they appear after the first rebalance run.
               </p>
             )}
             {positions.length > 10 && (
@@ -508,56 +506,20 @@ export default function OverviewPage() {
           </div>
         </div>
 
-        {/* Center: Actionable + Risk + Quick Links */}
-        <div className="lg:col-span-1 flex flex-col gap-4">
-
-          {/* (Removed) Latest run quick links block */}
-
-          {/* Actionable summary */}
-          <div className="glass-card p-5 flex-1">
-            <div className="flex items-center gap-2 mb-3">
-              <Zap size={14} className="text-fin-green shrink-0" />
-              <h3 className="text-sm font-semibold">Actionable</h3>
-            </div>
-            <ul className="space-y-2.5">
-              {strategy.actionable?.length > 0 ? (
-                strategy.actionable.map((a, i) => (
-                  <li key={i} className="flex items-start gap-2.5 text-sm text-text-secondary">
-                    <span className="mt-1 shrink-0 w-4 h-4 rounded-full bg-fin-green/15 border border-fin-green/30 flex items-center justify-center">
-                      <ArrowUpRight size={9} className="text-fin-green" />
-                    </span>
-                    {a}
-                  </li>
-                ))
-              ) : (
-                <li className="text-text-muted text-sm">No actionable items.</li>
-              )}
-            </ul>
-          </div>
-
-          {/* Risk radar */}
-          <div className="glass-card p-5 bg-gradient-to-b from-fin-red/[0.04] to-transparent">
-            <div className="flex items-center gap-2 mb-3">
-              <AlertTriangle size={14} className="text-fin-red shrink-0" />
-              <h3 className="text-sm font-semibold">Risk radar</h3>
-            </div>
-            <ul className="space-y-2.5">
-              {strategy.risks?.length > 0 ? (
-                strategy.risks.map((r, i) => (
-                  <li key={i} className="flex items-start gap-2.5 text-sm">
-                    <span className="mt-1 shrink-0 w-4 h-4 rounded-full bg-fin-red/15 border border-fin-red/30 flex items-center justify-center">
-                      <AlertTriangle size={8} className="text-fin-red" />
-                    </span>
-                    <span className="text-red-300/90">{r}</span>
-                  </li>
-                ))
-              ) : (
-                <li className="text-text-muted text-sm">No immediate risks flagged.</li>
-              )}
-            </ul>
-          </div>
-        </div>
+        {/* Right: market pulse (benchmark up/down) */}
+        {hasTopAssets && <TopAssetsPulse benchmarks={data.benchmarks ?? {}} />}
       </div>
+
+      {/* ── Deliberations — the "why" behind conviction moves ──────────────── */}
+      <DeliberationsStrip transcripts={deliberations} />
+
+      {/* ── Decision trail — read path into the day's artifacts ────────────── */}
+      <DecisionTrailPanel
+        latestDate={latestDate}
+        deliberations={deliberations}
+        hasPmMemo={hasPmMemo}
+        hasDigest={hasDigest}
+      />
 
       {/* ── Thesis Table ───────────────────────────────────────────────────── */}
       {strategy.theses?.length > 0 && (

--- a/frontend/olympus/components/overview/as-of-badge.test.tsx
+++ b/frontend/olympus/components/overview/as-of-badge.test.tsx
@@ -1,0 +1,32 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { AsOfBadge } from './as-of-badge';
+
+const NOW = new Date('2026-06-13T12:00:00Z');
+
+function render(date: string | null): string {
+  return renderToStaticMarkup(createElement(AsOfBadge, { date, now: NOW }));
+}
+
+describe('AsOfBadge', () => {
+  it('renders nothing without a date', () => {
+    expect(render(null)).toBe('');
+  });
+
+  it('shows a fresh "as of" pill for today (no stale marker)', () => {
+    const html = render('2026-06-13');
+    expect(html).toContain('as of Jun 13');
+    expect(html).not.toContain('stale');
+  });
+
+  it('treats yesterday as still fresh', () => {
+    expect(render('2026-06-12')).not.toContain('stale');
+  });
+
+  it('marks dates older than yesterday as stale', () => {
+    const html = render('2026-06-09');
+    expect(html).toContain('stale');
+    expect(html).toContain('as of Jun 9');
+  });
+});

--- a/frontend/olympus/components/overview/as-of-badge.tsx
+++ b/frontend/olympus/components/overview/as-of-badge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Badge } from '@/components/ui';
+
+/**
+ * Glanceable freshness pill for the regime hero. Amber when the run date is
+ * older than yesterday (UTC) — the same "today or yesterday is fresh" window
+ * the snapshot fetch uses — so the owner can tell at a glance whether the
+ * morning read reflects a current run. Self-contained: derives staleness from
+ * the date alone (no envelope timestamp needed).
+ */
+export function AsOfBadge({ date, now }: { date: string | null; now?: Date }) {
+  if (!date) return null;
+  const ref = now ?? new Date();
+  const yesterday = new Date(ref);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  const yIso = yesterday.toISOString().slice(0, 10);
+  const stale = date < yIso;
+
+  const label = `as of ${formatAsOf(date)}`;
+  if (stale) {
+    return (
+      <Badge variant="amber" className="font-mono">
+        {label} · stale
+      </Badge>
+    );
+  }
+  return (
+    <span className="font-mono text-[10px] text-text-muted tracking-wide">{label}</span>
+  );
+}
+
+/** "2026-06-13" → "Jun 13". Falls back to the raw string on a parse miss. */
+function formatAsOf(date: string): string {
+  const m = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return date;
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  const mi = Number(m[2]) - 1;
+  if (mi < 0 || mi > 11) return date;
+  return `${months[mi]} ${Number(m[3])}`;
+}

--- a/frontend/olympus/components/overview/daily-snapshot-panel.tsx
+++ b/frontend/olympus/components/overview/daily-snapshot-panel.tsx
@@ -17,7 +17,7 @@ import {
   isStale,
 } from '@/lib/snapshot-staleness';
 
-const BIAS_VARIANT: Record<SnapshotBias, 'green' | 'red' | 'amber' | 'blue' | 'default'> = {
+export const BIAS_VARIANT: Record<SnapshotBias, 'green' | 'red' | 'amber' | 'blue' | 'default'> = {
   strong_bullish: 'green',
   bullish: 'green',
   neutral: 'blue',
@@ -26,28 +26,19 @@ const BIAS_VARIANT: Record<SnapshotBias, 'green' | 'red' | 'amber' | 'blue' | 'd
   mixed: 'amber',
 };
 
-function biasLabel(bias: SnapshotBias): string {
+export function biasLabel(bias: SnapshotBias): string {
   return bias.replace(/_/g, ' ');
 }
 
-export interface DailySnapshotPanelProps {
-  /** Inject a fetch result for tests (skips network). */
-  fetchResult?: SnapshotFetchResult;
-  /** Override "now" for staleness checks (tests). */
-  now?: Date;
-}
-
-export function DailySnapshotPanel({ fetchResult, now }: DailySnapshotPanelProps) {
-  // Tests inject `fetchResult` directly — render synchronously without an
-  // effect. Production renders defer to `<DailySnapshotPanelLive />`, which
-  // owns the network fetch in an effect.
-  if (fetchResult) {
-    return <RenderResult result={fetchResult} now={now} />;
-  }
-  return <DailySnapshotPanelLive now={now} />;
-}
-
-function DailySnapshotPanelLive({ now }: { now?: Date }) {
+/**
+ * Fetch the latest snapshot envelope in an effect, with a refetch handle.
+ * Extracted so the Morning Brief (tabbed view) can share the exact same
+ * network path as the standalone panel without duplicating the effect.
+ */
+export function useLatestSnapshot(): {
+  result: SnapshotFetchResult | null;
+  refetch: () => void;
+} {
   const [reloadTick, setReloadTick] = useState(0);
   const [result, setResult] = useState<SnapshotFetchResult | null>(null);
 
@@ -74,6 +65,28 @@ function DailySnapshotPanelLive({ now }: { now?: Date }) {
     };
   }, [reloadTick]);
 
+  return { result, refetch };
+}
+
+export interface DailySnapshotPanelProps {
+  /** Inject a fetch result for tests (skips network). */
+  fetchResult?: SnapshotFetchResult;
+  /** Override "now" for staleness checks (tests). */
+  now?: Date;
+}
+
+export function DailySnapshotPanel({ fetchResult, now }: DailySnapshotPanelProps) {
+  // Tests inject `fetchResult` directly — render synchronously without an
+  // effect. Production renders defer to `<DailySnapshotPanelLive />`, which
+  // owns the network fetch in an effect.
+  if (fetchResult) {
+    return <RenderResult result={fetchResult} now={now} />;
+  }
+  return <DailySnapshotPanelLive now={now} />;
+}
+
+function DailySnapshotPanelLive({ now }: { now?: Date }) {
+  const { result, refetch } = useLatestSnapshot();
   if (result === null) return <SnapshotSkeleton />;
   return <RenderResult result={result} now={now} onRetry={refetch} />;
 }
@@ -101,7 +114,7 @@ function RenderResult({
   return <SnapshotContent envelope={result.envelope} now={now} />;
 }
 
-function SnapshotSkeleton() {
+export function SnapshotSkeleton() {
   return (
     <section
       data-testid="snapshot-loading"
@@ -119,7 +132,7 @@ function SnapshotSkeleton() {
   );
 }
 
-function SnapshotErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }) {
+export function SnapshotErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <section
       data-testid="snapshot-error"
@@ -143,7 +156,7 @@ function SnapshotErrorBanner({ message, onRetry }: { message: string; onRetry: (
   );
 }
 
-function SnapshotEmptyBanner({ reason }: { reason: 'no_recent_row' | 'unconfigured' }) {
+export function SnapshotEmptyBanner({ reason }: { reason: 'no_recent_row' | 'unconfigured' }) {
   const message =
     reason === 'unconfigured'
       ? 'Supabase credentials are not configured. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
@@ -252,7 +265,7 @@ function SnapshotContent({
   );
 }
 
-function NarrativeSection({ title, body, testId }: { title: string; body: string; testId: string }) {
+export function NarrativeSection({ title, body, testId }: { title: string; body: string; testId: string }) {
   return (
     <div data-testid={testId} className="space-y-1.5">
       <h3 className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
@@ -263,7 +276,7 @@ function NarrativeSection({ title, body, testId }: { title: string; body: string
   );
 }
 
-function ActionableList({ items }: { items: ActionableItem[] }) {
+export function ActionableList({ items }: { items: ActionableItem[] }) {
   if (!items.length) return null;
   return (
     <div data-testid="snapshot-actionable" className="space-y-2">
@@ -290,7 +303,7 @@ function ActionableList({ items }: { items: ActionableItem[] }) {
   );
 }
 
-function RiskList({ items }: { items: RiskItem[] }) {
+export function RiskList({ items }: { items: RiskItem[] }) {
   if (!items.length) return null;
   return (
     <div data-testid="snapshot-risk-radar" className="space-y-2">

--- a/frontend/olympus/components/overview/decision-trail-panel.test.tsx
+++ b/frontend/olympus/components/overview/decision-trail-panel.test.tsx
@@ -1,0 +1,51 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { DecisionTrailPanel, type DecisionTrailProps } from './decision-trail-panel';
+import type { PipelineTickerDoc } from '@/lib/types';
+
+function render(props: DecisionTrailProps): string {
+  return renderToStaticMarkup(createElement(DecisionTrailPanel, props));
+}
+
+const DEBATE: PipelineTickerDoc = {
+  document_key: 'deliberation/NVDA',
+  ticker: 'NVDA',
+  payload: { net_stance: 'bullish' },
+};
+
+describe('DecisionTrailPanel', () => {
+  it('shows an honest empty state naming the last run date', () => {
+    const html = render({
+      latestDate: '2026-06-13',
+      deliberations: [],
+      hasPmMemo: false,
+      hasDigest: false,
+    });
+    expect(html).toContain('No decision artifacts');
+    expect(html).toContain('2026-06-13');
+  });
+
+  it('renders rows for deliberations, PM memo, and digest when present', () => {
+    const html = render({
+      latestDate: '2026-06-13',
+      deliberations: [DEBATE],
+      hasPmMemo: true,
+      hasDigest: true,
+    });
+    expect(html).toContain('Deliberations');
+    expect(html).toContain('NVDA');
+    expect(html).toContain('PM allocation memo');
+    expect(html).toContain('Daily digest');
+  });
+
+  it('omits the risk-debate row until PR1b wires it', () => {
+    const html = render({
+      latestDate: '2026-06-13',
+      deliberations: [DEBATE],
+      hasPmMemo: false,
+      hasDigest: false,
+    });
+    expect(html).not.toContain('Risk debate');
+  });
+});

--- a/frontend/olympus/components/overview/decision-trail-panel.tsx
+++ b/frontend/olympus/components/overview/decision-trail-panel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Link from 'next/link';
+import type { Route } from 'next';
+import { Footprints, MessagesSquare, ClipboardList, FileText, Scale } from 'lucide-react';
+import type { PipelineTickerDoc } from '@/lib/types';
+
+/**
+ * The day's decision artifacts as a navigable trail — the read path from
+ * "what the pipeline decided" into the full documents. Resurrects the dead
+ * pmQuickLinks/latestRunDocByKey scaffolding that page.tsx computed but never
+ * rendered. Honest empty state naming the last run date.
+ */
+
+export interface DecisionTrailProps {
+  latestDate: string | null;
+  deliberations: PipelineTickerDoc[];
+  hasPmMemo: boolean;
+  hasDigest: boolean;
+  /** Phase C PR1b wires the risk-debate fetch; until then this is false. */
+  hasRiskDebate?: boolean;
+}
+
+interface TrailRow {
+  icon: typeof FileText;
+  label: string;
+  detail: string;
+  href: Route;
+}
+
+export function DecisionTrailPanel({
+  latestDate,
+  deliberations,
+  hasPmMemo,
+  hasDigest,
+  hasRiskDebate = false,
+}: DecisionTrailProps) {
+  const rows: TrailRow[] = [];
+
+  if (deliberations.length > 0) {
+    const tickers = deliberations
+      .map((d) => d.ticker)
+      .filter(Boolean)
+      .slice(0, 6)
+      .join(', ');
+    rows.push({
+      icon: MessagesSquare,
+      label: 'Deliberations',
+      detail: `${deliberations.length} ticker${deliberations.length !== 1 ? 's' : ''}${tickers ? ` · ${tickers}` : ''}`,
+      href: '/portfolio?tab=analysis' as Route,
+    });
+  }
+  if (hasPmMemo) {
+    rows.push({
+      icon: ClipboardList,
+      label: 'PM allocation memo',
+      detail: 'Rationale behind the target book',
+      href: '/portfolio?tab=analysis' as Route,
+    });
+  }
+  if (hasRiskDebate) {
+    rows.push({
+      icon: Scale,
+      label: 'Risk debate',
+      detail: 'Aggressive vs. conservative framing',
+      href: '/portfolio?tab=analysis' as Route,
+    });
+  }
+  if (hasDigest) {
+    rows.push({
+      icon: FileText,
+      label: 'Daily digest',
+      detail: 'Full narrative research report',
+      href: '/research?tab=daily' as Route,
+    });
+  }
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Footprints size={15} className="text-fin-amber" />
+          <h3 className="text-sm font-semibold">Decision trail</h3>
+        </div>
+        {latestDate && (
+          <span className="text-[10px] text-text-muted font-mono">as of {latestDate}</span>
+        )}
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="px-5 py-8 text-center text-sm text-text-muted">
+          {latestDate
+            ? `No decision artifacts published for ${latestDate} yet — they appear after the next pipeline run.`
+            : 'Decision artifacts appear after the first pipeline run.'}
+        </p>
+      ) : (
+        <div className="divide-y divide-border-subtle">
+          {rows.map((r) => {
+            const Icon = r.icon;
+            return (
+              <Link
+                key={r.label}
+                href={r.href}
+                className="flex items-center gap-3 px-5 py-3 hover:bg-white/[0.025] transition-colors group"
+              >
+                <Icon size={15} className="text-text-muted group-hover:text-fin-blue transition-colors shrink-0" />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-text-primary">{r.label}</div>
+                  <div className="text-xs text-text-muted truncate">{r.detail}</div>
+                </div>
+                <span className="text-fin-blue/60 group-hover:text-fin-blue text-xs shrink-0">→</span>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/olympus/components/overview/deliberations-strip.test.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.test.tsx
@@ -1,0 +1,45 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { DeliberationsStrip } from './deliberations-strip';
+import type { PipelineTickerDoc } from '@/lib/types';
+
+function render(transcripts: PipelineTickerDoc[]): string {
+  return renderToStaticMarkup(createElement(DeliberationsStrip, { transcripts }));
+}
+
+const NVDA: PipelineTickerDoc = {
+  document_key: 'deliberation/NVDA',
+  ticker: 'NVDA',
+  payload: {
+    net_stance: 'bullish',
+    conviction_delta: 1,
+    bull_thesis: 'Datacenter capex supercycle intact.',
+    bear_thesis: 'Multiple compression risk.',
+  },
+};
+
+describe('DeliberationsStrip', () => {
+  it('renders nothing when there are no debates', () => {
+    expect(render([])).toBe('');
+  });
+
+  it('renders nothing when transcripts lack a debate payload (e.g. analyst-only)', () => {
+    const noStance: PipelineTickerDoc = {
+      document_key: 'analyst/SPY',
+      ticker: 'SPY',
+      payload: { conviction_score: 0.6 },
+    };
+    expect(render([noStance])).toBe('');
+  });
+
+  it('renders a card with ticker, stance, conviction delta, and theses', () => {
+    const html = render([NVDA]);
+    expect(html).toContain('NVDA');
+    expect(html).toContain('bullish');
+    expect(html).toContain('+1');
+    expect(html).toContain('Datacenter capex');
+    expect(html).toContain('Bull:');
+    expect(html).toContain('Bear:');
+  });
+});

--- a/frontend/olympus/components/overview/deliberations-strip.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { MessagesSquare } from 'lucide-react';
+import type { PipelineTickerDoc } from '@/lib/types';
+import { renderDebateSummaryMarkdown } from '@/lib/render-pipeline-payloads';
+import { SafeMarkdown } from '@/components/SafeMarkdown';
+
+/**
+ * The "why" behind each conviction move — bull/bear debate summaries the
+ * Hermes pipeline now publishes (#699) and bundles into pipeline_observability
+ * for the latest run. Full payloads are already in context, so cards render +
+ * expand with no extra fetch. Renders null when no deliberations ran.
+ */
+
+const STANCE: Record<string, string> = {
+  bullish: 'text-fin-green border-fin-green/40 bg-fin-green/10',
+  bearish: 'text-fin-red border-fin-red/40 bg-fin-red/10',
+  neutral: 'text-fin-blue border-fin-blue/40 bg-fin-blue/10',
+};
+
+function s(v: unknown): string {
+  return v == null ? '' : String(v);
+}
+
+function DebateCard({ doc }: { doc: PipelineTickerDoc }) {
+  const [open, setOpen] = useState(false);
+  const p = doc.payload ?? {};
+  const stance = s(p.net_stance).toLowerCase() || 'neutral';
+  const delta = Number(p.conviction_delta ?? 0);
+  const deltaStr = `${delta > 0 ? '+' : ''}${delta}`;
+  const bull = s(p.bull_thesis).trim();
+  const bear = s(p.bear_thesis).trim();
+
+  return (
+    <div className="glass-card shrink-0 w-[260px] p-4 flex flex-col gap-2.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-sm font-bold text-text-primary">{doc.ticker}</span>
+        <span
+          className={`rounded-md border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${STANCE[stance] ?? STANCE.neutral}`}
+        >
+          {stance}
+        </span>
+      </div>
+      <div className="text-[11px] font-mono text-text-muted tabular-nums">
+        conviction Δ <span className={delta > 0 ? 'text-fin-green' : delta < 0 ? 'text-fin-red' : ''}>{deltaStr}</span>
+      </div>
+      {!open && (
+        <div className="space-y-1.5 text-xs leading-snug">
+          {bull && (
+            <p className="text-text-secondary line-clamp-2">
+              <span className="text-fin-green font-semibold">Bull:</span> {bull}
+            </p>
+          )}
+          {bear && (
+            <p className="text-text-secondary line-clamp-2">
+              <span className="text-fin-red font-semibold">Bear:</span> {bear}
+            </p>
+          )}
+        </div>
+      )}
+      {open && (
+        <div className="max-h-72 overflow-y-auto pr-1">
+          <SafeMarkdown className="prose-xs">{renderDebateSummaryMarkdown(p)}</SafeMarkdown>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="mt-auto text-left text-[10px] font-medium text-fin-blue hover:underline"
+      >
+        {open ? 'Collapse' : 'Read debate →'}
+      </button>
+    </div>
+  );
+}
+
+export function DeliberationsStrip({ transcripts }: { transcripts: PipelineTickerDoc[] }) {
+  const debates = (transcripts ?? []).filter(
+    (d) => d?.payload && typeof d.payload.net_stance === 'string'
+  );
+  if (debates.length === 0) return null;
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <MessagesSquare size={15} className="text-fin-purple" />
+          <h3 className="text-sm font-semibold">Deliberations</h3>
+          <span className="text-[10px] text-text-muted">bull vs. bear · {debates.length}</span>
+        </div>
+        <Link
+          href="/portfolio?tab=analysis"
+          className="text-[10px] text-fin-blue hover:underline font-medium"
+        >
+          Full analysis →
+        </Link>
+      </div>
+      <div className="flex gap-3 overflow-x-auto p-4">
+        {debates.map((d, i) => (
+          <DebateCard key={`${d.ticker}-${i}`} doc={d} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/olympus/components/overview/deliberations-strip.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.tsx
@@ -62,7 +62,11 @@ function DebateCard({ doc }: { doc: PipelineTickerDoc }) {
       )}
       {open && (
         <div className="max-h-72 overflow-y-auto pr-1">
-          <SafeMarkdown className="prose-xs">{renderDebateSummaryMarkdown(p)}</SafeMarkdown>
+          <SafeMarkdown className="prose-xs">
+            {/* Ensure the expanded heading is self-describing even if the
+                payload omitted its own ticker. */}
+            {renderDebateSummaryMarkdown({ ...p, ticker: s(p.ticker) || doc.ticker })}
+          </SafeMarkdown>
         </div>
       )}
       <button

--- a/frontend/olympus/components/overview/morning-brief-panel.test.tsx
+++ b/frontend/olympus/components/overview/morning-brief-panel.test.tsx
@@ -1,0 +1,60 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { fixtureEnvelope } from '@/lib/__fixtures__/snapshot-fixture';
+import type { SnapshotFetchResult } from '@/lib/snapshot-types';
+
+// Controllable hook result, hoisted so the vi.mock factory can close over it.
+const holder = vi.hoisted(() => ({ result: null as SnapshotFetchResult | null }));
+
+// Override only useLatestSnapshot; keep the real banners / sub-renderers the
+// Morning Brief reuses so this exercises the actual render path.
+vi.mock('./daily-snapshot-panel', async (importActual) => {
+  const actual = await importActual<typeof import('./daily-snapshot-panel')>();
+  return {
+    ...actual,
+    useLatestSnapshot: () => ({ result: holder.result, refetch: () => undefined }),
+  };
+});
+
+// Imported after vi.mock so the mocked dependency is in place.
+const { MorningBriefPanel } = await import('./morning-brief-panel');
+
+function render(): string {
+  return renderToStaticMarkup(createElement(MorningBriefPanel));
+}
+
+describe('MorningBriefPanel', () => {
+  it('renders the loading skeleton while the snapshot is null', () => {
+    holder.result = null;
+    expect(render()).toContain('snapshot-loading');
+  });
+
+  it('renders the error banner on a fetch error', () => {
+    holder.result = { kind: 'error', message: 'connection refused' };
+    const html = render();
+    expect(html).toContain('snapshot-error');
+    expect(html).toContain('connection refused');
+  });
+
+  it('renders the empty banner when there is no recent snapshot', () => {
+    holder.result = { kind: 'empty', reason: 'no_recent_row' };
+    expect(render()).toContain('snapshot-empty');
+  });
+
+  it('renders all tabs, the default Market content, and a complete ARIA tabs pattern', () => {
+    holder.result = { kind: 'present', envelope: fixtureEnvelope() };
+    const html = render();
+    expect(html).toContain('Morning brief');
+    for (const label of ['Market', 'Equities', 'Risk', 'Actions']) {
+      expect(html).toContain(label);
+    }
+    // Default tab is Market → its first NarrativeSection heading is present.
+    expect(html).toContain('Market regime');
+    // ARIA wiring: tablist + tab/panel association for the active tab.
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('aria-controls="morning-brief-panel-market"');
+    expect(html).toContain('id="morning-brief-panel-market"');
+    expect(html).toContain('aria-labelledby="morning-brief-tab-market"');
+  });
+});

--- a/frontend/olympus/components/overview/morning-brief-panel.tsx
+++ b/frontend/olympus/components/overview/morning-brief-panel.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Newspaper } from 'lucide-react';
+import {
+  ActionableList,
+  NarrativeSection,
+  RiskList,
+  SnapshotEmptyBanner,
+  SnapshotErrorBanner,
+  SnapshotSkeleton,
+  useLatestSnapshot,
+} from '@/components/overview/daily-snapshot-panel';
+import type { DigestPayload } from '@/lib/snapshot-types';
+
+/**
+ * The daily digest, partitioned into a glanceable tabbed read (Market /
+ * Equities / Risk / Actions). Shares the exact snapshot fetch the standalone
+ * panel uses (useLatestSnapshot) and reuses its section renderers — this
+ * replaces the single long scroll so the morning read is scannable. Nothing
+ * from the old Overview right-column (actionable + risk) is lost; it moves
+ * into the Risk/Actions tabs here.
+ */
+
+type TabKey = 'market' | 'equities' | 'risk' | 'actions';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'market', label: 'Market' },
+  { key: 'equities', label: 'Equities' },
+  { key: 'risk', label: 'Risk' },
+  { key: 'actions', label: 'Actions' },
+];
+
+function TabBody({ tab, digest }: { tab: TabKey; digest: DigestPayload }) {
+  if (tab === 'market') {
+    return (
+      <div className="space-y-5">
+        <NarrativeSection title="Market regime" body={digest.market_regime_snapshot} testId="brief-regime" />
+        <NarrativeSection title="Asset classes" body={digest.asset_classes_summary} testId="brief-asset-classes" />
+        {digest.alt_data_dashboard.trim() && (
+          <NarrativeSection title="Alt data" body={digest.alt_data_dashboard} testId="brief-alt-data" />
+        )}
+      </div>
+    );
+  }
+  if (tab === 'equities') {
+    return (
+      <div className="space-y-5">
+        <NarrativeSection title="US equities" body={digest.us_equities_summary} testId="brief-us-equities" />
+        <NarrativeSection title="Institutional flows" body={digest.institutional_summary} testId="brief-institutional" />
+        {digest.thesis_tracker.trim() && (
+          <NarrativeSection title="Thesis tracker" body={digest.thesis_tracker} testId="brief-thesis" />
+        )}
+      </div>
+    );
+  }
+  if (tab === 'risk') {
+    return digest.risk_radar.length ? (
+      <RiskList items={digest.risk_radar} />
+    ) : (
+      <p className="text-sm text-text-muted">No risks flagged for the latest run.</p>
+    );
+  }
+  return digest.actionable_summary.length ? (
+    <ActionableList items={digest.actionable_summary} />
+  ) : (
+    <p className="text-sm text-text-muted">No actionable items for the latest run.</p>
+  );
+}
+
+export function MorningBriefPanel() {
+  const { result, refetch } = useLatestSnapshot();
+  const [tab, setTab] = useState<TabKey>('market');
+
+  if (result === null) return <SnapshotSkeleton />;
+  if (result.kind === 'error') return <SnapshotErrorBanner message={result.message} onRetry={refetch} />;
+  if (result.kind === 'empty') return <SnapshotEmptyBanner reason={result.reason} />;
+
+  const digest = result.envelope.digest;
+
+  return (
+    <section data-testid="morning-brief" className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <Newspaper size={15} className="text-fin-blue shrink-0" />
+          <h3 className="text-sm font-semibold shrink-0">Morning brief</h3>
+          <span className="text-xs text-text-muted truncate hidden sm:inline">{digest.headline}</span>
+        </div>
+        <Link href="/research?tab=daily" className="text-[10px] text-fin-blue hover:underline font-medium shrink-0">
+          Read full research →
+        </Link>
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Daily digest sections"
+        className="flex gap-1 px-3 pt-3 border-b border-border-subtle overflow-x-auto"
+      >
+        {TABS.map((t) => {
+          const active = t.key === tab;
+          return (
+            <button
+              key={t.key}
+              role="tab"
+              type="button"
+              aria-selected={active}
+              onClick={() => setTab(t.key)}
+              className={`shrink-0 rounded-t-md px-3.5 py-2 text-xs font-semibold transition-colors ${
+                active
+                  ? 'bg-bg-secondary text-text-primary border-b-2 border-fin-blue'
+                  : 'text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div role="tabpanel" className="p-5 sm:p-6">
+        <TabBody tab={tab} digest={digest} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/olympus/components/overview/morning-brief-panel.tsx
+++ b/frontend/olympus/components/overview/morning-brief-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { type KeyboardEvent, useState } from 'react';
 import Link from 'next/link';
 import { Newspaper } from 'lucide-react';
 import {
@@ -69,9 +69,25 @@ function TabBody({ tab, digest }: { tab: TabKey; digest: DigestPayload }) {
   );
 }
 
+const tabId = (k: TabKey) => `morning-brief-tab-${k}`;
+const panelId = (k: TabKey) => `morning-brief-panel-${k}`;
+
 export function MorningBriefPanel() {
   const { result, refetch } = useLatestSnapshot();
   const [tab, setTab] = useState<TabKey>('market');
+
+  // Roving-tabindex arrow-key navigation to complete the ARIA tabs pattern.
+  const onTablistKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const idx = TABS.findIndex((t) => t.key === tab);
+    let next = idx;
+    if (e.key === 'ArrowRight') next = (idx + 1) % TABS.length;
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + TABS.length) % TABS.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = TABS.length - 1;
+    else return;
+    e.preventDefault();
+    setTab(TABS[next].key);
+  };
 
   if (result === null) return <SnapshotSkeleton />;
   if (result.kind === 'error') return <SnapshotErrorBanner message={result.message} onRetry={refetch} />;
@@ -95,6 +111,7 @@ export function MorningBriefPanel() {
       <div
         role="tablist"
         aria-label="Daily digest sections"
+        onKeyDown={onTablistKeyDown}
         className="flex gap-1 px-3 pt-3 border-b border-border-subtle overflow-x-auto"
       >
         {TABS.map((t) => {
@@ -102,9 +119,12 @@ export function MorningBriefPanel() {
           return (
             <button
               key={t.key}
+              id={tabId(t.key)}
               role="tab"
               type="button"
               aria-selected={active}
+              aria-controls={panelId(t.key)}
+              tabIndex={active ? 0 : -1}
               onClick={() => setTab(t.key)}
               className={`shrink-0 rounded-t-md px-3.5 py-2 text-xs font-semibold transition-colors ${
                 active
@@ -118,7 +138,13 @@ export function MorningBriefPanel() {
         })}
       </div>
 
-      <div role="tabpanel" className="p-5 sm:p-6">
+      <div
+        role="tabpanel"
+        id={panelId(tab)}
+        aria-labelledby={tabId(tab)}
+        tabIndex={0}
+        className="p-5 sm:p-6"
+      >
         <TabBody tab={tab} digest={digest} />
       </div>
     </section>

--- a/frontend/olympus/components/overview/today-actions-panel.test.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.test.tsx
@@ -1,0 +1,43 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { TodayActionsPanel } from './today-actions-panel';
+import type { RebalanceAction } from '@/lib/types';
+
+function render(actions: RebalanceAction[]): string {
+  return renderToStaticMarkup(createElement(TodayActionsPanel, { actions }));
+}
+
+describe('TodayActionsPanel', () => {
+  it('shows the no-rebalance state when there are no actions', () => {
+    expect(render([])).toContain('No rebalance proposed');
+  });
+
+  it('shows the at-target state when every action is HOLD', () => {
+    const html = render([
+      { ticker: 'SPY', current_pct: 50, recommended_pct: 50, action: 'HOLD' },
+      { ticker: 'GLD', current_pct: 50, recommended_pct: 50, action: 'HOLD' },
+    ]);
+    expect(html).toContain('No changes proposed');
+    expect(html).toContain('2 positions held');
+  });
+
+  it('renders changes with ticker, weights, and a delta', () => {
+    const html = render([
+      { ticker: 'NVDA', current_pct: 0, recommended_pct: 6.5, action: 'OPEN' },
+    ]);
+    expect(html).toContain('NVDA');
+    expect(html).toContain('OPEN');
+    expect(html).toContain('0.0%');
+    expect(html).toContain('6.5%');
+    expect(html).toContain('+6.5pp');
+  });
+
+  it('orders EXIT before ADD (decision-first sort)', () => {
+    const html = render([
+      { ticker: 'AAA', current_pct: 1, recommended_pct: 2, action: 'ADD' },
+      { ticker: 'ZZZ', current_pct: 3, recommended_pct: 0, action: 'EXIT' },
+    ]);
+    expect(html.indexOf('ZZZ')).toBeLessThan(html.indexOf('AAA'));
+  });
+});

--- a/frontend/olympus/components/overview/today-actions-panel.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { ArrowRight, ArrowDownRight, ArrowUpRight, XCircle, PlusCircle, ListChecks } from 'lucide-react';
+import type { RebalanceAction } from '@/lib/types';
+
+/**
+ * "What should I change today" — renders the PM's rebalance_actions (computed
+ * in queries.ts but, before #702, never surfaced). The decision spine of the
+ * morning read: EXIT/OPEN/TRIM/ADD sorted to the top, HOLDs collapsed.
+ */
+
+type ActionKind = 'EXIT' | 'OPEN' | 'TRIM' | 'ADD' | 'HOLD';
+
+const ORDER: Record<ActionKind, number> = { EXIT: 0, OPEN: 1, TRIM: 2, ADD: 3, HOLD: 4 };
+
+const STYLE: Record<ActionKind, { badge: string; icon: typeof ArrowRight }> = {
+  EXIT: { badge: 'bg-fin-red/15 text-fin-red border-fin-red/30', icon: XCircle },
+  OPEN: { badge: 'bg-fin-green/15 text-fin-green border-fin-green/30', icon: PlusCircle },
+  TRIM: { badge: 'bg-fin-amber/15 text-fin-amber border-fin-amber/30', icon: ArrowDownRight },
+  ADD: { badge: 'bg-fin-blue/15 text-fin-blue border-fin-blue/30', icon: ArrowUpRight },
+  HOLD: { badge: 'bg-white/[0.06] text-text-muted border-border-subtle', icon: ArrowRight },
+};
+
+function kindOf(action: string): ActionKind {
+  const a = (action || '').toUpperCase();
+  return (a in ORDER ? a : 'HOLD') as ActionKind;
+}
+
+function ActionRow({ a }: { a: RebalanceAction }) {
+  const kind = kindOf(a.action);
+  const { badge, icon: Icon } = STYLE[kind];
+  const delta = (a.recommended_pct ?? 0) - (a.current_pct ?? 0);
+  return (
+    <div className="flex items-center justify-between gap-3 px-5 py-2.5 hover:bg-white/[0.025] transition-colors">
+      <div className="flex items-center gap-3 min-w-0">
+        <span
+          className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${badge}`}
+        >
+          <Icon size={11} />
+          {kind}
+        </span>
+        <span className="font-mono text-xs font-bold text-text-primary">{a.ticker}</span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0 font-mono text-xs tabular-nums">
+        <span className="text-text-muted">{(a.current_pct ?? 0).toFixed(1)}%</span>
+        <ArrowRight size={11} className="text-text-muted/60" />
+        <span className="text-text-primary font-semibold">{(a.recommended_pct ?? 0).toFixed(1)}%</span>
+        {Math.abs(delta) >= 0.05 && (
+          <span className={delta > 0 ? 'text-fin-green' : 'text-fin-red'}>
+            {delta > 0 ? '+' : ''}
+            {delta.toFixed(1)}pp
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TodayActionsPanel({ actions }: { actions: RebalanceAction[] }) {
+  const [showHolds, setShowHolds] = useState(false);
+  const { changes, holds } = useMemo(() => {
+    const sorted = [...actions].sort((x, y) => ORDER[kindOf(x.action)] - ORDER[kindOf(y.action)]);
+    return {
+      changes: sorted.filter((a) => kindOf(a.action) !== 'HOLD'),
+      holds: sorted.filter((a) => kindOf(a.action) === 'HOLD'),
+    };
+  }, [actions]);
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ListChecks size={15} className="text-fin-green" />
+          <h3 className="text-sm font-semibold">Today&rsquo;s actions</h3>
+          {changes.length > 0 && (
+            <span className="rounded-full bg-fin-green/15 text-fin-green border border-fin-green/30 px-2 py-0.5 text-[10px] font-bold tabular-nums">
+              {changes.length}
+            </span>
+          )}
+        </div>
+        <Link
+          href="/portfolio?tab=analysis"
+          className="text-[10px] text-fin-blue hover:underline font-medium"
+        >
+          Full rebalance memo →
+        </Link>
+      </div>
+
+      {changes.length === 0 ? (
+        <p className="px-5 py-8 text-center text-sm text-text-muted">
+          {actions.length === 0
+            ? 'No rebalance proposed for the latest run.'
+            : 'No changes proposed — portfolio is at target weights.'}
+        </p>
+      ) : (
+        <div className="divide-y divide-border-subtle">
+          {changes.map((a, i) => (
+            <ActionRow key={`${a.ticker}-${i}`} a={a} />
+          ))}
+        </div>
+      )}
+
+      {holds.length > 0 && (
+        <div className="border-t border-border-subtle">
+          <button
+            type="button"
+            onClick={() => setShowHolds((v) => !v)}
+            className="w-full px-5 py-2 text-left text-[11px] text-text-muted hover:text-text-secondary transition-colors"
+          >
+            {showHolds ? '▾' : '▸'} {holds.length} position{holds.length !== 1 ? 's' : ''} held
+          </button>
+          {showHolds && (
+            <div className="divide-y divide-border-subtle/60">
+              {holds.map((a, i) => (
+                <ActionRow key={`hold-${a.ticker}-${i}`} a={a} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #702

Phase C PR1 "Morning Read Core" — reshape the Olympus Overview (`app/page.tsx`) **in place** into a daily decision document and wire three data surfaces the dashboard query already loads but never rendered. No new route, additive components, no auth dependency to land. Blueprint synthesized by a 7-agent design workflow (which caught a real bug: deliberations must read `pipeline_observability.deliberation_transcripts` — the `Doc` type carries no payload).

Serves the owner's verbatim vision: *"go every day to see what changes to make and understand why — reading the digest, the deliberations, the decision-making."*

## What ships

The page now reads top → bottom as a decision document: **regime+digest hero → KPIs → Today's Actions → Morning Brief → Positions | Market Pulse → Deliberations → Decision Trail → theses.**

- **Today's Actions** (`today-actions-panel.tsx`) — renders `portfolio_management.rebalance_actions` (computed in `queries.ts`, never surfaced before). EXIT→OPEN→TRIM→ADD→HOLD sort, color-coded badges, current%→target% Δ, HOLDs collapsed, explicit "no changes proposed" empty state.
- **Morning Brief** (`morning-brief-panel.tsx`) — the digest, tabbed (Market / Equities / Risk / Actions). Shares the snapshot fetch via a new exported `useLatestSnapshot()` hook and reuses the snapshot panel's section renderers — replaces the single long scroll. Nothing from the old Actionable+Risk right column is lost (it moves into the Risk/Actions tabs).
- **Deliberations** (`deliberations-strip.tsx`) — bull/bear `DebateSummary` cards from `pipeline_observability.deliberation_transcripts` (#699). Stance + conviction Δ + bull/bear lines; expand-in-place via `renderDebateSummaryMarkdown`. Renders **null** when no deliberations ran (honest empty state).
- **Decision Trail** (`decision-trail-panel.tsx`) — resurrects the dead `pmQuickLinks`/`latestRunDocByKey` scaffolding into a real navigation panel into the day's artifacts; honest empty state naming the last run date.
- **Fused hero** — `digest` bias + run_type badges + **AsOfBadge** freshness pill (amber when the run date is older than yesterday, UTC).

`daily-snapshot-panel.tsx` change is additive only (export the hook + sub-renderers + banners) — its existing test stays green.

## Verification

- tsc clean, eslint clean, `next build` (static export) green, `make score` 10/10/10/10.
- **80 vitest** (14 new: actions ordering/empty/at-target, deliberations null/render, decision-trail empty/rows, as-of fresh/stale). Existing `daily-snapshot-panel.test.tsx` unchanged + green.
- **Visually verified against live production data** (desktop + mobile, attached to the PR conversation): renders cleanly, zero console errors. Positions/deliberations show honest empty states because production hasn't run the pipeline with the new B1/B2 code yet — they populate on the next scheduled run.

## Not in this PR (follow-ups from the blueprint)
- PR1b: surface `risk-debate` (needs a small `queries.ts` fetch-key add — it's loaded nowhere today).
- PR2: rationale enrichment from `pm_allocation_memo`; historical-date deliberation expand via `useLibraryDocument`.
- **PR3 (HUMAN GATE):** auth before sharing — Cloudflare Access on `/olympus/*` + column-scrub migration (`pm_notes` / `est_cost_usd` / `token_usage_breakdown`). **Do not share the URL until this lands** (anon key is in the static bundle; all tables are anon-readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
