### PR TITLE
feat(atlas): Phase D PR-1 — FRED vol complex replaces paid search for alt-options-derivatives (#708)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/config/macro_series.yaml
+++ b/digiquant/src/digiquant/olympus/atlas/config/macro_series.yaml
@@ -57,6 +57,21 @@ fred:
     - id: VIXCLS
       title: "VIX close"
       unit: index
+    # Volatility complex (#708, Phase D) — FRED republishes the CBOE indices, so
+    # alt-options-derivatives reads the term structure (VIXCLS/VXVCLS) and
+    # cross-asset vol from Supabase instead of a paid web_search pre-pass.
+    - id: VXVCLS
+      title: "VIX 3-month (VIX3M)"
+      unit: index
+    - id: VXNCLS
+      title: "Nasdaq-100 volatility (VXN)"
+      unit: index
+    - id: GVZCLS
+      title: "Gold volatility (GVZ)"
+      unit: index
+    - id: OVXCLS
+      title: "Crude oil volatility (OVX)"
+      unit: index
     - id: DTWEXBGS
       title: "Trade-weighted US dollar (broad)"
       unit: index

--- a/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
@@ -1,0 +1,61 @@
+# Phase D — free-source ingestion replaces paid agentic search
+
+**Goal:** cut a daily delta run from ~$3 to **<$1** *without reducing research
+capability* (owner directive: optimize/replace, never narrow). ~$2.44 of the
+baseline is xAI agentic `web_search`/`x_search` ($5 per 1k server-side
+invocations; one call spawns dozens). The fix: push all fetching off the hot
+path to the existing GitHub Actions cron, store in Supabase, and have research
+phases read via in-process data tools instead of paid search.
+
+## The seam
+
+`phases/_node_factory.py:build_grounding()` — per segment, flip the
+`SegmentNodeSpec` from `live_search=True` to `use_data_tools=True`. Run time
+becomes flat Supabase SELECTs; the xAI internal-invocation multiplier disappears
+for converted segments. Scalar series reuse `macro_series_observations`
+(migration 015); relational data gets new tables.
+
+## Capability guarantee (fail-soft-to-paid)
+
+Every converted segment either reads fresh ingested data **or** (for
+fallback-flagged segments) falls through to the original paid call when the
+table is stale/empty. A dead free source raises cost for that one segment but
+never yields an ungrounded/degraded output. Most segments get *strictly better*
+data — exact regulator/central-bank integers vs lossy prose summaries.
+
+## PR sequence (greedy by leverage)
+
+| PR | Segment(s) | Source | New infra |
+|----|-----------|--------|-----------|
+| **PR-1** (this) | alt-options-derivatives | FRED vol complex (VIX/VIX3M/VXN/GVZ/OVX) | none — FRED job + `get_macro_series` exist |
+| PR-2 | macro, international | FRED non-US M2 + CB balance sheets; intl index levels (yfinance→price_history) | + the ingested-first/paid-fallback helper |
+| PR-3 | alt-cta-positioning | CFTC COT (Socrata SODA) | `cftc_ingest.py`, `get_cot_positioning` tool, weekly cron |
+| PR-4 | inst-institutional-flows, inst-hedge-fund-intel | SEC EDGAR (13F / 13D-G / Form 4) | `edgar_ingest.py`, `sec_filings_positions` table, 2 tools |
+| PR-5 | alt-politician-signals | House Clerk STOCK Act ZIP | `congress_ingest.py`, `congress_trades` table, tool; keep trimmed Fed/Treasury fallback search |
+| PR-6 | alt-sentiment-news | GDELT + RSS + FinBERT scoring | `news_ingest.py`, `news_sentiment_daily` table, tool |
+| PR-7 (opt) | alt-ai-portfolios | X archiver (best-effort) | `ai_portfolio_x_posts`; keep x_search fallback |
+| PR-8 | — | freshness/staleness panel + fallback-fired alert; final docs | — |
+
+## Deliberately-retained paid fallbacks (the honest gaps)
+
+- **alt-ai-portfolios x_search** (~$0.12/day) — X has no robust free read API.
+- **Fed/Treasury policy *rhetoric*** — a domain-trimmed (`federalreserve.gov` /
+  `treasury.gov` / `sec.gov`), `max_results=3`, **fallback-only** `web_search`,
+  fired only when the ingested layer is stale. Data series capture the numbers,
+  not "Powell signaled a cut at today's presser."
+
+The pipeline clears <$1/day even if both stay fully paid.
+
+## Known gaps / risks (see the design workflow output for detail)
+
+- Put/call ratio & dealer GEX: no free source (paid search never had real GEX
+  either). VIX term structure + cross-asset vol proxy it; state when absent.
+- China M2 (`MYAGM2CNM189N` discontinued — verify `MABMM301CNM189S`), Reuters/AP
+  RSS dead (use Google News RSS + GDELT tone), 13F/COT/congress freshness lags
+  are structural — store 2+ periods, compute deltas.
+- **Implementer must add the new data hosts to
+  `scripts/claude-hooks/network-host-guard.sh`**: `api.gdeltproject.org`,
+  `data.gdeltproject.org`, `efts.sec.gov`, `data.sec.gov`, `www.sec.gov`,
+  `publicreporting.cftc.gov`, `disclosures-clerk.house.gov`,
+  `production.dataviz.cnn.io`, `news.google.com`, RSS feed hosts. SEC/House
+  require a descriptive `User-Agent` (403 without).

--- a/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
@@ -171,7 +171,11 @@ Capability-preserving reductions in place:
 Deliberately **not** used (they reduce capability): higher triage carry
 thresholds, lower `max_search_results`, blanket fan-out caps. The remaining
 search-cost work is structural — free-source ingestion replacing paid agentic
-searches — not narrowing.
+searches — not narrowing. That program is **Phase D**: see
+[`PHASE-D.md`](PHASE-D.md) for the full architecture, PR sequence, and the
+retained paid fallbacks. PR-1 converts `alt-options-derivatives` to read the
+FRED vol complex (VIX/VIX3M/VXN/GVZ/OVX, in `config/macro_series.yaml`) via
+`get_macro_series` instead of a paid `web_search` (#708).
 
 `atlas_run_diagnostics.est_cost_usd` tracks each run; verify after changes.
 

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase1_altdata.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase1_altdata.py
@@ -118,7 +118,11 @@ _SPECS = (
         skill_slug="alt-options-derivatives",
         output_model=OptionsDerivativesReport,
         phase_outputs_field=_PHASE_FIELD,
-        live_search=True,
+        # Phase D PR-1 (#708): read the FRED-republished vol complex
+        # (VIX/VIX3M/VXN/GVZ/OVX) via the Supabase data tools instead of a paid
+        # web_search pre-pass — exact term-structure numbers, not paraphrased
+        # prose, at zero per-run search cost.
+        use_data_tools=True,
     ),
     SegmentNodeSpec(
         segment_slug="alt-politician-signals",

--- a/digiquant/src/digiquant/olympus/atlas/skills/alt-options-derivatives/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/alt-options-derivatives/SKILL.md
@@ -7,10 +7,19 @@ description: Analyzes options market structure, volatility term structure, gamma
 
 ## Grounding Tools (use first)
 
-- **Web grounding (pre-fetched)** — this segment has no maintained Supabase series. A
-  `web_grounding` block (a cited web/news/X summary over curated domains incl. reuters.com,
-  apnews.com, sec.gov, cftc.gov, treasury.gov, capitoltrades.com, finance.yahoo.com) is
-  provided in PHASE_INPUTS when available; ground on it and carry its source URLs for options positioning, gamma, put/call skew, and unusual activity. into the `sources` field; if no `web_grounding` is present, say so and lower conviction.
+- **Volatility data tool (`get_macro_series`)** — the volatility complex is ingested
+  from FRED (which republishes the CBOE indices) into Supabase. Call
+  `get_macro_series(series_ids=["VIXCLS", "VXVCLS", "VXNCLS", "GVZCLS", "OVXCLS"])`:
+  - `VIXCLS` = VIX (1-month S&P implied vol), `VXVCLS` = VIX3M (3-month).
+  - `VXNCLS` = Nasdaq-100 vol (VXN), `GVZCLS` = gold vol, `OVXCLS` = crude-oil vol.
+  These are exact daily closes — cite them as numbers (with `obs_date`) in `sources`,
+  not paraphrased commentary. The term-structure ratio **VIXCLS / VXVCLS** is the
+  contango/backwardation regime signal (ratio < 1 = contango/calm; > 1 = backwardation/stress).
+- **Coverage gap (be explicit):** put/call ratios, dealer gamma/GEX, max pain, and
+  unusual-activity scans have **no free data source** and are no longer fetched. Use the
+  VIX term structure + cross-asset vol (VXN/GVZ/OVX) as the sentiment/positioning proxy,
+  and explicitly state in the output that GEX/put-call are unavailable rather than
+  inventing them. Lower conviction where the proxy is thin.
 
 ## Purpose
 Options markets reveal institutional hedging, speculative bets, and gamma dynamics that can force dealer hedging flows and cause accelerated price moves. This skill reads the options market as a forward-looking intelligence source. Run before segment analysis.

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -18,10 +18,10 @@ def test_macro_uses_data_tools_and_search():
 
 
 @pytest.mark.unit
-def test_alt_phases_use_soft_grounding_only():
+def test_alt_phases_grounding_modes():
+    # alt-options-derivatives reads data tools (#708); every other alt-data
+    # segment still grounds on soft signals (web/x search).
     by_slug = {s.segment_slug: s for s in ALT_SPECS}
-    # alt-options-derivatives reads the FRED vol complex via the Supabase data
-    # tools — no paid search (Phase D PR-1, #708).
     opts = by_slug["alt-options-derivatives"]
     assert opts.use_data_tools is True
     assert opts.live_search is False and opts.ai_portfolios is False
@@ -85,9 +85,7 @@ def test_options_segment_makes_no_paid_search(monkeypatch):
     def _fail(**_k):  # a paid web_search call here would be the bug
         raise AssertionError("options segment must not call fetch_web_grounding")
 
-    monkeypatch.setattr(
-        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding", _fail
-    )
+    monkeypatch.setattr("digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding", _fail)
     _tools, _execute, grounding = _node_factory.build_grounding(
         use_data_tools=True,
         live_search=False,

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -19,12 +19,20 @@ def test_macro_uses_data_tools_and_search():
 
 @pytest.mark.unit
 def test_alt_phases_use_soft_grounding_only():
-    # Alt-data segments ground on soft signals (web_search or x_search), never data tools.
+    by_slug = {s.segment_slug: s for s in ALT_SPECS}
+    # alt-options-derivatives reads the FRED vol complex via the Supabase data
+    # tools — no paid search (Phase D PR-1, #708).
+    opts = by_slug["alt-options-derivatives"]
+    assert opts.use_data_tools is True
+    assert opts.live_search is False and opts.ai_portfolios is False
+    # Every other alt-data segment still grounds on soft signals (web/x search),
+    # never data tools.
     for spec in ALT_SPECS:
+        if spec.segment_slug == "alt-options-derivatives":
+            continue
         assert spec.use_data_tools is False, spec.segment_slug
         assert spec.live_search or spec.ai_portfolios, spec.segment_slug
     # alt-ai-portfolios is the x_search one; the rest use web_search.
-    by_slug = {s.segment_slug: s for s in ALT_SPECS}
     assert by_slug["alt-ai-portfolios"].ai_portfolios is True
     assert by_slug["alt-ai-portfolios"].live_search is False
     assert by_slug["alt-sentiment-news"].live_search is True
@@ -64,6 +72,42 @@ def test_build_grounding_respects_kill_switch(monkeypatch):
         use_data_tools=True, live_search=True, run_date=date(2026, 6, 8), model="xai/grok-4.3"
     )
     assert tools is not None and execute_tool is not None and grounding is not None
+
+
+@pytest.mark.unit
+def test_options_segment_makes_no_paid_search(monkeypatch):
+    # Phase D PR-1 (#708): with use_data_tools=True and live_search=False, the
+    # options segment must never fire a paid web_search — web_grounding is None
+    # regardless of whether the Supabase client is available.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
+
+    def _fail(**_k):  # a paid web_search call here would be the bug
+        raise AssertionError("options segment must not call fetch_web_grounding")
+
+    monkeypatch.setattr(
+        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding", _fail
+    )
+    _tools, _execute, grounding = _node_factory.build_grounding(
+        use_data_tools=True,
+        live_search=False,
+        run_date=date(2026, 6, 8),
+        model="xai/grok-4.3",
+        segment="alt-options-derivatives",
+    )
+    assert grounding is None
+
+
+@pytest.mark.unit
+def test_macro_series_yaml_has_volatility_complex():
+    # The FRED vol series alt-options-derivatives reads must be in the manifest.
+    import yaml
+
+    from digiquant.olympus.atlas.graph import _atlas_config_root
+
+    raw = yaml.safe_load((_atlas_config_root() / "macro_series.yaml").read_text())
+    ids = {s["id"] for s in raw["fred"]["series"]}
+    assert {"VIXCLS", "VXVCLS", "VXNCLS", "GVZCLS", "OVXCLS"} <= ids
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #708

Phase D PR-1 — first vertical slice of replacing paid xAI agentic search with free Supabase-ingested data (target <$1/day, **capability-preserving**). Converts **alt-options-derivatives** to read the FRED-republished volatility complex via the existing `get_macro_series` data tool instead of a paid `web_search` pre-pass. **Zero new infrastructure** — the FRED ingest job and the tool are already in production.

See [`PHASE-D.md`](../digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md) for the full architecture, the 8-PR sequence, and the deliberately-retained paid fallbacks.

## Changes

- **`config/macro_series.yaml`** — add the FRED vol series `VXVCLS` (VIX3M), `VXNCLS` (Nasdaq vol), `GVZCLS` (gold vol), `OVXCLS` (oil vol). `VIXCLS` already present. (The daily FRED job ingests these into `macro_series_observations` with no code change.)
- **`phases/phase1_altdata.py`** — `alt-options-derivatives` spec: `use_data_tools=True` (drops `live_search`). With data tools on and `live_search` off, `build_grounding` makes **no paid search**.
- **`skills/alt-options-derivatives/SKILL.md`** — replace the web-grounding block with `get_macro_series([VIXCLS,VXVCLS,VXNCLS,GVZCLS,OVXCLS])` + the term-structure (VIXCLS/VXVCLS) regime signal, and **explicitly note** that put/call ratios and dealer GEX have no free source (use VIX term structure + cross-asset vol as the proxy; state when unavailable rather than inventing).
- Docs: new `PHASE-D.md` (durable roadmap) + RUNBOOK cost-section pointer.

## A note on the plan's "fallback helper"

The design plan suggested landing the reusable ingested-first/paid-fallback helper here. I deferred it: alt-options-derivatives is **not** a fallback segment (FRED vol is reliable), so the helper would be dead code in PR-1 and ding the Optimization score. It lands in PR-2, the first segment (macro/international) that actually needs the paid-on-stale path.

## Verification

- 8/8 `test_phase_tool_flags` incl. 2 new: options segment makes **no** paid search (`fetch_web_grounding` is asserted never called), and the vol series are present in the manifest. Existing alt-grounding test updated for the new exception.
- `make score` 10/10/10/10; `make doc-check` OK; full atlas suite green (below).

## Effect

Removes 1 of 8 paid `web_search` calls. After merge, a delta run's diagnostics `sources_used` for alt-options-derivatives → 0, and the segment cites exact VIX/term-structure numbers instead of paraphrased prose. Net step toward <$1/day; capability improves (exact figures > prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
