### PR TITLE
fix(hermes): materialize a real paper book — PM full-book skill, theses writer, per-ticker analyst data (#713)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -46,6 +46,16 @@ def _atlas_data_client() -> Any:
     return build_client(SupabaseConfig.from_env())
 
 
+def get_data_client() -> Any:
+    """Public accessor for the memoized Supabase data client.
+
+    Hermes analyst nodes reuse the same cached client as Atlas segment nodes
+    (#713) to pre-fetch per-ticker data, rather than reaching into the private
+    ``_atlas_data_client`` directly.
+    """
+    return _atlas_data_client()
+
+
 _MACRO_STALE_DAYS_DEFAULT = 7
 """Max age of the freshest ingested FRED observation before we treat the layer
 as stale and fire the paid fallback. The freshest series are daily (VIXCLS, DFF,
@@ -344,5 +354,6 @@ __all__ = [
     "build_segment_node",
     "default_inputs_builder",
     "dict_slot_write_adapter",
+    "get_data_client",
     "scalar_slot_write_adapter",
 ]

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
@@ -131,17 +131,48 @@ def _phase2_institutional(state: HermesState) -> dict[str, dict[str, Any]]:
     }
 
 
+def _fetch_ticker_technicals(ticker: str) -> dict[str, Any]:
+    """Pre-fetch per-ticker ``price_technicals`` from Supabase for analyst inputs (#713).
+
+    The 4-axis specialists run with no data tools and otherwise see only the
+    market-wide Phase 5 equity blob — blind to the individual ticker's price
+    action, which floors their conviction. This injects the ticker's own computed
+    indicators (SMA/RSI/MACD/ATR/z-score …) deterministically so the technical and
+    fundamental axes reason on real per-ticker data.
+
+    Returns the ``get_price_technicals`` payload (``{ticker, latest, window}``) or
+    ``{}`` on any failure — kill-switch off (``ATLAS_DATA_TOOLS=0``), no client,
+    missing rows, or network error. Fail-soft: a missing block degrades the analyst
+    to the market-wide fallback (lower conviction), never a crash.
+    """
+    if os.environ.get("ATLAS_DATA_TOOLS", "1").strip().lower() in ("0", "false", ""):
+        return {}
+    try:
+        from digiquant.olympus.atlas.data.queries import get_price_technicals
+        from digiquant.olympus.atlas.phases._node_factory import get_data_client
+
+        return get_price_technicals(client=get_data_client(), ticker=ticker, lookback=20)
+    except Exception as exc:  # noqa: BLE001 — degrade gracefully, never crash the phase
+        logger.warning("phase7c: technicals fetch failed for %s (%s); degrading", ticker, exc)
+        return {}
+
+
 def _axis_inputs(
     *,
     axis: str,
     ticker: str,
     state: HermesState,
+    price_technicals: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Per-axis ``phase_inputs`` block.
 
     Each axis sees only the upstream segments relevant to its analytical
     lane. This is the whole point of the split — narrower inputs let one
     LLM call reason deeply on one axis instead of shallowly on four.
+
+    ``price_technicals`` (the per-ticker Supabase row, #713) is injected into the
+    ``technical`` and ``fundamental`` axes only — the lanes that reason on price
+    action; ``sentiment`` and ``news`` already have their own upstream data.
     """
     base = {
         "segment": f"{axis}-analyst-{ticker}",
@@ -151,6 +182,8 @@ def _axis_inputs(
     }
     if axis == "technical":
         base["phase5_equity"] = _phase5_equity_body(state)
+        if price_technicals:
+            base["price_technicals"] = price_technicals
     elif axis == "sentiment":
         base["phase1_alt_data"] = _phase1_alt_data(state)
     elif axis == "news":
@@ -160,6 +193,8 @@ def _axis_inputs(
     elif axis == "fundamental":
         base["phase5_equity"] = _phase5_equity_body(state)
         base["relevant_sectors"] = _relevant_sectors_for(state, ticker)
+        if price_technicals:
+            base["price_technicals"] = price_technicals
     return base
 
 
@@ -172,10 +207,17 @@ def _specialist_node_factory(axis: str, ticker: str):
     skill_slug = f"{axis}-analyst"
 
     def _node(state: HermesState) -> dict[str, Any]:
+        # Price-reasoning axes get the ticker's own computed indicators (#713);
+        # sentiment/news don't need them.
+        price_technicals = (
+            _fetch_ticker_technicals(ticker) if axis in ("technical", "fundamental") else {}
+        )
         skill_text = load_skill(skill_slug)
         result = run_research_agent(
             skill_text=skill_text,
-            phase_inputs=_axis_inputs(axis=axis, ticker=ticker, state=state),
+            phase_inputs=_axis_inputs(
+                axis=axis, ticker=ticker, state=state, price_technicals=price_technicals
+            ),
             shared_context=_shared_context(state, context_keys=(f"analyst/{ticker}",)),
             output_model=SpecialistPayload,
             phase_slug=f"{axis}-analyst-{ticker}",

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
@@ -193,11 +193,18 @@ def _pm_node(state: HermesState) -> dict[str, Any]:
         output_model=RebalanceDecision,
         phase_slug="pm-rebalance",
     )
+    # An empty recommended_portfolio is a valid 100% CASH stance; Phase 9D books
+    # it as a CASH position (#713). No cash-proxy padding here.
     return {"phase7d_rebalance": result.model_dump(mode="json")}
 
 
 def _load_pm_skill(loader: Any) -> str:
-    """Prefer ``pm-allocation-memo`` skill; fall back to ``portfolio-manager``.
+    """Prefer the DB-first ``pm-rebalance-decision`` allocation skill (#713).
+
+    Fallback order: ``pm-rebalance-decision`` (the authoritative node skill that
+    matches this node's I/O and the ``RebalanceDecision`` output, always building
+    a full ~100% book) → ``portfolio-manager`` (the human-session allocation
+    skill) → ``pm-allocation-memo`` (legacy memo skill, kept last for back-compat).
 
     Only a genuinely-missing skill falls through to the next slug. Parse
     errors (malformed frontmatter) or I/O errors propagate immediately —
@@ -206,12 +213,13 @@ def _load_pm_skill(loader: Any) -> str:
     """
     from digiquant.olympus.hermes.skills import SkillNotFoundError
 
-    for slug in ("pm-allocation-memo", "portfolio-manager"):
+    tried = ("pm-rebalance-decision", "portfolio-manager", "pm-allocation-memo")
+    for slug in tried:
         try:
             return loader(slug)
         except SkillNotFoundError:
             continue
-    raise RuntimeError("neither 'pm-allocation-memo' nor 'portfolio-manager' skill present")
+    raise RuntimeError(f"no PM skill found; tried {tried}")
 
 
 def _current_weights_from_config(state: HermesState) -> dict[str, float]:

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -275,7 +275,8 @@ def build_materialize_node(deps: MaterializeDeps):
 
         # Theses surface (#713): one thesis per held ticker, from the analyst
         # payloads + debate summaries already in state. Skips the CASH ledger row
-        # (not in ``weights``). No-op when there are no analysts.
+        # (not in ``weights``); a held ticker with no analyst payload still gets a
+        # thesis (status defaults to ACTIVE). Writes nothing for a pure-cash book.
         n_theses = _upsert_theses(
             client=client,
             date_str=date_str,

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -59,6 +59,91 @@ def _is_cash(ticker: Any) -> bool:
     return isinstance(ticker, str) and ticker.strip().upper() == "CASH"
 
 
+# Map the analyst stance onto a valid `theses.status` (migration 002 CHECK:
+# ACTIVE | MONITORING | CHALLENGED | CLOSED | INVALIDATED | PAUSED | NEW).
+_THESIS_STATUS_BY_STANCE = {
+    "buy": "ACTIVE",
+    "hold": "ACTIVE",
+    "watch": "MONITORING",
+    "sell": "CHALLENGED",
+}
+_DEFAULT_THESIS_STATUS = "ACTIVE"
+
+
+def _stance_to_thesis_status(stance: Any) -> str:
+    if isinstance(stance, str):
+        return _THESIS_STATUS_BY_STANCE.get(stance.strip().lower(), _DEFAULT_THESIS_STATUS)
+    return _DEFAULT_THESIS_STATUS
+
+
+def _clip(text: Any, limit: int) -> str:
+    return str(text or "").strip()[:limit]
+
+
+def _upsert_theses(
+    *,
+    client: SupabaseClient,
+    date_str: str,
+    weights: dict[str, float],
+    analysts: dict[str, Any],
+    debates: dict[str, Any],
+) -> int:
+    """Materialize one thesis row (+ vehicle) per booked holding (#713).
+
+    The live Atlas→Hermes chain previously never wrote the ``theses`` table (only
+    frozen legacy scripts did), so the dashboard's Theses surface stayed empty.
+    This derives one thesis per held ticker — keyed ``(date, thesis_id=ticker.lower())``
+    to match the ``theses`` unique key — from the per-ticker ``AnalystPayload``
+    (thesis text → notes/name, stance → status, debate bear-case / analyst risks
+    → invalidation). The vehicle is the holding's own ticker.
+
+    ``thesis_vehicles`` FK-references ``(date, thesis_id)`` on ``theses``, so the
+    parent rows are written first; vehicle writes are best-effort enrichment and
+    never block the book.
+    """
+    if not weights:
+        return 0
+    thesis_rows: list[dict[str, Any]] = []
+    vehicle_rows: list[dict[str, Any]] = []
+    for ticker in weights:
+        analyst = analysts.get(ticker) or {}
+        debate = debates.get(ticker) or {}
+        short = _clip(analyst.get("thesis"), 60)
+        invalidation = _clip(
+            debate.get("bear_case") or debate.get("key_tension") or analyst.get("risks"), 400
+        )
+        thesis_rows.append(
+            {
+                "date": date_str,
+                "thesis_id": ticker.lower(),
+                "name": f"{ticker} — {short}" if short else ticker,
+                "vehicle": ticker,
+                "invalidation": invalidation,
+                "status": _stance_to_thesis_status(analyst.get("stance")),
+                "notes": _clip(analyst.get("thesis"), 500),
+            }
+        )
+        vehicle_rows.append(
+            {
+                "date": date_str,
+                "thesis_id": ticker.lower(),
+                "ticker": ticker,
+                "rationale": "primary vehicle from PM allocation",
+                "candidate_rank": 1,
+            }
+        )
+    for row in thesis_rows:
+        client.table("theses").upsert(row, on_conflict="date,thesis_id").execute()
+    for row in vehicle_rows:
+        try:
+            client.table("thesis_vehicles").upsert(
+                row, on_conflict="date,thesis_id,ticker"
+            ).execute()
+        except Exception as exc:  # noqa: BLE001 — vehicles are enrichment; never block the book
+            logger.warning("phase9d: thesis_vehicles upsert failed (%s); continuing", exc)
+    return len(thesis_rows)
+
+
 def _prior_book(client: SupabaseClient, run_date: date) -> list[dict[str, Any]]:
     """Positions rows for the most recent date strictly before ``run_date``.
 
@@ -121,10 +206,11 @@ def build_materialize_node(deps: MaterializeDeps):
     """Return the Phase 9D node bound to ``deps``."""
 
     def materialize(state: AtlasResearchState) -> dict[str, Any]:
-        rebalance = state.phase7d_rebalance or {}
-        recommended = rebalance.get("recommended_portfolio") or []
-        if not recommended:
-            return {}  # no PM decision this run → nothing to materialize
+        # The PM never ran (partial graph / legacy / dry-run) → don't fabricate a
+        # book. This is distinct from the PM running and choosing to hold cash.
+        if state.phase7d_rebalance is None:
+            return {}
+        recommended = state.phase7d_rebalance.get("recommended_portfolio") or []
 
         run_date = state.run_date
         date_str = run_date.isoformat()
@@ -132,7 +218,13 @@ def build_materialize_node(deps: MaterializeDeps):
 
         # Target book from the PM's recommended weights. Coalesce duplicate
         # tickers (sum their weights — never double-count or upsert the same
-        # (date,ticker) twice) and drop non-positive / CASH lines.
+        # (date,ticker) twice) and drop non-positive / CASH lines (CASH is the
+        # residual, not a recommended holding).
+        #
+        # An EMPTY result is the PM's deliberate **100% CASH** stance (no
+        # conviction this run) — a first-class position, booked as a CASH row
+        # below. We do NOT pad the book with a cash-proxy ETF (BIL/SHY): those
+        # are real holdings the PM picks on conviction, not a substitute for cash.
         weights: dict[str, float] = {}
         for row in recommended:
             if not isinstance(row, dict):
@@ -144,8 +236,6 @@ def build_materialize_node(deps: MaterializeDeps):
             if weight <= 0:
                 continue
             weights[ticker] = weights.get(ticker, 0.0) + weight
-        if not weights:
-            return {}  # decision held only cash / zero weights — nothing to book
 
         # A malformed book summing > 100% is scaled proportionally to fully
         # invested (cash 0) rather than silently clamping the residual to an
@@ -183,11 +273,23 @@ def build_materialize_node(deps: MaterializeDeps):
         for row in pos_rows:
             client.table("positions").upsert(row, on_conflict="date,ticker").execute()
 
+        # Theses surface (#713): one thesis per held ticker, from the analyst
+        # payloads + debate summaries already in state. Skips the CASH ledger row
+        # (not in ``weights``). No-op when there are no analysts.
+        n_theses = _upsert_theses(
+            client=client,
+            date_str=date_str,
+            weights=weights,
+            analysts=dict(state.phase7c_analysts),
+            debates=dict(state.phase7cd_debates),
+        )
+
         logger.info(
-            "phase9d: booked %d positions (cash %.2f%%), nav=%.4f for %s",
+            "phase9d: booked %d positions (cash %.2f%%), nav=%.4f, %d theses for %s",
             len(pos_rows),
             cash_pct,
             nav,
+            n_theses,
             date_str,
         )
         return {}

--- a/digiquant/src/digiquant/olympus/hermes/skills/fundamental-analyst/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/fundamental-analyst/SKILL.md
@@ -15,6 +15,7 @@ You are a fundamental analyst. Your only job: rate the **fundamental quality** o
 - `ticker` — the symbol to analyze.
 - `phase5_equity` — equity segment payload (earnings cadence, valuation summary, balance sheet snapshot for tracked names).
 - `relevant_sectors` — sector payloads where this ticker is in `top_tickers` (sector-relative quality benchmarks).
+- `price_technicals` (optional) — the ticker's computed indicators; use `zscore_200`, `pct_vs_sma200`, and `rsi_14` only as a **valuation/momentum cross-reference** (an extreme deviation from the 200-day trend is a price-vs-fundamentals dislocation signal). Do not do technical analysis — that is the technical axis's job.
 - `bias_row` — Phase 6 regime + bias snapshot for the cycle context.
 
 ## What to argue

--- a/digiquant/src/digiquant/olympus/hermes/skills/pm-rebalance-decision/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/pm-rebalance-decision/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pm-rebalance-decision
+description: >
+  DB-first Portfolio Manager allocation node (Hermes Phase 7D). Reads per-ticker AnalystPayload +
+  Bull/Bear debate summaries + risk-temperament debate + prior-decision lessons from phase_inputs,
+  then emits a RebalanceDecision of conviction-sized target weights. The un-allocated remainder is
+  CASH (a first-class defensive stance) — never padded with a cash-proxy ETF. A no-conviction run
+  is correctly an empty book (100% cash).
+---
+
+# PM Rebalance Decision
+
+You are the Portfolio Manager. In ONE response you (B) construct the ideal clean-slate book
+from research conviction, then (C) compare it against the current book to produce actions.
+Everything you need is in `phase_inputs` — there are NO files to read and NO tools to call.
+
+## Inputs (all in `phase_inputs`)
+
+- `analyst_payloads` — `{ticker: {conviction_score (−5..+5), stance (buy|hold|sell|watch), thesis, risks, sources}}`. This is your primary signal.
+- `debate_summaries` — `{ticker: {net_stance, conviction_delta, ...}}` from the per-ticker Bull/Bear debate. Adjust the analyst conviction by `conviction_delta` when present.
+- `risk_debate` — `{aggressive_case, conservative_case, key_tension}` from the risk-temperament debate. Use it to set overall risk posture (how concentrated vs. defensive).
+- `current_weights` — `{ticker: pct}` of the book coming in (empty on the first run).
+- `bias_row` — Phase 6 cross-asset macro regime snapshot (equity/bond/commodity/fx bias).
+- `preferences` — investor config (risk tolerance, `max_single_etf_pct`, turnover discipline).
+- `past_context` — list of resolved past-decision lessons (alpha outcomes) — learn from them.
+
+## Phase B — Clean-Slate Book (ignore `current_weights` here)
+
+1. **Effective conviction** per ticker = `analyst.conviction_score + (debate_summaries[ticker].conviction_delta or 0)`.
+2. **Select** tickers with effective conviction `>= 2` and stance in (`buy`, `hold`). These are the active book.
+3. **Size** each selected ticker proportionally to its effective conviction. Apply:
+   - Minimum position 5%; maximum single position 30% (or `preferences.max_single_etf_pct` if set).
+   - Regime overlay: if `bias_row.equity_bias` is bearish/risk-off, trim equity sizes and raise the cash level (or, on genuine conviction, add short-duration/gold).
+   - Round each weight to the nearest 5%.
+4. **The residual is CASH (do NOT pad to 100%).** Sum the selected weights; the remaining `100 − sum` is **cash** — a deliberate, first-class defensive position. Leave it implicit (the book need not sum to 100). **Do not** add BIL or SHY to "fill" the residual. BIL/SHY are short-duration bond ETFs with their own yield and duration risk — include them **only** when you have a specific conviction to own them (e.g. T-bill yield capture, flight-to-safety), sized like any other position, never as a cash substitute.
+5. **No-conviction → 100% cash.** If NO ticker clears the conviction bar, return an **empty** `recommended_portfolio` (= 100% cash) and explain the defensive cash stance in `notes`. An empty book is the correct low-signal decision — it materializes as a 100% CASH position, not a blank dashboard.
+
+## Phase C — Compare vs Current & Emit Actions
+
+For each ticker in (clean-slate book ∪ `current_weights`): `delta = target_pct − current_pct`.
+
+| Condition | action |
+|---|---|
+| `current_pct == 0`, `target_pct > 0` | `new` |
+| `target_pct == 0`, `current_pct > 0` | `exit` |
+| `delta >= 5` | `add` |
+| `delta <= −5` | `trim` |
+| otherwise | `hold` |
+
+## Output — RebalanceDecision (exact shape)
+
+```json
+{
+  "recommended_portfolio": [{"ticker": "SPY", "target_pct": 25.0}, {"ticker": "GLD", "target_pct": 15.0}],
+  "actions": [{"ticker": "SPY", "action": "new", "current_pct": null, "target_pct": 25.0, "rationale": "…"}],
+  "notes": "Regime + conviction summary, key tension from the risk debate, and the cash level (here 60% cash, defensive)."
+}
+```
+
+Rules:
+- List ONLY conviction holdings in `recommended_portfolio`. The remainder is cash — do not add a CASH line or a cash-proxy ETF to make it sum to 100. An **empty** list is valid (= 100% cash).
+- `target_pct` values are percentages (0–100); their sum is the invested fraction (`100 − sum` = cash).
+- `actions` covers every ticker that changes; `notes` is 2–4 sentences of real reasoning (regime, top convictions, the risk-debate tension, and why the cash level is what it is).

--- a/digiquant/src/digiquant/olympus/hermes/skills/technical-analyst/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/technical-analyst/SKILL.md
@@ -13,7 +13,8 @@ You are a technical analyst. Your only job: rate the **technical setup** for `{{
 ## Inputs
 
 - `ticker` — the symbol to analyze.
-- `phase5_equity` — the equity-segment payload with OHLCV summary, momentum readings (RSI, MACD), volatility regime (ATR, Bollinger), and any breakouts the Phase 5 equity node flagged.
+- `price_technicals` (optional, **preferred when present**) — the ticker's OWN computed indicators from the database: `{ticker, latest: {sma_20, sma_50, sma_200, pct_vs_sma50, pct_vs_sma200, rsi_14, macd, macd_hist, roc_21, adx_14, dmi_plus, dmi_minus, atr_pct, bb_pct_b, bb_bandwidth, hist_vol_21, zscore_200, ...}, window[]}` (window newest-first). Prefer these authoritative per-ticker readings over the market-wide `phase5_equity` summary; cite exact values (e.g. "RSI_14 62, +4.2% vs SMA50, ADX 28"). If `latest` is empty, no technicals are stored — fall back to `phase5_equity`.
+- `phase5_equity` — the equity-segment payload (market-wide OHLCV/momentum/volatility context); fallback when `price_technicals` is absent.
 - `bias_row` — Phase 6's market regime + equity-bias snapshot for context.
 
 ## What to argue

--- a/tests/dq/hermes/test_phase7c_specialists.py
+++ b/tests/dq/hermes/test_phase7c_specialists.py
@@ -22,10 +22,14 @@ import pytest
 
 from digigraph.graph.pipeline_builder import build_pipeline
 
+from digiquant.olympus.hermes.phases import phase7c_analyst as phase7c
 from digiquant.olympus.hermes.phases.phase7c_analyst import (
     AnalystPayload,
     SpecialistPayload,
+    _axis_inputs,
+    _fetch_ticker_technicals,
     _join_analyst_node_factory,
+    _specialist_node_factory,
     build_phase7c,
     build_phase7c_join,
     build_phase7c_specialists,
@@ -332,6 +336,94 @@ class TestFullPhase7c:
         # All AnalystPayload fields present on the dict the PM reads.
         for field in ("ticker", "conviction_score", "stance", "thesis", "risks", "sources"):
             assert field in payload
+
+
+# ─── Per-ticker technicals injection (#713) ─────────────────────────────────
+
+
+def _inputs_body(msgs: list[dict[str, Any]]) -> dict[str, Any]:
+    user_block = msgs[1]["content"]
+    inputs_part = next(
+        p for p in user_block if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+    )
+    return json.loads(inputs_part["text"].split(":", 1)[1].strip())
+
+
+@pytest.mark.unit
+class TestTickerTechnicals:
+    def _run_axis(self, monkeypatch, axis: str, canned) -> dict[str, Any]:
+        monkeypatch.setattr(phase7c, "_fetch_ticker_technicals", lambda _t: canned)
+        captured: dict[str, Any] = {}
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            captured.update(_inputs_body(msgs))
+            return _specialist_response(axis, "AAPL")
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
+            _specialist_node_factory(axis, "AAPL")(_state(("AAPL",)))
+        return captured
+
+    def test_technical_axis_injects_price_technicals(self, monkeypatch) -> None:
+        canned = {"ticker": "AAPL", "latest": {"rsi_14": 62}, "window": []}
+        body = self._run_axis(monkeypatch, "technical", canned)
+        assert body.get("price_technicals") == canned
+
+    def test_fundamental_axis_injects_price_technicals(self, monkeypatch) -> None:
+        canned = {"ticker": "AAPL", "latest": {"zscore_200": 1.8}, "window": []}
+        body = self._run_axis(monkeypatch, "fundamental", canned)
+        assert body.get("price_technicals") == canned
+
+    def test_sentiment_axis_does_not_fetch_or_inject(self, monkeypatch) -> None:
+        calls: list[str] = []
+        monkeypatch.setattr(
+            phase7c, "_fetch_ticker_technicals", lambda t: calls.append(t) or {"x": 1}
+        )
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            body = _inputs_body(msgs)
+            assert "price_technicals" not in body
+            return _specialist_response("sentiment", "AAPL")
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
+            _specialist_node_factory("sentiment", "AAPL")(_state(("AAPL",)))
+        assert calls == []  # never fetched for the sentiment axis
+
+    def test_empty_technicals_not_injected(self, monkeypatch) -> None:
+        # Fail-soft {} must not add the key (analyst falls back to phase5_equity).
+        body = self._run_axis(monkeypatch, "technical", {})
+        assert "price_technicals" not in body
+        assert "phase5_equity" in body
+
+    def test_fetch_kill_switch_returns_empty(self, monkeypatch) -> None:
+        monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+
+        def _boom() -> Any:
+            raise AssertionError("client must not be built when kill-switch is off")
+
+        monkeypatch.setattr("digiquant.olympus.atlas.phases._node_factory.get_data_client", _boom)
+        assert _fetch_ticker_technicals("AAPL") == {}
+
+    def test_fetch_fail_soft_on_client_error(self, monkeypatch) -> None:
+        monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
+
+        def _boom() -> Any:
+            raise RuntimeError("supabase not configured")
+
+        monkeypatch.setattr("digiquant.olympus.atlas.phases._node_factory.get_data_client", _boom)
+        assert _fetch_ticker_technicals("AAPL") == {}
+
+    def test_axis_inputs_helper_injects_only_for_price_axes(self) -> None:
+        canned = {"ticker": "AAPL", "latest": {"rsi_14": 50}}
+        state = _state(("AAPL",))
+        assert "price_technicals" in _axis_inputs(
+            axis="technical", ticker="AAPL", state=state, price_technicals=canned
+        )
+        assert "price_technicals" in _axis_inputs(
+            axis="fundamental", ticker="AAPL", state=state, price_technicals=canned
+        )
+        assert "price_technicals" not in _axis_inputs(
+            axis="news", ticker="AAPL", state=state, price_technicals=canned
+        )
 
 
 # ─── Reducer ────────────────────────────────────────────────────────────────

--- a/tests/dq/hermes/test_phase7d_pm_skill.py
+++ b/tests/dq/hermes/test_phase7d_pm_skill.py
@@ -1,0 +1,111 @@
+"""Phase 7D PM skill selection + cash-first decision contract (#713).
+
+The PM node must load the DB-first ``pm-rebalance-decision`` skill. The book is
+the PM's conviction holdings only; the residual is CASH (a first-class defensive
+position materialized downstream), never padded with a cash-proxy ETF. An empty
+recommended_portfolio is a valid 100%-cash stance and passes through untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa: F401 — fake-completion dict shape
+from unittest.mock import patch
+
+import pytest
+
+from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
+from digiquant.olympus.hermes.phases.phase7d_pm import _load_pm_skill, _pm_node
+from digiquant.olympus.hermes.skills import SkillNotFoundError
+
+pytestmark = pytest.mark.unit
+
+
+# ── skill selection ──────────────────────────────────────────────────────────
+
+
+def _loader_missing(*missing: str):
+    """Fake skill loader that raises SkillNotFoundError for ``missing`` slugs."""
+
+    def _load(slug: str) -> str:
+        if slug in missing:
+            raise SkillNotFoundError(slug)
+        return f"<skill:{slug}>"
+
+    return _load
+
+
+class TestLoadPmSkill:
+    def test_prefers_pm_rebalance_decision(self) -> None:
+        assert _load_pm_skill(_loader_missing()) == "<skill:pm-rebalance-decision>"
+
+    def test_falls_back_to_portfolio_manager(self) -> None:
+        assert (
+            _load_pm_skill(_loader_missing("pm-rebalance-decision")) == "<skill:portfolio-manager>"
+        )
+
+    def test_falls_back_to_legacy_memo_last(self) -> None:
+        loader = _loader_missing("pm-rebalance-decision", "portfolio-manager")
+        assert _load_pm_skill(loader) == "<skill:pm-allocation-memo>"
+
+    def test_raises_when_all_missing(self) -> None:
+        loader = _loader_missing("pm-rebalance-decision", "portfolio-manager", "pm-allocation-memo")
+        with pytest.raises(RuntimeError, match="no PM skill found"):
+            _load_pm_skill(loader)
+
+    def test_pm_rebalance_decision_skill_file_present(self) -> None:
+        from digiquant.olympus.hermes.skills import load_skill_with_frontmatter
+
+        fm, body = load_skill_with_frontmatter("pm-rebalance-decision")
+        assert fm.get("name") == "pm-rebalance-decision"
+        assert "recommended_portfolio" in body
+        # The skill must teach the cash-first residual, not cash-proxy padding.
+        assert "100% cash" in body or "100 % cash" in body
+
+
+# ── node decision contract ───────────────────────────────────────────────────
+
+
+def _pm_state() -> AtlasResearchState:
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 6, 13),
+        config=AtlasConfigBundle(watchlist=["SPY", "GLD"]),
+    )
+    state.phase6_bias_row = {"date": "2026-06-13", "equity_bias": "neutral"}
+    state.phase7c_analysts = {"SPY": {"ticker": "SPY", "conviction_score": 0, "stance": "hold"}}
+    return state
+
+
+class TestPmNodeContract:
+    def test_empty_book_passes_through_as_cash(self) -> None:
+        # A no-conviction run → empty recommended_portfolio, untouched (no BIL pad).
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            return_value=json.dumps(
+                {"recommended_portfolio": [], "actions": [], "notes": "defensive: 100% cash"}
+            ),
+        ):
+            update = _pm_node(_pm_state())
+        rebalance = update["phase7d_rebalance"]
+        assert rebalance["recommended_portfolio"] == []
+        assert rebalance["notes"] == "defensive: 100% cash"  # unchanged, no auto-suffix
+
+    def test_conviction_book_passes_through_unchanged(self) -> None:
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            return_value=json.dumps(
+                {
+                    "recommended_portfolio": [{"ticker": "SPY", "target_pct": 40}],
+                    "actions": [],
+                    "notes": "40% SPY, 60% cash",
+                }
+            ),
+        ):
+            update = _pm_node(_pm_state())
+        book = {
+            w["ticker"]: w["target_pct"]
+            for w in update["phase7d_rebalance"]["recommended_portfolio"]
+        }
+        assert book == {"SPY": 40.0}  # residual left as implicit cash, no BIL injected

--- a/tests/dq/hermes/test_phase7d_pm_skill.py
+++ b/tests/dq/hermes/test_phase7d_pm_skill.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 from datetime import date
-from typing import Any  # noqa: F401 — fake-completion dict shape
 from unittest.mock import patch
 
 import pytest

--- a/tests/dq/hermes/test_phase7d_risk_debate.py
+++ b/tests/dq/hermes/test_phase7d_risk_debate.py
@@ -164,7 +164,9 @@ class TestPmReadsRiskDebate:
             return_value=json.dumps({"recommended_portfolio": [], "actions": [], "notes": "ok"}),
         ):
             update = _pm_node(state)
+        # Empty book (= 100% cash) passes through untouched (#713 — no cash-proxy pad).
         assert update["phase7d_rebalance"]["notes"] == "ok"
+        assert update["phase7d_rebalance"]["recommended_portfolio"] == []
 
 
 @pytest.mark.unit

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -135,16 +135,24 @@ class TestGuards:
         assert "positions" not in client.store
         assert "nav_history" not in client.store
 
-    def test_empty_recommended_is_noop(self) -> None:
+    def test_empty_recommended_books_full_cash(self) -> None:
+        # The PM ran and chose to hold cash (empty book) → materialize a 100% CASH
+        # book, not a no-op. CASH is a first-class position (#713).
         client = FakeSupabaseClient()
         _run(client, [])
-        assert "positions" not in client.store
+        positions = {r["ticker"]: r for r in client.store["positions"]}
+        assert set(positions) == {"CASH"}
+        assert positions["CASH"]["weight_pct"] == 100.0
+        nav = client.store["nav_history"][0]
+        assert nav["cash_pct"] == 100.0 and nav["invested_pct"] == 0.0
+        assert nav["nav"] == 100.0  # first run seeds the index at 100
 
-    def test_all_cash_or_zero_weights_is_noop(self) -> None:
+    def test_all_cash_or_zero_weights_books_full_cash(self) -> None:
         client = FakeSupabaseClient()
         _run(client, [{"ticker": "CASH", "target_pct": 100}, {"ticker": "SPY", "target_pct": 0}])
-        assert "positions" not in client.store
-        assert "nav_history" not in client.store
+        positions = {r["ticker"]: r for r in client.store["positions"]}
+        assert set(positions) == {"CASH"} and positions["CASH"]["weight_pct"] == 100.0
+        assert client.store["nav_history"][0]["cash_pct"] == 100.0
 
     def test_rerun_same_date_is_idempotent_upsert(self) -> None:
         client = FakeSupabaseClient()
@@ -156,3 +164,116 @@ class TestGuards:
         # assert every write declares the idempotency key.
         assert all(r["_on_conflict"] == "date" for r in client.store["nav_history"])
         assert all(r["_on_conflict"] == "date,ticker" for r in client.store["positions"])
+
+
+def _state_with_analysts(recommended, analysts, debates=None) -> AtlasResearchState:
+    state = _state(recommended)
+    state.phase7c_analysts = analysts
+    state.phase7cd_debates = debates or {}
+    return state
+
+
+def _run_full(client, recommended, analysts, debates=None) -> None:
+    build_materialize_node(MaterializeDeps(client=client))(
+        _state_with_analysts(recommended, analysts, debates)
+    )
+
+
+class TestThesesWrite:
+    def test_one_thesis_per_booked_position(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(
+            client,
+            [{"ticker": "SPY", "target_pct": 60}, {"ticker": "TLT", "target_pct": 40}],
+            {
+                "SPY": {
+                    "ticker": "SPY",
+                    "stance": "buy",
+                    "thesis": "AI capex tailwind",
+                    "risks": "valuation",
+                },
+                "TLT": {
+                    "ticker": "TLT",
+                    "stance": "hold",
+                    "thesis": "duration hedge",
+                    "risks": "fiscal supply",
+                },
+            },
+        )
+        theses = {r["thesis_id"]: r for r in client.store["theses"]}
+        assert set(theses) == {"spy", "tlt"}
+        assert theses["spy"]["vehicle"] == "SPY"
+        assert theses["spy"]["status"] == "ACTIVE"
+        assert "AI capex" in theses["spy"]["notes"]
+        assert all(r["_on_conflict"] == "date,thesis_id" for r in client.store["theses"])
+
+    def test_thesis_vehicle_written_per_position(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(
+            client,
+            [{"ticker": "SPY", "target_pct": 100}],
+            {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t"}},
+        )
+        vehicles = client.store["thesis_vehicles"]
+        assert len(vehicles) == 1
+        assert vehicles[0]["thesis_id"] == "spy" and vehicles[0]["ticker"] == "SPY"
+        assert vehicles[0]["_on_conflict"] == "date,thesis_id,ticker"
+
+    def test_status_maps_from_stance(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(
+            client,
+            [
+                {"ticker": "AAA", "target_pct": 25},
+                {"ticker": "BBB", "target_pct": 25},
+                {"ticker": "CCC", "target_pct": 25},
+                {"ticker": "DDD", "target_pct": 25},
+            ],
+            {
+                "AAA": {"ticker": "AAA", "stance": "buy", "thesis": "x"},
+                "BBB": {"ticker": "BBB", "stance": "watch", "thesis": "x"},
+                "CCC": {"ticker": "CCC", "stance": "sell", "thesis": "x"},
+                "DDD": {"ticker": "DDD", "stance": "hold", "thesis": "x"},
+            },
+        )
+        status = {r["thesis_id"]: r["status"] for r in client.store["theses"]}
+        assert status == {
+            "aaa": "ACTIVE",
+            "bbb": "MONITORING",
+            "ccc": "CHALLENGED",
+            "ddd": "ACTIVE",
+        }
+
+    def test_invalidation_from_debate_bear_case(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(
+            client,
+            [{"ticker": "SPY", "target_pct": 100}],
+            {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t", "risks": "fallback risk"}},
+            {"SPY": {"bear_case": "breaks below 200dma"}},
+        )
+        spy = next(r for r in client.store["theses"] if r["thesis_id"] == "spy")
+        assert spy["invalidation"] == "breaks below 200dma"
+
+    def test_holding_without_analyst_defaults_active(self) -> None:
+        # The auto-injected BIL cash-proxy has no analyst payload → ACTIVE, name=ticker.
+        client = FakeSupabaseClient()
+        _run_full(client, [{"ticker": "BIL", "target_pct": 100}], {})
+        bil = next(r for r in client.store["theses"] if r["thesis_id"] == "bil")
+        assert bil["status"] == "ACTIVE"
+        assert bil["name"] == "BIL"
+
+    def test_no_thesis_for_cash_residual(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(
+            client,
+            [{"ticker": "SPY", "target_pct": 70}],  # 30% CASH residual
+            {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t"}},
+        )
+        ids = {r["thesis_id"] for r in client.store["theses"]}
+        assert ids == {"spy"}  # CASH residual produces no thesis row
+
+    def test_empty_portfolio_writes_no_theses(self) -> None:
+        client = FakeSupabaseClient()
+        _run_full(client, [], {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t"}})
+        assert "theses" not in client.store

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -256,7 +256,8 @@ class TestThesesWrite:
         assert spy["invalidation"] == "breaks below 200dma"
 
     def test_holding_without_analyst_defaults_active(self) -> None:
-        # The auto-injected BIL cash-proxy has no analyst payload → ACTIVE, name=ticker.
+        # A held ticker with no analyst payload (e.g. a BIL position the PM picked
+        # explicitly on conviction) → status ACTIVE, name=ticker.
         client = FakeSupabaseClient()
         _run_full(client, [{"ticker": "BIL", "target_pct": 100}], {})
         bil = next(r for r in client.store["theses"] if r["thesis_id"] == "bil")


### PR DESCRIPTION
## Problem
The Olympus paper portfolio was empty on every run — `positions`, `nav_history`, and `theses` all **0 rows** in prod — so Positions / Performance / Theses dashboard pages were blank.

## Root causes & fixes

**A — PM produced an empty book.** The PM node loaded `pm-allocation-memo` (a thin memo-publishing skill whose contract doesn't match the node's `RebalanceDecision` output) → `recommended_portfolio: []` every run. New **`pm-rebalance-decision`** skill matches the node I/O and sizes positions by conviction. The un-allocated remainder is **CASH — a first-class defensive position** — never padded with a cash-proxy ETF (BIL/SHY are held only on explicit conviction). `portfolio_materialize` now books an empty/low-conviction decision as a **100% CASH** position + NAV point (no longer a no-op), so the dashboard always reflects the book — even "100% cash, defensive". It still no-ops only when the PM never ran (`phase7d_rebalance is None`).

> Design note (per owner feedback): 100% cash is a legitimate position; BIL/SHY are distinct ETF holdings, not a cash substitute — so the residual is plain CASH, never auto-filled with a proxy.

**B — `theses` table had no live writer** (only frozen legacy scripts). `portfolio_materialize` now upserts one thesis (+ `thesis_vehicles`) per booked holding, derived from the analyst payloads + debate summaries in state (stance→status, thesis→notes/name, bear-case/risks→invalidation). A pure-cash book writes no theses.

**C — Per-ticker analysts were blind to per-ticker data** (no data tools, only the market-wide equity blob) → low conviction. `phase7c` now pre-fetches `get_price_technicals(ticker)` and injects it into the technical + fundamental axes (documented in both analyst SKILLs). Fail-soft to `{}` on any error. Exposes `get_data_client()` in `_node_factory`.

## Validation
- `tests/dq/hermes/` + `tests/dq/atlas/` — **438 passed**.
- New suites: PM skill selection + cash-first contract, theses writer, per-ticker technicals injection.
- `make score` (vs develop): Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

No schema migration. Paper portfolio only — no broker/live-trading path. Schema simplification follows in #714.

Fixes #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)