### PR TITLE
docs(vision): refresh VISION + per-module docs for digillm/digifetch/digidev/olympus + Hermes/Kairos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Flagship vertical: **quantitative finance** — a "hedge-fund in a box" where on
 | **DigiClaw** | Heartbeat, audit, MCP skill → DigiGraph | [digiclaw/ARCHITECTURE.md](digiclaw/ARCHITECTURE.md) |
 | **DigiBase** | Shared HTTP/audit library + future data-plane service | [digibase/ARCHITECTURE.md](digibase/ARCHITECTURE.md) |
 | **DigiVault** | Obsidian-style markdown vault management (frontmatter, wikilinks, backlinks) | [digivault/ARCHITECTURE.md](digivault/ARCHITECTURE.md) |
+| **DigiLLM** | Provider-agnostic LLM client/routing library | [digillm/ARCHITECTURE.md](digillm/ARCHITECTURE.md) |
+| **DigiFetch** | Shared web-scraping / headless-fetch engine library | [digifetch/ARCHITECTURE.md](digifetch/ARCHITECTURE.md) |
+| **DigiDev** | Drop-in agentic-coding workflow kit | [digidev/README.md](digidev/README.md) |
 | **config** | LiteLLM + model modes (test/medium/best) | [config/MODELS.md](config/MODELS.md) |
 
 ## Quick start

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,6 +1,6 @@
 # DigiThings Vision
 
-**Last reviewed:** 2026-04-19
+**Last reviewed:** 2026-06-14
 **Status:** living document — source of truth for product direction. Implementation detail belongs in `ARCHITECTURE.md`, component `DIGIxxx.md` files, and ADRs under `docs/adr/`.
 
 > **Per-module vision & roadmap:** see [`docs/vision/`](vision/README.md) for one document per module (positioning, current state, 12-month roadmap, open vs. proprietary split).
@@ -15,11 +15,11 @@ AI-solutions work today is either:
 - **Too shallow** — thin wrappers over a single model, no retrieval, no execution, no audit.
 - **Too bespoke** — every engagement rebuilds orchestration, search, auth, and deployment from scratch.
 
-DigiThings is the middle path: a set of **composable, open-core components** (`digigraph`, `digisearch`, `digiquant`, `digichat`, `digikey`, `digiclaw`, `digismith`, `digibase`) that snap together into a running stack for any given client, product, or research project. Each engagement becomes a thin **configuration layer** over the shared platform — not a rewrite.
+DigiThings is the middle path: a set of **composable, open-core components** (`digigraph`, `digisearch`, `digiquant`, `digichat`, `digikey`, `digiclaw`, `digismith`, `digibase`, `digillm`, `digifetch`, `digidev`) that snap together into a running stack for any given client, product, or research project. Each engagement becomes a thin **configuration layer** over the shared platform — not a rewrite.
 
 ## Product surfaces
 
-Two public domains, three product surfaces.
+Two public domains, plus a developer-tooling product line.
 
 ### `digithings.ai` — ecosystem home
 - **Marketing site** (current `website/`) — landing, components, open-source story, case studies.
@@ -27,16 +27,23 @@ Two public domains, three product surfaces.
 
 ### `digiquant.io` — financial AI hub
 - **DigiQuant product** — algorithmic strategy generation, backtesting, optimization, broker connections, deployment.
-- **Atlas** at `digiquant.io/atlas` — high-level fundamental/research engine. Migrates to use **DigiGraph** as its AI orchestration backend (structured outputs, DB-persisted research). Future phases add:
-  - **Execution layer** — Atlas research biases feed DigiQuant strategies.
-  - **Tiering** — free tier: daily batch research across domains; paid tier: user-level preferences, prompts, portfolios, custom domains.
-  - **Atlas-embedded DigiChat** — navigation + research Q&A inside the Atlas UI.
+- **Olympus** — the human-facing dashboard (`frontend/olympus`) for DigiQuant's finance sub-graph trio. Atlas now lives inside `digiquant` as `digiquant.olympus` (see ADR-0014, ADR-0015); the three sub-graphs are:
+  - **Atlas** — high-level fundamental/research engine; runs daily batch research, structured outputs, DB-persisted.
+  - **Hermes** — portfolio deliberation (bull/bear theses, risk debate) with a **human approval gate** before any execution.
+  - **Kairos** — chat-based strategy development; a quant researcher's interactive strategy workbench inside DigiChat.
+- Tiering and posture:
+  - **Execution layer** — Atlas/Hermes biases feed DigiQuant strategies (research → live orders is the commercial, human-gated path).
+  - **Tiering** — free tier: daily batch research across shared domains; paid tier: user-level preferences, prompts, portfolios, custom domains.
+  - **Embedded DigiChat** — navigation + research Q&A inside the Olympus UI.
 
 ### Client and pilot projects
 Stored under `projects/` (confidential — never pushed to public remotes). Each is a **DigiThings Project** (see ADR-0001): a thin config-driven composition of components.
 
 Current and near-term:
 - **SITAAS** — POC with external client, DigiGraph + DigiSearch over a unified content index (emails, Teams, SharePoint). First pilot; template for future engagements.
+
+### DigiDev — agentic-coding workflow kit
+A drop-in product line that layers structured tasks, a 4-dimension scoring gate, PreToolUse guardrails, and existing-tool connectors (Jira, Linear, Slack, Supabase, and more) onto any codebase so AI coding agents (Claude Code, Copilot, Cursor) work safely and consistently. This monorepo dogfoods it: the `.claude/` agent surface, scoring rubrics, and task pipeline are DigiDev. Open core, with premium agents and skills as paid add-ons.
 
 ## Core concept: the DigiThings Project Spec
 
@@ -71,14 +78,21 @@ See **ADR-0001: DigiThings Project Spec** for the formal definition and **ADR-00
               ┌─────────────▼─┐    ┌───▼───────────┐
               │  DigiSearch    │    │  DigiQuant    │
               │  (RAG/search) │    │  (Nautilus)   │
-              └────────────────┘    └───────────────┘
+              └────────────────┘    └──────┬────────┘
+                                           │ olympus sub-graphs
+                                  ┌────────▼────────────┐
+                                  │  Atlas / Hermes /   │
+                                  │  Kairos             │
+                                  └─────────────────────┘
 
     digiquant.io ────▶  DigiQuant product UI
-         /atlas  ────▶  Atlas research engine ──▶ DigiGraph ──▶ DigiSearch
-                                                           └─▶ DigiQuant (execution, future)
+       Olympus    ────▶  Atlas + Hermes + Kairos dashboard (frontend/olympus)
+                          └─▶ DigiGraph ──▶ DigiSearch / DigiQuant (execution, human-gated)
 
-    projects/sitaas ──▶  DigiGraph + DigiSearch + LiteLLM (no DigiQuant)
+    projects/sitaas ──▶  DigiGraph + DigiSearch (no DigiQuant)
     projects/<next> ──▶  any subset, via Project Spec
+
+    digidev ──────────▶  drop-in agentic-coding kit (tasks, scoring, guardrails)
 ```
 
 Cross-cutting:
@@ -86,6 +100,8 @@ Cross-cutting:
 - **DigiSmith** — tracing/observability across all components.
 - **DigiClaw** — heartbeat, audit, deployment gateway for 24/7 agent work.
 - **DigiBase** — shared HTTP/audit library; future credential broker for multi-tenant deployments.
+- **DigiLLM** — provider-agnostic LLM client/routing library; the single home for LLM code, superseding the in-tree `digigraph.llm` module.
+- **DigiFetch** — shared web-scraping / headless-fetch engine (retry/backoff, rate limiting, browser lifecycle).
 
 ## Strategic posture
 
@@ -102,7 +118,7 @@ Cross-cutting:
 
 ## Strategic decisions
 
-**Last updated:** 2026-04-18.
+**Last updated:** 2026-06-14.
 
 ### Atlas tiering — hybrid
 
@@ -121,8 +137,8 @@ The BYOK requirement from ADR-0002 stands: zero server-side persistence of user 
 
 ### Open-source vs. managed — core open, some premium closed
 
-- **Open core** (MIT/Apache): `digigraph`, `digisearch`, `digiquant` (backtest/optimize only), `digichat`, `digikey`, `digiclaw`, `digismith`, `digibase` (single-tenant library).
-- **Closed / commercial:** Atlas execution layer (research → live orders), multi-tenant DigiBase credential broker, managed hosting of DigiThings Projects, any client-specific IP developed under `projects/`.
+- **Open core** (MIT/Apache): `digigraph`, `digisearch`, `digiquant` (backtest/optimize only), `digichat`, `digikey`, `digiclaw`, `digismith`, `digibase` (single-tenant library), `digillm`, `digifetch`, `digidev` (kit core; premium agents/skills closed).
+- **Closed / commercial:** the finance sub-graph *implementations* — Atlas research cycles, Hermes portfolio deliberation, Kairos strategy execution (research → live orders); multi-tenant DigiBase credential broker; managed hosting of DigiThings Projects; premium DigiDev agents/skills; any client-specific IP developed under `projects/`.
 - **Consultancy** stays its own revenue line, independent of the open/closed split.
 
 The exact boundary evolves. Guardrail: anything that's a meaningful moat for the commercial product (execution, multi-tenancy, hosting) can be closed; anything a user could reasonably want to self-host for their own agent work stays open.
@@ -137,4 +153,5 @@ The exact boundary evolves. Guardrail: anything that's a meaningful moat for the
 
 - Atlas seat price point and metered unit cost (defer to Phase 5 planning).
 - Guest-tier rate limits on `chat.digithings.ai` (defer to Phase 3b implementation).
-- Exact list of "closed" components — only execution layer + multi-tenant DigiBase + hosting are committed today; others may migrate into the closed column as commercial value becomes clear.
+- Exact list of "closed" components — only the finance sub-graph implementations + multi-tenant DigiBase + hosting + premium DigiDev add-ons are committed today; others may migrate into the closed column as commercial value becomes clear.
+- Library extraction is uneven: `digillm` and `digifetch` have shipped as standalone open-core libraries, while `digilink` (connector/protocol layer) and `digistore` (storage abstraction) remain designed-but-unshipped — their functions still live inside individual services for now.

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -58,7 +58,7 @@ Scheduled and continuous agent execution via OpenClaw. Heartbeat and audit capab
 HTTP utilities, error envelopes, immutable audit logging (JSONL with redaction). Shared across all service boundaries.
 
 ### DigiLLM — LLM client library
-The single home for LLM client code: provider-agnostic routing, response caching, retry/backoff, structured output, and the tool-calling loop. Extracted from `digigraph.llm`; no FastAPI or service coupling. Consumed by twelve-x today; DigiGraph and DigiSearch migrate to it next.
+The single home for LLM client code: provider-agnostic routing, response caching, retry/backoff, structured output, and the tool-calling loop. Extracted from `digigraph.llm`; no FastAPI or service coupling. Consumed by twelve-x (a downstream consumer app) today; DigiGraph and DigiSearch migrate to it next.
 
 ### DigiFetch — web-scraping engine library
 Shared headless-fetch engine: browser session lifecycle, composable retry/backoff, polite rate limiting, and an HTTP fetch/download path with Playwright→HTTP cookie hand-off. Standalone library, browser-free on import. One consumer today (twelve-x); 0.1.0 is provisional.

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -34,7 +34,7 @@ The platform integrates with and extends the open-source tools clients may alrea
 Shipped and in active use:
 
 ### DigiGraph — agent orchestration hub
-LangGraph-based workflow engine with a supervisor node, research and analysis sub-graphs, dynamic tool registry, OpenAI-compatible API, server-sent event (SSE) streaming, JWT auth, per-IP rate limiting, LiteLLM routing, DigiSmith tracing, and an MCP server. Parallel tool execution and tool allowlist/policy enforcement included.
+LangGraph-based workflow engine with a supervisor node, research and analysis sub-graphs, dynamic tool registry, OpenAI-compatible API, server-sent event (SSE) streaming, JWT auth, per-IP rate limiting, LLM routing (LiteLLM today, migrating to the shared DigiLLM library), DigiSmith tracing, and an MCP server. Parallel tool execution and tool allowlist/policy enforcement included.
 
 ### DigiQuant — quantitative finance platform
 NautilusTrader-backed strategy engine with backtest and optimisation nodes wired into DigiGraph. Connects to OpenBB for market data. Atlas (research), Hermes (portfolio), and Kairos (strategy execution) are in active development as sub-graph modules.
@@ -57,7 +57,19 @@ Scheduled and continuous agent execution via OpenClaw. Heartbeat and audit capab
 ### DigiBase — shared library
 HTTP utilities, error envelopes, immutable audit logging (JSONL with redaction). Shared across all service boundaries.
 
-**Note — not yet shipped:** DigiStore (unified storage abstraction over Supabase, SQLite, S3/MinIO) and DigiLink (the protocol translation and connector layer) are designed and specced but not yet implemented as standalone modules. Their functions exist today within individual services.
+### DigiLLM — LLM client library
+The single home for LLM client code: provider-agnostic routing, response caching, retry/backoff, structured output, and the tool-calling loop. Extracted from `digigraph.llm`; no FastAPI or service coupling. Consumed by twelve-x today; DigiGraph and DigiSearch migrate to it next.
+
+### DigiFetch — web-scraping engine library
+Shared headless-fetch engine: browser session lifecycle, composable retry/backoff, polite rate limiting, and an HTTP fetch/download path with Playwright→HTTP cookie hand-off. Standalone library, browser-free on import. One consumer today (twelve-x); 0.1.0 is provisional.
+
+### DigiDev — agentic-coding workflow kit
+Drop-in kit that gives AI coding agents a structured task backlog, a 4-dimension scoring gate, PreToolUse guardrails, and generated MCP config for existing tools (Jira, Linear, Slack, Notion, Supabase, GitLab). Installs onto any repo; this monorepo dogfoods it.
+
+### Olympus — finance dashboard
+Human-facing dashboard (`frontend/olympus`) for the DigiQuant sub-graph trio — Atlas research, Hermes deliberation, Kairos strategy work — with a "Morning Read" overview, risk-debate surfaces, and portfolio/NAV tracking. The locus of the human approval gate before execution.
+
+**Note — not yet shipped:** DigiStore (unified storage abstraction over Supabase, SQLite, S3/MinIO) and DigiLink (the protocol translation and connector layer) are designed and specced but not yet implemented as standalone modules. Their functions exist today within individual services. (By contrast, DigiLLM and DigiFetch *have* shipped as standalone libraries.)
 
 ## Capabilities — 12-month roadmap
 
@@ -80,14 +92,28 @@ HTTP utilities, error envelopes, immutable audit logging (JSONL with redaction).
 - DigiSmith tracing helpers
 - DigiClaw heartbeat and audit core
 - DigiBase shared library
+- DigiLLM LLM client library
+- DigiFetch web-scraping engine library
+- DigiDev agentic-coding workflow kit (core; premium agents/skills closed)
 - DigiLink connector framework (when shipped)
 - DigiStore storage abstraction (when shipped)
 
 **Proprietary (commercial):**
 - Domain-specific sub-graph implementations: Atlas research cycles, Hermes portfolio deliberation, Kairos strategy execution
+- Olympus dashboard as the product surface for those sub-graphs
 - Strategy library and backtest configuration templates
 - Investor document builder and scholarly synthesis sub-graphs
+- Premium DigiDev agents and skills
 - Managed hosting and deployment
 - Enterprise SSO federation and org management extensions
 
 The open core is the infrastructure. The proprietary layer is the domain expertise that makes it immediately useful for finance, research, and consulting deployments.
+
+## Per-module vision docs
+
+One document per module — positioning, current state, 12-month roadmap, and open vs. proprietary split:
+
+- [DigiGraph](digigraph.md) · [DigiQuant](digiquant.md) · [DigiSearch](digisearch.md) · [DigiChat](digichat.md)
+- [DigiKey](digikey.md) · [DigiSmith](digismith.md) · [DigiClaw](digiclaw.md) · [DigiBase](digibase.md)
+- [DigiLLM](digillm.md) · [DigiFetch](digifetch.md) · [DigiDev](digidev.md) · [Olympus](olympus.md)
+- [DigiLink](digilink.md) · [DigiStore](digistore.md) *(designed, not yet shipped)*

--- a/docs/vision/digidev.md
+++ b/docs/vision/digidev.md
@@ -1,0 +1,42 @@
+# DigiDev
+> A drop-in agentic-coding workflow kit — structured tasks, a quality gate, guardrails, and connectors to the tools you already use.
+
+## What it is
+
+DigiDev is a drop-in kit that turns any codebase — fresh or existing — into one where AI coding agents (Claude Code, Copilot, Cursor) work safely and consistently. Install it and your agents get a structured task backlog, a 4-dimension self-scoring quality gate, PreToolUse guardrails that block unsafe operations, per-component onboarding docs, and generated MCP configuration for the tools a team already uses (Jira, Linear, Slack, Notion, Supabase, GitLab, and more).
+
+DigiDev does not replace your tools — it layers on top of them. The core workflow (tasks → code → score → commit → PR) runs with zero integrations; connectors are additive.
+
+## The problem it solves
+
+Agentic coding fails in predictable ways: agents don't know what to work on, there's no quality bar before PRs, they write to the wrong files, they re-discover the codebase every session, and they have no connection to the team's existing issue tracker or chat. Teams paper over this with ad-hoc prompts that don't compound. DigiDev packages the hard-won conventions — backlog, scoring rubric, guardrail hooks, worktree-per-task isolation, conventional commits — into something installable in minutes.
+
+## How it fits in the ecosystem
+
+DigiDev is the developer-infrastructure product line of DigiThings, distinct from the agentic-stack services. This monorepo dogfoods it: the `.claude/` agent surface, the `make score` gate, the task pipeline, and the guardrail hooks here *are* DigiDev. It is also the most directly portable component — it installs onto repositories that use none of the other DigiThings modules, which makes it a low-friction front door to the ecosystem.
+
+## Capabilities — Current
+
+Shipped and in active use:
+
+- Structured agent-task backlog with execution-tier dispatch (Copilot / Cursor / Claude)
+- 4-dimension self-scoring gate (Security / Quality / Optimization / Accuracy) with rubrics
+- Claude Code PreToolUse guardrails — hook scripts that block unsafe operations
+- Per-component `AGENTS.md` plus a root onboarding doc
+- Generated `.mcp.json` for the team's existing tools (Jira, Linear, Slack, Notion, Supabase, GitLab, GitHub Issues)
+- Conventional-commit enforcement and worktree-per-task isolation
+- Bundled subagents and skills (spec-writer, pr-reviewer, finish-task, triage, and more)
+- An install wizard plus an interactive `AI_SETUP.md` walkthrough
+
+## Capabilities — 12-month roadmap
+
+- Broader connector coverage as new MCP servers stabilise
+- A curated marketplace of premium agents and skills as paid add-ons
+- Tighter feedback loop between the scoring gate and CI triage
+- Versioned, upgradable installs so adopting repos can pull kit improvements cleanly
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):** the DigiDev kit core — task backlog, scoring gate, guardrail hooks, onboarding docs, connector generation, and the base subagents/skills.
+
+**Proprietary (commercial):** premium agents and skills offered as paid add-ons, and any managed/hosted DigiDev offering. The kit is the open front door; the premium agent library is the upsell.

--- a/docs/vision/digifetch.md
+++ b/docs/vision/digifetch.md
@@ -1,0 +1,36 @@
+# DigiFetch
+> The shared web-scraping engine — headless-browser lifecycle, composable retry/backoff, and polite rate limiting, as a library with no service coupling.
+
+## What it is
+
+DigiFetch is the shared web-scraping / headless-fetch engine for the DigiThings stack. It is a standalone library — no FastAPI, no port, no service coupling — that extracts the reusable *mechanics* of web scraping (headless-browser session lifecycle, composable retry/backoff, polite-scraping rate limiting, and an HTTP fetch/download path with a Playwright→HTTP cookie hand-off) from site-specific scrapers, leaving only the site-specific logic in each consumer.
+
+The package is side-effect-free and browser-free on import: `import digifetch` never launches or imports a browser. Playwright is imported lazily at call time, so the library installs and imports cleanly on a machine with no browser present; the headless seam is opt-in via the `[browser]` extra.
+
+## The problem it solves
+
+Every scraper reinvents the same brittle plumbing — backoff loops, throttles, browser session management, cookie hand-off — wrapped tightly around one site's selectors. The mechanics never get reused and never get hardened. DigiFetch separates the durable mechanics (reusable, tested, injectable clocks/sleeps for fast tests) from the disposable site logic, so scraping infrastructure compounds instead of being rebuilt per source.
+
+## How it fits in the ecosystem
+
+DigiFetch is a leaf library that any data-acquisition path can depend on. Hard dependencies are just `pydantic` and `httpx` (the monorepo HTTP convention; `requests` is intentionally excluded). Today there is exactly one consumer — **twelve-x** — so the public interface was validated against a single use case and is treated as provisional (0.1.0); it should be expected to change when a second consumer arrives. It was built ahead of the usual "extract on the second consumer" rule by explicit request.
+
+## Capabilities — Current
+
+Shipped:
+
+- `RetryPolicy` — exponential backoff with full jitter, selective `retry_on`, injectable `sleep`/`rand`; and `with_retry(func, policy)` as a composable wrapper (not baked into any fetch primitive)
+- `RateLimiter` — single-process minimum-interval throttle for polite scraping (injectable clock/sleep)
+- `HttpFetcher` over `httpx` — `fetch`/`download` with a byte cap and `DownloadTooLargeError`
+- `browser_session(...)` — headless-browser lifecycle context manager (requires `digifetch[browser]`), with `cookies_from_playwright` for the browser→HTTP hand-off
+- Structural `Page`/`BrowserContext` protocols so consumers can test without a live browser
+
+## Capabilities — 12-month roadmap
+
+- Wire twelve-x's scrapers onto DigiFetch (the deferred companion to the extraction)
+- Stabilise the public API to 1.0 once a second consumer validates it
+- Distributed/Redis-backed rate limiting (today single-process; shared throttling is future DigiBase work)
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):** the entire DigiFetch library — retry, rate limiting, HTTP fetch/download, and the headless-browser seam. It is pure open-core infrastructure; any proprietary value lives in the site-specific scrapers and the data they feed, not in DigiFetch.

--- a/docs/vision/digigraph.md
+++ b/docs/vision/digigraph.md
@@ -42,7 +42,7 @@ Shipped and in production:
 - JWT authentication via DigiKey
 - Per-IP rate limiting
 - Checkpoint persistence via `DIGI_CHECKPOINTER` (memory / SQLite / Postgres today; migrates to DigiStore once that module ships)
-- LiteLLM routing — model selection, caching, cost controls
+- LLM routing — model selection, caching, cost controls (LiteLLM today; the in-tree `digigraph.llm` module is superseded by the shared [DigiLLM](digillm.md) library, to which DigiGraph migrates)
 - DigiSmith tracing — every workflow tagged with `workflow_id`, `request_id`, `session_id`
 - MCP server — DigiGraph capabilities available as MCP tools for Claude Desktop and similar clients
 - Parallel tool execution

--- a/docs/vision/digillm.md
+++ b/docs/vision/digillm.md
@@ -1,0 +1,39 @@
+# DigiLLM
+> The single home for LLM client code — provider-agnostic routing, structured output, and tool calling, with no service coupling.
+
+## What it is
+
+DigiLLM is the standalone LLM client/wrapper library for the DigiThings stack. It speaks to any OpenAI-compatible endpoint and carries no FastAPI or service coupling and no hard dependency on DigiSmith. It was extracted from the mature `digigraph.llm` implementation so that every component — services and libraries alike — shares one well-tested path to the model layer instead of each reinventing routing, caching, retries, and the tool-calling loop.
+
+It is provider-agnostic by design: a registered `provider/model_id` prefix routes to that provider; a bare model id is sent on the wire unchanged. There is no hidden environment- or YAML-driven model substitution — mode selection (test/medium/best) is an explicit, opt-in call.
+
+## The problem it solves
+
+LLM access code is where subtle production bugs live: inconsistent retry/backoff, accidental response caching of tool calls, BYOK keys leaking into shared caches, structured-output validation drift. When every service rolls its own, those bugs get fixed in one place and not the others. DigiLLM makes the model layer a single, audited dependency: fix it once, every consumer benefits.
+
+## How it fits in the ecosystem
+
+DigiLLM sits beneath every component that calls a model. Consumers: **twelve-x** adopts it today; **DigiGraph** and **DigiSearch** migrate to it next (their current in-tree LLM modules are superseded by this package). It depends only on `openai` and `pydantic`, with optional extras for path-based mode resolution (`[modes]`) and LangSmith tracing (`[trace]`). It imports cleanly with no side effects and no FastAPI in the dependency tree.
+
+## Capabilities — Current
+
+Shipped and in active use:
+
+- Provider registry + routing with a per-model client cache
+- `chat_completion` with retry/backoff and a SHA-256 response cache (caching skipped for tool loops and BYOK requests)
+- Tool-calling loop with first-class tool-call types
+- `structured_completion` — OpenAI `json_schema` → validated Pydantic model
+- `resolve_model` — opt-in test/medium/best resolution (no implicit substitution)
+- Per-request override contextvars for proxy key and BYOK (bring-your-own-key)
+- Optional DigiSmith/LangSmith tracing via the `[trace]` extra
+
+## Capabilities — 12-month roadmap
+
+- DigiGraph and DigiSearch fully migrated off their in-tree LLM modules onto DigiLLM
+- Streaming (SSE) response support exposed through the shared client
+- Richer cost/usage accounting surfaced to DigiSmith
+- Pluggable cache backends (today an in-process cache; Redis-backed shared cache is future DigiBase work)
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):** the entire DigiLLM library — routing, caching, retries, tool loop, structured output, mode resolution, and the BYOK/proxy override surface. DigiLLM is pure open-core infrastructure; the domain expertise that uses it lives in the proprietary sub-graphs, not here.

--- a/docs/vision/digiquant.md
+++ b/docs/vision/digiquant.md
@@ -68,7 +68,7 @@ Data and state flow across the broader stack:
 - **DigiSearch** indexes finalized research documents for semantic retrieval, so agents can pull relevant research context on demand.
 - **DigiClaw** runs Atlas and Hermes on their daily and weekly schedules autonomously — DigiQuant's scheduled execution layer.
 - **DigiChat** is the user-facing interface for Kairos product mode and for querying Atlas research interactively.
-- **Olympus** (`frontend/olympus`) is the dedicated dashboard for the trio — Atlas's "Morning Read", Hermes's deliberations and risk debate, and portfolio/NAV tracking — and the surface where the human approval gate is exercised. See [olympus.md](olympus.md). Atlas, Hermes, and Kairos run inside DigiQuant as `digiquant.olympus` (ADR-0014, ADR-0015).
+- **Olympus** (`frontend/olympus`) is the dedicated dashboard for the trio — Atlas's "Morning Read", Hermes's deliberations and risk debate, and portfolio/NAV tracking — and the surface where the human approval gate will be exercised once Hermes ships (see Current state below). See [olympus.md](olympus.md). Atlas, Hermes, and Kairos run inside DigiQuant as `digiquant.olympus` (ADR-0014, ADR-0015).
 
 ## Data philosophy
 

--- a/docs/vision/digiquant.md
+++ b/docs/vision/digiquant.md
@@ -68,6 +68,7 @@ Data and state flow across the broader stack:
 - **DigiSearch** indexes finalized research documents for semantic retrieval, so agents can pull relevant research context on demand.
 - **DigiClaw** runs Atlas and Hermes on their daily and weekly schedules autonomously — DigiQuant's scheduled execution layer.
 - **DigiChat** is the user-facing interface for Kairos product mode and for querying Atlas research interactively.
+- **Olympus** (`frontend/olympus`) is the dedicated dashboard for the trio — Atlas's "Morning Read", Hermes's deliberations and risk debate, and portfolio/NAV tracking — and the surface where the human approval gate is exercised. See [olympus.md](olympus.md). Atlas, Hermes, and Kairos run inside DigiQuant as `digiquant.olympus` (ADR-0014, ADR-0015).
 
 ## Data philosophy
 

--- a/docs/vision/olympus.md
+++ b/docs/vision/olympus.md
@@ -1,0 +1,44 @@
+# Olympus
+> The human-facing dashboard for DigiQuant's finance sub-graphs — Atlas research, Hermes deliberation, and Kairos strategy work in one surface.
+
+## What it is
+
+Olympus is the dashboard frontend (`frontend/olympus`) for the finance sub-graph trio that lives inside DigiQuant as `digiquant.olympus`. It turns the outputs of Atlas, Hermes, and Kairos into a navigable, daily decision surface rather than raw research dumps: a "Morning Read" overview, surfaced bull/bear theses and risk debate, portfolio/NAV tracking, and entry points into interactive strategy work.
+
+Where DigiChat is the general-purpose chat UI, Olympus is the purpose-built operator view for quantitative finance — the place a researcher starts their day and where Hermes's deliberations are published for human review.
+
+## The problem it solves
+
+Autonomous research and portfolio deliberation generate a firehose of structured output. Without a deliberate surface, that output is unreadable and untrustworthy — there's no way to see *why* an allocation is proposed or to gate it behind human judgment. Olympus gives the sub-graph trio a face: it presents reasoning, not just conclusions, and it is where the human approval gate before any execution actually happens.
+
+## How it fits in the ecosystem
+
+Olympus reads from the three `digiquant.olympus` sub-graphs (Atlas, Hermes, Kairos), which themselves orchestrate through DigiGraph and persist their state and outputs. It is served under `digiquant.io` and sits behind an access gate (it is not anonymously reachable). The boundary between Atlas (research) and Hermes (portfolio deliberation) is defined in ADR-0015; Atlas's move into `digiquant` is ADR-0014.
+
+The three sub-graphs it surfaces:
+- **Atlas** — fundamental/research engine; daily batch research, structured and persisted.
+- **Hermes** — portfolio deliberation (bull/bear theses, risk debate) with a human approval gate before any allocation change.
+- **Kairos** — chat-based strategy development; the quant researcher's interactive workbench.
+
+## Capabilities — Current
+
+Shipped and in active use:
+
+- "Morning Read" overview that frames the day as a decision document
+- Hermes deliberation surfaces — bull/bear theses, risk debate, rationale
+- Paper portfolio / NAV tracking for pipeline-owned positions
+- Access-gated entry (anonymous diagnostics access removed)
+- Navigation across Atlas research, Hermes deliberations, and Kairos strategy work
+
+## Capabilities — 12-month roadmap
+
+- Embedded DigiChat for navigation + research Q&A inside the Olympus UI
+- Tiered views — free batch research vs. paid user-level preferences, prompts, portfolios, and custom domains
+- Human-in-the-loop execution controls as the research → live-order path matures
+- Deeper drill-down from a thesis to the underlying research and source documents
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):** generic dashboard scaffolding and any reusable visualization components.
+
+**Proprietary (commercial):** Olympus as the product surface for the closed finance sub-graphs. Because it renders Atlas/Hermes/Kairos domain output and is the locus of the human-gated execution path, the dashboard ships as part of the commercial DigiQuant offering, not the open core.


### PR DESCRIPTION
Fixes #719

## Why

`docs/VISION.md` was last reviewed **2026-04-19** and had drifted from the current stack. This brings the strategic vision and the per-module vision docs back in sync with reality.

Gaps closed:
- **New shipped components** were missing from the vision: `digillm` (provider-agnostic LLM client/routing library, extracted from `digigraph.llm`), `digifetch` (shared web-scraping / headless-fetch engine library), and `digidev` (drop-in agentic-coding workflow kit).
- **Olympus** is now a first-class dashboard surface for the finance sub-graphs, not just a `digiquant.io/atlas` embed.
- **Atlas moved into `digiquant.olympus`** (ADR-0014) and now sits alongside **Hermes** (portfolio deliberation + human approval gate, ADR-0015) and **Kairos** (chat-based strategy dev). VISION previously mentioned Atlas only.
- The `docs/vision/*.md` set documented unshipped `digilink`/`digistore` but lacked docs for the shipped libraries.

## What changed

- **`docs/VISION.md`** — bumped review dates; added `digillm`/`digifetch`/`digidev` to the component set; reframed the `digiquant.io` surface around Olympus (Atlas + Hermes + Kairos); added a DigiDev product-line section; refreshed the composition map, cross-cutting list, and open/closed split. Kept the doc at strategic altitude (no implementation churn).
- **`docs/vision/`** — new `digillm.md`, `digifetch.md`, `digidev.md`, `olympus.md` (following the existing per-module template); reconciled the ecosystem `README.md` (shipped vs not-yet-shipped libraries, LLM routing now factored into DigiLLM, added a per-module index); light edits to `digigraph.md` and `digiquant.md`.
- **`README.md`** — added DigiLLM/DigiFetch/DigiDev to the Components table.

## Verification

- `make doc-check` — OK (162 markdown files scanned, all internal links resolve)
- `make score` — 10/10 on all four dimensions (Security/Quality/Optimization/Accuracy)

Docs-only change, tracked by #719.

https://claude.ai/code/session_015HHppoaQi3E6pvEJpHoyqB