### PR TITLE
feat(digivault): Obsidian-style markdown vault service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       digibase: ${{ steps.filter.outputs.digibase }}
       digikey: ${{ steps.filter.outputs.digikey }}
       digismith: ${{ steps.filter.outputs.digismith }}
+      digivault: ${{ steps.filter.outputs.digivault }}
       digiclaw: ${{ steps.filter.outputs.digiclaw }}
       digiquant: ${{ steps.filter.outputs.digiquant }}
       digisearch: ${{ steps.filter.outputs.digisearch }}
@@ -53,6 +54,10 @@ jobs:
               - 'digismith/**'
               - 'tests/dsm/**'
               - '.github/workflows/digismith-test.yml'
+            digivault:
+              - 'digivault/**'
+              - 'tests/dv/**'
+              - '.github/workflows/digivault-test.yml'
             digiclaw:
               - 'digiclaw/**'
               - 'tests/dc/**'
@@ -89,6 +94,7 @@ jobs:
               - 'digisearch/**'
               - 'digismith/**'
               - 'digikey/**'
+              - 'digivault/**'
               - 'frontend/**'
               - 'scripts/**'
               - 'tests/**'
@@ -121,6 +127,7 @@ jobs:
               - 'digiquant/**'
               - 'digisearch/**'
               - 'digismith/**'
+              - 'digivault/**'
               - 'tests/**'
               - 'scripts/**'
               - 'agents.yml'
@@ -153,6 +160,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.digismith == 'true'
     uses: ./.github/workflows/digismith-test.yml
+
+  digivault:
+    needs: changes
+    if: needs.changes.outputs.digivault == 'true'
+    uses: ./.github/workflows/digivault-test.yml
 
   digiclaw:
     needs: changes

--- a/.github/workflows/digivault-test.yml
+++ b/.github/workflows/digivault-test.yml
@@ -1,0 +1,31 @@
+name: digivault tests
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          # Service tests import digibase + digikey (auth/middleware); install all three.
+          pip install -e "./digibase" -e "./digikey" -e "./digivault[service,dev]"
+
+      - name: Ruff
+        run: |
+          python -m ruff check digivault/src tests/dv
+          python -m ruff format --check digivault/src tests/dv
+
+      - name: Import-cost guard (core must not pull FastAPI)
+        run: python -c "import sys, digivault; assert 'fastapi' not in sys.modules, 'core import leaked FastAPI'"
+
+      - name: Unit tests (tests/dv)
+        run: python -m pytest tests/dv -m unit -v --tb=short

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,7 @@ DigiThings (digithings.ai) is an open-core modular agentic stack for building co
 | **DigiQuant** | 8001 | NautilusTrader backtest/optimize; ordered quant pipeline; orchestrator endpoints | JWT (`digiquant:backtest`, `digiquant:optimize`) | core | Yes — `python -m digiquant.mcp_server` | Shipped |
 | **DigiSearch** | 8002 | RAG pipeline; document ingestion; vector search (Chroma/Azure) | JWT (`digisearch:query`, `digisearch:ingest`) | core | Yes — `docker compose --profile digisearch-mcp up` | Shipped |
 | **DigiSmith** | 8003 | LangSmith-aligned tracing helpers (library); health + `/v1/status` endpoint | None (public metadata) | core | No | Shipped |
+| **DigiVault** | 8004 | Obsidian-style markdown vault management (frontmatter, wikilinks, backlinks, tags) | JWT (`digivault:read`, `digivault:write`) | digivault | Yes — `python -m digivault.mcp_server` | New |
 | **LiteLLM** | 4000 | LLM routing proxy (100+ providers); response cache; rate limiting | `LITELLM_MASTER_KEY` Bearer | core | No | Shipped |
 | **DigiKey** | 8005 | API key issuance; JWT exchange (RS256); JWKS endpoint | Admin token for key issuance | core | No | Shipped |
 | **Ollama** | 11435 (host) | Local LLM inference (maps to container port 11434) | None | core | No | Shipped |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Rules and context for Claude Code in this repo. See also [docs/agents/AGENT_WORK
 
 ## What this is
 
-DigiThings — open-core agentic stack (quant finance, RAG, chat). Services: **digigraph** (8000, LangGraph orchestration), **digiquant** (8001, NautilusTrader quant + Atlas + Hermes sub-graphs), **digisearch** (8002, RAG), **digikey** (8005, JWT + API keys), **digismith** (8003, tracing), **digiclaw** (heartbeat + audit), **digibase** (shared library). Frontends: **digichat** (3005, chat UI), **olympus** (Atlas + Hermes dashboard). Sub-graphs in digiquant: Atlas at `digiquant/src/digiquant/olympus/atlas/`, Hermes at `digiquant/src/digiquant/olympus/hermes/`. Old `apps/digiquant-atlas/` is gone.
+DigiThings — open-core agentic stack (quant finance, RAG, chat). Services: **digigraph** (8000, LangGraph orchestration), **digiquant** (8001, NautilusTrader quant + Atlas + Hermes sub-graphs), **digisearch** (8002, RAG), **digikey** (8005, JWT + API keys), **digismith** (8003, tracing), **digivault** (8004, Obsidian-style markdown vault management — profile `digivault`), **digiclaw** (heartbeat + audit), **digibase** (shared library). Frontends: **digichat** (3005, chat UI), **olympus** (Atlas + Hermes dashboard). Sub-graphs in digiquant: Atlas at `digiquant/src/digiquant/olympus/atlas/`, Hermes at `digiquant/src/digiquant/olympus/hermes/`. Old `apps/digiquant-atlas/` is gone.
 
 ## Non-negotiable rules
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Flagship vertical: **quantitative finance** — a "hedge-fund in a box" where on
 | **DigiSmith** | LangSmith-aligned tracing helpers; health + `/v1/status` | [digismith/ARCHITECTURE.md](digismith/ARCHITECTURE.md) |
 | **DigiClaw** | Heartbeat, audit, MCP skill → DigiGraph | [digiclaw/ARCHITECTURE.md](digiclaw/ARCHITECTURE.md) |
 | **DigiBase** | Shared HTTP/audit library + future data-plane service | [digibase/ARCHITECTURE.md](digibase/ARCHITECTURE.md) |
+| **DigiVault** | Obsidian-style markdown vault management (frontmatter, wikilinks, backlinks) | [digivault/ARCHITECTURE.md](digivault/ARCHITECTURE.md) |
 | **config** | LiteLLM + model modes (test/medium/best) | [config/MODELS.md](config/MODELS.md) |
 
 ## Quick start
@@ -95,6 +96,7 @@ curl -s -X POST http://127.0.0.1:8000/workflow \
 | DigiSmith | 8003 | Observability status API |
 | LiteLLM   | 4000 | LLM routing       |
 | DigiKey   | 8005 | API keys + JWT exchange |
+| DigiVault | 8004 | Markdown vault management (profile `digivault`) |
 | DigiChat  | 3005 | Chat UI + BFF (profile `digichat`) |
 
 All bind to `127.0.0.1`. Use Tailscale or Cloudflare Tunnel for remote access.

--- a/digivault/AGENTS.md
+++ b/digivault/AGENTS.md
@@ -1,0 +1,53 @@
+# DigiVault – Agent guide
+
+## Purpose
+
+DigiVault manages an Obsidian-style markdown vault: frontmatter, `[[wikilinks]]`,
+backlinks, tags, and folder taxonomy. A pure-Python core library plus a thin
+FastAPI + MCP + CLI service layer. First consumer: the project documentation
+(`docs/vision/`).
+
+## Read first
+
+1. `digivault/ARCHITECTURE.md` — module map, public API, design decisions.
+2. Root `AGENTS.md` and `CLAUDE.md` — stack-wide non-negotiables.
+3. `digifetch/ARCHITECTURE.md` — the library-conventions reference this mirrors.
+
+## Pre-flight checklist
+
+- [ ] `import digivault` stays FastAPI-free (core depends only on `pydantic` + `pyyaml`).
+- [ ] New result data is a Pydantic v2 model in `models.py`, not a bare dict.
+- [ ] Any new write path goes through `Vault._safe_path` (no traversal escapes).
+- [ ] `frontmatter.split(frontmatter.dump(fm, body)) == (fm, body)` still holds.
+- [ ] Wikilink rewrites skip code spans/blocks (use the helpers in `wikilinks.py`).
+- [ ] Service routes carry the right scope in `path_scopes.py` (read vs write).
+
+## Non-negotiable rules
+
+- Do **not** import or modify `digikey` internals — reuse `DigiAuthMiddleware`
+  and define scope policy locally in `path_scopes.py`.
+- `/healthz` stays auth-exempt, secret-free, `{"ok": true}`, no downstream checks.
+- No new hard dependency on the core library without a human gate; service-only
+  deps belong in the `[service]` extra.
+
+## Anti-patterns
+
+- ❌ Importing `fastapi` from `digivault/__init__.py`, `vault.py`, `frontmatter.py`, or `wikilinks.py`.
+- ❌ Returning dicts from `Vault` methods (use the models).
+- ❌ Regex-rewriting wikilinks without masking code regions (breaks examples in docs).
+- ❌ Adding standard Markdown link validation (the `[label]` + `(target)` inline form) here — that is `scripts/check_doc_links.py`'s job; DigiVault validates `[[wikilinks]]`.
+
+## Test commands
+
+```bash
+# Core only (pydantic + pyyaml):
+pip install -e ./digivault && pytest tests/dv -m unit
+
+# Full (service + cli):
+pip install -e ./digibase -e ./digikey -e "./digivault[service,dev]"
+pytest tests/dv -m unit
+ruff check digivault/src tests/dv && ruff format --check digivault/src tests/dv
+
+# Import-cost guard (must not pull FastAPI):
+python -c "import sys, digivault; assert 'fastapi' not in sys.modules"
+```

--- a/digivault/ARCHITECTURE.md
+++ b/digivault/ARCHITECTURE.md
@@ -1,0 +1,110 @@
+# DigiVault – Architecture
+
+`digivault` is the **Obsidian-style markdown vault service** for the DigiThings
+monorepo. It manages the creation, storage, and maintenance of a folder of
+markdown notes: YAML frontmatter, `[[wikilinks]]`, backlinks, tags, and a folder
+taxonomy. The first consumer is the project's own documentation (`docs/vision/`),
+migrated to a managed vault so ideation and maintenance compound instead of
+drifting.
+
+It is split into a **pure-Python core library** (no FastAPI, side-effect-free on
+import) and a thin **service layer** (FastAPI + MCP + CLI) behind the `[service]`
+extra.
+
+## Non-negotiables
+
+- Python 3.12, Pydantic v2, full type hints, ruff line-length 100.
+- Core hard deps: `pydantic>=2`, `pyyaml>=6` only. `import digivault` never
+  imports FastAPI, uvicorn, mcp, or typer.
+- Service deps live in the `[service]` extra; auth, tracing, metrics, and error
+  envelopes reuse `digikey` + `digibase` (the service does **not** modify
+  `digikey`).
+- Result types are Pydantic models (`Note`, `LintReport`, …), never bare dicts.
+- All write paths are sandboxed to the vault root — `Vault` refuses path
+  traversal (`../`) and absolute escapes.
+
+## Module map
+
+| Module | Responsibility |
+|--------|----------------|
+| `digivault/models.py` | Pydantic v2 result models: `Note`, `LinkRef`, `ValidationIssue`, `LintReport`, `VaultConfig`. |
+| `digivault/frontmatter.py` | Round-trip-safe YAML frontmatter `split` / `dump` / `set_keys` (PyYAML). `split(dump(fm, body)) == (fm, body)`. |
+| `digivault/wikilinks.py` | Parse `[[note]]`/`[[note#h\|alias]]`/`![[embed]]`; `rewrite_target` / `map_targets` rewrite links while skipping code spans/blocks. |
+| `digivault/vault.py` | `Vault` — load a directory, build the note index + link graph + backlinks + tag index; maintenance ops (`create_note`, `rename` with inbound-link rewrite, `set_frontmatter`, `reindex`, `lint`). |
+| `digivault/path_scopes.py` | DigiKey scope policy: reads need `digivault:read`, writes `digivault:write`. |
+| `digivault/orchestrator_tools.py` | OpenAI-style tool manifest fetched by DigiGraph via `POST /v1/orchestrator_tools`. |
+| `digivault/server.py` | FastAPI app: `/healthz`, `/v1/status`, note CRUD, lint, backlinks, tags, orchestrator endpoints. |
+| `digivault/mcp_server.py` | `python -m digivault.mcp_server` — vault tools over MCP (streamable HTTP, default `127.0.0.1:8766`). |
+| `digivault/cli.py` | `digivault init|lint|reindex|new-note`. |
+
+## Public API (core)
+
+```python
+from digivault import (
+    Vault, VaultError, VaultConfig,
+    Note, LinkRef, LintReport, ValidationIssue,
+    parse_links, rewrite_target,
+    split_frontmatter, dump_frontmatter, set_keys,
+)
+
+vault = Vault("docs/vision")
+vault.list_notes()              # -> list[Note] (with backlinks)
+vault.backlinks("digigraph")    # -> tuple[str, ...]
+vault.search_by_tag("module")   # -> list[Note]
+vault.create_note("kairos", frontmatter={"title": "Kairos"}, body="see [[digiquant]]")
+vault.rename("atlas", "atlas-research")   # rewrites every inbound [[atlas]]
+report = vault.lint()           # -> LintReport(ok, note_count, issues)
+```
+
+## Service topology
+
+- **Port 8004**, host-loopback-bound, under the dedicated `digivault` Compose
+  profile (not part of the always-on `core` stack).
+- **Auth:** DigiKey JWT via `DigiAuthMiddleware`; `digivault:read` for GET
+  routes and discovery, `digivault:write` for mutations and `orchestrator_invoke`.
+  `/healthz`, `/v1/status`, `/metrics`, OpenAPI are auth-exempt.
+- **Vault root:** `DIGIVAULT_ROOT` (required for any note route; routes return
+  503 when unset). The vault is re-read from disk per request — small docs vault,
+  correctness over caching.
+- **Hub:** DigiGraph discovers tools via `POST /v1/orchestrator_tools` and
+  executes via `POST /v1/orchestrator_invoke`.
+
+## Design decisions
+
+- **Core/service split.** The vault semantics are useful as a library (CI doc
+  linting, scripts, other services); FastAPI is an optional delivery surface.
+- **Re-read per request.** A documentation vault is small; recomputing the index
+  from disk avoids a whole class of cache-coherency bugs. If a large vault ever
+  needs it, add an explicit cache behind `reindex`.
+- **Storage = filesystem (v1).** DigiVault owns *how knowledge is organized and
+  traversed* (frontmatter, wikilinks, backlinks, taxonomy); `digistore` (when it
+  ships) owns *where bytes live*. They are complementary — DigiVault would sit
+  above DigiStore, not replace it.
+- **Wikilinks, not standard links.** The vault speaks Obsidian `[[...]]`. The
+  repo's `scripts/check_doc_links.py` validates only `[text](path)` links, so
+  DigiVault owns wikilink validation via `lint` (wired into `make vault-check`
+  when the docs migrate).
+
+## Environment variables
+
+| Var | Purpose |
+|-----|---------|
+| `DIGIVAULT_ROOT` | Path to the managed vault directory (required for note routes). |
+| `DIGIVAULT_MCP_HOST` | MCP bind host (default `127.0.0.1`). |
+| `DIGIKEY_JWKS_URL` / `DIGIKEY_ISSUER` / `DIGIKEY_AUDIENCE` / `DIGIKEY_PUBLIC_KEY_PEM` | DigiKey JWT verification (shared convention). |
+
+## Testing
+
+`tests/dv/` — `@pytest.mark.unit`, deterministic, filesystem via `tmp_path`.
+Core tests (frontmatter, wikilinks, vault) need only `pydantic` + `pyyaml`.
+Service and CLI tests `pytest.importorskip` their extras so the suite stays green
+without `digivault[service]` installed. CI (`.github/workflows/digivault-test.yml`)
+installs `digibase` + `digikey` + `digivault[service]` and runs the full set.
+
+## Monorepo integration
+
+Registered in `pytest.ini`, `scripts/ci_paths.yaml` (→ `ci.yml`),
+`.github/workflows/digivault-test.yml`, `docker-compose.yml` (profile
+`digivault`, port 8004), root `ARCHITECTURE.md` topology, `README.md`, and
+`CLAUDE.md`. Human follow-ups: `CODEOWNERS`, `scripts/commit_helper.sh`
+`VALID_COMPONENTS`, `scripts/project_routing.json`.

--- a/digivault/Dockerfile
+++ b/digivault/Dockerfile
@@ -1,0 +1,32 @@
+# DigiVault – Obsidian-style markdown vault management for the Digi ecosystem
+# Build from repo root: docker compose build digivault (context: .)
+# See digivault/ARCHITECTURE.md. HTTP API + MCP tooling for DigiGraph.
+
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN pip install --upgrade pip && pip install uv
+
+COPY digibase/pyproject.toml digibase/README.md ./digibase/
+COPY digibase/src ./digibase/src
+RUN uv pip install --system -e "./digibase"
+
+COPY digikey/pyproject.toml digikey/README.md ./digikey/
+COPY digikey/src ./digikey/src
+RUN uv pip install --system -e "./digikey"
+
+COPY digivault/pyproject.toml digivault/ARCHITECTURE.md ./digivault/
+COPY digivault/src ./digivault/src
+WORKDIR /app/digivault
+RUN uv pip install --system -e ".[service]"
+
+WORKDIR /app
+EXPOSE 8004
+CMD ["uvicorn", "digivault.server:app", "--host", "0.0.0.0", "--port", "8004"]

--- a/digivault/pyproject.toml
+++ b/digivault/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "digivault"
+version = "0.1.0"
+description = "DigiVault – Obsidian-style markdown vault management (frontmatter, wikilinks, backlinks, tags, taxonomy) for DigiThings"
+readme = "ARCHITECTURE.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+dependencies = [
+    "pydantic>=2",
+    # PyYAML for round-trip YAML frontmatter parse/serialize. Already a repo-wide
+    # dependency (digisearch, config loaders); kept here as a direct, flat dep so
+    # the core library installs without monorepo-sibling ordering.
+    "pyyaml>=6",
+]
+
+[project.optional-dependencies]
+# FastAPI service + MCP server + CLI. The core library (frontmatter, wikilinks,
+# vault) imports none of these; ``import digivault`` never imports FastAPI.
+service = [
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
+    "mcp>=1.0",
+    "typer>=0.12",
+]
+dev = ["pytest>=8", "ruff>=0.8"]
+
+[project.scripts]
+digivault = "digivault.cli:app"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint.per-file-ignores]
+# Package __init__ re-exports public symbols; ruff flags them as unused.
+# Matches the repo-root ruff.toml, digibase, digisearch, digifetch.
+"**/__init__.py" = ["F401"]

--- a/digivault/src/digivault/__init__.py
+++ b/digivault/src/digivault/__init__.py
@@ -1,0 +1,39 @@
+"""DigiVault — Obsidian-style markdown vault management.
+
+Core library: frontmatter parsing, wikilink parsing/rewriting, and the ``Vault``
+index with backlinks, tags, and maintenance operations. Importing ``digivault``
+pulls in only ``pydantic`` and ``pyyaml`` — never FastAPI. The HTTP service, MCP
+server, and CLI live in ``digivault.server`` / ``digivault.mcp_server`` /
+``digivault.cli`` and require the ``[service]`` extra.
+"""
+
+from __future__ import annotations
+
+from digivault.frontmatter import dump_frontmatter, set_keys, split_frontmatter
+from digivault.models import (
+    LinkRef,
+    LintReport,
+    Note,
+    ValidationIssue,
+    VaultConfig,
+)
+from digivault.vault import Vault, VaultError
+from digivault.wikilinks import parse_links, rewrite_target
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Vault",
+    "VaultError",
+    "VaultConfig",
+    "Note",
+    "LinkRef",
+    "LintReport",
+    "ValidationIssue",
+    "parse_links",
+    "rewrite_target",
+    "split_frontmatter",
+    "dump_frontmatter",
+    "set_keys",
+    "__version__",
+]

--- a/digivault/src/digivault/cli.py
+++ b/digivault/src/digivault/cli.py
@@ -26,7 +26,7 @@ def _resolve_root(root: str | None) -> Path:
 
 @app.command()
 def init(
-    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+    root: str | None = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
 ) -> None:
     """Create the vault directory and a default ``.digivault.yml`` manifest."""
     path = _resolve_root(root)
@@ -41,7 +41,7 @@ def init(
 
 @app.command()
 def lint(
-    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+    root: str | None = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
 ) -> None:
     """Validate the vault; exit non-zero if any issues are found."""
     try:
@@ -59,7 +59,7 @@ def lint(
 
 @app.command()
 def reindex(
-    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+    root: str | None = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
 ) -> None:
     """Rebuild the index and report note and link counts."""
     vault = Vault(_resolve_root(root))
@@ -71,8 +71,8 @@ def reindex(
 @app.command("new-note")
 def new_note(
     name: str = typer.Argument(..., help="New note name (filename stem)"),
-    title: str = typer.Option(None, "--title", help="Frontmatter title"),
-    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+    title: str | None = typer.Option(None, "--title", help="Frontmatter title"),
+    root: str | None = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
 ) -> None:
     """Create a new note in the vault."""
     try:

--- a/digivault/src/digivault/cli.py
+++ b/digivault/src/digivault/cli.py
@@ -1,0 +1,88 @@
+"""DigiVault CLI. Typer-based. Entry point: ``digivault``.
+
+Operates on a vault directory passed via ``--root`` or the ``DIGIVAULT_ROOT``
+environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import typer
+
+from digivault.vault import MANIFEST_NAME, Vault, VaultError
+
+app = typer.Typer(help="DigiVault – Obsidian-style markdown vault management")
+
+
+def _resolve_root(root: str | None) -> Path:
+    chosen = (root or os.environ.get("DIGIVAULT_ROOT") or "").strip()
+    if not chosen:
+        typer.echo("No vault root: pass --root or set DIGIVAULT_ROOT", err=True)
+        raise typer.Exit(code=2)
+    return Path(chosen)
+
+
+@app.command()
+def init(
+    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+) -> None:
+    """Create the vault directory and a default ``.digivault.yml`` manifest."""
+    path = _resolve_root(root)
+    path.mkdir(parents=True, exist_ok=True)
+    manifest = path / MANIFEST_NAME
+    if not manifest.exists():
+        manifest.write_text("required_frontmatter: []\nallow_orphans: true\n", encoding="utf-8")
+        typer.echo(f"Initialized vault at {path} ({MANIFEST_NAME} written)")
+    else:
+        typer.echo(f"Vault already initialized at {path}")
+
+
+@app.command()
+def lint(
+    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+) -> None:
+    """Validate the vault; exit non-zero if any issues are found."""
+    try:
+        report = Vault(_resolve_root(root)).lint()
+    except VaultError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    if report.ok:
+        typer.echo(f"vault OK ({report.note_count} notes)")
+        return
+    for issue in report.issues:
+        typer.echo(f"{issue.note}: {issue.kind}: {issue.message}", err=True)
+    raise typer.Exit(code=1)
+
+
+@app.command()
+def reindex(
+    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+) -> None:
+    """Rebuild the index and report note and link counts."""
+    vault = Vault(_resolve_root(root))
+    notes = vault.list_notes()
+    links = sum(len(n.outlinks) for n in notes)
+    typer.echo(f"{len(notes)} notes, {links} wikilinks")
+
+
+@app.command("new-note")
+def new_note(
+    name: str = typer.Argument(..., help="New note name (filename stem)"),
+    title: str = typer.Option(None, "--title", help="Frontmatter title"),
+    root: str = typer.Option(None, "--root", help="Vault directory (or DIGIVAULT_ROOT)"),
+) -> None:
+    """Create a new note in the vault."""
+    try:
+        fm = {"title": title} if title else {}
+        note = Vault(_resolve_root(root)).create_note(name, frontmatter=fm)
+    except VaultError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(f"created {note.rel_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/digivault/src/digivault/frontmatter.py
+++ b/digivault/src/digivault/frontmatter.py
@@ -1,0 +1,69 @@
+"""YAML frontmatter parse/serialize — round-trip safe.
+
+A note file is ``---\\n<yaml>\\n---\\n<body>``. We keep this self-contained (no
+``python-frontmatter`` dependency) and lean on PyYAML, which is already a
+repo-wide dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any  # noqa: ANN401 — frontmatter values are arbitrary YAML scalars/maps
+
+import yaml
+
+_FENCE = "---"
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Split note text into ``(frontmatter_mapping, body)``.
+
+    Returns an empty mapping and the original text when there is no frontmatter
+    block. A frontmatter block must start on the very first line with ``---`` and
+    be closed by a line that is exactly ``---``.
+    """
+    if not text.startswith(_FENCE):
+        return {}, text
+    lines = text.splitlines(keepends=True)
+    # lines[0] is the opening fence; find the closing fence.
+    closing_idx: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n").rstrip("\r") == _FENCE:
+            closing_idx = i
+            break
+    if closing_idx is None:
+        # Unterminated fence — treat the whole file as body, no frontmatter.
+        return {}, text
+    raw_yaml = "".join(lines[1:closing_idx])
+    body = "".join(lines[closing_idx + 1 :])
+    try:
+        loaded = yaml.safe_load(raw_yaml) if raw_yaml.strip() else {}
+    except yaml.YAMLError:
+        return {}, text
+    if not isinstance(loaded, dict):
+        return {}, text
+    return loaded, body
+
+
+def dump_frontmatter(frontmatter: dict[str, Any], body: str) -> str:
+    """Serialize ``frontmatter`` + ``body`` back into note text.
+
+    With an empty mapping, returns the body unchanged (no empty fence block).
+    """
+    if not frontmatter:
+        return body
+    yaml_text = yaml.safe_dump(
+        frontmatter,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).rstrip("\n")
+    # No extra newline after the closing fence: the body is appended verbatim so
+    # that split_frontmatter(dump_frontmatter(fm, body)) == (fm, body) exactly.
+    return f"{_FENCE}\n{yaml_text}\n{_FENCE}\n{body}"
+
+
+def set_keys(text: str, updates: dict[str, Any]) -> str:
+    """Return note text with ``updates`` merged into its frontmatter mapping."""
+    fm, body = split_frontmatter(text)
+    merged = {**fm, **updates}
+    return dump_frontmatter(merged, body)

--- a/digivault/src/digivault/mcp_server.py
+++ b/digivault/src/digivault/mcp_server.py
@@ -1,0 +1,83 @@
+"""DigiVault MCP server — exposes vault management as MCP tools for DigiGraph.
+
+Run: ``python -m digivault.mcp_server`` (streamable HTTP, default 127.0.0.1:8766).
+Operates on the vault directory named by ``DIGIVAULT_ROOT``.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from digivault.vault import Vault, VaultError
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("DigiVault", json_response=True)
+
+
+def _open_vault() -> Vault:
+    root = (os.environ.get("DIGIVAULT_ROOT") or "").strip()
+    if not root:
+        raise VaultError("DIGIVAULT_ROOT is not configured")
+    return Vault(root)
+
+
+@mcp.tool()
+def digivault_search_tag(tag: str) -> str:
+    """Find vault notes carrying a given tag (without '#'). Use to locate docs by topic."""
+    try:
+        notes = _open_vault().search_by_tag(tag)
+    except VaultError as e:
+        return f"[DigiVault error: {e}]"
+    return _json.dumps([{"name": n.name, "title": n.title, "rel_path": n.rel_path} for n in notes])
+
+
+@mcp.tool()
+def digivault_backlinks(name: str) -> str:
+    """List notes that link to a given note (its backlinks)."""
+    try:
+        vault = _open_vault()
+    except VaultError as e:
+        return f"[DigiVault error: {e}]"
+    if vault.get_note(name) is None:
+        return f"[DigiVault: no such note {name!r}]"
+    return _json.dumps({"name": name, "backlinks": list(vault.backlinks(name))})
+
+
+@mcp.tool()
+def digivault_lint() -> str:
+    """Validate the vault: unresolved wikilinks, missing frontmatter, orphans, tags."""
+    try:
+        report = _open_vault().lint()
+    except VaultError as e:
+        return f"[DigiVault error: {e}]"
+    return report.model_dump_json(indent=2)
+
+
+@mcp.tool()
+def digivault_create_note(name: str, title: str | None = None, body: str = "") -> str:
+    """Create a new markdown note in the vault with optional title and body."""
+    try:
+        fm = {"title": title} if title else {}
+        note = _open_vault().create_note(name, frontmatter=fm, body=body)
+    except VaultError as e:
+        return f"[DigiVault error: {e}]"
+    return note.model_dump_json()
+
+
+def run_mcp(
+    transport: str = "streamable-http",
+    host: str | None = None,
+    port: int = 8766,
+) -> None:
+    """Run the MCP server. Default: streamable HTTP on 127.0.0.1:8766."""
+    bind = host or os.environ.get("DIGIVAULT_MCP_HOST", "127.0.0.1")
+    mcp.run(transport=transport, host=bind, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_mcp()

--- a/digivault/src/digivault/models.py
+++ b/digivault/src/digivault/models.py
@@ -52,7 +52,9 @@ class ValidationIssue(BaseModel):
     )
     kind: str = Field(
         ...,
-        description="unresolved_link | orphan_note | missing_frontmatter | duplicate_note",
+        description=(
+            "unresolved_link | missing_frontmatter | disallowed_tag | orphan_note | duplicate_note"
+        ),
     )
     message: str = Field(..., description="Human-readable description")
 

--- a/digivault/src/digivault/models.py
+++ b/digivault/src/digivault/models.py
@@ -1,0 +1,88 @@
+"""Pydantic v2 models for the DigiVault core.
+
+These are the typed result objects the vault returns — never bare dicts. The
+service and MCP layers serialize these directly.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LinkRef(BaseModel):
+    """A single Obsidian-style ``[[wikilink]]`` occurrence inside a note.
+
+    ``target`` is the note name as written (without the ``[[`` / ``]]``), with any
+    ``#heading`` and ``|alias`` stripped off into their own fields.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target: str = Field(..., description="Linked note name, e.g. 'digigraph'")
+    heading: str | None = Field(default=None, description="Optional #heading fragment")
+    alias: str | None = Field(default=None, description="Optional |display alias")
+    embed: bool = Field(default=False, description="True for transclusions: ![[note]]")
+    raw: str = Field(..., description="The full matched text, e.g. '[[digigraph#api|API]]'")
+
+
+class Note(BaseModel):
+    """A single markdown note in the vault."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(..., description="Note name (filename stem), e.g. 'digigraph'")
+    rel_path: str = Field(..., description="Path relative to the vault root, POSIX form")
+    title: str | None = Field(default=None, description="Frontmatter 'title' if present")
+    tags: tuple[str, ...] = Field(default=(), description="Frontmatter tags, normalized")
+    aliases: tuple[str, ...] = Field(default=(), description="Frontmatter aliases")
+    frontmatter: dict = Field(default_factory=dict, description="Raw parsed frontmatter mapping")
+    outlinks: tuple[LinkRef, ...] = Field(default=(), description="Wikilinks found in the body")
+    backlinks: tuple[str, ...] = Field(
+        default=(), description="Names of notes that link to this note"
+    )
+
+
+class ValidationIssue(BaseModel):
+    """One problem found by ``Vault.lint``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    note: str = Field(
+        ..., description="Note rel_path the issue was found in (or '' for vault-wide)"
+    )
+    kind: str = Field(
+        ...,
+        description="unresolved_link | orphan_note | missing_frontmatter | duplicate_note",
+    )
+    message: str = Field(..., description="Human-readable description")
+
+
+class LintReport(BaseModel):
+    """Result of linting the whole vault."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool = Field(..., description="True when there are no issues")
+    note_count: int = Field(..., description="Number of notes scanned")
+    issues: tuple[ValidationIssue, ...] = Field(default=(), description="All issues found")
+
+
+class VaultConfig(BaseModel):
+    """Vault manifest — required frontmatter keys and the tag taxonomy.
+
+    Loaded from ``.digivault.yml`` at the vault root when present; otherwise the
+    defaults apply (no required keys, any tags allowed).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    required_frontmatter: tuple[str, ...] = Field(
+        default=(), description="Frontmatter keys every note must define"
+    )
+    allowed_tags: tuple[str, ...] | None = Field(
+        default=None,
+        description="If set, lint flags any tag not in this taxonomy. None = allow all.",
+    )
+    allow_orphans: bool = Field(
+        default=True, description="If False, lint flags notes with no in- or out-links"
+    )

--- a/digivault/src/digivault/orchestrator_tools.py
+++ b/digivault/src/digivault/orchestrator_tools.py
@@ -1,0 +1,90 @@
+"""OpenAI-style orchestrator tool definitions for DigiVault.
+
+Hubs (e.g. DigiGraph) fetch these via ``POST /v1/orchestrator_tools`` and execute
+via ``POST /v1/orchestrator_invoke`` so vault tooling is owned by this service.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict  # noqa: ANN401 — OpenAI tool JSON-schema property maps
+
+
+class FunctionParametersSchema(TypedDict, total=False):
+    type: str
+    properties: dict[str, Any]
+    required: list[str]
+
+
+class FunctionToolSchema(TypedDict):
+    name: str
+    description: str
+    parameters: FunctionParametersSchema
+
+
+class OpenAIToolDict(TypedDict):
+    type: str
+    function: FunctionToolSchema
+
+
+TOOL_VAULT_SEARCH_TAG = "digivault_search_tag"
+TOOL_VAULT_BACKLINKS = "digivault_backlinks"
+TOOL_VAULT_LINT = "digivault_lint"
+TOOL_VAULT_CREATE_NOTE = "digivault_create_note"
+
+ORCHESTRATOR_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        TOOL_VAULT_SEARCH_TAG,
+        TOOL_VAULT_BACKLINKS,
+        TOOL_VAULT_LINT,
+        TOOL_VAULT_CREATE_NOTE,
+    }
+)
+
+
+def _fn(name: str, description: str, params: FunctionParametersSchema) -> OpenAIToolDict:
+    return {
+        "type": "function",
+        "function": {"name": name, "description": description, "parameters": params},
+    }
+
+
+def build_orchestrator_tool_manifest() -> list[OpenAIToolDict]:
+    """Return the OpenAI function-tool definitions owned by DigiVault."""
+    return [
+        _fn(
+            TOOL_VAULT_SEARCH_TAG,
+            "Find vault notes carrying a given tag. Use to locate documentation by topic.",
+            {
+                "type": "object",
+                "properties": {"tag": {"type": "string", "description": "Tag without '#'"}},
+                "required": ["tag"],
+            },
+        ),
+        _fn(
+            TOOL_VAULT_BACKLINKS,
+            "List notes that link to a given note (its backlinks).",
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string", "description": "Note name (stem)"}},
+                "required": ["name"],
+            },
+        ),
+        _fn(
+            TOOL_VAULT_LINT,
+            "Validate the vault: unresolved wikilinks, missing frontmatter, orphans.",
+            {"type": "object", "properties": {}},
+        ),
+        _fn(
+            TOOL_VAULT_CREATE_NOTE,
+            "Create a new markdown note in the vault with optional frontmatter and body.",
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "New note name (stem)"},
+                    "title": {"type": "string"},
+                    "body": {"type": "string"},
+                },
+                "required": ["name"],
+            },
+        ),
+    ]

--- a/digivault/src/digivault/path_scopes.py
+++ b/digivault/src/digivault/path_scopes.py
@@ -1,0 +1,38 @@
+"""DigiKey scope policy for DigiVault routes.
+
+Defined here (not in ``digikey``) so the auth plane stays untouched — the
+middleware accepts any ``(method, path) -> scopes | None`` function. Reads need
+``digivault:read``; mutations need ``digivault:write``.
+"""
+
+from __future__ import annotations
+
+SCOPE_READ = "digivault:read"
+SCOPE_WRITE = "digivault:write"
+
+_PUBLIC_PATHS = frozenset(
+    {
+        "/health",
+        "/healthz",
+        "/metrics",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+        "/v1/status",
+    }
+)
+
+
+def digivault_path_scopes(method: str, path: str) -> list[str] | None:
+    """Return required scopes for a request, or None if the route is auth-exempt."""
+    if path in _PUBLIC_PATHS:
+        return None
+    # Discovery is a read; the hub fetches the tool manifest before invoking.
+    if path == "/v1/orchestrator_tools":
+        return [SCOPE_READ]
+    # Invocation and all mutating note routes require write — invoke can create.
+    if path == "/v1/orchestrator_invoke":
+        return [SCOPE_WRITE]
+    if method in ("POST", "PUT", "PATCH", "DELETE"):
+        return [SCOPE_WRITE]
+    return [SCOPE_READ]

--- a/digivault/src/digivault/server.py
+++ b/digivault/src/digivault/server.py
@@ -1,0 +1,238 @@
+"""DigiVault HTTP API — Obsidian-style vault management for the Digi ecosystem.
+
+Operates on the vault directory named by ``DIGIVAULT_ROOT``. The vault is re-read
+from disk on each request (a documentation vault is small and correctness beats
+caching), so there is no index to fall out of sync.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any  # noqa: ANN401 — frontmatter / orchestrator argument maps are arbitrary
+
+from digibase.cors import install_cors
+from digibase.errors import register_fastapi_error_handlers
+from digibase.http import install_request_id_logging, install_request_id_middleware
+from digibase.metrics import install_metrics
+from digibase.otel import setup_otel_fastapi
+from digikey.integrations.service_middleware import DigiAuthMiddleware
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from digivault import __version__
+from digivault.models import LintReport, Note
+from digivault.orchestrator_tools import (
+    TOOL_VAULT_BACKLINKS,
+    TOOL_VAULT_CREATE_NOTE,
+    TOOL_VAULT_LINT,
+    TOOL_VAULT_SEARCH_TAG,
+    OpenAIToolDict,
+    build_orchestrator_tool_manifest,
+)
+from digivault.path_scopes import digivault_path_scopes
+from digivault.vault import Vault, VaultError
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="DigiVault",
+    description="Obsidian-style markdown vault management (frontmatter, wikilinks, backlinks, tags).",
+    version=__version__,
+)
+install_metrics(app, service="digivault", version=__version__)
+install_cors(app, service="digivault")
+app.add_middleware(DigiAuthMiddleware, service="digivault", path_scopes=digivault_path_scopes)
+install_request_id_middleware(app)
+install_request_id_logging()
+
+
+def _vault_root() -> str:
+    root = (os.environ.get("DIGIVAULT_ROOT") or "").strip()
+    if not root:
+        raise HTTPException(status_code=503, detail="DIGIVAULT_ROOT is not configured")
+    return root
+
+
+def _open_vault() -> Vault:
+    try:
+        return Vault(_vault_root())
+    except VaultError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+# ── request/response models ────────────────────────────────────────────────
+class CreateNoteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1, description="New note name (filename stem)")
+    title: str | None = Field(default=None)
+    tags: list[str] | None = Field(default=None)
+    body: str = Field(default="")
+    subdir: str = Field(default="", description="Optional subfolder under the vault root")
+
+
+class SetFrontmatterRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    updates: dict[str, Any] = Field(..., description="Frontmatter keys to merge")
+
+
+class RenameRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    new_name: str = Field(..., min_length=1)
+
+
+class NoteList(BaseModel):
+    notes: list[Note]
+
+
+class BacklinksResponse(BaseModel):
+    name: str
+    backlinks: list[str]
+
+
+class OrchestratorToolsResponse(BaseModel):
+    tools: list[OpenAIToolDict]
+    version: int = 1
+
+
+class OrchestratorInvokeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tool: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class OrchestratorInvokeResponse(BaseModel):
+    ok: bool
+    service: str = "digivault"
+    tool: str | None = None
+    data: dict[str, Any] | None = None
+    error: str | None = None
+
+
+# ── health / status ────────────────────────────────────────────────────────
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    """Minimal liveness probe. Auth-exempt, secret-free, no downstream checks."""
+    return {"ok": True}
+
+
+@app.get("/v1/status")
+def status() -> dict[str, Any]:
+    """Operator diagnostic. Reports config presence only — never secrets."""
+    return {
+        "service": "digivault",
+        "version": __version__,
+        "vault_configured": bool((os.environ.get("DIGIVAULT_ROOT") or "").strip()),
+    }
+
+
+# ── note routes ────────────────────────────────────────────────────────────
+@app.get("/v1/notes", response_model=NoteList)
+def list_notes() -> NoteList:
+    """List every note in the vault with its tags, links, and backlinks."""
+    return NoteList(notes=_open_vault().list_notes())
+
+
+@app.get("/v1/notes/{name}", response_model=Note)
+def get_note(name: str) -> Note:
+    note = _open_vault().get_note(name)
+    if note is None:
+        raise HTTPException(status_code=404, detail=f"No such note: {name!r}")
+    return note
+
+
+@app.post("/v1/notes", response_model=Note, status_code=201)
+def create_note(req: CreateNoteRequest) -> Note:
+    fm: dict[str, Any] = {}
+    if req.title:
+        fm["title"] = req.title
+    if req.tags:
+        fm["tags"] = req.tags
+    try:
+        return _open_vault().create_note(req.name, frontmatter=fm, body=req.body, subdir=req.subdir)
+    except VaultError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.patch("/v1/notes/{name}/frontmatter", response_model=Note)
+def set_frontmatter(name: str, req: SetFrontmatterRequest) -> Note:
+    try:
+        return _open_vault().set_frontmatter(name, req.updates)
+    except VaultError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/v1/notes/{name}/rename", response_model=Note)
+def rename_note(name: str, req: RenameRequest) -> Note:
+    try:
+        return _open_vault().rename(name, req.new_name)
+    except VaultError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/v1/notes/{name}/backlinks", response_model=BacklinksResponse)
+def get_backlinks(name: str) -> BacklinksResponse:
+    vault = _open_vault()
+    if vault.get_note(name) is None:
+        raise HTTPException(status_code=404, detail=f"No such note: {name!r}")
+    return BacklinksResponse(name=name, backlinks=list(vault.backlinks(name)))
+
+
+@app.get("/v1/tags/{tag}", response_model=NoteList)
+def search_by_tag(tag: str) -> NoteList:
+    return NoteList(notes=_open_vault().search_by_tag(tag))
+
+
+@app.get("/v1/lint", response_model=LintReport)
+def lint() -> LintReport:
+    """Validate the vault: unresolved links, missing frontmatter, orphans, tags."""
+    return _open_vault().lint()
+
+
+# ── orchestrator (hub) ─────────────────────────────────────────────────────
+@app.post("/v1/orchestrator_tools", response_model=OrchestratorToolsResponse)
+def orchestrator_tools() -> OrchestratorToolsResponse:
+    """Return OpenAI-style tool definitions owned by DigiVault (for DigiGraph)."""
+    return OrchestratorToolsResponse(tools=build_orchestrator_tool_manifest())
+
+
+@app.post("/v1/orchestrator_invoke", response_model=OrchestratorInvokeResponse)
+def orchestrator_invoke(req: OrchestratorInvokeRequest) -> OrchestratorInvokeResponse:
+    """Execute one DigiVault orchestrator tool by name (hub dispatch)."""
+    vault = _open_vault()
+    tool = (req.tool or "").strip()
+    args = req.arguments if isinstance(req.arguments, dict) else {}
+    try:
+        if tool == TOOL_VAULT_SEARCH_TAG:
+            notes = vault.search_by_tag(str(args.get("tag") or ""))
+            data = {"notes": [n.model_dump(mode="json") for n in notes]}
+        elif tool == TOOL_VAULT_BACKLINKS:
+            name = str(args.get("name") or "")
+            if vault.get_note(name) is None:
+                return OrchestratorInvokeResponse(
+                    ok=False, tool=tool, error=f"No such note: {name!r}"
+                )
+            data = {"name": name, "backlinks": list(vault.backlinks(name))}
+        elif tool == TOOL_VAULT_LINT:
+            data = vault.lint().model_dump(mode="json")
+        elif tool == TOOL_VAULT_CREATE_NOTE:
+            fm = {"title": args["title"]} if args.get("title") else {}
+            note = vault.create_note(
+                str(args["name"]), frontmatter=fm, body=str(args.get("body") or "")
+            )
+            data = note.model_dump(mode="json")
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown orchestrator tool: {tool!r}")
+    except VaultError as exc:
+        return OrchestratorInvokeResponse(ok=False, tool=tool, error=str(exc))
+    except KeyError as exc:
+        return OrchestratorInvokeResponse(ok=False, tool=tool, error=f"missing argument: {exc}")
+    return OrchestratorInvokeResponse(ok=True, tool=tool, data=data)
+
+
+register_fastapi_error_handlers(app, service="digivault")
+setup_otel_fastapi(app, service_name="digivault")

--- a/digivault/src/digivault/vault.py
+++ b/digivault/src/digivault/vault.py
@@ -1,0 +1,248 @@
+"""The Vault — load, index, validate, and maintain a folder of markdown notes.
+
+A vault is a directory of ``*.md`` notes. ``Vault`` builds an in-memory index
+(note-by-name), a link graph with backlinks, and a tag index, and exposes the
+maintenance operations that keep the vault consistent (create, rename with
+inbound-link rewrite, set frontmatter, lint, reindex).
+
+Storage is the local filesystem in v1. Everything is recomputed from disk on
+``reindex``; there is no hidden cache to fall out of sync.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any  # noqa: ANN401 — frontmatter values are arbitrary YAML scalars/maps
+
+import yaml
+
+from digivault import frontmatter as _fm
+from digivault import wikilinks as _wl
+from digivault.models import LintReport, Note, ValidationIssue, VaultConfig
+
+MANIFEST_NAME = ".digivault.yml"
+
+
+def _normalize_tags(value: Any) -> tuple[str, ...]:
+    """Coerce a frontmatter 'tags' value into a normalized tuple of tag strings."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        parts: Iterable[str] = value.replace(",", " ").split()
+    elif isinstance(value, (list, tuple)):
+        parts = [str(v) for v in value]
+    else:
+        return ()
+    return tuple(p.strip().lstrip("#") for p in parts if str(p).strip())
+
+
+def _normalize_aliases(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value.strip(),) if value.strip() else ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(v).strip() for v in value if str(v).strip())
+    return ()
+
+
+class VaultError(ValueError):
+    """Raised on invalid vault operations (e.g. path escape, duplicate note)."""
+
+
+class Vault:
+    """An in-memory index over a directory of markdown notes."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root).resolve()
+        if not self.root.is_dir():
+            raise VaultError(f"Vault root is not a directory: {self.root}")
+        self.config = self._load_config()
+        self._notes: dict[str, Note] = {}
+        self.reindex()
+
+    # ── loading ────────────────────────────────────────────────────────────
+    def _load_config(self) -> VaultConfig:
+        manifest = self.root / MANIFEST_NAME
+        if not manifest.is_file():
+            return VaultConfig()
+        try:
+            data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as exc:
+            raise VaultError(f"Invalid {MANIFEST_NAME}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise VaultError(f"{MANIFEST_NAME} must be a mapping")
+        return VaultConfig.model_validate(data)
+
+    def _iter_markdown(self) -> Iterable[Path]:
+        for p in sorted(self.root.rglob("*.md")):
+            if any(part.startswith(".") for part in p.relative_to(self.root).parts):
+                continue
+            yield p
+
+    def reindex(self) -> None:
+        """Rebuild the note index, link graph, and backlinks from disk."""
+        notes: dict[str, Note] = {}
+        raw_outlinks: dict[str, list] = {}
+        for path in self._iter_markdown():
+            text = path.read_text(encoding="utf-8", errors="replace")
+            fm, body = _fm.split_frontmatter(text)
+            name = path.stem
+            links = _wl.parse_links(body)
+            raw_outlinks[name] = links
+            notes[name] = Note(
+                name=name,
+                rel_path=path.relative_to(self.root).as_posix(),
+                title=fm.get("title"),
+                tags=_normalize_tags(fm.get("tags")),
+                aliases=_normalize_aliases(fm.get("aliases")),
+                frontmatter=fm,
+                outlinks=tuple(links),
+            )
+        # Compute backlinks: name -> names that link to it.
+        backlinks: dict[str, set[str]] = {n: set() for n in notes}
+        for src, links in raw_outlinks.items():
+            for link in links:
+                if link.target in backlinks:
+                    backlinks[link.target].add(src)
+        self._notes = {
+            name: note.model_copy(update={"backlinks": tuple(sorted(backlinks[name]))})
+            for name, note in notes.items()
+        }
+
+    # ── reads ──────────────────────────────────────────────────────────────
+    def list_notes(self) -> list[Note]:
+        return [self._notes[n] for n in sorted(self._notes)]
+
+    def get_note(self, name: str) -> Note | None:
+        return self._notes.get(name)
+
+    def backlinks(self, name: str) -> tuple[str, ...]:
+        note = self._notes.get(name)
+        return note.backlinks if note else ()
+
+    def search_by_tag(self, tag: str) -> list[Note]:
+        want = tag.strip().lstrip("#")
+        return [self._notes[n] for n in sorted(self._notes) if want in self._notes[n].tags]
+
+    def read_text(self, name: str) -> str:
+        note = self._notes.get(name)
+        if note is None:
+            raise VaultError(f"No such note: {name!r}")
+        return (self.root / note.rel_path).read_text(encoding="utf-8", errors="replace")
+
+    # ── writes ─────────────────────────────────────────────────────────────
+    def _safe_path(self, rel: str) -> Path:
+        """Resolve ``rel`` under the vault root, refusing escapes (path traversal)."""
+        candidate = (self.root / rel).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise VaultError(f"Path escapes vault root: {rel!r}")
+        return candidate
+
+    def create_note(
+        self,
+        name: str,
+        *,
+        frontmatter: dict[str, Any] | None = None,
+        body: str = "",
+        subdir: str = "",
+    ) -> Note:
+        """Create a new note ``<subdir>/<name>.md``. Fails if the name exists."""
+        clean = name.strip()
+        if not clean or "/" in clean or clean.startswith("."):
+            raise VaultError(f"Invalid note name: {name!r}")
+        if clean in self._notes:
+            raise VaultError(f"Note already exists: {clean!r}")
+        rel = f"{subdir.strip('/')}/{clean}.md" if subdir.strip("/") else f"{clean}.md"
+        path = self._safe_path(rel)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        text = _fm.dump_frontmatter(frontmatter or {}, body)
+        path.write_text(text, encoding="utf-8")
+        self.reindex()
+        created = self._notes.get(clean)
+        if created is None:  # pragma: no cover - defensive
+            raise VaultError(f"Failed to create note: {clean!r}")
+        return created
+
+    def set_frontmatter(self, name: str, updates: dict[str, Any]) -> Note:
+        """Merge ``updates`` into a note's frontmatter and persist."""
+        note = self._notes.get(name)
+        if note is None:
+            raise VaultError(f"No such note: {name!r}")
+        path = self.root / note.rel_path
+        path.write_text(_fm.set_keys(path.read_text(encoding="utf-8"), updates), encoding="utf-8")
+        self.reindex()
+        return self._notes[name]
+
+    def rename(self, old_name: str, new_name: str) -> Note:
+        """Rename a note and rewrite every inbound ``[[wikilink]]`` to match."""
+        note = self._notes.get(old_name)
+        if note is None:
+            raise VaultError(f"No such note: {old_name!r}")
+        clean_new = new_name.strip()
+        if not clean_new or "/" in clean_new or clean_new.startswith("."):
+            raise VaultError(f"Invalid new note name: {new_name!r}")
+        if clean_new in self._notes:
+            raise VaultError(f"Target note already exists: {clean_new!r}")
+        old_path = self.root / note.rel_path
+        new_rel = note.rel_path[: -len(f"{old_name}.md")] + f"{clean_new}.md"
+        new_path = self._safe_path(new_rel)
+        old_path.rename(new_path)
+        # Rewrite inbound links in every other note.
+        for src in note.backlinks:
+            src_note = self._notes.get(src)
+            if src_note is None:
+                continue
+            src_path = self.root / src_note.rel_path
+            src_path.write_text(
+                _wl.rewrite_target(src_path.read_text(encoding="utf-8"), old_name, clean_new),
+                encoding="utf-8",
+            )
+        self.reindex()
+        return self._notes[clean_new]
+
+    # ── validation ─────────────────────────────────────────────────────────
+    def lint(self) -> LintReport:
+        """Validate the vault: unresolved links, missing frontmatter, orphans, tags."""
+        issues: list[ValidationIssue] = []
+        names = set(self._notes)
+        for name in sorted(self._notes):
+            note = self._notes[name]
+            for link in note.outlinks:
+                if link.target not in names:
+                    issues.append(
+                        ValidationIssue(
+                            note=note.rel_path,
+                            kind="unresolved_link",
+                            message=f"[[{link.target}]] does not resolve to a note",
+                        )
+                    )
+            for key in self.config.required_frontmatter:
+                if key not in note.frontmatter:
+                    issues.append(
+                        ValidationIssue(
+                            note=note.rel_path,
+                            kind="missing_frontmatter",
+                            message=f"required frontmatter key '{key}' is missing",
+                        )
+                    )
+            if self.config.allowed_tags is not None:
+                for tag in note.tags:
+                    if tag not in self.config.allowed_tags:
+                        issues.append(
+                            ValidationIssue(
+                                note=note.rel_path,
+                                kind="missing_frontmatter",
+                                message=f"tag '{tag}' is not in the vault taxonomy",
+                            )
+                        )
+            if not self.config.allow_orphans and not note.outlinks and not note.backlinks:
+                issues.append(
+                    ValidationIssue(
+                        note=note.rel_path,
+                        kind="orphan_note",
+                        message="note has no inbound or outbound links",
+                    )
+                )
+        return LintReport(ok=not issues, note_count=len(self._notes), issues=tuple(issues))

--- a/digivault/src/digivault/vault.py
+++ b/digivault/src/digivault/vault.py
@@ -60,6 +60,7 @@ class Vault:
             raise VaultError(f"Vault root is not a directory: {self.root}")
         self.config = self._load_config()
         self._notes: dict[str, Note] = {}
+        self._duplicates: dict[str, list[str]] = {}
         self.reindex()
 
     # ── loading ────────────────────────────────────────────────────────────
@@ -85,10 +86,18 @@ class Vault:
         """Rebuild the note index, link graph, and backlinks from disk."""
         notes: dict[str, Note] = {}
         raw_outlinks: dict[str, list] = {}
+        duplicates: dict[str, list[str]] = {}
         for path in self._iter_markdown():
             text = path.read_text(encoding="utf-8", errors="replace")
             fm, body = _fm.split_frontmatter(text)
             name = path.stem
+            rel = path.relative_to(self.root).as_posix()
+            if name in notes:
+                # Two notes share a filename stem in different folders. Keep the
+                # first (deterministic via sorted iteration) and surface the
+                # collision through lint instead of silently dropping a note.
+                duplicates.setdefault(name, [notes[name].rel_path]).append(rel)
+                continue
             links = _wl.parse_links(body)
             raw_outlinks[name] = links
             notes[name] = Note(
@@ -110,6 +119,7 @@ class Vault:
             name: note.model_copy(update={"backlinks": tuple(sorted(backlinks[name]))})
             for name, note in notes.items()
         }
+        self._duplicates = duplicates
 
     # ── reads ──────────────────────────────────────────────────────────────
     def list_notes(self) -> list[Note]:
@@ -204,7 +214,7 @@ class Vault:
 
     # ── validation ─────────────────────────────────────────────────────────
     def lint(self) -> LintReport:
-        """Validate the vault: unresolved links, missing frontmatter, orphans, tags."""
+        """Validate: unresolved links, missing frontmatter, disallowed tags, orphans, dup stems."""
         issues: list[ValidationIssue] = []
         names = set(self._notes)
         for name in sorted(self._notes):
@@ -233,7 +243,7 @@ class Vault:
                         issues.append(
                             ValidationIssue(
                                 note=note.rel_path,
-                                kind="missing_frontmatter",
+                                kind="disallowed_tag",
                                 message=f"tag '{tag}' is not in the vault taxonomy",
                             )
                         )
@@ -245,4 +255,15 @@ class Vault:
                         message="note has no inbound or outbound links",
                     )
                 )
+        for stem, paths in sorted(self._duplicates.items()):
+            issues.append(
+                ValidationIssue(
+                    note=paths[0],
+                    kind="duplicate_note",
+                    message=(
+                        f"note stem '{stem}' is shared by {len(paths)} files "
+                        f"({', '.join(paths)}); only the first is indexed"
+                    ),
+                )
+            )
         return LintReport(ok=not issues, note_count=len(self._notes), issues=tuple(issues))

--- a/digivault/src/digivault/wikilinks.py
+++ b/digivault/src/digivault/wikilinks.py
@@ -1,0 +1,116 @@
+"""Parse and rewrite Obsidian-style ``[[wikilinks]]``.
+
+Supported forms:
+
+- ``[[note]]``               — plain link
+- ``[[note#heading]]``       — link to a heading
+- ``[[note|alias]]``         — link with display text
+- ``[[note#heading|alias]]`` — both
+- ``![[note]]``              — embed / transclusion (also ``![[note#heading]]``)
+
+Code spans and fenced code blocks are skipped so that ``[[...]]`` appearing in
+examples is not treated as a real link.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+from digivault.models import LinkRef
+
+# Capture the optional embed '!', then the inner target between [[ ]].
+_WIKILINK_RE = re.compile(r"(?P<embed>!)?\[\[(?P<inner>[^\[\]\n]+?)\]\]")
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def _strip_code(text: str) -> str:
+    """Blank out fenced code blocks and inline code spans (length-preserving)."""
+    out_lines: list[str] = []
+    in_fence = False
+    for line in text.splitlines(keepends=True):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            out_lines.append(" " * len(line))
+            continue
+        if in_fence:
+            out_lines.append(" " * len(line))
+        else:
+            out_lines.append(line)
+    joined = "".join(out_lines)
+    # Inline code: replace `...` runs with spaces of equal length.
+    return re.sub(r"`[^`\n]*`", lambda m: " " * len(m.group(0)), joined)
+
+
+def _parse_inner(inner: str, embed: bool, raw: str) -> LinkRef:
+    target_part, _, alias = inner.partition("|")
+    name, _, heading = target_part.partition("#")
+    return LinkRef(
+        target=name.strip(),
+        heading=heading.strip() or None,
+        alias=alias.strip() or None,
+        embed=embed,
+        raw=raw,
+    )
+
+
+def parse_links(text: str) -> list[LinkRef]:
+    """Return every wikilink in ``text`` (ignoring code spans/blocks)."""
+    scannable = _strip_code(text)
+    links: list[LinkRef] = []
+    for m in _WIKILINK_RE.finditer(scannable):
+        inner = m.group("inner").strip()
+        if not inner:
+            continue
+        links.append(_parse_inner(inner, embed=bool(m.group("embed")), raw=m.group(0)))
+    return links
+
+
+def rewrite_target(text: str, old_name: str, new_name: str) -> str:
+    """Rewrite every ``[[old_name...]]`` to point at ``new_name`` (preserving
+    heading, alias and embed markers). Code spans/blocks are left untouched.
+
+    Matching on the target name is exact (case-sensitive), consistent with how
+    the vault indexes note names.
+    """
+    code_mask = _strip_code(text)
+
+    def _repl(m: re.Match[str]) -> str:
+        # Only rewrite matches that are NOT inside masked code (the mask blanks
+        # code regions, so a real link still shows through in `code_mask`).
+        if code_mask[m.start() : m.end()] != m.group(0):
+            return m.group(0)
+        inner = m.group("inner").strip()
+        ref = _parse_inner(inner, embed=bool(m.group("embed")), raw=m.group(0))
+        if ref.target != old_name:
+            return m.group(0)
+        rebuilt = new_name
+        if ref.heading:
+            rebuilt += f"#{ref.heading}"
+        if ref.alias:
+            rebuilt += f"|{ref.alias}"
+        prefix = "!" if ref.embed else ""
+        return f"{prefix}[[{rebuilt}]]"
+
+    return _WIKILINK_RE.sub(_repl, text)
+
+
+def map_targets(text: str, mapper: Callable[[str], str | None]) -> str:
+    """Rewrite link targets via ``mapper`` (returns a new name, or None to skip)."""
+    code_mask = _strip_code(text)
+
+    def _repl(m: re.Match[str]) -> str:
+        if code_mask[m.start() : m.end()] != m.group(0):
+            return m.group(0)
+        ref = _parse_inner(m.group("inner").strip(), bool(m.group("embed")), m.group(0))
+        new = mapper(ref.target)
+        if not new or new == ref.target:
+            return m.group(0)
+        rebuilt = new
+        if ref.heading:
+            rebuilt += f"#{ref.heading}"
+        if ref.alias:
+            rebuilt += f"|{ref.alias}"
+        return f"{'!' if ref.embed else ''}[[{rebuilt}]]"
+
+    return _WIKILINK_RE.sub(_repl, text)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,38 @@ services:
       retries: 3
       start_period: 10s
 
+  # ─── DigiVault: Obsidian-style markdown vault management (profile: digivault) ───
+  digivault:
+    build:
+      context: .
+      dockerfile: digivault/Dockerfile
+    image: digi-digivault:latest
+    container_name: digi-digivault
+    profiles:
+      - digivault
+    ports:
+      - "127.0.0.1:8004:8004"
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - DIGIVAULT_ROOT=${DIGIVAULT_ROOT:-/data/vault}
+      - DIGIKEY_JWKS_URL=${DIGIKEY_JWKS_URL:-http://digikey:8005/.well-known/jwks.json}
+      - DIGIKEY_ISSUER=${DIGIKEY_ISSUER:-http://digikey:8005}
+      - DIGIKEY_AUDIENCE=${DIGIKEY_AUDIENCE:-digi-ecosystem}
+      - DIGIKEY_PUBLIC_KEY_PEM=${DIGIKEY_PUBLIC_KEY_PEM:-}
+    volumes:
+      - digivault_data:/data/vault
+    depends_on:
+      digikey:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8004/healthz"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
   # ─── LiteLLM router (Phase 1: DigiGraph uses this for all LLM calls) ───
   # Image: see DOCKER.md § LiteLLM upgrades (pin digest in production).
   litellm:
@@ -419,5 +451,6 @@ volumes:
   digichat_pg:
   digikey_data:
   digisearch_chroma:
+  digivault_data:
   prometheus_data:
   grafana_data:

--- a/docs/vision/digivault.md
+++ b/docs/vision/digivault.md
@@ -1,0 +1,73 @@
+# DigiVault
+> The knowledge-vault layer — every note, link, and tag in a managed Obsidian-style markdown vault.
+
+## What it is
+
+DigiVault manages an Obsidian-style vault: a folder of markdown notes with YAML
+frontmatter, `[[wikilinks]]`, backlinks, tags, and a folder taxonomy. It creates,
+stores, and maintains that vault — building the link graph, rewriting inbound
+links when a note is renamed, and validating the whole vault for unresolved
+links, missing frontmatter, and orphans.
+
+It ships as a pure-Python core library plus a thin service (FastAPI + MCP + CLI),
+so the same vault semantics power CI documentation checks, ad-hoc scripts, and
+agent tool calls through DigiGraph.
+
+## The problem it solves
+
+Documentation rots. Cross-references break silently, frontmatter drifts, and
+there is no cheap way to ask "what links here?" or "which notes are about X?".
+Teams either adopt a heavyweight wiki or let a folder of markdown decay. DigiVault
+makes a plain folder of markdown a first-class, queryable, self-validating
+knowledge base — the ideation and maintenance surface compounds instead of
+drifting.
+
+## How it fits in the ecosystem
+
+DigiVault is a vertical service that DigiGraph orchestrates: the hub fetches its
+tools via `POST /v1/orchestrator_tools` and invokes them via
+`POST /v1/orchestrator_invoke`, so agents can search the vault by tag, fetch
+backlinks, lint, and create notes. It reuses DigiKey for JWT auth
+(`digivault:read` / `digivault:write`) and DigiSmith for tracing.
+
+It is complementary to two other modules:
+
+- **[DigiStore](digistore.md)** owns *where bytes live* (storage backend
+  abstraction). DigiVault owns *how knowledge is organized and traversed*
+  (frontmatter, wikilinks, backlinks, taxonomy). DigiVault would sit above
+  DigiStore, not replace it.
+- **[DigiSearch](digisearch.md)** indexes content for semantic retrieval.
+  DigiVault can feed it: a managed vault is a clean ingestion source, and
+  DigiVault's tags/links add structure DigiSearch can exploit later.
+
+The first consumer is the project's own documentation (`docs/vision/`), migrated
+to a managed vault so ideation and maintenance of all docs run through one tool.
+
+## Capabilities — Current
+
+Shipped:
+
+- Round-trip-safe YAML frontmatter parse/serialize
+- Wikilink parsing (`[[note]]`, `[[note#heading|alias]]`, `![[embed]]`), code-aware
+- Vault index with backlinks and a tag index
+- Maintenance ops: create note, rename (rewrites every inbound `[[link]]`),
+  set frontmatter, reindex
+- Lint: unresolved links, missing required frontmatter, tag-taxonomy violations,
+  orphans (driven by a `.digivault.yml` manifest)
+- FastAPI service (port 8004, profile `digivault`) behind DigiKey JWT
+- MCP server (`python -m digivault.mcp_server`) and a `digivault` CLI
+
+## Capabilities — 12-month roadmap
+
+- Migrate `docs/vision/` (and then the wider docs tree) to a managed vault, with
+  `make vault-check` validating wikilinks and frontmatter in CI
+- Generated backlink sections / maps-of-content per note
+- DigiSearch ingestion of vault notes with tag- and link-aware metadata
+- DigiStore-backed storage so a vault can live on Supabase/S3, not just local disk
+- Bidirectional Obsidian compatibility (open the same vault in the Obsidian app)
+
+## Open source vs. proprietary
+
+**Open (MIT/Apache):** the entire DigiVault module — core library, service, MCP
+server, and CLI. It is open-core infrastructure for organizing knowledge; any
+proprietary value lives in the *content* of a given vault, not in DigiVault.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Digi Ecosystem – pytest config (root). Run: pytest (from repo root).
 [pytest]
 testpaths = tests digillm/tests digifetch/tests
-pythonpath = . digibase/src digillm/src digifetch/src digikey/src digiquant/src digigraph/src digisearch/src digismith/src digiclaw/src
+pythonpath = . digibase/src digillm/src digifetch/src digikey/src digiquant/src digigraph/src digisearch/src digismith/src digiclaw/src digivault/src
 python_files = test_*.py
 python_functions = test_*
 addopts = -v --tb=short -ra

--- a/scripts/ci_paths.yaml
+++ b/scripts/ci_paths.yaml
@@ -17,6 +17,11 @@ digismith:
   - tests/dsm/**
   - .github/workflows/digismith-test.yml
 
+digivault:
+  - digivault/**
+  - tests/dv/**
+  - .github/workflows/digivault-test.yml
+
 digiclaw:
   - digiclaw/**
   - tests/dc/**
@@ -59,6 +64,7 @@ score:
   - digisearch/**
   - digismith/**
   - digikey/**
+  - digivault/**
   - frontend/**
   - scripts/**
   - tests/**
@@ -95,6 +101,7 @@ ruff_and_scripts:
   - digiquant/**
   - digisearch/**
   - digismith/**
+  - digivault/**
   - tests/**
   - scripts/**
   - agents.yml

--- a/tests/dv/test_cli.py
+++ b/tests/dv/test_cli.py
@@ -1,0 +1,46 @@
+"""CLI tests. Skipped unless typer (the [service] extra) is installed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("typer")
+
+from typer.testing import CliRunner  # noqa: E402
+
+from digivault.cli import app  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+def test_init_and_lint(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["init", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / ".digivault.yml").is_file()
+
+    (tmp_path / "a.md").write_text("links [[b]]\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("leaf\n", encoding="utf-8")
+    ok = runner.invoke(app, ["lint", "--root", str(tmp_path)])
+    assert ok.exit_code == 0
+    assert "vault OK" in ok.stdout
+
+
+def test_lint_fails_on_unresolved(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("links [[missing]]\n", encoding="utf-8")
+    result = runner.invoke(app, ["lint", "--root", str(tmp_path)])
+    assert result.exit_code == 1
+
+
+def test_new_note(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["new-note", "hello", "--title", "Hi", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "hello.md").is_file()
+
+
+def test_missing_root_errors() -> None:
+    result = runner.invoke(app, ["lint"])
+    assert result.exit_code == 2

--- a/tests/dv/test_frontmatter.py
+++ b/tests/dv/test_frontmatter.py
@@ -1,0 +1,56 @@
+"""Frontmatter parse/serialize round-trip tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from digivault import dump_frontmatter, set_keys, split_frontmatter
+
+pytestmark = pytest.mark.unit
+
+
+def test_split_no_frontmatter() -> None:
+    fm, body = split_frontmatter("# Title\n\nbody text\n")
+    assert fm == {}
+    assert body == "# Title\n\nbody text\n"
+
+
+def test_split_basic_frontmatter() -> None:
+    text = "---\ntitle: DigiGraph\ntags: [module, shipped]\n---\n# DigiGraph\n\nbody\n"
+    fm, body = split_frontmatter(text)
+    assert fm == {"title": "DigiGraph", "tags": ["module", "shipped"]}
+    assert body == "# DigiGraph\n\nbody\n"
+
+
+def test_unterminated_fence_is_body() -> None:
+    text = "---\ntitle: oops\nno closing fence\n"
+    fm, body = split_frontmatter(text)
+    assert fm == {}
+    assert body == text
+
+
+def test_round_trip_preserves_body_and_keys() -> None:
+    text = "---\ntitle: A\nstatus: shipped\n---\n# A\n\nhello\n"
+    fm, body = split_frontmatter(text)
+    rebuilt = dump_frontmatter(fm, body)
+    fm2, body2 = split_frontmatter(rebuilt)
+    assert fm2 == fm
+    assert body2 == body
+
+
+def test_dump_empty_frontmatter_returns_body() -> None:
+    assert dump_frontmatter({}, "# Just body\n") == "# Just body\n"
+
+
+def test_set_keys_merges_and_persists() -> None:
+    text = "---\ntitle: A\n---\nbody\n"
+    out = set_keys(text, {"status": "shipped", "title": "A2"})
+    fm, _ = split_frontmatter(out)
+    assert fm == {"title": "A2", "status": "shipped"}
+
+
+def test_set_keys_adds_frontmatter_when_absent() -> None:
+    out = set_keys("# Only body\n", {"title": "X"})
+    fm, body = split_frontmatter(out)
+    assert fm == {"title": "X"}
+    assert "# Only body" in body

--- a/tests/dv/test_server.py
+++ b/tests/dv/test_server.py
@@ -1,0 +1,87 @@
+"""Service-layer tests. Skipped unless the [service] extra (fastapi/digikey) is installed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("digikey")
+pytest.importorskip("digibase")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from digivault import server  # noqa: E402
+from digivault.orchestrator_tools import ORCHESTRATOR_TOOL_NAMES  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def vault_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    (tmp_path / "a.md").write_text(
+        "---\ntitle: A\ntags: [doc]\n---\nlinks [[b]]\n", encoding="utf-8"
+    )
+    (tmp_path / "b.md").write_text("---\ntitle: B\n---\nleaf\n", encoding="utf-8")
+    monkeypatch.setenv("DIGIVAULT_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def test_healthz_is_public() -> None:
+    resp = TestClient(server.app).get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_status_is_public() -> None:
+    resp = TestClient(server.app).get("/v1/status")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "digivault"
+
+
+def test_protected_route_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No DigiKey configured -> middleware returns 503 auth_not_configured.
+    monkeypatch.delenv("DIGIKEY_JWKS_URL", raising=False)
+    monkeypatch.delenv("DIGIKEY_PUBLIC_KEY_PEM", raising=False)
+    resp = TestClient(server.app).get("/v1/notes")
+    assert resp.status_code == 503
+    assert resp.json()["code"] == "auth_not_configured"
+
+
+def test_list_and_create_handlers(vault_dir: Path) -> None:
+    listing = server.list_notes()
+    assert {n.name for n in listing.notes} == {"a", "b"}
+
+    created = server.create_note(server.CreateNoteRequest(name="c", title="C", body="see [[a]]\n"))
+    assert created.name == "c"
+    assert (vault_dir / "c.md").is_file()
+
+    backlinks = server.get_backlinks("a")
+    assert "c" in backlinks.backlinks
+
+
+def test_lint_handler(vault_dir: Path) -> None:
+    report = server.lint()
+    assert report.ok is True
+    assert report.note_count == 2
+
+
+def test_orchestrator_tools_manifest() -> None:
+    resp = server.orchestrator_tools()
+    names = {t["function"]["name"] for t in resp.tools}
+    assert names == ORCHESTRATOR_TOOL_NAMES
+
+
+def test_orchestrator_invoke_search_tag(vault_dir: Path) -> None:
+    resp = server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(tool="digivault_search_tag", arguments={"tag": "doc"})
+    )
+    assert resp.ok is True
+    assert resp.data is not None
+    assert [n["name"] for n in resp.data["notes"]] == ["a"]
+
+
+def test_orchestrator_invoke_unknown_tool(vault_dir: Path) -> None:
+    with pytest.raises(Exception):
+        server.orchestrator_invoke(server.OrchestratorInvokeRequest(tool="nope"))

--- a/tests/dv/test_vault.py
+++ b/tests/dv/test_vault.py
@@ -1,0 +1,106 @@
+"""Vault index, backlinks, maintenance ops, and lint tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from digivault import Vault, VaultError
+
+pytestmark = pytest.mark.unit
+
+
+def _write(root: Path, name: str, text: str) -> None:
+    (root / f"{name}.md").write_text(text, encoding="utf-8")
+
+
+def _vault_with_notes(root: Path) -> Vault:
+    _write(root, "a", "---\ntitle: A\ntags: [module]\n---\nlinks to [[b]] and [[c]]\n")
+    _write(root, "b", "---\ntitle: B\ntags: [module, shipped]\n---\nlinks to [[c]]\n")
+    _write(root, "c", "---\ntitle: C\n---\nleaf note\n")
+    return Vault(root)
+
+
+def test_index_and_backlinks(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    assert {n.name for n in vault.list_notes()} == {"a", "b", "c"}
+    assert vault.backlinks("c") == ("a", "b")
+    assert vault.backlinks("b") == ("a",)
+    assert vault.backlinks("a") == ()
+
+
+def test_search_by_tag(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    assert [n.name for n in vault.search_by_tag("shipped")] == ["b"]
+    assert [n.name for n in vault.search_by_tag("module")] == ["a", "b"]
+
+
+def test_create_note(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    note = vault.create_note("d", frontmatter={"title": "D"}, body="points at [[a]]\n")
+    assert note.name == "d"
+    assert (tmp_path / "d.md").is_file()
+    assert vault.backlinks("a") == ("d",)
+
+
+def test_create_duplicate_rejected(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    with pytest.raises(VaultError):
+        vault.create_note("a")
+
+
+def test_create_rejects_path_escape(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    with pytest.raises(VaultError):
+        vault.create_note("../evil")
+
+
+def test_rename_rewrites_inbound_links(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    vault.rename("c", "gamma")
+    assert vault.get_note("c") is None
+    assert vault.get_note("gamma") is not None
+    # a and b should now link to gamma
+    assert "[[gamma]]" in (tmp_path / "a.md").read_text()
+    assert "[[gamma]]" in (tmp_path / "b.md").read_text()
+    assert vault.backlinks("gamma") == ("a", "b")
+
+
+def test_set_frontmatter(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    note = vault.set_frontmatter("c", {"status": "shipped"})
+    assert note.frontmatter["status"] == "shipped"
+
+
+def test_lint_clean_vault(tmp_path: Path) -> None:
+    vault = _vault_with_notes(tmp_path)
+    report = vault.lint()
+    assert report.ok is True
+    assert report.note_count == 3
+
+
+def test_lint_flags_unresolved_link(tmp_path: Path) -> None:
+    _write(tmp_path, "a", "links to [[missing]]\n")
+    report = Vault(tmp_path).lint()
+    assert report.ok is False
+    assert any(i.kind == "unresolved_link" for i in report.issues)
+
+
+def test_lint_required_frontmatter(tmp_path: Path) -> None:
+    (tmp_path / ".digivault.yml").write_text("required_frontmatter: [title]\n", encoding="utf-8")
+    _write(tmp_path, "a", "no frontmatter here\n")
+    report = Vault(tmp_path).lint()
+    assert any(i.kind == "missing_frontmatter" for i in report.issues)
+
+
+def test_manifest_taxonomy_flags_unknown_tag(tmp_path: Path) -> None:
+    (tmp_path / ".digivault.yml").write_text("allowed_tags: [module]\n", encoding="utf-8")
+    _write(tmp_path, "a", "---\ntags: [bogus]\n---\nbody\n")
+    report = Vault(tmp_path).lint()
+    assert any("taxonomy" in i.message for i in report.issues)
+
+
+def test_missing_root_raises(tmp_path: Path) -> None:
+    with pytest.raises(VaultError):
+        Vault(tmp_path / "does-not-exist")

--- a/tests/dv/test_vault.py
+++ b/tests/dv/test_vault.py
@@ -99,6 +99,24 @@ def test_manifest_taxonomy_flags_unknown_tag(tmp_path: Path) -> None:
     _write(tmp_path, "a", "---\ntags: [bogus]\n---\nbody\n")
     report = Vault(tmp_path).lint()
     assert any("taxonomy" in i.message for i in report.issues)
+    # Taxonomy violations carry their own kind, not 'missing_frontmatter'.
+    assert any(i.kind == "disallowed_tag" for i in report.issues)
+    assert not any(i.kind == "missing_frontmatter" for i in report.issues)
+
+
+def test_lint_flags_duplicate_stems(tmp_path: Path) -> None:
+    _write(tmp_path, "a", "first copy\n")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "a.md").write_text("second copy\n", encoding="utf-8")
+    vault = Vault(tmp_path)
+    # Only the first (deterministic) note is indexed; the collision is not lost.
+    assert vault.get_note("a") is not None
+    report = vault.lint()
+    assert report.ok is False
+    dups = [i for i in report.issues if i.kind == "duplicate_note"]
+    assert len(dups) == 1
+    assert "a.md" in dups[0].message and "sub/a.md" in dups[0].message
 
 
 def test_missing_root_raises(tmp_path: Path) -> None:

--- a/tests/dv/test_wikilinks.py
+++ b/tests/dv/test_wikilinks.py
@@ -1,0 +1,50 @@
+"""Wikilink parse/rewrite tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from digivault import parse_links, rewrite_target
+from digivault.wikilinks import map_targets
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_plain_link() -> None:
+    (link,) = parse_links("see [[digigraph]] for details")
+    assert link.target == "digigraph"
+    assert link.heading is None
+    assert link.alias is None
+    assert link.embed is False
+
+
+def test_parse_heading_alias_and_embed() -> None:
+    links = parse_links("[[digigraph#api|the API]] and ![[diagram]]")
+    assert links[0].target == "digigraph"
+    assert links[0].heading == "api"
+    assert links[0].alias == "the API"
+    assert links[1].target == "diagram"
+    assert links[1].embed is True
+
+
+def test_links_in_code_are_ignored() -> None:
+    text = "real [[one]]\n```\nfake [[two]]\n```\ninline `[[three]]`\n"
+    targets = [link.target for link in parse_links(text)]
+    assert targets == ["one"]
+
+
+def test_rewrite_target_preserves_heading_and_alias() -> None:
+    text = "[[old#sec|Alias]] and [[old]] and [[keep]]"
+    out = rewrite_target(text, "old", "new")
+    assert out == "[[new#sec|Alias]] and [[new]] and [[keep]]"
+
+
+def test_rewrite_does_not_touch_code() -> None:
+    text = "[[old]]\n```\n[[old]]\n```\n"
+    out = rewrite_target(text, "old", "new")
+    assert out == "[[new]]\n```\n[[old]]\n```\n"
+
+
+def test_map_targets() -> None:
+    out = map_targets("[[a]] [[b]]", lambda t: t.upper() if t == "a" else None)
+    assert out == "[[A]] [[b]]"


### PR DESCRIPTION
Fixes #724

## What

Adds **digivault** — a new service that manages an Obsidian-style markdown vault: YAML frontmatter, `[[wikilinks]]`, backlinks, tags, and folder taxonomy. First consumer will be the project's own documentation (the `docs/vision/` migration is tracked separately).

This is **PR1 of 2**: the module itself. PR2 will migrate `docs/vision/` onto it and add `make vault-check`.

## Shape

- **Full service** on **port 8004**, under a dedicated `digivault` Compose profile (not always-on), host-loopback-bound.
- **Core/service split:** `import digivault` pulls only `pydantic` + `pyyaml` (never FastAPI). The FastAPI app, MCP server, and CLI live behind the `[service]` extra.
- Reuses DigiKey JWT auth (`digivault:read` / `digivault:write`) and DigiBase/DigiSmith helpers; **does not modify `digikey/`**.

## Contents

**Core library** (`digivault/src/digivault/`)
- `frontmatter.py` — round-trip-safe YAML frontmatter (`split(dump(fm, body)) == (fm, body)`)
- `wikilinks.py` — parse `[[note#h|alias]]` / `[[embed]]`; code-aware link rewriting
- `vault.py` — note index + link graph + backlinks + tag index; `create_note`, `rename` (rewrites inbound links), `set_frontmatter`, `reindex`, `lint` (manifest-driven)
- `models.py` — Pydantic v2 result types

**Service layer**
- `server.py` — FastAPI: `/healthz`, `/v1/status`, note CRUD, lint, backlinks, tags, `/v1/orchestrator_tools` + `/v1/orchestrator_invoke`
- `mcp_server.py` — `python -m digivault.mcp_server`
- `cli.py` — `digivault init|lint|reindex|new-note`

**Wiring:** `pytest.ini`, `scripts/ci_paths.yaml` (+ regenerated `ci.yml`), `.github/workflows/digivault-test.yml`, `docker-compose.yml` (profile `digivault`, port 8004, named volume), root `ARCHITECTURE.md` topology, `README.md` (Components + Services), `CLAUDE.md`, `docs/vision/digivault.md`.

## Verification

- 37 unit tests pass (core + service + CLI; service/CLI tests `importorskip` their extras)
- `ruff check` / `ruff format --check` clean; import-cost guard asserts no FastAPI in core import
- `make score` → Security 9, Quality 10, Optimization 10, Accuracy 10
- `make doc-check` OK; CI path-filter drift check OK

## ⚠️ Human gate

New **network-exposed service** — per `CLAUDE.md` this requires explicit human review before merge. Auth is enforced (protected routes 503 without DigiKey configured; reads/writes require scopes); the `0.0.0.0` bind in the Dockerfile is container-internal and host-loopback-bound in compose, matching the other services.

Follow-ups (need a human / GitHub Project number): `CODEOWNERS`, `scripts/commit_helper.sh` `VALID_COMPONENTS`, `scripts/project_routing.json`.

https://claude.ai/code/session_015HHppoaQi3E6pvEJpHoyqB

---
_Generated by [Claude Code](https://claude.ai/code/session_015HHppoaQi3E6pvEJpHoyqB)_