### PR TITLE
fix(olympus): NAV-vs-comparables chart empty-state when <2 NAV points

### DIFF
--- a/frontend/olympus/components/portfolio/performance-chart-workspace.tsx
+++ b/frontend/olympus/components/portfolio/performance-chart-workspace.tsx
@@ -74,6 +74,14 @@ function NavComparableChart({
   /** Pre-aggregated events per date for tooltip enrichment. */
   activityEventsByDate?: Record<string, { ticker: string; event: string }[]>;
 }) {
+  if (data.length < 2) {
+    return (
+      <div className="h-full min-h-[280px] flex items-center justify-center text-text-muted text-sm">
+        Need at least two NAV points in this range.
+      </div>
+    );
+  }
+
   const legendContent = (props: { payload?: LegendPayloadItem[] }) => {
     const { payload } = props;
     if (!payload?.length) return null;


### PR DESCRIPTION
## What

The Performance tab's `NavComparableChart` (in `performance-chart-workspace.tsx`) rendered a **blank chart box** when there were fewer than 2 NAV history points — the common case on a freshly-seeded paper book. This adds the same `data.length < 2` early-return empty-state already used by the sibling `DailyReturnsComboChart` and `PerformanceDrawdownChart` in the same module, so the slot reads *"Need at least two NAV points in this range."* instead of an empty box.

## Why

Flagged during the Olympus visual review. Until the paper book accrues NAV history, the main NAV chart was the one performance panel without a graceful empty-state, looking broken rather than empty.

## Change

One 7-line guard in `NavComparableChart`, verbatim-consistent with the existing siblings (same classes, same wording).

## Validation

- `tsc --noEmit`: 0 errors (matches develop baseline)
- `eslint`: clean (exit 0)
- `make score`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10 — all pass
- No portfolio test files affected

Refs #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)