### PR TITLE
feat(atlas): Phase D PR-2 — macro web_search becomes a stale-only paid fallback (#711)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
@@ -15,6 +15,15 @@ becomes flat Supabase SELECTs; the xAI internal-invocation multiplier disappears
 for converted segments. Scalar series reuse `macro_series_observations`
 (migration 015); relational data gets new tables.
 
+For segments that still need a paid search as a *safety net* (not a daily
+input), set `SegmentNodeSpec.live_search_is_fallback=True` alongside
+`live_search=True`. `build_grounding` then gates the `web_search` pre-pass on
+`_ingested_macro_stale(run_date)`: it fires only when the freshest ingested FRED
+observation is older than `ATLAS_MACRO_STALE_DAYS` (default 7) — i.e. the daily
+ingestion cron is genuinely broken. On a healthy run the paid call is skipped
+and the segment grounds on its data tools. The probe fail-soft's to "stale"
+(fire paid) on any error, so grounding is never silently dropped.
+
 ## Capability guarantee (fail-soft-to-paid)
 
 Every converted segment either reads fresh ingested data **or** (for
@@ -27,8 +36,9 @@ data — exact regulator/central-bank integers vs lossy prose summaries.
 
 | PR | Segment(s) | Source | New infra |
 |----|-----------|--------|-----------|
-| **PR-1** (this) | alt-options-derivatives | FRED vol complex (VIX/VIX3M/VXN/GVZ/OVX) | none — FRED job + `get_macro_series` exist |
-| PR-2 | macro, international | FRED non-US M2 + CB balance sheets; intl index levels (yfinance→price_history) | + the ingested-first/paid-fallback helper |
+| PR-1 | alt-options-derivatives | FRED vol complex (VIX/VIX3M/VXN/GVZ/OVX) | none — FRED job + `get_macro_series` exist |
+| **PR-2** (this) | macro | existing US FRED series (`get_macro_series`); web_search demoted to stale-only fallback | the ingested-first/paid-fallback helper (`_ingested_macro_stale` + `SegmentNodeSpec.live_search_is_fallback`) |
+| PR-2b (deferred) | macro, international | FRED non-US M2 (`MABMM301*`) + CB balance sheets; intl index levels (yfinance→price_history) | new FRED ids — **need live verification before ingesting** (see Known gaps) |
 | PR-3 | alt-cta-positioning | CFTC COT (Socrata SODA) | `cftc_ingest.py`, `get_cot_positioning` tool, weekly cron |
 | PR-4 | inst-institutional-flows, inst-hedge-fund-intel | SEC EDGAR (13F / 13D-G / Form 4) | `edgar_ingest.py`, `sec_filings_positions` table, 2 tools |
 | PR-5 | alt-politician-signals | House Clerk STOCK Act ZIP | `congress_ingest.py`, `congress_trades` table, tool; keep trimmed Fed/Treasury fallback search |

--- a/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/PHASE-D.md
@@ -21,7 +21,7 @@ input), set `SegmentNodeSpec.live_search_is_fallback=True` alongside
 `_ingested_macro_stale(run_date)`: it fires only when the freshest ingested FRED
 observation is older than `ATLAS_MACRO_STALE_DAYS` (default 7) — i.e. the daily
 ingestion cron is genuinely broken. On a healthy run the paid call is skipped
-and the segment grounds on its data tools. The probe fail-soft's to "stale"
+and the segment grounds on its data tools. The probe fail-softs to "stale"
 (fire paid) on any error, so grounding is never silently dropped.
 
 ## Capability guarantee (fail-soft-to-paid)

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from datetime import date, datetime
 from functools import lru_cache
 from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-update dict shape
 
@@ -45,6 +46,65 @@ def _atlas_data_client() -> Any:
     return build_client(SupabaseConfig.from_env())
 
 
+_MACRO_STALE_DAYS_DEFAULT = 7
+"""Max age of the freshest ingested FRED observation before we treat the layer
+as stale and fire the paid fallback. The freshest series are daily (VIXCLS, DFF,
+DGS10), so a healthy daily cron keeps the max obs_date within a normal market
+close gap (≤ a long holiday weekend); only a genuinely broken ingestion exceeds
+a week. Override via ``ATLAS_MACRO_STALE_DAYS``."""
+
+
+def _macro_stale_days() -> int:
+    raw = os.environ.get("ATLAS_MACRO_STALE_DAYS", "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            logger.warning(
+                "invalid ATLAS_MACRO_STALE_DAYS=%r; using default %d",
+                raw,
+                _MACRO_STALE_DAYS_DEFAULT,
+            )
+    return _MACRO_STALE_DAYS_DEFAULT
+
+
+def _ingested_macro_stale(run_date: Any) -> bool:
+    """Is the ingested FRED macro layer stale → should a fallback segment fire paid search?
+
+    Returns ``True`` (→ use the paid fallback) unless the layer is *confirmed
+    fresh*: the latest ``macro_series_observations.obs_date`` is within
+    ``ATLAS_MACRO_STALE_DAYS`` of ``run_date``. Every failure mode — kill-switch
+    off, no client, query error, empty table, unparseable/exotic ``run_date`` —
+    fail-soft to ``True`` so a ``live_search_is_fallback`` segment never silently
+    loses its grounding (Phase D capability guarantee). Only the confirmed-fresh
+    path returns ``False``, which is what lets the paid call be skipped on the
+    hot path.
+    """
+    if not _data_tools_enabled():
+        return True
+    try:
+        client = _atlas_data_client()
+    except Exception as exc:  # noqa: BLE001 — any client failure → paid fallback, never crash
+        logger.warning("macro freshness probe: client unavailable (%s); paid fallback", exc)
+        return True
+    try:
+        from digiquant.olympus.atlas.supabase_io import query_macro_series_freshness
+
+        latest = query_macro_series_freshness(client=client)
+    except Exception as exc:  # noqa: BLE001 — any probe failure → paid fallback
+        logger.warning("macro freshness probe failed (%s); paid fallback", exc)
+        return True
+    if latest is None:
+        return True
+    run_d = run_date.date() if isinstance(run_date, datetime) else run_date
+    if not isinstance(run_d, date):
+        return True
+    age = (run_d - latest).days
+    stale = age > _macro_stale_days()
+    logger.info("macro ingested layer: latest=%s age=%dd stale=%s", latest, age, stale)
+    return stale
+
+
 def build_grounding(
     *,
     use_data_tools: bool,
@@ -54,6 +114,7 @@ def build_grounding(
     segment: str = "",
     scope: str = "",
     ai_portfolios: bool = False,
+    live_search_is_fallback: bool = False,
 ) -> tuple[list[dict[str, Any]] | None, Callable[[str, dict[str, Any]], str] | None, dict | None]:
     """Resolve ``(tools, execute_tool, web_grounding)`` for one research call.
 
@@ -61,6 +122,13 @@ def build_grounding(
     - ``web_grounding``: a cited grounding-summary dict to inject into ``phase_inputs`` —
       either an xAI ``web_search`` pre-pass (``live_search``) or an ``x_search`` read of
       the tracked AI-portfolio accounts (``ai_portfolios``). ``None`` if unavailable.
+
+    When ``live_search_is_fallback`` is set, the ``web_search`` pre-pass is treated
+    as a *paid fallback*: it fires only when the ingested FRED macro layer is stale
+    (see ``_ingested_macro_stale``). On a normal run with fresh ingested data the
+    paid call is skipped entirely — the segment grounds on its in-process data
+    tools — which is the Phase D cost cut. A stale/broken ingested layer still
+    falls through to the paid call, so grounding is never silently dropped.
 
     Honors the ``ATLAS_DATA_TOOLS`` kill-switch. Shared by ``build_segment_node``
     and the bespoke phase nodes (equity / sectors) so the gating + wiring live in
@@ -86,11 +154,17 @@ def build_grounding(
 
         web_grounding = fetch_ai_portfolio_grounding(model=model, run_date=run_date)
     elif live_search and model:
-        from digiquant.olympus.atlas.data.web_grounding import fetch_web_grounding
+        if live_search_is_fallback and not _ingested_macro_stale(run_date):
+            logger.info(
+                "%s: ingested macro layer fresh — skipping paid fallback web_search",
+                segment or "macro",
+            )
+        else:
+            from digiquant.olympus.atlas.data.web_grounding import fetch_web_grounding
 
-        web_grounding = fetch_web_grounding(
-            model=model, segment=segment or "research", run_date=run_date, scope=scope
-        )
+            web_grounding = fetch_web_grounding(
+                model=model, segment=segment or "research", run_date=run_date, scope=scope
+            )
     return tools, execute_tool, web_grounding
 
 
@@ -115,6 +189,13 @@ class SegmentNodeSpec:
 
     live_search: bool = False
     """Enable the web_search grounding pre-pass (curated domains) for this segment."""
+
+    live_search_is_fallback: bool = False
+    """Treat ``live_search`` as a paid *fallback* fired only when the ingested
+    FRED macro layer is stale (Phase D #711). With fresh ingested data the paid
+    web_search is skipped and the segment grounds on its data tools; a stale or
+    broken ingested layer still falls through to the paid call. No effect unless
+    ``live_search`` is also set."""
 
     ai_portfolios: bool = False
     """Enable the x_search AI-portfolio-accounts grounding pre-pass for this segment."""
@@ -224,6 +305,7 @@ def build_segment_node(
             model=eff_model,
             segment=spec.segment_slug,
             ai_portfolios=spec.ai_portfolios,
+            live_search_is_fallback=spec.live_search_is_fallback,
         )
         if web_grounding:
             inputs = {**inputs, "web_grounding": web_grounding}

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -96,8 +96,14 @@ def _ingested_macro_stale(run_date: Any) -> bool:
         return True
     if latest is None:
         return True
+    # query_macro_series_freshness may hand back a datetime (datetime subclasses
+    # date, so supabase_io._parse_date returns it unchanged) — normalize BOTH
+    # sides to a pure date, else `date - datetime` would raise here (outside the
+    # try blocks) and defeat the fail-soft guarantee.
+    if isinstance(latest, datetime):
+        latest = latest.date()
     run_d = run_date.date() if isinstance(run_date, datetime) else run_date
-    if not isinstance(run_d, date):
+    if not isinstance(run_d, date) or not isinstance(latest, date):
         return True
     age = (run_d - latest).days
     stale = age > _macro_stale_days()

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase3_macro.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase3_macro.py
@@ -44,8 +44,9 @@ _SPEC = SegmentNodeSpec(
     skill_slug="macro",
     output_model=MacroRegimeReport,
     phase_outputs_field="phase3_output",  # single slot, not a dict
-    use_data_tools=True,  # FRED macro series via get_macro_series
-    live_search=True,  # non-US M2 / policy freshness fallback
+    use_data_tools=True,  # FRED macro series via get_macro_series (primary grounding)
+    live_search=True,  # non-US M2 / CB rhetoric — now a stale-only paid fallback (#711)
+    live_search_is_fallback=True,  # fire web_search only when the FRED layer is stale (#711)
     extra_context_keys=("bonds", "commodities", "forex", "equity"),  # cross-asset priors (#696)
 )
 

--- a/digiquant/src/digiquant/olympus/atlas/skills/macro/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/macro/SKILL.md
@@ -7,12 +7,16 @@ description: Run global macro analysis as part of the daily digest. Covers econo
 
 ## Grounding Tools (use first)
 
-- **`get_macro_series`** — fetch real values before classifying the regime. Call with the
-  FRED ids: `M2SL`, `DFF`, `DGS10`, `DGS2`, `T10Y2Y`, `T10Y3M`, `T10YIE`, `T5YIE`,
-  `DFII10`, `VIXCLS`, `DTWEXBGS`, `CPIAUCSL`, `PCEPI`, `UNRATE`. Do not assert a level or
-  spread you did not retrieve.
-- A pre-fetched **`web_grounding`** block (when present) covers central-bank speeches, the
-  economic calendar, geopolitics, and stale **non-US M2**. Cite its source URLs in `sources`.
+- **`get_macro_series`** — your **primary** grounding. Fetch real values before classifying
+  the regime. Call with the FRED ids: `M2SL`, `DFF`, `DGS10`, `DGS2`, `T10Y2Y`, `T10Y3M`,
+  `T10YIE`, `T5YIE`, `DFII10`, `VIXCLS`, `DTWEXBGS`, `CPIAUCSL`, `PCEPI`, `UNRATE`. Do not
+  assert a level or spread you did not retrieve. These series carry the 4-factor regime.
+- A pre-fetched **`web_grounding`** block is now a **stale-only fallback** (#711): it is
+  injected *only* when the ingested FRED layer is stale/broken, and then covers central-bank
+  speeches, the economic calendar, geopolitics, and **non-US M2**. On a normal run it is
+  absent — classify the regime from `get_macro_series` alone and state any qualitative gap
+  (e.g. "no fresh central-bank rhetoric this run") rather than inventing it. When the block
+  *is* present, cite its source URLs in `sources`.
 
 ## Inputs
 - `config/watchlist.md` (macro section)

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -12,9 +12,11 @@ from digiquant.olympus.atlas.phases.phase4_assetclass import _SPECS as ASSET_SPE
 
 
 @pytest.mark.unit
-def test_macro_uses_data_tools_and_search():
+def test_macro_uses_data_tools_and_fallback_search():
     assert MACRO.use_data_tools is True
-    assert MACRO.live_search is True  # intl-M2 fallback
+    assert MACRO.live_search is True
+    # #711: macro's web_search is now a stale-only paid fallback, not a daily input.
+    assert MACRO.live_search_is_fallback is True
 
 
 @pytest.mark.unit
@@ -127,3 +129,137 @@ def test_build_grounding_degrades_when_client_unavailable(monkeypatch):
     )
     assert tools is None and execute_tool is None
     assert grounding is not None  # web grounding unaffected
+
+
+# --- Phase D #711: ingested-first / paid-on-stale macro fallback -------------
+
+
+def _stub_freshness(monkeypatch, value):
+    """Point query_macro_series_freshness at a canned date / None / raiser."""
+    if isinstance(value, BaseException) or (
+        isinstance(value, type) and issubclass(value, BaseException)
+    ):
+
+        def _impl(**_k):
+            raise value if isinstance(value, BaseException) else value()
+    else:
+
+        def _impl(**_k):
+            return value
+
+    monkeypatch.setattr("digiquant.olympus.atlas.supabase_io.query_macro_series_freshness", _impl)
+
+
+@pytest.mark.unit
+def test_macro_fallback_skips_paid_search_when_layer_fresh(monkeypatch):
+    # Fresh ingested FRED layer → the fallback web_search must NOT fire; the
+    # segment grounds on data tools alone. This is the Phase D cost cut.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    _stub_freshness(monkeypatch, date(2026, 6, 12))  # 1 day stale → fresh
+
+    def _fail(**_k):
+        raise AssertionError("fresh ingested layer must not fire the paid fallback web_search")
+
+    monkeypatch.setattr("digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding", _fail)
+    _tools, _execute, grounding = _node_factory.build_grounding(
+        use_data_tools=True,
+        live_search=True,
+        live_search_is_fallback=True,
+        run_date=date(2026, 6, 13),
+        model="xai/grok-4.3",
+        segment="macro",
+    )
+    assert grounding is None
+
+
+@pytest.mark.unit
+def test_macro_fallback_fires_paid_search_when_layer_stale(monkeypatch):
+    # Stale ingested layer (older than the window) → fall through to paid search.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    _stub_freshness(monkeypatch, date(2026, 5, 1))  # >7 days stale
+    monkeypatch.setattr(
+        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
+        lambda **_k: {"summary": "fallback", "sources": [], "as_of": "2026-06-13"},
+    )
+    _tools, _execute, grounding = _node_factory.build_grounding(
+        use_data_tools=True,
+        live_search=True,
+        live_search_is_fallback=True,
+        run_date=date(2026, 6, 13),
+        model="xai/grok-4.3",
+        segment="macro",
+    )
+    assert grounding is not None and grounding["summary"] == "fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("freshness", [None, RuntimeError("supabase read failed")])
+def test_macro_fallback_fires_when_layer_unknown_or_probe_errors(monkeypatch, freshness):
+    # Empty table (None) or a probe error both fail-soft to "stale" → paid search
+    # fires, so grounding is never silently dropped.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    _stub_freshness(monkeypatch, freshness)
+    monkeypatch.setattr(
+        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
+        lambda **_k: {"summary": "fallback", "sources": [], "as_of": "2026-06-13"},
+    )
+    _tools, _execute, grounding = _node_factory.build_grounding(
+        use_data_tools=True,
+        live_search=True,
+        live_search_is_fallback=True,
+        run_date=date(2026, 6, 13),
+        model="xai/grok-4.3",
+        segment="macro",
+    )
+    assert grounding is not None
+
+
+@pytest.mark.unit
+def test_ingested_macro_stale_threshold_and_env_override(monkeypatch):
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    _stub_freshness(monkeypatch, date(2026, 6, 7))  # age = 6 days vs run 2026-06-13
+    run = date(2026, 6, 13)
+    monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
+    assert _node_factory._ingested_macro_stale(run) is False  # 6 <= 7 default
+    monkeypatch.setenv("ATLAS_MACRO_STALE_DAYS", "3")
+    assert _node_factory._ingested_macro_stale(run) is True  # 6 > 3
+
+
+@pytest.mark.unit
+def test_ingested_macro_stale_when_data_tools_disabled(monkeypatch):
+    # Kill-switch off → can't read the ingested layer → treat as stale (paid path).
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+    assert _node_factory._ingested_macro_stale(date(2026, 6, 13)) is True
+
+
+@pytest.mark.unit
+def test_non_fallback_live_search_ignores_freshness(monkeypatch):
+    # A plain live_search segment (live_search_is_fallback=False) must always fire
+    # web_search regardless of ingested-layer freshness — the gate is opt-in.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    _stub_freshness(monkeypatch, date(2026, 6, 13))  # perfectly fresh
+
+    def _probe_should_not_run(_run_date):
+        raise AssertionError("freshness probe must not run for non-fallback live_search")
+
+    monkeypatch.setattr(_node_factory, "_ingested_macro_stale", _probe_should_not_run)
+    monkeypatch.setattr(
+        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
+        lambda **_k: {"summary": "always", "sources": [], "as_of": "2026-06-13"},
+    )
+    _tools, _execute, grounding = _node_factory.build_grounding(
+        use_data_tools=False,
+        live_search=True,
+        live_search_is_fallback=False,
+        run_date=date(2026, 6, 13),
+        model="xai/grok-4.3",
+        segment="international",
+    )
+    assert grounding is not None and grounding["summary"] == "always"

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
@@ -156,7 +156,7 @@ def test_macro_fallback_skips_paid_search_when_layer_fresh(monkeypatch):
     # segment grounds on data tools alone. This is the Phase D cost cut.
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
     monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
-    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
     _stub_freshness(monkeypatch, date(2026, 6, 12))  # 1 day stale → fresh
 
     def _fail(**_k):
@@ -179,7 +179,7 @@ def test_macro_fallback_fires_paid_search_when_layer_stale(monkeypatch):
     # Stale ingested layer (older than the window) → fall through to paid search.
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
     monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
-    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
     _stub_freshness(monkeypatch, date(2026, 5, 1))  # >7 days stale
     monkeypatch.setattr(
         "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
@@ -202,7 +202,7 @@ def test_macro_fallback_fires_when_layer_unknown_or_probe_errors(monkeypatch, fr
     # Empty table (None) or a probe error both fail-soft to "stale" → paid search
     # fires, so grounding is never silently dropped.
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
-    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
     _stub_freshness(monkeypatch, freshness)
     monkeypatch.setattr(
         "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
@@ -222,13 +222,26 @@ def test_macro_fallback_fires_when_layer_unknown_or_probe_errors(monkeypatch, fr
 @pytest.mark.unit
 def test_ingested_macro_stale_threshold_and_env_override(monkeypatch):
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
-    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
     _stub_freshness(monkeypatch, date(2026, 6, 7))  # age = 6 days vs run 2026-06-13
     run = date(2026, 6, 13)
     monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
     assert _node_factory._ingested_macro_stale(run) is False  # 6 <= 7 default
     monkeypatch.setenv("ATLAS_MACRO_STALE_DAYS", "3")
     assert _node_factory._ingested_macro_stale(run) is True  # 6 > 3
+
+
+@pytest.mark.unit
+def test_ingested_macro_stale_normalizes_datetime_freshness(monkeypatch):
+    # query_macro_series_freshness can hand back a datetime (datetime subclasses
+    # date, so _parse_date returns it unchanged). _ingested_macro_stale must
+    # normalize it — `date - datetime` would otherwise raise outside the try and
+    # defeat fail-soft. Should compute age cleanly, not crash.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+    monkeypatch.delenv("ATLAS_MACRO_STALE_DAYS", raising=False)
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
+    _stub_freshness(monkeypatch, datetime(2026, 6, 12, 16, 30))  # 1 day before run
+    assert _node_factory._ingested_macro_stale(date(2026, 6, 13)) is False
 
 
 @pytest.mark.unit
@@ -243,7 +256,7 @@ def test_non_fallback_live_search_ignores_freshness(monkeypatch):
     # A plain live_search segment (live_search_is_fallback=False) must always fire
     # web_search regardless of ingested-layer freshness — the gate is opt-in.
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
-    monkeypatch.setattr(_node_factory, "_atlas_data_client", lambda: object())
+    monkeypatch.setattr(_node_factory, "_atlas_data_client", object)
     _stub_freshness(monkeypatch, date(2026, 6, 13))  # perfectly fresh
 
     def _probe_should_not_run(_run_date):


### PR DESCRIPTION
## What

Adds the **ingested-first / paid-on-stale** grounding seam (Phase D capability guarantee) and applies it to the **macro** phase, so the daily paid xAI `web_search` pre-pass is skipped whenever the free ingested FRED layer is fresh — and only fires when that layer is genuinely stale/broken.

## How

- `SegmentNodeSpec.live_search_is_fallback: bool = False` — opt-in flag.
- `build_grounding(..., live_search_is_fallback=...)` — when set, gates the `web_search` pre-pass on `_ingested_macro_stale(run_date)`.
- `_ingested_macro_stale()` — probes `query_macro_series_freshness`; returns *fresh* (→ skip paid) only when the latest ingested obs is within `ATLAS_MACRO_STALE_DAYS` (default **7d**) of the run date. Every failure mode (kill-switch off, no client, query error, empty table, exotic `run_date`) **fail-softs to "stale"** → fires paid, so grounding is never silently dropped.
- `phase3_macro._SPEC` → `live_search_is_fallback=True`; macro `SKILL.md` updated so the agent treats `web_grounding` as a stale-only fallback and the FRED series as primary grounding.

## Cost impact

On a healthy run macro now grounds on free in-process data tools only — removing macro's daily contribution to the ~$2.44/run xAI agentic-search multiplier. The paid call returns automatically when ingestion breaks.

## Deferred (PR-2b)

Non-US M2 (`MABMM301*`) + CB balance-sheet FRED series and international index ingestion (the original PR-2 source-add scope) are **deferred pending live verification of the FRED series ids** — recorded in `PHASE-D.md`. Until then macro's non-US/rhetoric coverage is via the stale fallback only; the US 4-factor regime (the downstream-bias driver) is fully covered by existing series.

## Validation

- `tests/dq/atlas/` — **328 passed** (+7 new: fresh→skip, stale→fire, unknown/error→fail-soft-fire, threshold + env override, kill-switch, non-fallback unaffected).
- `make score` (vs develop): Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

Fixes #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)