### PR TITLE
fix(atlas): fail-soft research nodes — one empty LLM body can't abort the run

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -18,11 +18,11 @@ from pydantic import BaseModel
 from digigraph.graph.research_agent import run_research_agent
 from digigraph.model_config import get_model_for_mode, get_model_for_phase
 
+from digiquant.olympus.atlas.phases.fail_soft import run_segment_fail_soft
 from digiquant.olympus.atlas.skills import load_skill
 from digiquant.olympus.atlas.state import (
     AtlasResearchState,
     Carried,
-    SegmentPayload,
     SegmentSlot,
 )
 
@@ -326,22 +326,30 @@ def build_segment_node(
         if web_grounding:
             inputs = {**inputs, "web_grounding": web_grounding}
 
-        result = run_research_agent(
-            skill_text=skill_text,
-            phase_inputs=inputs,
-            shared_context=shared,
-            output_model=spec.output_model,
-            model=model,
-            phase_slug=spec.segment_slug,
-            tools=tools,
-            execute_tool=execute_tool,
+        # Fail-soft: an empty/invalid LLM body or transient provider error degrades
+        # this one segment to a Carried slot + a PhaseError instead of aborting the
+        # whole run. Only the LLM call is wrapped; the input prep above stays outside
+        # the thunk so genuine wiring bugs still fail loud.
+        slot, errors = run_segment_fail_soft(
+            run_fn=lambda: run_research_agent(
+                skill_text=skill_text,
+                phase_inputs=inputs,
+                shared_context=shared,
+                output_model=spec.output_model,
+                model=model,
+                phase_slug=spec.segment_slug,
+                tools=tools,
+                execute_tool=execute_tool,
+            ),
+            segment_slug=spec.segment_slug,
+            phase=spec.phase_outputs_field,
+            run_date=state.run_date,
+            baseline_date=state.baseline_date,
         )
-        payload = SegmentPayload(
-            segment=spec.segment_slug,
-            body=result.model_dump(mode="json"),
-            as_of=state.run_date,
-        )
-        return write_adapter(spec, SegmentSlot(payload=payload))
+        update = write_adapter(spec, slot)
+        if errors:
+            update["errors"] = errors
+        return update
 
     return _node
 

--- a/digiquant/src/digiquant/olympus/atlas/phases/fail_soft.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/fail_soft.py
@@ -1,0 +1,99 @@
+"""Fail-soft execution wrapper for Atlas research nodes (Pillar 1A).
+
+A single research node that gets an empty/invalid LLM body (or a transient
+provider error) must not abort the whole run. Before this, an empty OpenRouter
+response made ``run_research_agent`` raise ``JSONDecodeError`` after its retries,
+the exception propagated through LangGraph, and the entire Atlas→Hermes chain
+died **before publish + materialize** — so 19 healthy phases' work and the paper
+book were lost to one bad sector call.
+
+``run_segment_fail_soft`` runs the node's research call and, on any recoverable
+failure, degrades the segment to an explicit ``Carried`` slot (read the prior
+baseline payload for this segment) plus a ``PhaseError`` the caller merges into
+``state.errors`` for the diagnostics audit row — instead of raising. A data gap
+thus yields a *more conservative* book (one stale segment), never a crashed run.
+
+This is a **deliberate, observable** degrade boundary, not a silent swallow: every
+failure is logged at WARNING with the exception type and recorded as a structured
+``PhaseError`` that surfaces in ``atlas_run_diagnostics``. ``KeyboardInterrupt`` /
+``SystemExit`` (``BaseException``) still propagate.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import date
+
+from pydantic import BaseModel
+
+from digiquant.olympus.atlas.state import (
+    Carried,
+    PhaseError,
+    SegmentPayload,
+    SegmentSlot,
+)
+
+logger = logging.getLogger(__name__)
+
+NODE_FAILED_REASON = "node_failed_no_data"
+"""``Carried.reason`` marker distinguishing a node FAILURE carry from a triage carry."""
+
+
+def run_segment_fail_soft(
+    *,
+    run_fn: Callable[[], BaseModel],
+    segment_slug: str,
+    phase: str,
+    run_date: date,
+    baseline_date: date | None,
+) -> tuple[SegmentSlot, list[PhaseError]]:
+    """Run one research node's LLM call, degrading any failure to a Carried slot.
+
+    Args:
+        run_fn: Thunk that performs ONLY the ``run_research_agent(...)`` call and
+            returns its validated model. Input preparation (skill load, grounding,
+            inputs_builder) must happen *outside* the thunk so genuine wiring bugs
+            still fail loud — only the LLM call + validation is made fail-soft.
+        segment_slug: The segment this node owns (becomes ``PhaseError.node`` and
+            the fresh payload's ``segment``).
+        phase: The owning phase label (e.g. ``"phase5_outputs"``) for ``PhaseError.phase``.
+        run_date: Run date for the fresh payload's ``as_of`` and the carry fallback.
+        baseline_date: Baseline the carry points at (falls back to ``run_date``).
+
+    Returns:
+        ``(slot, errors)`` — on success a fresh ``SegmentPayload`` slot and ``[]``;
+        on a recoverable failure a ``Carried`` slot and a single-element error list
+        the caller merges into ``state.errors``.
+    """
+    try:
+        result = run_fn()
+        slot = SegmentSlot(
+            payload=SegmentPayload(
+                segment=segment_slug,
+                body=result.model_dump(mode="json"),
+                as_of=run_date,
+            )
+        )
+        return slot, []
+    except Exception as exc:  # noqa: BLE001 — deliberate fail-soft boundary; see module docstring
+        logger.warning(
+            "atlas node %r (phase %s) failed (%s: %s); carrying baseline forward",
+            segment_slug,
+            phase,
+            type(exc).__name__,
+            exc,
+        )
+        slot = SegmentSlot(
+            payload=Carried(baseline_date=baseline_date or run_date, reason=NODE_FAILED_REASON)
+        )
+        error = PhaseError(
+            phase=phase,
+            node=segment_slug,
+            message=f"{type(exc).__name__}: {exc}"[:500],
+            retryable=True,
+        )
+        return slot, [error]
+
+
+__all__ = ["NODE_FAILED_REASON", "run_segment_fail_soft"]

--- a/digiquant/src/digiquant/olympus/atlas/phases/fail_soft.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/fail_soft.py
@@ -83,6 +83,7 @@ def run_segment_fail_soft(
             phase,
             type(exc).__name__,
             exc,
+            exc_info=True,  # keep the stack trace — this is an observable degrade, not a swallow
         )
         slot = SegmentSlot(
             payload=Carried(baseline_date=baseline_date or run_date, reason=NODE_FAILED_REASON)

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase5_equities.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase5_equities.py
@@ -11,6 +11,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import Field
 
 from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.phases.fail_soft import run_segment_fail_soft
 from digiquant.olympus.atlas.sectors_config import SectorConfig, load_sectors
 from digiquant.olympus.atlas.segments import Bias, SegmentReport
 from digiquant.olympus.atlas.state import AtlasResearchState, SegmentPayload, SegmentSlot
@@ -71,22 +72,28 @@ def _equity_node(state: AtlasResearchState) -> dict[str, Any]:
     tools, execute_tool, _ = build_grounding(
         use_data_tools=True, live_search=False, run_date=state.run_date
     )
-    result = run_research_agent(
-        skill_text=skill_text,
-        phase_inputs=phase_inputs,
-        shared_context=_shared_context(state, context_keys=("equity", "macro")),
-        output_model=EquityOverviewReport,
-        phase_slug="equity",
-        tools=tools,
-        execute_tool=execute_tool,
-    )
-    payload = SegmentPayload(
-        segment="equity",
-        body=result.model_dump(mode="json"),
-        as_of=state.run_date,
+    # Fail-soft: degrade an empty/invalid equity call to a Carried slot + PhaseError
+    # rather than aborting the run (Pillar 1A).
+    slot, errors = run_segment_fail_soft(
+        run_fn=lambda: run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=phase_inputs,
+            shared_context=_shared_context(state, context_keys=("equity", "macro")),
+            output_model=EquityOverviewReport,
+            phase_slug="equity",
+            tools=tools,
+            execute_tool=execute_tool,
+        ),
+        segment_slug="equity",
+        phase="phase5_outputs",
+        run_date=state.run_date,
+        baseline_date=state.baseline_date,
     )
     # Equity is a single slot — same pattern as macro.
-    return {"phase5_outputs": {"equity": SegmentSlot(payload=payload)}}
+    update: dict[str, Any] = {"phase5_outputs": {"equity": slot}}
+    if errors:
+        update["errors"] = errors
+    return update
 
 
 # ─── Sector node factory ────────────────────────────────────────────────────
@@ -123,21 +130,29 @@ def _sector_node_factory(sector: SectorConfig):
         tools, execute_tool, _ = build_grounding(
             use_data_tools=True, live_search=False, run_date=state.run_date
         )
-        result = run_research_agent(
-            skill_text=skill_text,
-            phase_inputs=phase_inputs,
-            shared_context=_shared_context(state, context_keys=(sector.slug, "equity", "macro")),
-            output_model=SectorReport,
-            phase_slug=sector.slug,
-            tools=tools,
-            execute_tool=execute_tool,
+        # Fail-soft: one bad sector call degrades to a Carried slot + PhaseError
+        # instead of aborting all 11 sectors and the downstream book (Pillar 1A).
+        slot, errors = run_segment_fail_soft(
+            run_fn=lambda: run_research_agent(
+                skill_text=skill_text,
+                phase_inputs=phase_inputs,
+                shared_context=_shared_context(
+                    state, context_keys=(sector.slug, "equity", "macro")
+                ),
+                output_model=SectorReport,
+                phase_slug=sector.slug,
+                tools=tools,
+                execute_tool=execute_tool,
+            ),
+            segment_slug=sector.slug,
+            phase="phase5_outputs",
+            run_date=state.run_date,
+            baseline_date=state.baseline_date,
         )
-        payload = SegmentPayload(
-            segment=sector.slug,
-            body=result.model_dump(mode="json"),
-            as_of=state.run_date,
-        )
-        return {"phase5_outputs": {sector.slug: SegmentSlot(payload=payload)}}
+        update: dict[str, Any] = {"phase5_outputs": {sector.slug: slot}}
+        if errors:
+            update["errors"] = errors
+        return update
 
     return _node
 

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -99,6 +99,17 @@ def _merge_specialist_dict(
     return merged
 
 
+def _merge_append_list[T](left: list[T] | None, right: list[T] | None) -> list[T]:
+    """Reducer for append-only ledgers written concurrently (e.g. ``state.errors``).
+
+    Parallel fan-out nodes (11 sectors, 5 alt-data) each return ``{"errors": [...]}``
+    for their own recoverable failure; without an append reducer LangGraph's default
+    last-writer-wins would drop all but one. Concatenate so every node's
+    ``PhaseError`` survives the fan-in into the diagnostics audit row.
+    """
+    return [*(left or []), *(right or [])]
+
+
 RunType = Literal["baseline", "delta", "monthly"]
 """Three-tier cadence: Sunday full, weekday delta, month-end rollup."""
 
@@ -323,9 +334,9 @@ class AtlasResearchState(BaseModel):
     - Frozen context (config, prior_context, data_layer) — shared-context cache key.
     - Per-phase outputs as ``dict[str, SegmentSlot]`` keyed by segment slug.
     - Triage result (delta runs only).
-    - Side-effect ledgers (``published``, ``errors``) — append-only by
-      convention. Phase nodes should use ``list.append`` (never reassign).
-      A future commit may replace with an ``Annotated[list, add]`` reducer.
+    - Side-effect ledgers (``published``, ``errors``). ``errors`` uses an
+      append reducer (``_merge_append_list``) so concurrent per-node writes
+      concatenate; ``published`` stays append-by-convention (single-node writer).
     """
 
     run_id: UUID = Field(default_factory=uuid4)
@@ -397,4 +408,7 @@ class AtlasResearchState(BaseModel):
         description="Per-ticker fractional pct_change from triage.",
     )
     published: list[PublishedArtifact] = Field(default_factory=list)
-    errors: list[PhaseError] = Field(default_factory=list)
+    # Append reducer (not last-writer-wins): parallel fan-out nodes each record
+    # their own recoverable failure via ``{"errors": [PhaseError(...)]}``; the
+    # reducer concatenates them so none are lost before the diagnostics row.
+    errors: Annotated[list[PhaseError], _merge_append_list] = Field(default_factory=list)

--- a/tests/dq/atlas/test_fail_soft.py
+++ b/tests/dq/atlas/test_fail_soft.py
@@ -1,0 +1,176 @@
+"""Tests for fail-soft research nodes (Pillar 1A).
+
+A single empty/invalid LLM response (or transient provider error) must degrade
+ONE segment to a Carried slot + PhaseError, never abort the whole run. Regression
+guard for the live 2026-06-14 baseline that died when ``sector-utilities`` got an
+empty OpenRouter body.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.phases.fail_soft import (
+    NODE_FAILED_REASON,
+    run_segment_fail_soft,
+)
+from digiquant.olympus.atlas.phases.phase5_equities import (
+    EquityOverviewReport,
+    build_phase5,
+)
+from digiquant.olympus.atlas.state import (
+    AtlasResearchState,
+    PhaseError,
+    SegmentPayload,
+    SegmentSlot,
+    _merge_append_list,
+)
+
+
+@pytest.mark.unit
+class TestMergeAppendList:
+    def test_concatenates_left_then_right(self) -> None:
+        left = [PhaseError(phase="p", node="a", message="x")]
+        right = [PhaseError(phase="p", node="b", message="y")]
+        merged = _merge_append_list(left, right)
+        assert [e.node for e in merged] == ["a", "b"]
+
+    def test_handles_none_sides(self) -> None:
+        e = [PhaseError(phase="p", node="a", message="x")]
+        assert _merge_append_list(None, e) == e
+        assert _merge_append_list(e, None) == e
+        assert _merge_append_list(None, None) == []
+
+    def test_does_not_mutate_inputs(self) -> None:
+        left = [PhaseError(phase="p", node="a", message="x")]
+        _merge_append_list(left, [PhaseError(phase="p", node="b", message="y")])
+        assert len(left) == 1  # left untouched
+
+
+@pytest.mark.unit
+class TestRunSegmentFailSoft:
+    def test_success_returns_fresh_slot_no_errors(self) -> None:
+        model = EquityOverviewReport(
+            segment="equity", date=date(2026, 6, 14), bias="neutral", headline="ok"
+        )
+        slot, errors = run_segment_fail_soft(
+            run_fn=lambda: model,
+            segment_slug="equity",
+            phase="phase5_outputs",
+            run_date=date(2026, 6, 14),
+            baseline_date=None,
+        )
+        assert errors == []
+        assert slot.payload.source == "today"
+        assert isinstance(slot.payload, SegmentPayload)
+        assert slot.payload.body["headline"] == "ok"
+
+    def test_failure_degrades_to_carried_with_error(self) -> None:
+        def boom() -> EquityOverviewReport:
+            raise ValueError("empty body")
+
+        slot, errors = run_segment_fail_soft(
+            run_fn=boom,
+            segment_slug="sector-utilities",
+            phase="phase5_outputs",
+            run_date=date(2026, 6, 14),
+            baseline_date=date(2026, 6, 7),
+        )
+        # Carried, pointing at the baseline, marked as a node failure (not a triage carry).
+        assert slot.payload.source == "carried"
+        assert slot.payload.reason == NODE_FAILED_REASON  # type: ignore[union-attr]
+        assert slot.payload.baseline_date == date(2026, 6, 7)  # type: ignore[union-attr]
+        # One structured, attributable error.
+        assert len(errors) == 1
+        assert errors[0].node == "sector-utilities"
+        assert errors[0].phase == "phase5_outputs"
+        assert "ValueError" in errors[0].message
+
+    def test_carried_falls_back_to_run_date_when_no_baseline(self) -> None:
+        def boom() -> EquityOverviewReport:
+            raise RuntimeError("provider 500")
+
+        slot, _ = run_segment_fail_soft(
+            run_fn=boom,
+            segment_slug="macro",
+            phase="phase3_output",
+            run_date=date(2026, 6, 14),
+            baseline_date=None,
+        )
+        assert slot.payload.baseline_date == date(2026, 6, 14)  # type: ignore[union-attr]
+
+    def test_message_is_truncated(self) -> None:
+        def boom() -> EquityOverviewReport:
+            raise ValueError("x" * 1000)
+
+        _, errors = run_segment_fail_soft(
+            run_fn=boom,
+            segment_slug="s",
+            phase="p",
+            run_date=date(2026, 6, 14),
+            baseline_date=None,
+        )
+        assert len(errors[0].message) <= 500
+
+
+@pytest.mark.unit
+class TestPhase5FailSoftIntegration:
+    """Drive the real Phase 5 pipeline with an empty LLM body — it must NOT raise."""
+
+    def _seed(self) -> AtlasResearchState:
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 14))
+        state.phase3_output = SegmentSlot(
+            payload=SegmentPayload(
+                segment="macro",
+                body={"regime_label": "Slowing / Cooling / Neutral / Mixed"},
+                as_of=date(2026, 6, 14),
+            )
+        )
+        return state
+
+    def test_empty_response_carries_every_segment_and_records_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import patch
+
+        from digigraph.graph.pipeline_builder import build_pipeline
+
+        # Force the no-tools path so completion_text is the LLM seam we mock.
+        monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+
+        compiled = build_pipeline(AtlasResearchState, build_phase5())
+        state = self._seed()
+
+        # Empty body → json.loads("") raises → run_research_agent exhausts retries
+        # and raises → fail-soft degrades the segment. The run must complete.
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            side_effect=lambda *a, **k: "",
+        ):
+            result = compiled.invoke(state)
+
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        # Equity + 11 sectors all degraded to carried (the scorecard is deterministic).
+        assert final.phase5_outputs["equity"].payload.source == "carried"
+        sector_slugs = [
+            k for k in final.phase5_outputs if k.startswith("sector-") and k != "sector-scorecard"
+        ]
+        assert len(sector_slugs) == 11
+        assert all(final.phase5_outputs[s].payload.source == "carried" for s in sector_slugs)
+
+        # Every failure is recorded (append reducer kept all 12 across the fan-in),
+        # and all marked as node-failure carries.
+        assert len(final.errors) == 12
+        assert {e.phase for e in final.errors} == {"phase5_outputs"}
+        carried_reasons = {
+            final.phase5_outputs[s].payload.reason  # type: ignore[union-attr]
+            for s in sector_slugs
+        }
+        assert carried_reasons == {NODE_FAILED_REASON}
+
+        # Deterministic scorecard still ran — with no fresh sectors it has 0 rows.
+        scorecard = final.phase5_outputs["sector-scorecard"].payload.body  # type: ignore[union-attr]
+        assert scorecard["rows"] == []


### PR DESCRIPTION
## What
The first chunk of the Olympus overhaul (#726, Pillar 1A). Makes a single research node's empty/invalid LLM response **degrade gracefully** instead of aborting the entire Atlas→Hermes run.

## Why
The live 2026-06-14 baseline **crashed**: `sector-utilities` got an empty OpenRouter body, `run_research_agent` raised `JSONDecodeError` after its retries, and the exception propagated through LangGraph — aborting the whole chain **before publish + materialize**. 19 healthy phases' work and the paper book were lost to one bad sector call. (CI only survives this via the workflow's 3-attempt outer retry; a bare run has no safety net.)

## Change
- New `olympus/atlas/phases/fail_soft.py::run_segment_fail_soft` — wraps a node's LLM call; on failure returns a `Carried` slot (reason `node_failed_no_data`, pointing at the prior baseline) + a structured `PhaseError`, instead of raising. Deliberate, **observable** degrade (WARNING log + PhaseError), not a silent swallow.
- Wired the **three** research-node call sites: `_node_factory` segment node, `phase5_equities` equity + sector nodes. Only the LLM call is wrapped — input prep stays outside so genuine wiring bugs still fail loud.
- `state.py`: `errors` now uses an append reducer (`_merge_append_list`) so concurrent per-node failures concatenate across the parallel fan-in (11 sectors + 5 alt-data) instead of last-writer-wins dropping all but one. (state.py's own docstring anticipated this exact change.)

A data gap now yields a *more conservative* book (one stale segment), never a crashed run.

## Validation
- New `tests/dq/atlas/test_fail_soft.py` (8 tests): wrapper success/failure paths, reducer, and an **integration test** driving the real Phase 5 pipeline with an empty body → all 12 segments degrade to Carried + 12 errors recorded + run completes (the exact regression).
- Full atlas + hermes suite: **442 passed**, 0 regressions.
- `make score`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

Part of #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)