### PR TITLE
feat(olympus): surface risk-debate + wire pipeline deliberation keys + action rationale (#704)

### DIFF
--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -118,15 +118,19 @@ regime → KPIs → what to do → why → where to read more. The panels under
 
 - **Today's Actions** (`today-actions-panel.tsx`) — `portfolio_management.rebalance_actions`
   (computed in `queries.ts`, surfaced from #702). EXIT→OPEN→TRIM→ADD→HOLD sort;
-  HOLDs collapse; explicit "no changes proposed" state.
+  HOLDs collapse; explicit "no changes proposed" state. Per-ticker rationale is
+  joined from the `pm-rebalance` doc's actions when present (#704).
 - **Morning Brief** (`morning-brief-panel.tsx`) — the digest, tabbed
   (Market / Equities / Risk / Actions). Shares the snapshot fetch via the
   exported `useLatestSnapshot()` hook and reuses the snapshot panel's section
   renderers; it replaces the single long scroll on the Overview.
 - **Deliberations** (`deliberations-strip.tsx`) — bull/bear `DebateSummary`
-  cards from `pipeline_observability.deliberation_transcripts` (#699 publishes
-  them; full payloads are already in context). Expand-in-place via
-  `renderDebateSummaryMarkdown`. Renders null when no deliberations ran.
+  cards from `pipeline_observability.deliberation_transcripts` (the
+  pipeline `deliberation/{ticker}` docs, #699) plus a portfolio-level
+  **risk-debate** card (`risk-debate` doc, via `renderRiskDebateMarkdown`).
+  `fetchPipelineObservabilityForDate` loads both the flat pipeline keys
+  (`deliberation/%`, `risk-debate`, `pm-rebalance`) and the operator-flow
+  keys (#704). Expand-in-place, no extra fetch; renders null when neither ran.
 - **Decision Trail** (`decision-trail-panel.tsx`) — navigable rows into the
   day's artifacts (deliberations, PM memo, digest); honest empty state.
 - **AsOfBadge** (`as-of-badge.tsx`) — freshness pill in the hero; amber when the

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -29,6 +29,7 @@ import { TodayActionsPanel } from '@/components/overview/today-actions-panel';
 import { DeliberationsStrip } from '@/components/overview/deliberations-strip';
 import { DecisionTrailPanel } from '@/components/overview/decision-trail-panel';
 import { AsOfBadge } from '@/components/overview/as-of-badge';
+import { isRiskDebatePayload } from '@/lib/render-pipeline-payloads';
 import AtlasLoader from '@/components/AtlasLoader';
 import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
 
@@ -292,9 +293,13 @@ export default function OverviewPage() {
   const hasPmMemo = pipe?.pm_allocation_memo != null;
   const rebalanceActions = data.portfolio_management?.rebalance_actions ?? [];
   const riskDebate = pipe?.risk_debate ?? null;
+  // Trail row only when the payload is a real risk debate (matches the strip's
+  // own shape gate — a malformed payload must not surface a phantom row).
+  const hasRiskDebate = isRiskDebatePayload(riskDebate);
 
   // Per-ticker rationale from the Hermes pm-rebalance decision (#704) — joined
-  // onto Today's Actions by ticker; absent rows just show no rationale line.
+  // onto Today's Actions by ticker (normalized trim+UPPER so casing/whitespace
+  // differences between pm-rebalance and rebalance_actions don't drop it).
   const rationaleByTicker: Record<string, string> = {};
   const pmActions = (pipe?.pm_rebalance as { actions?: unknown } | null)?.actions;
   if (Array.isArray(pmActions)) {
@@ -302,7 +307,7 @@ export default function OverviewPage() {
       if (row && typeof row === 'object') {
         const r = row as { ticker?: unknown; rationale?: unknown };
         if (typeof r.ticker === 'string' && typeof r.rationale === 'string' && r.rationale.trim()) {
-          rationaleByTicker[r.ticker] = r.rationale.trim();
+          rationaleByTicker[r.ticker.trim().toUpperCase()] = r.rationale.trim();
         }
       }
     }
@@ -540,7 +545,7 @@ export default function OverviewPage() {
         deliberations={deliberations}
         hasPmMemo={hasPmMemo}
         hasDigest={hasDigest}
-        hasRiskDebate={riskDebate != null}
+        hasRiskDebate={hasRiskDebate}
       />
 
       {/* ── Thesis Table ───────────────────────────────────────────────────── */}

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -291,6 +291,22 @@ export default function OverviewPage() {
   );
   const hasPmMemo = pipe?.pm_allocation_memo != null;
   const rebalanceActions = data.portfolio_management?.rebalance_actions ?? [];
+  const riskDebate = pipe?.risk_debate ?? null;
+
+  // Per-ticker rationale from the Hermes pm-rebalance decision (#704) — joined
+  // onto Today's Actions by ticker; absent rows just show no rationale line.
+  const rationaleByTicker: Record<string, string> = {};
+  const pmActions = (pipe?.pm_rebalance as { actions?: unknown } | null)?.actions;
+  if (Array.isArray(pmActions)) {
+    for (const row of pmActions) {
+      if (row && typeof row === 'object') {
+        const r = row as { ticker?: unknown; rationale?: unknown };
+        if (typeof r.ticker === 'string' && typeof r.rationale === 'string' && r.rationale.trim()) {
+          rationaleByTicker[r.ticker] = r.rationale.trim();
+        }
+      }
+    }
+  }
 
   // NAV sparkline — last N points for the P&L stat card
   const navSnaps = portfolio.snapshots ?? [];
@@ -420,7 +436,7 @@ export default function OverviewPage() {
       </div>
 
       {/* ── Today's Actions — the decision spine ───────────────────────────── */}
-      <TodayActionsPanel actions={rebalanceActions} />
+      <TodayActionsPanel actions={rebalanceActions} rationaleByTicker={rationaleByTicker} />
 
       {/* ── Morning Brief — the digest, tabbed for a scannable read ────────── */}
       <MorningBriefPanel />
@@ -516,7 +532,7 @@ export default function OverviewPage() {
       </div>
 
       {/* ── Deliberations — the "why" behind conviction moves ──────────────── */}
-      <DeliberationsStrip transcripts={deliberations} />
+      <DeliberationsStrip transcripts={deliberations} riskDebate={riskDebate} />
 
       {/* ── Decision trail — read path into the day's artifacts ────────────── */}
       <DecisionTrailPanel
@@ -524,6 +540,7 @@ export default function OverviewPage() {
         deliberations={deliberations}
         hasPmMemo={hasPmMemo}
         hasDigest={hasDigest}
+        hasRiskDebate={riskDebate != null}
       />
 
       {/* ── Thesis Table ───────────────────────────────────────────────────── */}

--- a/frontend/olympus/components/overview/deliberations-strip.test.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.test.tsx
@@ -4,9 +4,18 @@ import { describe, expect, it } from 'vitest';
 import { DeliberationsStrip } from './deliberations-strip';
 import type { PipelineTickerDoc } from '@/lib/types';
 
-function render(transcripts: PipelineTickerDoc[]): string {
-  return renderToStaticMarkup(createElement(DeliberationsStrip, { transcripts }));
+function render(
+  transcripts: PipelineTickerDoc[],
+  riskDebate?: Record<string, unknown> | null,
+): string {
+  return renderToStaticMarkup(createElement(DeliberationsStrip, { transcripts, riskDebate }));
 }
+
+const RISK_DEBATE = {
+  aggressive_case: 'Add beta into the breakout.',
+  conservative_case: 'Keep the cash buffer.',
+  key_tension: 'Momentum vs. participation.',
+};
 
 const NVDA: PipelineTickerDoc = {
   document_key: 'deliberation/NVDA',
@@ -41,5 +50,24 @@ describe('DeliberationsStrip', () => {
     expect(html).toContain('Datacenter capex');
     expect(html).toContain('Bull:');
     expect(html).toContain('Bear:');
+  });
+
+  it('renders the risk-debate card when a risk debate is present (#704)', () => {
+    const html = render([], RISK_DEBATE);
+    expect(html).not.toBe('');
+    expect(html).toContain('Risk debate');
+    expect(html).toContain('Key tension');
+    expect(html).toContain('Momentum vs. participation.');
+  });
+
+  it('still renders nothing when both per-ticker debates and risk debate are absent', () => {
+    expect(render([], null)).toBe('');
+    expect(render([], { aggressive_case: 'only one field' })).toBe('');
+  });
+
+  it('renders both per-ticker debates and the risk debate together', () => {
+    const html = render([NVDA], RISK_DEBATE);
+    expect(html).toContain('NVDA');
+    expect(html).toContain('Risk debate');
   });
 });

--- a/frontend/olympus/components/overview/deliberations-strip.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.tsx
@@ -2,9 +2,13 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { MessagesSquare } from 'lucide-react';
+import { MessagesSquare, Scale } from 'lucide-react';
 import type { PipelineTickerDoc } from '@/lib/types';
-import { renderDebateSummaryMarkdown } from '@/lib/render-pipeline-payloads';
+import {
+  isRiskDebatePayload,
+  renderDebateSummaryMarkdown,
+  renderRiskDebateMarkdown,
+} from '@/lib/render-pipeline-payloads';
 import { SafeMarkdown } from '@/components/SafeMarkdown';
 
 /**
@@ -80,11 +84,49 @@ function DebateCard({ doc }: { doc: PipelineTickerDoc }) {
   );
 }
 
-export function DeliberationsStrip({ transcripts }: { transcripts: PipelineTickerDoc[] }) {
+function RiskDebateCard({ payload }: { payload: Record<string, unknown> }) {
+  const [open, setOpen] = useState(false);
+  const tension = s(payload.key_tension).trim();
+  return (
+    <div className="border-t border-border-subtle p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Scale size={14} className="text-fin-amber shrink-0" />
+        <h4 className="text-xs font-semibold">Risk debate</h4>
+        <span className="text-[10px] text-text-muted">aggressive vs. conservative</span>
+      </div>
+      {!open && tension && (
+        <p className="text-xs text-text-secondary leading-snug">
+          <span className="text-fin-amber font-semibold">Key tension:</span> {tension}
+        </p>
+      )}
+      {open && (
+        <div className="max-h-72 overflow-y-auto pr-1">
+          <SafeMarkdown className="prose-xs">{renderRiskDebateMarkdown(payload)}</SafeMarkdown>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="mt-2 text-left text-[10px] font-medium text-fin-blue hover:underline"
+      >
+        {open ? 'Collapse' : 'Read risk debate →'}
+      </button>
+    </div>
+  );
+}
+
+export function DeliberationsStrip({
+  transcripts,
+  riskDebate,
+}: {
+  transcripts: PipelineTickerDoc[];
+  riskDebate?: Record<string, unknown> | null;
+}) {
   const debates = (transcripts ?? []).filter(
     (d) => d?.payload && typeof d.payload.net_stance === 'string'
   );
-  if (debates.length === 0) return null;
+  const hasRisk = !!riskDebate && isRiskDebatePayload(riskDebate);
+  if (debates.length === 0 && !hasRisk) return null;
 
   return (
     <div className="glass-card p-0 overflow-hidden">
@@ -92,7 +134,9 @@ export function DeliberationsStrip({ transcripts }: { transcripts: PipelineTicke
         <div className="flex items-center gap-2">
           <MessagesSquare size={15} className="text-fin-purple" />
           <h3 className="text-sm font-semibold">Deliberations</h3>
-          <span className="text-[10px] text-text-muted">bull vs. bear · {debates.length}</span>
+          {debates.length > 0 && (
+            <span className="text-[10px] text-text-muted">bull vs. bear · {debates.length}</span>
+          )}
         </div>
         <Link
           href="/portfolio?tab=analysis"
@@ -101,11 +145,14 @@ export function DeliberationsStrip({ transcripts }: { transcripts: PipelineTicke
           Full analysis →
         </Link>
       </div>
-      <div className="flex gap-3 overflow-x-auto p-4">
-        {debates.map((d, i) => (
-          <DebateCard key={`${d.ticker}-${i}`} doc={d} />
-        ))}
-      </div>
+      {debates.length > 0 && (
+        <div className="flex gap-3 overflow-x-auto p-4">
+          {debates.map((d, i) => (
+            <DebateCard key={`${d.ticker}-${i}`} doc={d} />
+          ))}
+        </div>
+      )}
+      {hasRisk && <RiskDebateCard payload={riskDebate as Record<string, unknown>} />}
     </div>
   );
 }

--- a/frontend/olympus/components/overview/today-actions-panel.test.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.test.tsx
@@ -40,4 +40,14 @@ describe('TodayActionsPanel', () => {
     ]);
     expect(html.indexOf('ZZZ')).toBeLessThan(html.indexOf('AAA'));
   });
+
+  it('renders per-ticker rationale from the PM memo when provided (#704)', () => {
+    const html = renderToStaticMarkup(
+      createElement(TodayActionsPanel, {
+        actions: [{ ticker: 'NVDA', current_pct: 0, recommended_pct: 6.5, action: 'OPEN' }],
+        rationaleByTicker: { NVDA: 'Initiate on the datacenter capex breakout.' },
+      }),
+    );
+    expect(html).toContain('Initiate on the datacenter capex breakout.');
+  });
 });

--- a/frontend/olympus/components/overview/today-actions-panel.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.tsx
@@ -28,38 +28,51 @@ function kindOf(action: string): ActionKind {
   return (a in ORDER ? a : 'HOLD') as ActionKind;
 }
 
-function ActionRow({ a }: { a: RebalanceAction }) {
+function ActionRow({ a, rationale }: { a: RebalanceAction; rationale?: string }) {
   const kind = kindOf(a.action);
   const { badge, icon: Icon } = STYLE[kind];
   const delta = (a.recommended_pct ?? 0) - (a.current_pct ?? 0);
   return (
-    <div className="flex items-center justify-between gap-3 px-5 py-2.5 hover:bg-white/[0.025] transition-colors">
-      <div className="flex items-center gap-3 min-w-0">
-        <span
-          className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${badge}`}
-        >
-          <Icon size={11} />
-          {kind}
-        </span>
-        <span className="font-mono text-xs font-bold text-text-primary">{a.ticker}</span>
-      </div>
-      <div className="flex items-center gap-2 shrink-0 font-mono text-xs tabular-nums">
-        <span className="text-text-muted">{(a.current_pct ?? 0).toFixed(1)}%</span>
-        <ArrowRight size={11} className="text-text-muted/60" />
-        <span className="text-text-primary font-semibold">{(a.recommended_pct ?? 0).toFixed(1)}%</span>
-        {Math.abs(delta) >= 0.05 && (
-          <span className={delta > 0 ? 'text-fin-green' : 'text-fin-red'}>
-            {delta > 0 ? '+' : ''}
-            {delta.toFixed(1)}pp
+    <div className="px-5 py-2.5 hover:bg-white/[0.025] transition-colors">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <span
+            className={`inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${badge}`}
+          >
+            <Icon size={11} />
+            {kind}
           </span>
-        )}
+          <span className="font-mono text-xs font-bold text-text-primary">{a.ticker}</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 font-mono text-xs tabular-nums">
+          <span className="text-text-muted">{(a.current_pct ?? 0).toFixed(1)}%</span>
+          <ArrowRight size={11} className="text-text-muted/60" />
+          <span className="text-text-primary font-semibold">{(a.recommended_pct ?? 0).toFixed(1)}%</span>
+          {Math.abs(delta) >= 0.05 && (
+            <span className={delta > 0 ? 'text-fin-green' : 'text-fin-red'}>
+              {delta > 0 ? '+' : ''}
+              {delta.toFixed(1)}pp
+            </span>
+          )}
+        </div>
       </div>
+      {rationale && (
+        <p className="mt-1 pl-1 text-[11px] leading-snug text-text-muted">{rationale}</p>
+      )}
     </div>
   );
 }
 
-export function TodayActionsPanel({ actions }: { actions: RebalanceAction[] }) {
+export function TodayActionsPanel({
+  actions,
+  rationaleByTicker,
+}: {
+  actions: RebalanceAction[];
+  /** Per-ticker rationale from the PM rebalance memo (#704); `—` when absent. */
+  rationaleByTicker?: Record<string, string>;
+}) {
   const [showHolds, setShowHolds] = useState(false);
+  const rationale = (ticker: string): string | undefined => rationaleByTicker?.[ticker];
   const { changes, holds } = useMemo(() => {
     const sorted = [...actions].sort((x, y) => ORDER[kindOf(x.action)] - ORDER[kindOf(y.action)]);
     return {
@@ -97,7 +110,7 @@ export function TodayActionsPanel({ actions }: { actions: RebalanceAction[] }) {
       ) : (
         <div className="divide-y divide-border-subtle">
           {changes.map((a, i) => (
-            <ActionRow key={`${a.ticker}-${i}`} a={a} />
+            <ActionRow key={`${a.ticker}-${i}`} a={a} rationale={rationale(a.ticker)} />
           ))}
         </div>
       )}

--- a/frontend/olympus/components/overview/today-actions-panel.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.tsx
@@ -68,11 +68,13 @@ export function TodayActionsPanel({
   rationaleByTicker,
 }: {
   actions: RebalanceAction[];
-  /** Per-ticker rationale from the PM rebalance memo (#704); `—` when absent. */
+  /** Per-ticker rationale from the PM rebalance memo (#704); the rationale line
+   *  is omitted entirely for tickers with no memo entry. */
   rationaleByTicker?: Record<string, string>;
 }) {
   const [showHolds, setShowHolds] = useState(false);
-  const rationale = (ticker: string): string | undefined => rationaleByTicker?.[ticker];
+  const rationale = (ticker: string): string | undefined =>
+    rationaleByTicker?.[ticker.trim().toUpperCase()];
   const { changes, holds } = useMemo(() => {
     const sorted = [...actions].sort((x, y) => ORDER[kindOf(x.action)] - ORDER[kindOf(y.action)]);
     return {

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -198,12 +198,16 @@ async function fetchPipelineObservabilityForDate(dashboardDate: string): Promise
   const kMap = `thesis-vehicle-map/${dashboardDate}.json`;
   const kMemo = `pm-allocation-memo/${dashboardDate}.json`;
   const kIdx = `deliberation-transcript-index/${dashboardDate}.json`;
-  const [exactRes, arRes, delRes] = await Promise.all([
+  // Hermes pipeline docs (#699/#700) use flat keys (no date segment) — the date
+  // lives in the row's `date` column. risk-debate + pm-rebalance are singletons.
+  const kRisk = 'risk-debate';
+  const kPmReb = 'pm-rebalance';
+  const [exactRes, arRes, delRes, pipeDelRes] = await Promise.all([
     sb
       .from('documents')
       .select('document_key, payload')
       .eq('date', dashboardDate)
-      .in('document_key', [kExpl, kMap, kMemo, kIdx]),
+      .in('document_key', [kExpl, kMap, kMemo, kIdx, kRisk, kPmReb]),
     sb
       .from('documents')
       .select('document_key, payload')
@@ -214,10 +218,18 @@ async function fetchPipelineObservabilityForDate(dashboardDate: string): Promise
       .select('document_key, payload')
       .eq('date', dashboardDate)
       .ilike('document_key', `deliberation-transcript/${dashboardDate}/%`),
+    // Pipeline bull/bear summaries: `deliberation/{ticker}` (the `/%` pattern
+    // never matches `deliberation-transcript/…` — different separator).
+    sb
+      .from('documents')
+      .select('document_key, payload')
+      .eq('date', dashboardDate)
+      .ilike('document_key', 'deliberation/%'),
   ]);
   if (exactRes.error) console.warn('Supabase pipeline exact docs:', exactRes.error);
   if (arRes.error) console.warn('Supabase asset-recommendation docs:', arRes.error);
   if (delRes.error) console.warn('Supabase deliberation-transcript docs:', delRes.error);
+  if (pipeDelRes.error) console.warn('Supabase pipeline deliberation docs:', pipeDelRes.error);
 
   const byKey = new Map<string, unknown>();
   for (const row of (exactRes.data ?? []) as Pick<TableRow<'documents'>, 'document_key' | 'payload'>[]) {
@@ -249,6 +261,18 @@ async function fetchPipelineObservabilityForDate(dashboardDate: string): Promise
       payload: pl,
     });
   }
+  // Pipeline `deliberation/{ticker}` bull/bear summaries — ticker is the flat
+  // suffix after the single slash.
+  for (const row of (pipeDelRes.data ?? []) as Pick<TableRow<'documents'>, 'document_key' | 'payload'>[]) {
+    if (!row?.document_key) continue;
+    const pl = payloadAsRecord(row.payload);
+    if (!pl) continue;
+    deliberation_transcripts.push({
+      document_key: row.document_key,
+      ticker: (row.document_key.split('/')[1] ?? '').toUpperCase(),
+      payload: pl,
+    });
+  }
   deliberation_transcripts.sort((a, b) => a.ticker.localeCompare(b.ticker));
 
   return {
@@ -259,6 +283,8 @@ async function fetchPipelineObservabilityForDate(dashboardDate: string): Promise
     deliberation_session_index: get(kIdx),
     deliberation_transcripts,
     asset_recommendations,
+    risk_debate: get(kRisk),
+    pm_rebalance: get(kPmReb),
   };
 }
 

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -267,11 +267,12 @@ async function fetchPipelineObservabilityForDate(dashboardDate: string): Promise
     if (!row?.document_key) continue;
     const pl = payloadAsRecord(row.payload);
     if (!pl) continue;
-    deliberation_transcripts.push({
-      document_key: row.document_key,
-      ticker: (row.document_key.split('/')[1] ?? '').toUpperCase(),
-      payload: pl,
-    });
+    const ticker = (row.document_key.split('/')[1] ?? '')
+      .replace(/\.json$/i, '')
+      .trim()
+      .toUpperCase();
+    if (!ticker) continue; // skip a malformed `deliberation/` key
+    deliberation_transcripts.push({ document_key: row.document_key, ticker, payload: pl });
   }
   deliberation_transcripts.sort((a, b) => a.ticker.localeCompare(b.ticker));
 

--- a/frontend/olympus/lib/types.ts
+++ b/frontend/olympus/lib/types.ts
@@ -282,8 +282,17 @@ export interface PipelineObservabilityBundle {
   thesis_vehicle_map: Record<string, unknown> | null;
   pm_allocation_memo: Record<string, unknown> | null;
   deliberation_session_index: Record<string, unknown> | null;
+  /**
+   * Per-ticker bull/bear `DebateSummary` docs. Carries both the Hermes pipeline
+   * shape (`deliberation/{ticker}`, has `net_stance`) and any operator-flow
+   * `deliberation-transcript/{date}/{ticker}` docs; consumers filter by shape.
+   */
   deliberation_transcripts: PipelineTickerDoc[];
   asset_recommendations: PipelineTickerDoc[];
+  /** Hermes `risk-debate` doc (aggressive/conservative/key_tension), or null. */
+  risk_debate: Record<string, unknown> | null;
+  /** Hermes `pm-rebalance` decision doc (actions carry per-ticker rationale), or null. */
+  pm_rebalance: Record<string, unknown> | null;
 }
 
 /** The complete data object returned by getFullDashboardData(). */


### PR DESCRIPTION
Fixes #704

Phase C read-polish (PR1b + PR2 from the Morning Read blueprint). Completes the deliberation + decision surfaces wired in #703 — and fixes a latent gap that would have left them empty on real data.

## The latent gap (PR1b core)

`fetchPipelineObservabilityForDate` only loaded **operator-flow** doc keys (`deliberation-transcript/{date}/{ticker}`, `pm-allocation-memo/{date}`). But the Hermes pipeline (#699/#700) publishes **flat** keys: `deliberation/{ticker}` (bull/bear `DebateSummary`), `risk-debate`, `pm-rebalance`. So #703's Deliberations strip would have stayed empty even after a real pipeline run. This PR wires the pipeline keys into the observability bundle.

## Changes

- **`lib/queries.ts`** — `fetchPipelineObservabilityForDate` now also loads `deliberation/%` (merged into `deliberation_transcripts`, ticker = flat suffix), `risk-debate`, and `pm-rebalance` (the `/%` pattern never matches `deliberation-transcript/…` — different separator).
- **`lib/types.ts`** — `PipelineObservabilityBundle` gains `risk_debate` + `pm_rebalance`.
- **Deliberations strip** — adds a portfolio-level **risk-debate** card (`renderRiskDebateMarkdown`, expand-in-place) below the per-ticker bull/bear cards; renders when either is present, null when neither.
- **Decision Trail** — the stubbed `hasRiskDebate` row now lights up from real data.
- **Today's Actions** — per-ticker **rationale** joined from the `pm-rebalance` doc's `actions[].rationale` when present (no fabrication; absent → no rationale line). The computed `rebalance_actions` array has no rationale field, so this fills the `—` the blueprint flagged.

## Verification

- 88 vitest (4 new: risk-debate card present/both/neither, rationale render). Existing tests green.
- tsc clean, `next build` (static export) green, eslint clean, `make doc-check` OK, `make score` 10/10/10/10.

Once the next pipeline run lands `deliberation/{ticker}` + `risk-debate` + `pm-rebalance` docs, the Morning Read deliberations strip + risk-debate card + action rationales populate automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
