### PR TITLE
feat(atlas): consolidate raw tools onto query_data + tool-grounding skill prompts

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -143,20 +143,6 @@ _VIX_SPOT_SERIES = "VIXCLS"
 _VIX_3M_SERIES = "VXVCLS"
 
 
-def get_price_history(*, client: Any, ticker: str, lookback: int = 60) -> dict[str, Any]:
-    """Raw OHLCV daily bars for one ticker — ``{ticker, latest, window[]}`` newest-first."""
-    resp = (
-        client.table("price_history")
-        .select("date,open,high,low,close,volume")
-        .eq("ticker", ticker)
-        .order("date", desc=True)
-        .limit(lookback)
-        .execute()
-    )
-    rows = getattr(resp, "data", None) or []
-    return {"ticker": ticker, "latest": rows[0] if rows else {}, "window": rows}
-
-
 def default_sector_etfs() -> list[str]:
     """Headline ETF per configured sector (relative-strength universe)."""
     try:

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -14,8 +14,6 @@ from typing import Any, Callable  # noqa  # scored-lint suppression: duck-typed 
 from digiquant.olympus.atlas.data.queries import (
     get_macro_series,
     get_market_breadth,
-    get_price_history,
-    get_price_technicals,
     get_sector_relative_strength,
     get_vix_term_structure,
     query_data,
@@ -67,28 +65,6 @@ DATA_TOOLS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {
-            "name": "get_price_technicals",
-            "description": (
-                "Latest technical indicators (sma/rsi/macd/adx/atr/zscore, etc.) plus a "
-                "recent daily window for one ticker (e.g. SPY, XLK, TLT). Use to ground "
-                "trend, momentum, and relative-strength claims on real data."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "ticker": {"type": "string", "description": "Ticker symbol, e.g. SPY."},
-                    "lookback": {
-                        "type": "integer",
-                        "description": "Recent trading days (default 20).",
-                    },
-                },
-                "required": ["ticker"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
             "name": "get_macro_series",
             "description": (
                 "Latest values + recent window for FRED macro series ids (e.g. M2SL, DFF, "
@@ -104,28 +80,6 @@ DATA_TOOLS: list[dict[str, Any]] = [
                     },
                 },
                 "required": ["series_ids"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_price_history",
-            "description": (
-                "Raw daily OHLCV bars (open/high/low/close/volume) for one ticker, newest "
-                "first. Use when you need actual price levels, returns, gaps, or volume — "
-                "not just the pre-computed indicators."
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "ticker": {"type": "string", "description": "Ticker symbol, e.g. SPY."},
-                    "lookback": {
-                        "type": "integer",
-                        "description": "Recent trading days (default 60).",
-                    },
-                },
-                "required": ["ticker"],
             },
         },
     },
@@ -204,19 +158,11 @@ def build_data_tool_dispatcher(
                     desc=_coerce_bool(args.get("desc", True)),
                     limit=int(args.get("limit", 50)),
                 )
-            elif name == "get_price_technicals":
-                result = get_price_technicals(
-                    client=client, ticker=args["ticker"], lookback=int(args.get("lookback", 20))
-                )
             elif name == "get_macro_series":
                 result = get_macro_series(
                     client=client,
                     series_ids=list(args.get("series_ids", [])),
                     lookback=int(args.get("lookback", 6)),
-                )
-            elif name == "get_price_history":
-                result = get_price_history(
-                    client=client, ticker=args["ticker"], lookback=int(args.get("lookback", 60))
                 )
             elif name == "get_market_breadth":
                 # Readers filter <= as_of and take the newest row → "as of the run date".

--- a/digiquant/src/digiquant/olympus/atlas/skills/bonds/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/bonds/SKILL.md
@@ -9,11 +9,12 @@ description: Run bond market and interest rates analysis as part of the daily di
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Also **`get_macro_series`** for `DGS10`, `DGS2`, `T10Y2Y`, `T10Y3M`, `DFF` to anchor the curve.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/bonds/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/bonds/SKILL.md
@@ -7,10 +7,13 @@ description: Run bond market and interest rates analysis as part of the daily di
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Also **`get_macro_series`** for `DGS10`, `DGS2`, `T10Y2Y`, `T10Y3M`, `DFF` to anchor the curve.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/commodities/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/commodities/SKILL.md
@@ -9,11 +9,12 @@ description: Run commodities analysis as part of the daily digest. Covers energy
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Cover the commodity ETFs in scope (e.g. GLD/SLV/USO/DBC) for trend and momentum.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/commodities/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/commodities/SKILL.md
@@ -7,10 +7,13 @@ description: Run commodities analysis as part of the daily digest. Covers energy
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Cover the commodity ETFs in scope (e.g. GLD/SLV/USO/DBC) for trend and momentum.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/crypto/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/crypto/SKILL.md
@@ -9,11 +9,12 @@ description: Run crypto market analysis as part of the daily digest. Covers BTC,
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Cover the crypto proxies in scope; use the pre-fetched **`web_grounding`** block (when present) for 24/7 spot moves not in the daily series.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/crypto/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/crypto/SKILL.md
@@ -7,10 +7,13 @@ description: Run crypto market analysis as part of the daily digest. Covers BTC,
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Cover the crypto proxies in scope; use the pre-fetched **`web_grounding`** block (when present) for 24/7 spot moves not in the daily series.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/equity/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/equity/SKILL.md
@@ -9,11 +9,12 @@ description: Run US equity market overview analysis. In the orchestrator pipelin
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Cover the broad-market proxies in scope (e.g. SPY/QQQ/IWM/DIA) for breadth and trend.
 - **AI-portfolio proxy** — `phase1_signals` includes `alt-ai-portfolios` (what other AI
   systems are picking). Use its `sector_tilt` / `consensus_longs` as a **weighted, subordinate**

--- a/digiquant/src/digiquant/olympus/atlas/skills/equity/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/equity/SKILL.md
@@ -7,10 +7,13 @@ description: Run US equity market overview analysis. In the orchestrator pipelin
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Cover the broad-market proxies in scope (e.g. SPY/QQQ/IWM/DIA) for breadth and trend.
 - **AI-portfolio proxy** — `phase1_signals` includes `alt-ai-portfolios` (what other AI
   systems are picking). Use its `sector_tilt` / `consensus_longs` as a **weighted, subordinate**

--- a/digiquant/src/digiquant/olympus/atlas/skills/forex/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/forex/SKILL.md
@@ -7,10 +7,13 @@ description: Run forex and currency analysis as part of the daily digest. Covers
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Also **`get_macro_series`** for `DTWEXBGS` (broad USD index) to anchor the dollar view.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/forex/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/forex/SKILL.md
@@ -9,11 +9,12 @@ description: Run forex and currency analysis as part of the daily digest. Covers
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Also **`get_macro_series`** for `DTWEXBGS` (broad USD index) to anchor the dollar view.
 
 ## Inputs

--- a/digiquant/src/digiquant/olympus/atlas/skills/international/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/international/SKILL.md
@@ -9,11 +9,12 @@ description: Deep-dive analysis of international and emerging markets. Covers De
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Cover the regional ETFs in scope (e.g. EFA/EEM/FXI/EWJ/VGK).
 - A pre-fetched **`web_grounding`** block (when present) covers non-US markets and stale non-US M2 / policy data; cite its URLs.
 

--- a/digiquant/src/digiquant/olympus/atlas/skills/international/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/international/SKILL.md
@@ -7,10 +7,13 @@ description: Deep-dive analysis of international and emerging markets. Covers De
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Cover the regional ETFs in scope (e.g. EFA/EEM/FXI/EWJ/VGK).
 - A pre-fetched **`web_grounding`** block (when present) covers non-US markets and stale non-US M2 / policy data; cite its URLs.
 

--- a/digiquant/src/digiquant/olympus/atlas/skills/sector-research/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/sector-research/SKILL.md
@@ -7,10 +7,13 @@ description: Templated single-sector deep-dive. Parameterized by sectors.yaml �
 
 ## Grounding Tools (use first)
 
-- **`get_price_technicals`** — call for each ticker/ETF in scope (your watchlist and any
-  `sector_config` / asset-class symbols in PHASE_INPUTS) before asserting trend, momentum,
-  or relative strength. Use the returned sma/rsi/macd/adx/atr/zscore values; never invent a
-  number. If the tool returns no data for a symbol, say so and lower conviction.
+- **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
+  any `sector_config` / asset-class symbols in PHASE_INPUTS), call
+  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Use the returned
+  sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
+  cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
+  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
 - Call it for every ETF in `sector_config.etfs` and each name in `sector_config.top_tickers`.
 
 This skill is parameterized. The sub-graph injects the target sector's

--- a/digiquant/src/digiquant/olympus/atlas/skills/sector-research/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/sector-research/SKILL.md
@@ -9,11 +9,12 @@ description: Templated single-sector deep-dive. Parameterized by sectors.yaml �
 
 - **`query_data`** — your primary grounding. For each ticker/ETF in scope (your watchlist and
   any `sector_config` / asset-class symbols in PHASE_INPUTS), call
-  `query_data(table="price_technicals", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
-  before asserting trend, momentum, or relative strength. Use the returned
+  `query_data(table="price_technicals", columns="date,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,zscore_200", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=20)`
+  before asserting trend, momentum, or relative strength. Pass that exact `columns` list so you
+  fetch only the indicators you need (not all 35+ columns). Use the returned
   sma/rsi/macd/adx/atr/zscore values; **never invent a number** — every quantitative claim must
   cite a value you fetched. If a call returns no rows for a symbol, say so and lower conviction.
-  Raw OHLCV is available via `query_data(table="price_history", eq={"ticker": "<SYMBOL>"}, ...)`.
+  Need raw prices? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "<SYMBOL>"}, order="date", desc=true, limit=30)`.
 - Call it for every ETF in `sector_config.etfs` and each name in `sector_config.top_tickers`.
 
 This skill is parameterized. The sub-graph injects the target sector's

--- a/tests/dq/atlas/data/test_queries_derived.py
+++ b/tests/dq/atlas/data/test_queries_derived.py
@@ -15,7 +15,6 @@ import pytest
 from digiquant.olympus.atlas.data.queries import (
     ALLOWED_READ_TABLES,
     get_market_breadth,
-    get_price_history,
     get_sector_relative_strength,
     get_vix_term_structure,
     query_data,
@@ -112,20 +111,6 @@ def _rs_rows() -> list[dict]:
 
 @pytest.mark.unit
 class TestReaders:
-    def test_get_price_history(self) -> None:
-        client = _FakeClient(
-            {
-                "price_history": [
-                    {"date": "2026-06-15", "ticker": "SPY", "close": 110.0, "volume": 5},
-                    {"date": "2026-06-12", "ticker": "SPY", "close": 100.0, "volume": 4},
-                ]
-            }
-        )
-        out = get_price_history(client=client, ticker="SPY", lookback=5)
-        assert out["ticker"] == "SPY"
-        assert out["latest"]["close"] == 110.0
-        assert len(out["window"]) == 2
-
     def test_get_market_breadth(self) -> None:
         client = _FakeClient({"price_technicals": _breadth_rows()})
         out = get_market_breadth(client=client, run_date=date(2026, 6, 15))
@@ -246,7 +231,7 @@ class TestToolDispatcher:
         names = {t["function"]["name"] for t in DATA_TOOLS}
         assert {
             "query_data",
-            "get_price_history",
+            "get_macro_series",
             "get_market_breadth",
             "get_sector_relative_strength",
             "get_vix_term_structure",
@@ -268,13 +253,16 @@ class TestToolDispatcher:
         result = json.loads(execute("get_market_breadth", {}))
         assert result["universe_size"] == 4
 
-    def test_dispatch_price_history(self) -> None:
+    def test_dispatch_query_data_price_history(self) -> None:
+        # Raw OHLCV now flows through the generic query_data reader (get_price_history retired).
         client = _FakeClient(
             {"price_history": [{"date": "2026-06-15", "ticker": "QQQ", "close": 1.0, "volume": 1}]}
         )
         execute = build_data_tool_dispatcher(client)
-        result = json.loads(execute("get_price_history", {"ticker": "QQQ"}))
-        assert result["ticker"] == "QQQ"
+        result = json.loads(
+            execute("query_data", {"table": "price_history", "eq": {"ticker": "QQQ"}})
+        )
+        assert result["rows"][0]["ticker"] == "QQQ"
 
     def test_dispatch_unknown_tool(self) -> None:
         execute = build_data_tool_dispatcher(_FakeClient({}))

--- a/tests/dq/atlas/data/test_tools.py
+++ b/tests/dq/atlas/data/test_tools.py
@@ -11,11 +11,12 @@ from tests.dq.atlas.data.test_queries import _FakeClient
 @pytest.mark.unit
 def test_tool_definitions_shape():
     names = {t["function"]["name"] for t in DATA_TOOLS}
+    # get_price_technicals/get_price_history retired from the tool surface in favor of
+    # the generic query_data reader; get_macro_series kept (per-series-latest across
+    # mixed cadences, which query_data can't do without starving slow series).
     assert names == {
         "query_data",
-        "get_price_technicals",
         "get_macro_series",
-        "get_price_history",
         "get_market_breadth",
         "get_sector_relative_strength",
         "get_vix_term_structure",
@@ -51,8 +52,8 @@ def test_dispatcher_routes_and_returns_json_string():
         }
     )
     dispatch = build_data_tool_dispatcher(client)
-    pt = json.loads(dispatch("get_price_technicals", {"ticker": "SPY", "lookback": 5}))
-    assert pt["latest"]["rsi_14"] == 55.0
+    pt = json.loads(dispatch("query_data", {"table": "price_technicals", "eq": {"ticker": "SPY"}}))
+    assert pt["rows"][0]["rsi_14"] == 55.0
     mc = json.loads(dispatch("get_macro_series", {"series_ids": ["DFF"], "lookback": 3}))
     assert mc["DFF"]["latest"]["value"] == 4.5
     err = dispatch("nonexistent_tool", {})


### PR DESCRIPTION
## What
The Atlas side of the **grounding step**. Retires the bespoke per-ticker raw tools in favor of the generic digibase-backed `query_data` reader (#729), and rewrites the segment skills to **require grounding every quantitative claim in a tool-fetched value**.

## Change
**Tool surface** (`data/tools.py`): removed `get_price_technicals` + `get_price_history` from `DATA_TOOLS` + dispatcher — `query_data(table="price_technicals"/"price_history", ...)` replaces them. **Kept `get_macro_series`**: it fetches per-series-latest across mixed cadences, which `query_data` with a single `limit` can't (it would starve monthly series like M2SL behind daily ones). The `get_price_technicals` *function* stays (used by `mcp_server` + Hermes phase7c); the unused `get_price_history` function is removed.

**Skills** (7 — bonds, commodities, crypto, equity, forex, international, sector-research): the "Grounding Tools" section now instructs `query_data(table="price_technicals", eq={"ticker": "<SYM>"}, order="date", desc=true, limit=20)` and states *"never invent a number — every quantitative claim must cite a value you fetched."* `get_macro_series` lines (bonds/forex) preserved. The rewrites were fanned out one-agent-per-file via a workflow and independently verified — all 7 PASS, no leftover `get_price_technicals` references.

## Validation
- **452 atlas + data tests pass**; tool-surface, dispatcher, and query_data security tests updated.
- `make score`: 10 / 10 / 10 / 10.

## Next
Hermes node wiring (`DATA_TOOLS` into phase7c/7cd/7d + drop the phase7c pre-fetch) + Hermes analyst/debate/PM skill grounding — the Hermes half of the grounding step.

Part of #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)