### PR TITLE
feat(atlas): generic scoped data reader (query_data) via digibase connector

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -7,6 +7,7 @@ not full history. Selected technical columns only — the model gets signal, not
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date, timedelta
 from typing import Any  # noqa  # scored-lint suppression: duck-typed Supabase client + rows
 
@@ -295,6 +296,11 @@ ALLOWED_READ_TABLES: frozenset[str] = frozenset(
 
 _MAX_QUERY_ROWS = 500
 
+# columns must be "*" or a comma-separated list of bare column names. This blocks
+# PostgREST relationship/embedding syntax (e.g. "*,decision_log(*)") that would
+# otherwise read a NON-whitelisted table through an embedded select.
+_SAFE_COLUMNS_RE = re.compile(r"^(\*|[A-Za-z_][A-Za-z0-9_]*(\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*)$")
+
 
 def query_data(
     *,
@@ -319,12 +325,16 @@ def query_data(
         return {
             "error": f"table {table!r} is not readable; choose one of {sorted(ALLOWED_READ_TABLES)}"
         }
+    safe_columns = (columns or "*").strip()
+    if not _SAFE_COLUMNS_RE.fullmatch(safe_columns):
+        # Block PostgREST relationship/embedding syntax that could reach other tables.
+        return {"error": "columns must be '*' or a comma-separated list of plain column names"}
     from digibase.connectors.supabase import SupabaseConnector
 
     capped = max(1, min(int(limit), _MAX_QUERY_ROWS))
     result = SupabaseConnector(client).select(
         table,
-        columns or "*",
+        safe_columns,
         eq=eq or None,
         gte=gte or None,
         lte=lte or None,

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -269,3 +269,70 @@ def get_vix_term_structure(*, client: Any, run_date: date) -> dict[str, Any]:
         "ratio": round(spot_f / three_m_f, 3) if three_m_f else None,
         "state": "backwardation" if spot_f > three_m_f else "contango",
     }
+
+
+# ── Generic scoped data reader (Pillar 1D) ───────────────────────────────────
+#
+# One read-only, table-whitelisted reader the agents + PM call via the ``query_data``
+# tool — backed by the shared ``digibase`` Supabase connector, so we don't hand-roll
+# a bespoke tool per table or hand the model raw SQL. Scoped to the market-data +
+# paper-book tables; operator-internal telemetry (decision_log, atlas_run_diagnostics)
+# is deliberately NOT readable.
+ALLOWED_READ_TABLES: frozenset[str] = frozenset(
+    {
+        "price_history",
+        "price_technicals",
+        "macro_series_observations",
+        "positions",
+        "nav_history",
+        "theses",
+        "thesis_vehicles",
+        "position_events",
+        "portfolio_metrics",
+        "trading_calendar",
+    }
+)
+
+_MAX_QUERY_ROWS = 500
+
+
+def query_data(
+    *,
+    client: Any,
+    table: str,
+    columns: str = "*",
+    eq: dict[str, Any] | None = None,
+    gte: dict[str, Any] | None = None,
+    lte: dict[str, Any] | None = None,
+    in_: dict[str, list[Any] | tuple[Any, ...]] | None = None,
+    order: str | None = None,
+    desc: bool = True,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Read rows from a whitelisted market-data table via the digibase connector.
+
+    Read-only and table-scoped: a table outside :data:`ALLOWED_READ_TABLES` is
+    refused (the error is returned to the model, not raised). ``limit`` is capped
+    at :data:`_MAX_QUERY_ROWS` so one tool call can't pull unbounded rows.
+    """
+    if table not in ALLOWED_READ_TABLES:
+        return {
+            "error": f"table {table!r} is not readable; choose one of {sorted(ALLOWED_READ_TABLES)}"
+        }
+    from digibase.connectors.supabase import SupabaseConnector
+
+    capped = max(1, min(int(limit), _MAX_QUERY_ROWS))
+    result = SupabaseConnector(client).select(
+        table,
+        columns or "*",
+        eq=eq or None,
+        gte=gte or None,
+        lte=lte or None,
+        in_=in_ or None,
+        order=order,
+        desc=desc,
+        limit=capped,
+    )
+    if not result.success:
+        return {"error": result.error}
+    return {"table": table, "row_count": len(result.rows), "rows": result.rows}

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -18,11 +18,51 @@ from digiquant.olympus.atlas.data.queries import (
     get_price_technicals,
     get_sector_relative_strength,
     get_vix_term_structure,
+    query_data,
 )
 
 logger = logging.getLogger(__name__)
 
 DATA_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "query_data",
+            "description": (
+                "Generic read of any market-data table to ground a claim in real numbers "
+                "(backed by digibase, scoped read-only to the data tables). Allowed tables: "
+                "price_history (daily OHLCV), price_technicals (sma/rsi/macd/adx/atr/bb/"
+                "zscore indicators per ticker), macro_series_observations (FRED macro by "
+                "series_id: VIXCLS, DGS10, T10Y2Y, M2SL, DFF, DTWEXBGS, T10YIE), positions, "
+                "nav_history, theses, position_events, portfolio_metrics, trading_calendar. "
+                "Filter with eq/gte/lte/in, sort with order+desc, cap with limit. Examples: "
+                "{table:'price_technicals', eq:{ticker:'XLK'}, order:'date', desc:true, "
+                "limit:20} or {table:'macro_series_observations', eq:{series_id:'DGS10'}, "
+                "order:'obs_date', desc:true, limit:6}."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "table": {"type": "string", "description": "One of the allowed tables."},
+                    "columns": {
+                        "type": "string",
+                        "description": "Comma-separated columns, or '*' (default).",
+                    },
+                    "eq": {"type": "object", "description": "Equality filters {column: value}."},
+                    "gte": {"type": "object", "description": ">= filters {column: value}."},
+                    "lte": {"type": "object", "description": "<= filters {column: value}."},
+                    "in_": {
+                        "type": "object",
+                        "description": "Membership filters {column: [values]}.",
+                    },
+                    "order": {"type": "string", "description": "Column to sort by."},
+                    "desc": {"type": "boolean", "description": "Sort descending (default true)."},
+                    "limit": {"type": "integer", "description": "Max rows (default 50, max 500)."},
+                },
+                "required": ["table"],
+            },
+        },
+    },
     {
         "type": "function",
         "function": {
@@ -140,7 +180,20 @@ def build_data_tool_dispatcher(
 
     def execute_tool(name: str, args: dict[str, Any]) -> str:
         try:
-            if name == "get_price_technicals":
+            if name == "query_data":
+                result = query_data(
+                    client=client,
+                    table=args["table"],
+                    columns=str(args.get("columns", "*")),
+                    eq=args.get("eq"),
+                    gte=args.get("gte"),
+                    lte=args.get("lte"),
+                    in_=args.get("in_"),
+                    order=args.get("order"),
+                    desc=bool(args.get("desc", True)),
+                    limit=int(args.get("limit", 50)),
+                )
+            elif name == "get_price_technicals":
                 result = get_price_technicals(
                     client=client, ticker=args["ticker"], lookback=int(args.get("lookback", 20))
                 )

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -34,8 +34,9 @@ DATA_TOOLS: list[dict[str, Any]] = [
                 "price_history (daily OHLCV), price_technicals (sma/rsi/macd/adx/atr/bb/"
                 "zscore indicators per ticker), macro_series_observations (FRED macro by "
                 "series_id: VIXCLS, DGS10, T10Y2Y, M2SL, DFF, DTWEXBGS, T10YIE), positions, "
-                "nav_history, theses, position_events, portfolio_metrics, trading_calendar. "
-                "Filter with eq/gte/lte/in, sort with order+desc, cap with limit. Examples: "
+                "nav_history, theses, thesis_vehicles, position_events, portfolio_metrics, "
+                "trading_calendar. Filter with eq/gte/lte/in_, sort with order+desc, cap with "
+                "limit. Examples: "
                 "{table:'price_technicals', eq:{ticker:'XLK'}, order:'date', desc:true, "
                 "limit:20} or {table:'macro_series_observations', eq:{series_id:'DGS10'}, "
                 "order:'obs_date', desc:true, limit:6}."
@@ -167,6 +168,16 @@ DATA_TOOLS: list[dict[str, Any]] = [
 ]
 
 
+def _coerce_bool(value: Any, *, default: bool = True) -> bool:
+    """Coerce a tool-call arg to bool. Tool args may arrive as strings, so treat
+    'false'/'0'/'no'/'' as False rather than letting ``bool('false')`` be True."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() not in ("false", "0", "no", "")
+
+
 def build_data_tool_dispatcher(
     client: Any, run_date: date | None = None
 ) -> Callable[[str, dict[str, Any]], str]:
@@ -190,7 +201,7 @@ def build_data_tool_dispatcher(
                     lte=args.get("lte"),
                     in_=args.get("in_"),
                     order=args.get("order"),
-                    desc=bool(args.get("desc", True)),
+                    desc=_coerce_bool(args.get("desc", True)),
                     limit=int(args.get("limit", 50)),
                 )
             elif name == "get_price_technicals":

--- a/tests/dq/atlas/data/test_queries_derived.py
+++ b/tests/dq/atlas/data/test_queries_derived.py
@@ -223,6 +223,22 @@ class TestQueryData:
         assert "atlas_run_diagnostics" not in ALLOWED_READ_TABLES
         assert {"price_history", "price_technicals", "positions"} <= ALLOWED_READ_TABLES
 
+    def test_rejects_relationship_columns(self) -> None:
+        # PostgREST embedded-select (e.g. "*,decision_log(*)") must not reach a
+        # non-whitelisted table through the columns arg — security regression guard.
+        client = _FakeClient({"positions": [{"ticker": "SPY"}]})
+        out = query_data(client=client, table="positions", columns="*, decision_log(*)")
+        assert "error" in out
+        assert "columns" in out["error"]
+        assert "rows" not in out
+
+    def test_allows_plain_column_list(self) -> None:
+        client = _FakeClient(
+            {"price_history": [{"date": "2026-06-15", "close": 1.0, "ticker": "A"}]}
+        )
+        out = query_data(client=client, table="price_history", columns="date, close")
+        assert out["row_count"] == 1
+
 
 @pytest.mark.unit
 class TestToolDispatcher:

--- a/tests/dq/atlas/data/test_queries_derived.py
+++ b/tests/dq/atlas/data/test_queries_derived.py
@@ -13,10 +13,12 @@ from datetime import date
 import pytest
 
 from digiquant.olympus.atlas.data.queries import (
+    ALLOWED_READ_TABLES,
     get_market_breadth,
     get_price_history,
     get_sector_relative_strength,
     get_vix_term_structure,
+    query_data,
 )
 from digiquant.olympus.atlas.data.tools import DATA_TOOLS, build_data_tool_dispatcher
 
@@ -184,15 +186,65 @@ class TestReaders:
 
 
 @pytest.mark.unit
+class TestQueryData:
+    def test_reads_whitelisted_table_with_eq_filter(self) -> None:
+        client = _FakeClient(
+            {
+                "price_technicals": [
+                    {"ticker": "XLK", "date": "2026-06-15", "rsi_14": 60.0},
+                    {"ticker": "XLF", "date": "2026-06-15", "rsi_14": 50.0},
+                ]
+            }
+        )
+        out = query_data(client=client, table="price_technicals", eq={"ticker": "XLK"})
+        assert out["table"] == "price_technicals"
+        assert out["row_count"] == 1
+        assert out["rows"][0]["ticker"] == "XLK"
+
+    def test_rejects_non_whitelisted_table(self) -> None:
+        # Operator-internal tables must not be readable via the generic tool.
+        client = _FakeClient({"decision_log": [{"id": 1}]})
+        out = query_data(client=client, table="decision_log")
+        assert "error" in out
+        assert "not readable" in out["error"]
+        assert "rows" not in out
+
+    def test_limit_passthrough(self) -> None:
+        rows = [
+            {"ticker": "A", "date": f"2026-06-{d:02d}", "close": float(d)} for d in range(1, 11)
+        ]
+        out = query_data(
+            client=_FakeClient({"price_history": rows}), table="price_history", limit=3
+        )
+        assert out["row_count"] == 3
+
+    def test_whitelist_excludes_operator_tables(self) -> None:
+        assert "decision_log" not in ALLOWED_READ_TABLES
+        assert "atlas_run_diagnostics" not in ALLOWED_READ_TABLES
+        assert {"price_history", "price_technicals", "positions"} <= ALLOWED_READ_TABLES
+
+
+@pytest.mark.unit
 class TestToolDispatcher:
     def test_new_tools_registered(self) -> None:
         names = {t["function"]["name"] for t in DATA_TOOLS}
         assert {
+            "query_data",
             "get_price_history",
             "get_market_breadth",
             "get_sector_relative_strength",
             "get_vix_term_structure",
         } <= names
+
+    def test_dispatch_query_data(self) -> None:
+        client = _FakeClient(
+            {"price_technicals": [{"ticker": "XLK", "date": "2026-06-15", "rsi_14": 60.0}]}
+        )
+        execute = build_data_tool_dispatcher(client)
+        result = json.loads(
+            execute("query_data", {"table": "price_technicals", "eq": {"ticker": "XLK"}})
+        )
+        assert result["rows"][0]["ticker"] == "XLK"
 
     def test_dispatch_breadth_returns_json(self) -> None:
         client = _FakeClient({"price_technicals": _breadth_rows()})

--- a/tests/dq/atlas/data/test_tools.py
+++ b/tests/dq/atlas/data/test_tools.py
@@ -12,6 +12,7 @@ from tests.dq.atlas.data.test_queries import _FakeClient
 def test_tool_definitions_shape():
     names = {t["function"]["name"] for t in DATA_TOOLS}
     assert names == {
+        "query_data",
         "get_price_technicals",
         "get_macro_series",
         "get_price_history",

--- a/tests/dq/atlas/data/test_tools.py
+++ b/tests/dq/atlas/data/test_tools.py
@@ -26,6 +26,21 @@ def test_tool_definitions_shape():
 
 
 @pytest.mark.unit
+def test_coerce_bool_handles_string_args():
+    from digiquant.olympus.atlas.data.tools import _coerce_bool
+
+    assert _coerce_bool(True) is True
+    assert _coerce_bool(False) is False
+    # Tool args sometimes arrive as strings — "false" must not become True.
+    assert _coerce_bool("false") is False
+    assert _coerce_bool("0") is False
+    assert _coerce_bool("no") is False
+    assert _coerce_bool("true") is True
+    assert _coerce_bool(None, default=True) is True
+    assert _coerce_bool(None, default=False) is False
+
+
+@pytest.mark.unit
 def test_dispatcher_routes_and_returns_json_string():
     client = _FakeClient(
         {


### PR DESCRIPTION
## What
Adds **`query_data`** — one generic, read-only, **table-scoped** data tool the research agents and PM call to ground claims in real numbers, backed by the **shared `digibase.connectors.supabase.SupabaseConnector`** (no bespoke per-table tool, no raw SQL). Your direction: *use digibase, scoped to the data tables.*

## Why this shape (not the Supabase MCP directly)
The headless Atlas/Hermes pipeline (OpenRouter) is **not an MCP client** — confirmed repo-wide: the LLM only calls in-process function-tools via `chat_completion_with_tools`. Using the hosted Supabase MCP would mean building an MCP client + adapter into the pipeline AND solving that MCP's interactive auth in CI (an external hosted dependency, against cheap/self-hostable). digibase already ships the connector and is already a digiquant dep, so this reuses it with **zero new dependency** and **no MCP-client lift**.

## Change
- `query_data(table, columns?, eq/gte/lte/in_?, order?, desc?, limit?)` → `SupabaseConnector(client).select(...)`. `ALLOWED_READ_TABLES` whitelists the market-data + paper-book tables (price_history, price_technicals, macro_series_observations, positions, nav_history, theses, thesis_vehicles, position_events, portfolio_metrics, trading_calendar); **operator-internal telemetry (decision_log, atlas_run_diagnostics) is not readable**. `limit` capped at 500. A disallowed table returns an error to the model (not raised).
- Registered as a DATA_TOOL + dispatcher branch.

## Scope / sequencing
Additive: the typed `get_price_technicals`/`get_macro_series` tools remain for now because **~9 Atlas skill prompts name them**. Consolidating those onto `query_data` + the forceful "ground every claim in tool-fetched numbers" rewrite is the **next step (grounding prompts)** — done once, properly, rather than a rushed 9-file skill edit here. (`get_price_history` left in place too; retired with the others next step.)

## Validation
- New `query_data` tests: whitelist enforcement (rejects `decision_log`), eq filter, limit pass-through, dispatcher routing; whitelist excludes operator tables.
- **450 atlas + data tests pass**, 0 regressions. `make score`: 10 / 10 / 10 / 10.

Part of #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)