### PR TITLE
refactor(supabase): consolidate daily_snapshots — drop legacy flat columns, single source of truth (#714)

### DIFF
--- a/digiquant/supabase/migrations/034_drop_daily_snapshots_legacy_columns.sql
+++ b/digiquant/supabase/migrations/034_drop_daily_snapshots_legacy_columns.sql
@@ -1,0 +1,22 @@
+-- 034_drop_daily_snapshots_legacy_columns.sql — remove the legacy flat columns
+-- on daily_snapshots that were superseded by the `snapshot` JSONB digest (008).
+--
+-- Rationale (#714): daily_snapshots carried a dual source of truth — five flat
+-- columns (regime, market_data, segment_biases, actionable, risks) AND the
+-- `snapshot` JSONB that supersedes them. Migration 029 already made the flat
+-- columns nullable after the publish adapter stopped writing them; every recent
+-- row has them NULL and the live writer (supabase_io.DailySnapshotUpsertRow)
+-- only writes {date, run_type, baseline_date, snapshot, digest_markdown}. The
+-- frontend now reads the equivalent data from the snapshot JSONB
+-- (market_regime_snapshot / bias / actionable_summary / risk_radar). Drop the
+-- dead columns so the table has a single source of truth.
+--
+-- Safe: no live writer populates these; no data loss (all NULL). Idempotent via
+-- IF EXISTS so re-applying is a no-op.
+
+ALTER TABLE daily_snapshots
+  DROP COLUMN IF EXISTS regime,
+  DROP COLUMN IF EXISTS market_data,
+  DROP COLUMN IF EXISTS segment_biases,
+  DROP COLUMN IF EXISTS actionable,
+  DROP COLUMN IF EXISTS risks;

--- a/frontend/olympus/lib/database.types.ts
+++ b/frontend/olympus/lib/database.types.ts
@@ -15,12 +15,7 @@ export interface Database {
           date: string;           // date (ISO string)
           run_type: 'baseline' | 'delta';
           baseline_date: string | null;
-          regime: Json;           // jsonb — RegimeJson at runtime
-          market_data: Json;      // jsonb
-          segment_biases: Json | null;
-          actionable: string[] | null;
-          risks: string[] | null;
-          snapshot?: Json | null;        // jsonb — full digest snapshot (DB-first)
+          snapshot?: Json | null;        // jsonb — full digest snapshot (single source of truth)
           digest_markdown?: string | null; // rendered digest for Library
           created_at: string | null;
         };

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -518,16 +518,19 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     ? allTheses.filter((t) => t.date === latestThesisDate)
     : [];
 
-  // The flat `regime` column was dropped (#714); the regime now lives in the
-  // snapshot JSONB. The strategy block below falls through to digest.* via ??,
-  // so an empty object preserves that resolution with no flat-column read.
-  const regime: Record<string, unknown> = {};
-
-  // The Atlas pipeline (SIMP-013) writes the digest into the `snapshot` JSONB
-  // and leaves the legacy `regime`/`actionable`/`risks`/`market_data`/
-  // `segment_biases` columns null — fall back to the digest for the strategy
-  // panel when the legacy columns are absent.
+  // The Atlas pipeline (SIMP-013) writes the digest into the `snapshot` JSONB;
+  // the legacy flat columns were dropped (#714). The strategy panel reads
+  // everything from the digest.
   const digest = (snapshotJson ?? {}) as Record<string, unknown>;
+
+  // Regime now comes from the snapshot JSONB. Newer digests expose
+  // `market_regime_snapshot` (consumed directly in the strategy block below);
+  // older v1 payloads embed a nested `regime` object — honor it when present so
+  // those rows still resolve a label, rather than forcing it empty.
+  const regime: Record<string, unknown> =
+    digest.regime && typeof digest.regime === 'object' && !Array.isArray(digest.regime)
+      ? (digest.regime as Record<string, unknown>)
+      : {};
 
   // Build benchmark map
   const benchmarks: BenchmarkHistoryMap = {};
@@ -1549,8 +1552,9 @@ export async function getDigestMarkdownDiffPair(
 
 export async function getDailySnapshots(
   fromDate?: string
-): Promise<TableRow<'daily_snapshots'>[]> {
-  return querySupabase<TableRow<'daily_snapshots'>[]>((sb) => {
+): Promise<Pick<TableRow<'daily_snapshots'>, 'date' | 'run_type' | 'snapshot'>[]> {
+  type Row = Pick<TableRow<'daily_snapshots'>, 'date' | 'run_type' | 'snapshot'>;
+  return querySupabase<Row[]>((sb) => {
     let q = sb
       .from('daily_snapshots')
       .select('date, run_type, snapshot')

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -15,7 +15,6 @@ import type {
   ResearchChangelogMeta,
   DashboardPositionEvent,
   ServerPortfolioMetrics,
-  HoldingTechnicalSnapshot,
   MacroSeriesPoint,
   ThesisHistoryPoint,
   PositionHistoryRow,
@@ -26,11 +25,7 @@ import type {
 import { renderDigestMarkdownFromSnapshot, type DigestSnapshot } from './render-digest-from-snapshot';
 import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
 import { DASHBOARD_BENCHMARK_TICKERS, sortTickerUniverse } from './benchmark-tickers';
-import {
-  digestItemsToStrings,
-  extractDigestContextBullets,
-  extractSnapshotContextBullets,
-} from './snapshot-context';
+import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
 import { MACRO_PREVIEW_SERIES_IDS } from './macro-curated';
 import { getDocLibraryTier } from './library-doc-tier';
 
@@ -383,7 +378,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     snapshotRes, positionsRes, thesesRes, navRes,
     benchRes, metricsRes, docsRes, deltaDocsRes, changelogDocsRes, tickerViewRes, snapshotRunTypesRes,
   ] = await Promise.all([
-    supabase.from('daily_snapshots').select('*').order('date', { ascending: false }).limit(1).single(),
+    supabase.from('daily_snapshots').select('id,date,run_type,baseline_date,snapshot,digest_markdown,created_at').order('date', { ascending: false }).limit(1).single(),
     supabase.from('positions').select('*').order('date', { ascending: false }).limit(1000),
     supabase.from('theses').select('*').order('date', { ascending: false }).limit(50),
     supabase.from('nav_history').select('*').order('date', { ascending: true }),
@@ -523,14 +518,10 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     ? allTheses.filter((t) => t.date === latestThesisDate)
     : [];
 
-  // Parse regime — stored as JSONB (may come back as string or object)
-  const rawRegime = snapshot.regime;
-  const regime: Record<string, unknown> =
-    typeof rawRegime === 'string'
-      ? (JSON.parse(rawRegime) as Record<string, unknown>)
-      : typeof rawRegime === 'object' && rawRegime !== null
-      ? (rawRegime as Record<string, unknown>)
-      : {};
+  // The flat `regime` column was dropped (#714); the regime now lives in the
+  // snapshot JSONB. The strategy block below falls through to digest.* via ??,
+  // so an empty object preserves that resolution with no flat-column read.
+  const regime: Record<string, unknown> = {};
 
   // The Atlas pipeline (SIMP-013) writes the digest into the `snapshot` JSONB
   // and leaves the legacy `regime`/`actionable`/`risks`/`market_data`/
@@ -792,57 +783,25 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     return { ticker: p.ticker, current_pct: curr, recommended_pct: rec, action };
   });
 
-  const legacyContextBullets = extractSnapshotContextBullets(
-    snapshot.segment_biases,
-    snapshot.market_data
-  );
-  const snapshot_context_bullets = legacyContextBullets.length
-    ? legacyContextBullets
-    : extractDigestContextBullets(digest);
+  // segment_biases / market_data flat columns dropped (#714) — bullets come
+  // from the snapshot JSONB digest.
+  const snapshot_context_bullets = extractDigestContextBullets(digest);
 
   const runTypeRaw = String(snapshot.run_type || '').toLowerCase();
   const latest_snapshot_run_type: 'baseline' | 'delta' | null =
     runTypeRaw === 'baseline' || runTypeRaw === 'delta' ? runTypeRaw : null;
 
-  let holding_technicals: Record<string, HoldingTechnicalSnapshot> = {};
+  // price_technicals was fetched into `holding_technicals` but never rendered —
+  // removed (#714) to drop a wasted Supabase round-trip on every dashboard load.
   const macro_series_preview: Record<string, MacroSeriesPoint[]> = {};
 
-  if (posTickers.length > 0 || MACRO_PREVIEW_SERIES_IDS.length > 0) {
-    const [techRes, macroRes] = await Promise.all([
-      posTickers.length > 0
-        ? supabase
-            .from('price_technicals')
-            .select('date,ticker,rsi_14,pct_vs_sma50')
-            .in('ticker', posTickers)
-            .order('date', { ascending: false })
-            .limit(400)
-        : Promise.resolve({ data: null as unknown, error: null }),
-      supabase
-        .from('macro_series_observations')
-        .select('series_id,obs_date,value')
-        .in('series_id', MACRO_PREVIEW_SERIES_IDS)
-        .order('obs_date', { ascending: false })
-        .limit(800),
-    ]);
-
-    if (techRes.error) {
-      console.warn('Supabase price_technicals query:', techRes.error);
-    } else if (techRes.data && Array.isArray(techRes.data)) {
-      const seen = new Set<string>();
-      for (const row of techRes.data as Pick<
-        TableRow<'price_technicals'>,
-        'date' | 'ticker' | 'rsi_14' | 'pct_vs_sma50'
-      >[]) {
-        if (!row?.ticker || seen.has(row.ticker)) continue;
-        seen.add(row.ticker);
-        holding_technicals[row.ticker] = {
-          date: row.date,
-          rsi_14: row.rsi_14 != null ? Number(row.rsi_14) : null,
-          pct_vs_sma50: row.pct_vs_sma50 != null ? Number(row.pct_vs_sma50) : null,
-        };
-        if (seen.size >= posTickers.length) break;
-      }
-    }
+  if (MACRO_PREVIEW_SERIES_IDS.length > 0) {
+    const macroRes = await supabase
+      .from('macro_series_observations')
+      .select('series_id,obs_date,value')
+      .in('series_id', MACRO_PREVIEW_SERIES_IDS)
+      .order('obs_date', { ascending: false })
+      .limit(800);
 
     if (macroRes.error) {
       console.warn('Supabase macro_series_observations query:', macroRes.error);
@@ -896,8 +855,8 @@ export async function getFullDashboardData(): Promise<DashboardData> {
         ),
         regime_label: String(regime.bias ?? regime.regime_label ?? digest.bias ?? 'neutral'),
         summary: String(regime.summary ?? digest.headline ?? ''),
-        actionable: snapshot.actionable ?? digestItemsToStrings(digest.actionable_summary),
-        risks: snapshot.risks ?? digestItemsToStrings(digest.risk_radar),
+        actionable: digestItemsToStrings(digest.actionable_summary),
+        risks: digestItemsToStrings(digest.risk_radar),
         theses,
         next_review: 'Daily',
       },
@@ -955,7 +914,6 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       alpha: metrics.alpha != null ? Number(metrics.alpha) : 0,
     },
     snapshot_context_bullets,
-    holding_technicals,
     macro_series_preview,
     pipeline_observability,
   };
@@ -1595,7 +1553,7 @@ export async function getDailySnapshots(
   return querySupabase<TableRow<'daily_snapshots'>[]>((sb) => {
     let q = sb
       .from('daily_snapshots')
-      .select('date, regime, market_data, segment_biases')
+      .select('date, run_type, snapshot')
       .order('date', { ascending: true });
     if (fromDate) q = q.gte('date', fromDate);
     return q;

--- a/frontend/olympus/lib/snapshot-context.ts
+++ b/frontend/olympus/lib/snapshot-context.ts
@@ -1,6 +1,7 @@
 /**
- * Defensive extraction of human-readable bullets from snapshot JSON
- * (segment_biases, market_data) for Overview / Strategy footnotes.
+ * Context bullets + digest list normalization for Overview / Strategy footnotes,
+ * read from the `daily_snapshots.snapshot` JSONB digest. The legacy flat
+ * segment_biases / market_data columns (and their extractor) were dropped in #714.
  */
 
 function pushUnique(out: string[], line: string, max: number) {
@@ -8,59 +9,6 @@ function pushUnique(out: string[], line: string, max: number) {
   if (!t || out.length >= max) return;
   if (out.includes(t)) return;
   out.push(t.length > 160 ? `${t.slice(0, 157)}…` : t);
-}
-
-export function extractSnapshotContextBullets(
-  segment_biases: unknown,
-  market_data: unknown,
-  max = 5
-): string[] {
-  const out: string[] = [];
-
-  if (Array.isArray(segment_biases)) {
-    for (const item of segment_biases) {
-      if (out.length >= max) break;
-      if (typeof item === 'string') {
-        pushUnique(out, item, max);
-        continue;
-      }
-      if (item && typeof item === 'object' && !Array.isArray(item)) {
-        const o = item as Record<string, unknown>;
-        const segment = typeof o.segment === 'string' ? o.segment : typeof o.name === 'string' ? o.name : '';
-        const bias = typeof o.bias === 'string' ? o.bias : typeof o.direction === 'string' ? o.direction : '';
-        const conf = typeof o.confidence === 'string' ? o.confidence : '';
-        const summary = typeof o.summary === 'string' ? o.summary : typeof o.note === 'string' ? o.note : '';
-        const parts = [segment, bias, conf].filter(Boolean);
-        if (parts.length) pushUnique(out, parts.join(' · '), max);
-        else if (summary) pushUnique(out, summary, max);
-      }
-    }
-  }
-
-  if (out.length >= max) return out.slice(0, max);
-
-  if (market_data && typeof market_data === 'object' && !Array.isArray(market_data)) {
-    const md = market_data as Record<string, unknown>;
-    for (const [k, v] of Object.entries(md)) {
-      if (out.length >= max) break;
-      if (typeof v === 'string' && v.trim()) {
-        pushUnique(out, `${k}: ${v.trim()}`, max);
-        continue;
-      }
-      if (v && typeof v === 'object' && !Array.isArray(v)) {
-        const inner = v as Record<string, unknown>;
-        const s =
-          typeof inner.summary === 'string'
-            ? inner.summary
-            : typeof inner.label === 'string'
-              ? inner.label
-              : null;
-        if (s?.trim()) pushUnique(out, `${k}: ${s.trim()}`, max);
-      }
-    }
-  }
-
-  return out.slice(0, max);
 }
 
 /** Narrative sections of the pipeline digest payload used as Overview context bullets. */

--- a/frontend/olympus/lib/types.ts
+++ b/frontend/olympus/lib/types.ts
@@ -170,13 +170,6 @@ export interface PerfChartPoint {
   [benchmark: string]: number | null | string;
 }
 
-/** Latest row from price_technicals for a holding (Overview / Portfolio). */
-export interface HoldingTechnicalSnapshot {
-  date: string;
-  rsi_14: number | null;
-  pct_vs_sma50: number | null;
-}
-
 /** One observation for macro sparklines. */
 export interface MacroSeriesPoint {
   obs_date: string;
@@ -318,10 +311,8 @@ export interface DashboardData {
   /** Distinct tickers in price_history (view); sorted with majors first. */
   price_history_tickers: string[];
   calculated: CalculatedMetrics;
-  /** Short bullets from latest snapshot segment_biases / market_data. */
+  /** Short context bullets derived from the snapshot JSONB digest. */
   snapshot_context_bullets: string[];
-  /** Latest price_technicals row per current holding ticker. */
-  holding_technicals: Record<string, HoldingTechnicalSnapshot>;
   /** Recent points per series_id for macro preview (curated list). */
   macro_series_preview: Record<string, MacroSeriesPoint[]>;
   /** Published thesis / PM pipeline artifacts for `portfolio.meta.last_updated` when present. */


### PR DESCRIPTION
## What
`daily_snapshots` carried a **dual source of truth**: five legacy flat columns (`regime`, `market_data`, `segment_biases`, `actionable`, `risks`) **and** the `snapshot` JSONB digest that supersedes them (migration 029 already documented the breakage and made them nullable). This consolidates to the `snapshot` JSONB as the single source of truth.

## Verified safe (against prod)
- The flat columns are **NULL on every row** — no data loss.
- The live publish writer (`supabase_io.DailySnapshotUpsertRow`) writes only `{date, run_type, baseline_date, snapshot, digest_markdown}`.
- The active prior-context load selects only those columns.
- The 8 scripts that still write the flat columns are **frozen one-shot backfills**, not in any cron.

## Changes
- **migration 034** — `DROP COLUMN IF EXISTS` the five flat columns.
- **`lib/queries.ts`** — read regime/bias/actionable/risks/context-bullets from the snapshot JSONB (`market_regime_snapshot` / `bias` / `actionable_summary` / `risk_radar`); replace `select('*')` + `getDailySnapshots` select with explicit column lists (no flat-column reliance).
- Remove the `price_technicals` → `holding_technicals` fetch that was **never rendered** (a wasted Supabase round-trip every dashboard load) + its type.
- Drop the now-orphaned `extractSnapshotContextBullets`; update `database.types.ts` + `types.ts`.

**Net −86 lines.**

## Validation
- `tsc --noEmit` clean (only pre-existing `security-headers.test.ts` `.mjs` warning), `eslint` clean, **88 olympus tests pass**, `next build` green (13 pages).
- `make score` (vs develop): 10 / 10 / 10 / 10.

## Deferred (deliberate)
The other audit drops — `bb_middle`, `price_history.is_trading_day`, `position_events.weight_change_pct`, `positions.contribution_pct`, and the `portfolio_metrics.cash_pct`/`total_invested` dedupe — are **coupled to live writers** (`bb_middle`/`is_trading_day` to the active `digiquant-prices.yml` cron; the rest to ~20 backfill scripts). Dropping them without updating every writer would break daily price ingestion. They're redundant/derived (harmless operationally) and are left for a separate, carefully-scoped PR.

Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)