### PR TITLE
refactor(supabase): drop derived/duplicate columns (bb_middle, is_trading_day, weight_change_pct, contribution_pct, portfolio_metrics dedupe) (#714)

### DIFF
--- a/digiquant/scripts/atlas/backfill-supabase.py
+++ b/digiquant/scripts/atlas/backfill-supabase.py
@@ -58,8 +58,7 @@ def main():
             "volatility": 0,
             "max_drawdown": 0,
             "alpha": 0,
-            "cash_pct": 100,
-            "total_invested": 0,
+            "invested_pct": 0,
         }
 
     if cli_args.dry_run:

--- a/digiquant/scripts/atlas/compute-technicals.py
+++ b/digiquant/scripts/atlas/compute-technicals.py
@@ -142,17 +142,15 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     # Column names vary by pandas_ta version: try both "BBU_20_2.0" and "BBU_20_2.0_2.0"
     if bb_df is not None:
         _bbu_key  = next((c for c in bb_df.columns if c.startswith("BBU_")), None)
-        _bbm_key  = next((c for c in bb_df.columns if c.startswith("BBM_")), None)
         _bbl_key  = next((c for c in bb_df.columns if c.startswith("BBL_")), None)
         _bbp_key  = next((c for c in bb_df.columns if c.startswith("BBP_")), None)
         _bbb_key  = next((c for c in bb_df.columns if c.startswith("BBB_")), None)
         bb_upper    = bb_df[_bbu_key]  if _bbu_key  else None
-        bb_middle   = bb_df[_bbm_key]  if _bbm_key  else None
         bb_lower    = bb_df[_bbl_key]  if _bbl_key  else None
         bb_pct_b    = bb_df[_bbp_key]  if _bbp_key  else None
         bb_bandwidth = bb_df[_bbb_key] if _bbb_key  else None
     else:
-        bb_upper = bb_middle = bb_lower = bb_pct_b = bb_bandwidth = None
+        bb_upper = bb_lower = bb_pct_b = bb_bandwidth = None
 
     # 21-day realized volatility: annualized std of log returns (%)
     log_ret  = np.log(close / close.shift(1))
@@ -193,7 +191,6 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
         "atr_14":       atr_14,
         "atr_pct":      atr_pct,
         "bb_upper":     bb_upper,
-        "bb_middle":    bb_middle,
         "bb_lower":     bb_lower,
         "bb_pct_b":     bb_pct_b,
         "bb_bandwidth": bb_bandwidth,

--- a/digiquant/scripts/atlas/execute_at_open.py
+++ b/digiquant/scripts/atlas/execute_at_open.py
@@ -212,7 +212,6 @@ def _hold_events_for_positions_not_in_rebalance(
         if w is None or w <= 0:
             continue
         prev_w = _prior_position_weight(sb, prior_d, ticker)
-        wch = (w - prev_w) if prev_w is not None and w is not None else None
         price = _fetch_open(sb, ticker, execution_date)
         reason = row.get("rationale")
         if isinstance(reason, str) and reason.strip():
@@ -229,7 +228,6 @@ def _hold_events_for_positions_not_in_rebalance(
                 "event": "HOLD",
                 "weight_pct": w,
                 "prev_weight_pct": prev_w,
-                "weight_change_pct": wch,
                 "price": price,
                 "reason": reason_s,
                 "thesis_id": row.get("thesis_id"),
@@ -313,7 +311,6 @@ def build_events_from_digest_snapshot(sb, execution_d: str) -> Optional[List[Dic
                 "event": ev,
                 "weight_pct": rec,
                 "prev_weight_pct": prev if prev > eps else None,
-                "weight_change_pct": chg if abs(chg) > eps else None,
                 "price": price,
                 "reason": (
                     "Derived from digest snapshot proposed_positions vs prior session positions "
@@ -388,7 +385,6 @@ def build_events_from_positions_book(sb, execution_d: str) -> Optional[List[Dict
                 "event": ev,
                 "weight_pct": rec,
                 "prev_weight_pct": prev if prev > eps else None,
-                "weight_change_pct": chg if abs(chg) > eps else None,
                 "price": price,
                 "reason": (
                     "Derived from positions book vs prior session positions "
@@ -578,7 +574,6 @@ def main() -> int:
             "event": event,
             "weight_pct": weight_pct,
             "prev_weight_pct": prev_weight_pct,
-            "weight_change_pct": weight_change_pct,
             "price": price,
             "reason": row.get("rationale"),
             "thesis_id": None,

--- a/digiquant/scripts/atlas/refresh_performance_metrics.py
+++ b/digiquant/scripts/atlas/refresh_performance_metrics.py
@@ -5,8 +5,7 @@ refresh_performance_metrics.py
 Run after price_history (and optionally price_technicals) are updated for the day.
 Uses Supabase price_history closes + positions snapshot rows to populate:
 
-  - positions: unrealized_pnl_pct, day_change_pct, since_entry_return_pct,
-    contribution_pct, metrics_as_of
+  - positions: unrealized_pnl_pct, day_change_pct, since_entry_return_pct, metrics_as_of
   - position_events: cumulative_return_since_event_pct (where price exists)
   - nav_history: one indexed NAV point per calendar day (uses forward-filled prices)
   - portfolio_metrics: one row per calendar day for continuity (computed_from=refresh_script).
@@ -42,7 +41,6 @@ _METRIC_CLEAR = (
     "unrealized_pnl_pct",
     "day_change_pct",
     "since_entry_return_pct",
-    "contribution_pct",
     "metrics_as_of",
 )
 
@@ -160,17 +158,11 @@ def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
 
     pos_res = sb.table("positions").select("ticker", "weight_pct").eq("date", as_of).execute()
     prow = getattr(pos_res, "data", None) or []
-    cash_pct: Optional[float] = None
     total_invested = 0.0
     for p in prow:
         t = p.get("ticker")
-        w = float(p.get("weight_pct") or 0)
-        if t == "CASH":
-            cash_pct = w
-        elif t:
-            total_invested += w
-    if cash_pct is None and prow:
-        cash_pct = max(0.0, 100.0 - total_invested)
+        if t and t != "CASH":
+            total_invested += float(p.get("weight_pct") or 0)
 
     prev_m = (
         sb.table("portfolio_metrics")
@@ -191,8 +183,7 @@ def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
         "volatility": prev.get("volatility"),
         "max_drawdown": prev.get("max_drawdown"),
         "alpha": prev.get("alpha"),
-        "cash_pct": round(cash_pct, 4) if cash_pct is not None else None,
-        "total_invested": round(total_invested, 4) if prow else None,
+        "invested_pct": round(total_invested, 4) if prow else None,
         "computed_from": "refresh_script",
         "as_of_date": as_of,
         "generated_at": ts,
@@ -240,7 +231,6 @@ def refresh_positions_metrics(sb, metrics_date: str) -> int:
             continue
         entry = r.get("entry_price")
         entry_dt = r.get("entry_date")
-        w = float(r.get("weight_pct") or 0)
         dates_needed = [metrics_date]
         if prev_d:
             dates_needed.append(prev_d)
@@ -264,14 +254,10 @@ def refresh_positions_metrics(sb, metrics_date: str) -> int:
                 c_entry = c_entry_map.get(ed)
             if c_entry and c_entry > 0:
                 since = (c_now - c_entry) / c_entry * 100.0
-        contrib = None
-        if since is not None:
-            contrib = w * (since / 100.0)
         patch = {
             "unrealized_pnl_pct": unreal,
             "day_change_pct": day_ch,
             "since_entry_return_pct": since,
-            "contribution_pct": contrib,
             "metrics_as_of": metrics_date,
             "current_price": c_now if c_now is not None else r.get("current_price"),
         }

--- a/digiquant/scripts/atlas/sync_positions_from_rebalance.py
+++ b/digiquant/scripts/atlas/sync_positions_from_rebalance.py
@@ -141,7 +141,6 @@ def main() -> int:
                 "unrealized_pnl_pct": None,
                 "day_change_pct": None,
                 "since_entry_return_pct": None,
-                "contribution_pct": None,
                 "metrics_as_of": None,
             }
         )
@@ -164,7 +163,6 @@ def main() -> int:
                     "unrealized_pnl_pct": None,
                     "day_change_pct": None,
                     "since_entry_return_pct": None,
-                    "contribution_pct": None,
                     "metrics_as_of": None,
                 }
             )

--- a/digiquant/scripts/atlas/update_tearsheet.py
+++ b/digiquant/scripts/atlas/update_tearsheet.py
@@ -869,8 +869,7 @@ def main():
             "volatility": round(volatility, 4),
             "max_drawdown": round(max_dd, 4),
             "alpha": round(alpha, 4),
-            "cash_pct": round(cash_pct, 2),
-            "total_invested": round(total_invested, 2),
+            "invested_pct": round(total_invested, 2),
         }
         push_to_supabase(parsed_digests, docs, history, metrics_row, pj_positions)
     else:

--- a/digiquant/src/digiquant/data/prices/__init__.py
+++ b/digiquant/src/digiquant/data/prices/__init__.py
@@ -61,7 +61,6 @@ TECHNICAL_COLUMNS: tuple[str, ...] = (
     "atr_14",
     "atr_pct",
     "bb_upper",
-    "bb_middle",
     "bb_lower",
     "bb_pct_b",
     "bb_bandwidth",

--- a/digiquant/src/digiquant/data/prices/technicals.py
+++ b/digiquant/src/digiquant/data/prices/technicals.py
@@ -132,9 +132,7 @@ def compute_indicators(
     """
     if trading_days is not None:
         if len(trading_days) == 0:
-            _logger.warning(
-                "trading_days filter is empty — computing technicals on all rows"
-            )
+            _logger.warning("trading_days filter is empty — computing technicals on all rows")
         elif "timestamp" in df.columns:
             df = filter_rows_by_trading_days(df, trading_days)
         else:
@@ -219,7 +217,7 @@ def compute_indicators(
         + roc_exprs
         + [
             atr_expr,
-            bb_mid.alias("bb_middle"),
+            bb_mid.alias("_bb_mid"),
             bb_std.alias("_bb_std"),
             log_ret.alias("_log_ret"),
             raw_k.alias("_raw_k"),
@@ -246,8 +244,8 @@ def compute_indicators(
             pl.col("stoch_k").rolling_mean(window_size=3, min_periods=3).alias("stoch_d"),
             (pl.col("macd") - pl.col("macd_signal")).alias("macd_hist"),
             (pl.col("atr_14") / pl.col("close") * 100).alias("atr_pct"),
-            (pl.col("bb_middle") + 2.0 * pl.col("_bb_std")).alias("bb_upper"),
-            (pl.col("bb_middle") - 2.0 * pl.col("_bb_std")).alias("bb_lower"),
+            (pl.col("_bb_mid") + 2.0 * pl.col("_bb_std")).alias("bb_upper"),
+            (pl.col("_bb_mid") - 2.0 * pl.col("_bb_std")).alias("bb_lower"),
             (
                 pl.col("_log_ret").rolling_std(window_size=21, min_periods=21, ddof=1)
                 * math.sqrt(_TRADING_DAYS_YEAR)
@@ -276,7 +274,7 @@ def compute_indicators(
             (
                 (pl.col("close") - pl.col("bb_lower")) / (pl.col("bb_upper") - pl.col("bb_lower"))
             ).alias("bb_pct_b"),
-            ((pl.col("bb_upper") - pl.col("bb_lower")) / pl.col("bb_middle") * 100.0).alias(
+            ((pl.col("bb_upper") - pl.col("bb_lower")) / pl.col("_bb_mid") * 100.0).alias(
                 "bb_bandwidth"
             ),
         ]

--- a/digiquant/supabase/migrations/035_drop_derived_duplicate_columns.sql
+++ b/digiquant/supabase/migrations/035_drop_derived_duplicate_columns.sql
@@ -1,0 +1,44 @@
+-- 035_drop_derived_duplicate_columns.sql — remove derived / duplicate columns (#714)
+--
+-- Second consolidation pass after 034 (daily_snapshots). Each column here is
+-- either a stored value that is trivially derivable at read time, or a literal
+-- duplicate of a column on another table. All writers are updated in the same
+-- change (see PR) — notably the active digiquant-prices.yml cron, which runs
+-- `prices compute-technicals` (bb_middle) and `execute_at_open.py`
+-- (weight_change_pct). IF EXISTS guards keep this idempotent.
+--
+--   price_technicals.bb_middle    == sma_20 (Bollinger middle band == 20-day SMA)
+--   price_history.is_trading_day  — deprecated by trading_calendar (ADR-0013 / migration 025);
+--                                   never written to price_history, computed via the calendar join
+--   position_events.weight_change_pct == weight_pct - prev_weight_pct (computed at read time)
+--   positions.contribution_pct    == weight_pct * since_entry_return_pct/100 (computed at read time)
+--   portfolio_metrics.cash_pct    duplicates nav_history.cash_pct
+--   portfolio_metrics.total_invested -> invested_pct (renamed to match nav_history.invested_pct)
+
+ALTER TABLE price_technicals DROP COLUMN IF EXISTS bb_middle;
+
+ALTER TABLE price_history DROP COLUMN IF EXISTS is_trading_day;
+
+ALTER TABLE position_events DROP COLUMN IF EXISTS weight_change_pct;
+
+ALTER TABLE positions DROP COLUMN IF EXISTS contribution_pct;
+
+-- portfolio_metrics: drop the duplicate cash_pct (auto-drops chk_metrics_cash_range),
+-- then rename total_invested -> invested_pct. The invested-range CHECK references the
+-- old column name, so drop it first and recreate it against the new name (a plain
+-- RENAME would leave a constraint whose stored definition cannot be relied on).
+ALTER TABLE portfolio_metrics DROP CONSTRAINT IF EXISTS chk_metrics_invested_range;
+ALTER TABLE portfolio_metrics DROP COLUMN IF EXISTS cash_pct;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'portfolio_metrics' AND column_name = 'total_invested'
+  ) THEN
+    ALTER TABLE portfolio_metrics RENAME COLUMN total_invested TO invested_pct;
+  END IF;
+END $$;
+
+ALTER TABLE portfolio_metrics ADD CONSTRAINT chk_metrics_invested_range
+  CHECK (invested_pct IS NULL OR (invested_pct >= 0 AND invested_pct <= 100));

--- a/frontend/olympus/components/portfolio/server-metrics-strip.tsx
+++ b/frontend/olympus/components/portfolio/server-metrics-strip.tsx
@@ -44,7 +44,7 @@ export function ServerMetricsStrip({ m }: { m: ServerPortfolioMetrics }) {
         <span className="text-text-secondary">
           Invested:{' '}
           <span className="qn-metric text-text-primary">
-            {m.total_invested != null ? `${m.total_invested.toFixed(1)}%` : '—'}
+            {m.invested_pct != null ? `${m.invested_pct.toFixed(1)}%` : '—'}
           </span>
         </span>
       </div>

--- a/frontend/olympus/lib/database.types.ts
+++ b/frontend/olympus/lib/database.types.ts
@@ -39,7 +39,6 @@ export interface Database {
           unrealized_pnl_pct?: number | null;
           day_change_pct?: number | null;
           since_entry_return_pct?: number | null;
-          contribution_pct?: number | null;
           metrics_as_of?: string | null;
         };
         Insert: Omit<Database['public']['Tables']['positions']['Row'], 'id'> & { id?: string };
@@ -67,7 +66,6 @@ export interface Database {
           event: 'OPEN' | 'EXIT' | 'TRIM' | 'ADD' | 'HOLD';
           weight_pct: number | null;
           prev_weight_pct: number | null;
-          weight_change_pct?: number | null;
           cumulative_return_since_event_pct?: number | null;
           price: number | null;
           thesis_id: string | null;
@@ -117,8 +115,7 @@ export interface Database {
           volatility: number | null;
           max_drawdown: number | null;
           alpha: number | null;
-          cash_pct: number | null;
-          total_invested: number | null;
+          invested_pct: number | null;
           generated_at: string | null;
           computed_from?: string | null;
           as_of_date?: string | null;
@@ -151,7 +148,7 @@ export interface Database {
           macd: number | null; macd_signal: number | null; macd_hist: number | null;
           roc_5: number | null; roc_10: number | null; roc_21: number | null;
           atr_14: number | null; atr_pct: number | null;
-          bb_upper: number | null; bb_middle: number | null; bb_lower: number | null;
+          bb_upper: number | null; bb_lower: number | null;
           bb_pct_b: number | null; bb_bandwidth: number | null;
           hist_vol_21: number | null;
           stoch_k: number | null; stoch_d: number | null;

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -327,7 +327,6 @@ type PositionEventRowPick = Pick<
   | 'event'
   | 'weight_pct'
   | 'prev_weight_pct'
-  | 'weight_change_pct'
   | 'price'
   | 'thesis_id'
   | 'reason'
@@ -340,7 +339,7 @@ async function fetchPositionEventsForDashboard(): Promise<PositionEventRowPick[]
     const { data, error } = await supabase
       .from('position_events')
       .select(
-        'date,ticker,event,weight_pct,prev_weight_pct,weight_change_pct,price,thesis_id,reason'
+        'date,ticker,event,weight_pct,prev_weight_pct,price,thesis_id,reason'
       )
       .order('date', { ascending: false })
       .range(offset, offset + POSITION_EVENTS_PAGE - 1);
@@ -479,7 +478,11 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       event: e.event,
       weight_pct: e.weight_pct != null ? Number(e.weight_pct) : null,
       prev_weight_pct: e.prev_weight_pct != null ? Number(e.prev_weight_pct) : null,
-      weight_change_pct: e.weight_change_pct != null ? Number(e.weight_change_pct) : null,
+      // weight_change_pct column dropped (#714) — derive at read time.
+      weight_change_pct:
+        e.weight_pct != null && e.prev_weight_pct != null
+          ? Number(e.weight_pct) - Number(e.prev_weight_pct)
+          : null,
       price: e.price != null ? Number(e.price) : null,
       thesis_id: e.thesis_id ?? null,
       reason: e.reason ?? null,
@@ -496,8 +499,10 @@ export async function getFullDashboardData(): Promise<DashboardData> {
           volatility: metrics.volatility != null ? Number(metrics.volatility) : null,
           max_drawdown: metrics.max_drawdown != null ? Number(metrics.max_drawdown) : null,
           alpha: metrics.alpha != null ? Number(metrics.alpha) : null,
-          cash_pct: metrics.cash_pct != null ? Number(metrics.cash_pct) : null,
-          total_invested: metrics.total_invested != null ? Number(metrics.total_invested) : null,
+          // portfolio_metrics.cash_pct dropped (#714, dup of nav_history); derive
+          // from invested_pct (renamed from total_invested).
+          invested_pct: metrics.invested_pct != null ? Number(metrics.invested_pct) : null,
+          cash_pct: metrics.invested_pct != null ? 100 - Number(metrics.invested_pct) : null,
           generated_at: metrics.generated_at ?? null,
         }
       : null;
@@ -628,7 +633,6 @@ export async function getFullDashboardData(): Promise<DashboardData> {
               unrealized_pnl_pct: null,
               day_change_pct: null,
               since_entry_return_pct: null,
-              contribution_pct: null,
               metrics_as_of: null,
             } as unknown as TableRow<'positions'>)),
             ticker: p.ticker,
@@ -764,7 +768,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       return ((curr - entry) / entry) * 100;
     })(),
     contribution_pct: (() => {
-      if (p.contribution_pct != null) return Number(p.contribution_pct);
+      // contribution_pct column dropped (#714) — always derive client-side.
       const entry = resolvedEntryPrice(p);
       const curr =
         p.current_price != null ? Number(p.current_price) : latestClose(p.ticker).curr;
@@ -906,11 +910,11 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       total_invested:
         proposedPositions.length > 0
           ? totalInvested
-          : (metrics.total_invested != null ? Number(metrics.total_invested) : totalInvested),
+          : (metrics.invested_pct != null ? Number(metrics.invested_pct) : totalInvested),
       cash_pct:
         proposedPositions.length > 0
           ? 100 - totalInvested
-          : (metrics.cash_pct != null ? Number(metrics.cash_pct) : 100 - totalInvested),
+          : (metrics.invested_pct != null ? 100 - Number(metrics.invested_pct) : 100 - totalInvested),
       sharpe: metrics.sharpe != null ? Number(metrics.sharpe) : 0,
       volatility: metrics.volatility != null ? Number(metrics.volatility) : 0,
       max_drawdown: metrics.max_drawdown != null ? Number(metrics.max_drawdown) : 0,
@@ -1195,7 +1199,7 @@ export async function fetchPositionPriceChart(
 
   type EvPick = Pick<
     TableRow<'position_events'>,
-    'date' | 'event' | 'price' | 'reason' | 'weight_pct' | 'prev_weight_pct' | 'weight_change_pct'
+    'date' | 'event' | 'price' | 'reason' | 'weight_pct' | 'prev_weight_pct'
   >;
   type PhPick = Pick<TableRow<'price_history'>, 'date' | 'close'>;
 
@@ -1227,7 +1231,7 @@ export async function fetchPositionPriceChart(
   while (evOffset < EVENT_MAX) {
     const { data, error } = await supabase
       .from('position_events')
-      .select('date, event, price, reason, weight_pct, prev_weight_pct, weight_change_pct')
+      .select('date, event, price, reason, weight_pct, prev_weight_pct')
       .eq('ticker', t)
       .gte('date', safeFrom)
       .lte('date', end)
@@ -1265,7 +1269,11 @@ export async function fetchPositionPriceChart(
     reason: row.reason ?? null,
     weight_pct: row.weight_pct != null ? Number(row.weight_pct) : null,
     prev_weight_pct: row.prev_weight_pct != null ? Number(row.prev_weight_pct) : null,
-    weight_change_pct: row.weight_change_pct != null ? Number(row.weight_change_pct) : null,
+    // weight_change_pct column dropped (#714) — derive at read time.
+    weight_change_pct:
+      row.weight_pct != null && row.prev_weight_pct != null
+        ? Number(row.weight_pct) - Number(row.prev_weight_pct)
+        : null,
   }));
 
   const result = { priceHistory, events };

--- a/frontend/olympus/lib/types.ts
+++ b/frontend/olympus/lib/types.ts
@@ -158,8 +158,9 @@ export interface ServerPortfolioMetrics {
   volatility: number | null;
   max_drawdown: number | null;
   alpha: number | null;
+  /** Derived from invested_pct (the portfolio_metrics.cash_pct column was dropped, #714). */
   cash_pct: number | null;
-  total_invested: number | null;
+  invested_pct: number | null;
   generated_at: string | null;
 }
 

--- a/tests/dq/data/test_technicals.py
+++ b/tests/dq/data/test_technicals.py
@@ -488,7 +488,9 @@ def test_bollinger_bands_match_reference() -> None:
     out = compute_indicators(df)
     closes = _close(df)
     mid, upper, lower, pct_b, bandwidth = _ref_bollinger(closes, length=20)
-    _assert_close(out["bb_middle"].to_list(), mid, tol=1e-9)
+    # bb_middle was dropped (#714) — it is the 20-day SMA by definition; assert the
+    # equivalence against sma_20 rather than a dedicated (redundant) column.
+    _assert_close(out["sma_20"].to_list(), mid, tol=1e-9)
     _assert_close(out["bb_upper"].to_list(), upper, tol=1e-9)
     _assert_close(out["bb_lower"].to_list(), lower, tol=1e-9)
     _assert_close(out["bb_pct_b"].to_list(), pct_b, tol=1e-9)


### PR DESCRIPTION
## What
Second schema-consolidation pass (after #716). Drops five derived/duplicate columns; every writer — **including the active `digiquant-prices.yml` cron** — is updated in lockstep, and readers compute the values at read time. Migration **035**.

| Column | Why | Reader after drop |
|---|---|---|
| `price_technicals.bb_middle` | == `sma_20` (Bollinger middle = 20-day SMA) | use `sma_20` |
| `price_history.is_trading_day` | deprecated by `trading_calendar` (ADR-0013); never written here | calendar join (already) |
| `position_events.weight_change_pct` | == `weight_pct − prev_weight_pct` | computed in `queries.ts` |
| `positions.contribution_pct` | derived cache (`weight × since_entry_return`) | already computed client-side |
| `portfolio_metrics.cash_pct` | duplicates `nav_history.cash_pct` | derived from `invested_pct` |
| `portfolio_metrics.total_invested` → `invested_pct` | name parity with `nav_history` | renamed |

## Key correctness points (from the adversarial verification pass)
- **bb_middle** is a load-bearing Polars intermediate for bb_upper/lower/bandwidth → renamed to `_bb_mid` (excluded from output by the existing `TECHNICAL_COLUMNS` select), not deleted.
- **Migration** drops+recreates `chk_metrics_invested_range` (a plain `RENAME` would leave the CHECK referencing the old column name); `chk_metrics_cash_range` auto-drops with the column.
- **Computed fields stay on the domain types** (`weight_change_pct` on the event types, `contribution_pct` on `Position`, `cash_pct` on `ServerPortfolioMetrics`) — only the DB columns + `.select()` strings change, so no PostgREST 500 and no TS excess-property errors.

Writer map + completeness came from a parallel mapping workflow (5 column-groups) with an adversarial verification pass per group.

## Validation
- Backend: 88 `tests/dq/data` + 19 technicals tests pass; all edited scripts compile; pandas-boundary OK.
- Frontend: `tsc`/`eslint` clean, 88 olympus tests pass, `next build` green.
- `make score` (vs develop): 10 / 10 / 10 / 10.
- Scripts diff kept minimal (no whole-file reformat of the frozen legacy scripts).

Closes #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)