### PR TITLE
feat(olympus): auth gate — revoke anon run-diagnostics + Cloudflare Access runbook (HUMAN GATE, #706)

### DIFF
--- a/digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql
+++ b/digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql
@@ -1,0 +1,26 @@
+-- 033_revoke_anon_run_diagnostics.sql
+--
+-- Run with:  supabase db push   (or paste into the Supabase SQL editor / apply via MCP)
+--
+-- Privacy hardening ahead of sharing the Olympus dashboard (#706). The
+-- `atlas_run_diagnostics` table (migration 032) carries operator-internal
+-- telemetry — LLM spend (`est_cost_usd`), token counts, and the per-phase
+-- `breakdown` JSONB — and was granted anon SELECT `USING (true)` "so an Olympus
+-- dashboard can query it". The dashboard never does: a repo-wide search shows
+-- no frontend read of `atlas_run_diagnostics` (the observability panel reads the
+-- `documents`/`daily_snapshots` payloads, not this table). Today that telemetry
+-- is therefore world-readable to anyone replaying the bundled anon key while
+-- adding zero value to a portfolio viewer.
+--
+-- Drop the anon SELECT policy so the table is service-role-only (the chain's
+-- fail-soft `diagnostics.write_row` uses the service role, which bypasses RLS —
+-- writes are unaffected). This is the most-restrictive direction and is
+-- frontend-safe. The edge gate (Cloudflare Access) remains the primary control;
+-- this is defense-in-depth so cost/token internals never leave the DB even to
+-- allow-listed viewers. Idempotent.
+
+DROP POLICY IF EXISTS atlas_run_diagnostics_anon_select ON public.atlas_run_diagnostics;
+
+-- Note: RLS stays ENABLED on the table (migration 032). With no anon SELECT
+-- policy, anon reads return zero rows / are denied; the service role still has
+-- full access (RLS bypass), so the pipeline's diagnostics writes are unaffected.

--- a/digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql
+++ b/digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql
@@ -21,6 +21,8 @@
 
 DROP POLICY IF EXISTS atlas_run_diagnostics_anon_select ON public.atlas_run_diagnostics;
 
--- Note: RLS stays ENABLED on the table (migration 032). With no anon SELECT
--- policy, anon reads return zero rows / are denied; the service role still has
--- full access (RLS bypass), so the pipeline's diagnostics writes are unaffected.
+-- Note: RLS stays ENABLED on the table (migration 032). This drops the anon
+-- SELECT *policy* (not a SQL GRANT/REVOKE) — with RLS on and no SELECT policy,
+-- anon reads return an empty result set (RLS denies all rows), not a permission
+-- error. The service role still has full access (RLS bypass), so the pipeline's
+-- diagnostics writes are unaffected.

--- a/frontend/olympus/AUTH.md
+++ b/frontend/olympus/AUTH.md
@@ -1,0 +1,75 @@
+# Olympus access gating (before sharing)
+
+The Olympus dashboard at `digiquant.io/olympus/` is a **static export** that reads
+Supabase directly with the **publishable anon key baked into the JS bundle**, and
+every relevant table has an `anon` RLS policy of `USING (true)`. So **anyone with
+the URL can read all published data** — the anon key cannot be hidden in a static
+bundle, and any client-side gate (passphrase, Supabase-Auth-without-RLS-rewrite)
+is bypassable by reading the bundle and replaying the key directly against
+Supabase. Treat the URL as public until the edge gate below is live.
+
+## The exposure, concretely
+
+With the URL alone, an anonymous reader can `SELECT` from every table carrying an
+`anon … USING (true)` policy — `daily_snapshots`, `documents` (incl. the
+`deliberation/*`, `risk-debate`, `pm-rebalance` payloads), `positions`,
+`nav_history`, `price_history`, `price_technicals`, `macro_series_observations`,
+etc. Migration [`033_revoke_anon_run_diagnostics.sql`](../../digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql)
+removes the one piece of operator-internal telemetry that leaked
+(`atlas_run_diagnostics`: LLM spend, token counts) and that the dashboard never
+reads. Everything else *is* the product (research, deliberations, the paper book)
+and stays readable to allow-listed viewers once the gate is up.
+
+> Note: `positions.pm_notes` is **not** scrubbed — it is PM commentary the
+> dashboard renders and the owner reads; it is part of the decision narrative,
+> not operator-internal leakage.
+
+## The gate: Cloudflare Access (edge, before the bundle loads)
+
+Cloudflare Access is the only option that actually closes the exposure for a
+static export: it authenticates the request **at Cloudflare's edge, before the
+browser ever receives the bundle or reaches Supabase**. Zero code, ~15 minutes,
+and it fits Pages perfectly (no API routes / server runtime needed). It is a
+**network-exposure change → human gate** (CLAUDE.md): the owner performs the
+dashboard config below.
+
+### One-time setup (owner)
+
+1. Cloudflare dashboard → **Zero Trust → Access → Applications → Add an
+   application → Self-hosted**.
+2. **Application domain:** `digiquant.io`, path `/olympus` (covers `/olympus/*`).
+   Leave the apex and `digiquant.io/` (the marketing site) **ungated**.
+3. **Session duration:** e.g. 24h–1 week to taste.
+4. **Add a policy** → Action **Allow** → Include **Emails** (or *Emails ending
+   in* a domain) — the allow-list of people who may view the dashboard:
+   ```
+   <you@example.com>
+   <trusted-viewer@example.com>
+   ```
+   (Add an *Emails ending in* rule for a whole org if desired.)
+5. Identity provider: the built-in **one-time PIN** (email code) needs no IdP
+   setup; or wire Google/GitHub SSO under Zero Trust → Settings →
+   Authentication.
+6. Save. Visiting `digiquant.io/olympus/` now prompts for login; only
+   allow-listed identities reach the bundle. The marketing site is unaffected.
+
+### Verify
+
+- Incognito → `digiquant.io/olympus/` → redirected to the Access login (not the
+  dashboard). After allow-listed login → dashboard loads.
+- `digiquant.io/` (marketing) still loads with no prompt.
+
+## Why not the alternatives
+
+- **Supabase Auth + per-row RLS** — the self-hostable long-term path, but it
+  requires rewriting every `anon … USING (true)` policy to `auth.uid()`-scoped
+  rules and adding a login flow; 6–8h and pointless until those policies are
+  tightened. Defer unless multi-tenant/self-host hosting becomes a requirement.
+- **Passphrase / client-side gate** — friction only. The anon key is in the
+  bundle; a determined viewer replays it straight against Supabase. Not shipped.
+
+## Status
+
+- [x] `033` revokes anon read of `atlas_run_diagnostics` (cost/token telemetry).
+- [ ] **Owner:** configure Cloudflare Access on `/olympus/*` with the allow-list.
+- [ ] **Do not share the URL until the Access app is live.**

--- a/frontend/olympus/AUTH.md
+++ b/frontend/olympus/AUTH.md
@@ -70,6 +70,7 @@ dashboard config below.
 
 ## Status
 
-- [x] `033` revokes anon read of `atlas_run_diagnostics` (cost/token telemetry).
+- [x] `033` drops the anon SELECT RLS policy on `atlas_run_diagnostics` (cost/token
+  telemetry) — anon reads return an empty result set; service-role writes unaffected.
 - [ ] **Owner:** configure Cloudflare Access on `/olympus/*` with the allow-list.
 - [ ] **Do not share the URL until the Access app is live.**

--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -137,9 +137,11 @@ regime → KPIs → what to do → why → where to read more. The panels under
   run date is older than yesterday (UTC).
 
 > **Sharing:** the static export embeds the Supabase anon key and every table
-> has `anon` RLS `USING (true)`, so the dashboard URL is world-readable. Do not
-> share it until the auth gate (Cloudflare Access) + column scrub land in the
-> separate human-gated auth PR.
+> has `anon` RLS `USING (true)`, so the dashboard URL is world-readable. Gate it
+> with **Cloudflare Access** before sharing — see [`AUTH.md`](AUTH.md) for the
+> runbook and the exact exposure. Migration `033` already revokes anon read of
+> the operator cost/token telemetry (`atlas_run_diagnostics`); `pm_notes` is
+> intentionally kept (it's PM commentary the dashboard renders).
 
 ## Daily snapshot envelope
 

--- a/frontend/olympus/README.md
+++ b/frontend/olympus/README.md
@@ -139,9 +139,9 @@ regime → KPIs → what to do → why → where to read more. The panels under
 > **Sharing:** the static export embeds the Supabase anon key and every table
 > has `anon` RLS `USING (true)`, so the dashboard URL is world-readable. Gate it
 > with **Cloudflare Access** before sharing — see [`AUTH.md`](AUTH.md) for the
-> runbook and the exact exposure. Migration `033` already revokes anon read of
-> the operator cost/token telemetry (`atlas_run_diagnostics`); `pm_notes` is
-> intentionally kept (it's PM commentary the dashboard renders).
+> runbook and the exact exposure. Migration `033` drops the anon SELECT RLS
+> policy on the operator cost/token telemetry table (`atlas_run_diagnostics`);
+> `pm_notes` is intentionally kept (it's PM commentary the dashboard renders).
 
 ## Daily snapshot envelope
 


### PR DESCRIPTION
Fixes #706

⚠️ **HUMAN GATE** — network-exposure / RLS change (CLAUDE.md). The code-side pieces are here; the **Cloudflare Access dashboard config + allow-list is the owner's manual step** (runbook included). Nothing is shared until that gate is live.

## Context

Olympus is a static export that ships the Supabase **anon key in the bundle**, and every table has `anon` RLS `USING (true)` — so the dashboard URL is world-readable, and no client-side gate can fix that (the key is replayable straight against Supabase). The only real control is an **edge gate before the bundle loads**.

## What this PR ships

1. **`033_revoke_anon_run_diagnostics.sql`** — drops the anon SELECT policy on `atlas_run_diagnostics`. That table is operator-internal telemetry (LLM `est_cost_usd`, token counts, per-phase `breakdown`) that was anon-readable but, verified by repo-wide grep, **the frontend never queries it**. A strict REVOKE in the safe direction; the service-role writer bypasses RLS so pipeline diagnostics writes are unaffected. This is the correct "scrub" — done as a table-level revoke, not a column REVOKE.
2. **`frontend/olympus/AUTH.md`** — Cloudflare Access runbook: exact Zero Trust app + policy + allow-list placeholder, the precise exposure it closes, verification steps, and why Supabase-Auth/passphrase alternatives are deferred/theater.
3. **README** share-gating note → links AUTH.md; corrects the earlier guidance.

## Investigation that shaped this (why no `pm_notes` scrub)

The design blueprint suggested scrubbing `pm_notes` too. But the frontend **actively reads `positions.pm_notes`** (`queries.ts:748`, rendered in the UI) *and* `select('*')`s the `positions` table — so a column REVOKE would both break `select('*')` and remove a real feature. `pm_notes` is PM commentary the owner reads (decision narrative), not operator leakage — it **stays**. Only `atlas_run_diagnostics` (never read by the frontend) is revoked.

## Verification

- `make score` 10/10/10/10; `make doc-check` OK (AUTH.md ↔ migration ↔ README links resolve).
- No code/test changes (migration + docs); existing suites unaffected.
- Security posture: REVOKE-only (more restrictive), on a frontend-unused table — reviewed against the actual frontend read surface.

## Owner steps to actually close the exposure
- [ ] Apply migration `033` (supabase db push / normal flow).
- [ ] Configure Cloudflare Access on `digiquant.io/olympus/*` per AUTH.md with your allow-list.
- [ ] Then — and only then — share the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
