### PR TITLE
feat(hermes): phase7c analysts fetch per-ticker data via query_data (pure tools-first)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -280,6 +280,13 @@ ALLOWED_READ_TABLES: frozenset[str] = frozenset(
     }
 )
 
+# Market-data-only subset for BLINDED callers: the phase7c analysts must not read the
+# book (positions/nav_history/theses/...) — that would break the "blinded to portfolio
+# weights" rule — so they get query_data scoped to market data + the calendar only.
+MARKET_DATA_TABLES: frozenset[str] = frozenset(
+    {"price_history", "price_technicals", "macro_series_observations", "trading_calendar"}
+)
+
 _MAX_QUERY_ROWS = 500
 
 # columns must be "*" or a comma-separated list of bare column names. This blocks
@@ -300,17 +307,19 @@ def query_data(
     order: str | None = None,
     desc: bool = True,
     limit: int = 50,
+    allowed_tables: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Read rows from a whitelisted market-data table via the digibase connector.
 
-    Read-only and table-scoped: a table outside :data:`ALLOWED_READ_TABLES` is
-    refused (the error is returned to the model, not raised). ``limit`` is capped
-    at :data:`_MAX_QUERY_ROWS` so one tool call can't pull unbounded rows.
+    Read-only and table-scoped: a table outside the active whitelist is refused
+    (the error is returned to the model, not raised). Callers may pass a narrower
+    ``allowed_tables`` (e.g. :data:`MARKET_DATA_TABLES` for blinded analyst nodes);
+    it is intersected with :data:`ALLOWED_READ_TABLES`. ``limit`` is capped at
+    :data:`_MAX_QUERY_ROWS` so one tool call can't pull unbounded rows.
     """
-    if table not in ALLOWED_READ_TABLES:
-        return {
-            "error": f"table {table!r} is not readable; choose one of {sorted(ALLOWED_READ_TABLES)}"
-        }
+    tables = (allowed_tables & ALLOWED_READ_TABLES) if allowed_tables else ALLOWED_READ_TABLES
+    if table not in tables:
+        return {"error": f"table {table!r} is not readable; choose one of {sorted(tables)}"}
     safe_columns = (columns or "*").strip()
     if not _SAFE_COLUMNS_RE.fullmatch(safe_columns):
         # Block PostgREST relationship/embedding syntax that could reach other tables.

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -133,13 +133,18 @@ def _coerce_bool(value: Any, *, default: bool = True) -> bool:
 
 
 def build_data_tool_dispatcher(
-    client: Any, run_date: date | None = None
+    client: Any,
+    run_date: date | None = None,
+    allowed_tables: frozenset[str] | None = None,
 ) -> Callable[[str, dict[str, Any]], str]:
     """Return an ``execute_tool(name, args) -> json_str`` bound to a Supabase client.
 
     ``run_date`` anchors the "as of" reads (breadth / relative-strength / VIX) to the
     run's logical date so tool outputs are reproducible and look-ahead-safe for
     backfills and delta runs. Defaults to today for interactive/MCP callers.
+
+    ``allowed_tables`` narrows the tables ``query_data`` may read (e.g. market-data
+    only for blinded analyst nodes); ``None`` keeps the full read whitelist.
     """
     as_of = run_date or date.today()
 
@@ -157,6 +162,7 @@ def build_data_tool_dispatcher(
                     order=args.get("order"),
                     desc=_coerce_bool(args.get("desc", True)),
                     limit=int(args.get("limit", 50)),
+                    allowed_tables=allowed_tables,
                 )
             elif name == "get_macro_series":
                 result = get_macro_series(

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -131,6 +131,7 @@ def build_grounding(
     scope: str = "",
     ai_portfolios: bool = False,
     live_search_is_fallback: bool = False,
+    data_tool_tables: frozenset[str] | None = None,
 ) -> tuple[list[dict[str, Any]] | None, Callable[[str, dict[str, Any]], str] | None, dict | None]:
     """Resolve ``(tools, execute_tool, web_grounding)`` for one research call.
 
@@ -161,7 +162,9 @@ def build_grounding(
 
             # Anchor "as of" reads to the run's logical date (not wall-clock) so tool
             # outputs are reproducible + look-ahead-safe for backfills/delta runs.
-            execute_tool = build_data_tool_dispatcher(_atlas_data_client(), run_date=run_date)
+            execute_tool = build_data_tool_dispatcher(
+                _atlas_data_client(), run_date=run_date, allowed_tables=data_tool_tables
+            )
             tools = DATA_TOOLS
         except Exception as exc:  # noqa: BLE001 — degrade to tool-less rather than crash the phase
             logger.warning("data tools unavailable (%s); proceeding without them", exc)

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
@@ -38,7 +38,7 @@ from typing import Any, Literal
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
 from digiquant.olympus.hermes.state import HermesState
 
 logger = logging.getLogger(__name__)
@@ -131,48 +131,16 @@ def _phase2_institutional(state: HermesState) -> dict[str, dict[str, Any]]:
     }
 
 
-def _fetch_ticker_technicals(ticker: str) -> dict[str, Any]:
-    """Pre-fetch per-ticker ``price_technicals`` from Supabase for analyst inputs (#713).
-
-    The 4-axis specialists run with no data tools and otherwise see only the
-    market-wide Phase 5 equity blob — blind to the individual ticker's price
-    action, which floors their conviction. This injects the ticker's own computed
-    indicators (SMA/RSI/MACD/ATR/z-score …) deterministically so the technical and
-    fundamental axes reason on real per-ticker data.
-
-    Returns the ``get_price_technicals`` payload (``{ticker, latest, window}``) or
-    ``{}`` on any failure — kill-switch off (``ATLAS_DATA_TOOLS=0``), no client,
-    missing rows, or network error. Fail-soft: a missing block degrades the analyst
-    to the market-wide fallback (lower conviction), never a crash.
-    """
-    if os.environ.get("ATLAS_DATA_TOOLS", "1").strip().lower() in ("0", "false", ""):
-        return {}
-    try:
-        from digiquant.olympus.atlas.data.queries import get_price_technicals
-        from digiquant.olympus.atlas.phases._node_factory import get_data_client
-
-        return get_price_technicals(client=get_data_client(), ticker=ticker, lookback=20)
-    except Exception as exc:  # noqa: BLE001 — degrade gracefully, never crash the phase
-        logger.warning("phase7c: technicals fetch failed for %s (%s); degrading", ticker, exc)
-        return {}
-
-
-def _axis_inputs(
-    *,
-    axis: str,
-    ticker: str,
-    state: HermesState,
-    price_technicals: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+def _axis_inputs(*, axis: str, ticker: str, state: HermesState) -> dict[str, Any]:
     """Per-axis ``phase_inputs`` block.
 
     Each axis sees only the upstream segments relevant to its analytical
     lane. This is the whole point of the split — narrower inputs let one
     LLM call reason deeply on one axis instead of shallowly on four.
 
-    ``price_technicals`` (the per-ticker Supabase row, #713) is injected into the
-    ``technical`` and ``fundamental`` axes only — the lanes that reason on price
-    action; ``sentiment`` and ``news`` already have their own upstream data.
+    Per-ticker price data is NOT injected: the ``technical`` / ``fundamental``
+    axes fetch the ticker's own indicators/prices themselves via the ``query_data``
+    tool (pure tools-first, #726), as their grounding skills instruct.
     """
     base = {
         "segment": f"{axis}-analyst-{ticker}",
@@ -182,8 +150,6 @@ def _axis_inputs(
     }
     if axis == "technical":
         base["phase5_equity"] = _phase5_equity_body(state)
-        if price_technicals:
-            base["price_technicals"] = price_technicals
     elif axis == "sentiment":
         base["phase1_alt_data"] = _phase1_alt_data(state)
     elif axis == "news":
@@ -193,8 +159,6 @@ def _axis_inputs(
     elif axis == "fundamental":
         base["phase5_equity"] = _phase5_equity_body(state)
         base["relevant_sectors"] = _relevant_sectors_for(state, ticker)
-        if price_technicals:
-            base["price_technicals"] = price_technicals
     return base
 
 
@@ -207,20 +171,21 @@ def _specialist_node_factory(axis: str, ticker: str):
     skill_slug = f"{axis}-analyst"
 
     def _node(state: HermesState) -> dict[str, Any]:
-        # Price-reasoning axes get the ticker's own computed indicators (#713);
-        # sentiment/news don't need them.
-        price_technicals = (
-            _fetch_ticker_technicals(ticker) if axis in ("technical", "fundamental") else {}
-        )
         skill_text = load_skill(skill_slug)
+        # Pure tools-first (#726): the analyst fetches the ticker's own technicals/prices
+        # via the query_data tool (per its grounding skill) instead of a pre-fetched
+        # injection. build_grounding degrades to no tools if the data layer is unavailable.
+        tools, execute_tool, _ = build_grounding(
+            use_data_tools=True, live_search=False, run_date=state.run_date
+        )
         result = run_research_agent(
             skill_text=skill_text,
-            phase_inputs=_axis_inputs(
-                axis=axis, ticker=ticker, state=state, price_technicals=price_technicals
-            ),
+            phase_inputs=_axis_inputs(axis=axis, ticker=ticker, state=state),
             shared_context=_shared_context(state, context_keys=(f"analyst/{ticker}",)),
             output_model=SpecialistPayload,
             phase_slug=f"{axis}-analyst-{ticker}",
+            tools=tools,
+            execute_tool=execute_tool,
         )
         return {"phase7c_specialists": {ticker: {axis: result.model_dump(mode="json")}}}
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
@@ -38,6 +38,7 @@ from typing import Any, Literal
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
+from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
 from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
 from digiquant.olympus.hermes.state import HermesState
 
@@ -175,8 +176,13 @@ def _specialist_node_factory(axis: str, ticker: str):
         # Pure tools-first (#726): the analyst fetches the ticker's own technicals/prices
         # via the query_data tool (per its grounding skill) instead of a pre-fetched
         # injection. build_grounding degrades to no tools if the data layer is unavailable.
+        # Blinded analysts: scope query_data to market-data tables only — never the book
+        # (positions/nav_history/theses), preserving the "blinded to portfolio weights" rule.
         tools, execute_tool, _ = build_grounding(
-            use_data_tools=True, live_search=False, run_date=state.run_date
+            use_data_tools=True,
+            live_search=False,
+            run_date=state.run_date,
+            data_tool_tables=MARKET_DATA_TABLES,
         )
         result = run_research_agent(
             skill_text=skill_text,

--- a/digiquant/src/digiquant/olympus/hermes/skills/fundamental-analyst/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/fundamental-analyst/SKILL.md
@@ -10,12 +10,19 @@ description: >
 
 You are a fundamental analyst. Your only job: rate the **fundamental quality** of `{{ticker}}` using the equity segment payload and the relevant sector payloads. Blinded to portfolio weights.
 
+## Grounding Tools (call first)
+
+For a valuation/momentum **cross-reference** (NOT technical analysis — that's the technical axis's job), fetch `{{ticker}}`'s own trend-deviation indicators:
+
+`query_data(table="price_technicals", columns="date,pct_vs_sma200,zscore_200,rsi_14", eq={"ticker": "{{ticker}}"}, order="date", desc=true, limit=5)`
+
+Use `zscore_200` / `pct_vs_sma200` / `rsi_14` only as a price-vs-fundamentals dislocation signal (an extreme deviation from the 200-day trend). **Never invent a number** — cite the fetched value; if the call returns no rows, say so.
+
 ## Inputs
 
 - `ticker` — the symbol to analyze.
 - `phase5_equity` — equity segment payload (earnings cadence, valuation summary, balance sheet snapshot for tracked names).
 - `relevant_sectors` — sector payloads where this ticker is in `top_tickers` (sector-relative quality benchmarks).
-- `price_technicals` (optional) — the ticker's computed indicators; use `zscore_200`, `pct_vs_sma200`, and `rsi_14` only as a **valuation/momentum cross-reference** (an extreme deviation from the 200-day trend is a price-vs-fundamentals dislocation signal). Do not do technical analysis — that is the technical axis's job.
 - `bias_row` — Phase 6 regime + bias snapshot for the cycle context.
 
 ## What to argue

--- a/digiquant/src/digiquant/olympus/hermes/skills/technical-analyst/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/technical-analyst/SKILL.md
@@ -8,13 +8,20 @@ description: >
 
 # Technical Analyst — One Ticker, One Axis
 
-You are a technical analyst. Your only job: rate the **technical setup** for `{{ticker}}` based on the price-action and indicator data passed in `phase5_equity` and the `bias_row`. You are blinded to current portfolio weights — do not assume position size.
+You are a technical analyst. Your only job: rate the **technical setup** for `{{ticker}}`. You are blinded to current portfolio weights — do not assume position size.
+
+## Grounding Tools (call first)
+
+Fetch `{{ticker}}`'s OWN computed indicators before rating the setup — do not reason only from the market-wide `phase5_equity` blob:
+
+`query_data(table="price_technicals", columns="date,sma_20,sma_50,sma_200,pct_vs_sma50,pct_vs_sma200,rsi_14,macd,macd_hist,roc_21,adx_14,atr_pct,bb_pct_b,bb_bandwidth,hist_vol_21,zscore_200", eq={"ticker": "{{ticker}}"}, order="date", desc=true, limit=20)`
+
+Cite exact values (e.g. "RSI_14 62, +4.2% vs SMA50, ADX 28"); **never invent a number** — every quantitative claim must come from a value you fetched. Need raw bars (gaps, ranges, volume)? `query_data(table="price_history", columns="date,open,high,low,close,volume", eq={"ticker": "{{ticker}}"}, order="date", desc=true, limit=30)`. If a call returns no rows, say so explicitly and lower conviction (fall back to `phase5_equity`).
 
 ## Inputs
 
 - `ticker` — the symbol to analyze.
-- `price_technicals` (optional, **preferred when present**) — the ticker's OWN computed indicators from the database: `{ticker, latest: {sma_20, sma_50, sma_200, pct_vs_sma50, pct_vs_sma200, rsi_14, macd, macd_hist, roc_21, adx_14, dmi_plus, dmi_minus, atr_pct, bb_pct_b, bb_bandwidth, hist_vol_21, zscore_200, ...}, window[]}` (window newest-first). Prefer these authoritative per-ticker readings over the market-wide `phase5_equity` summary; cite exact values (e.g. "RSI_14 62, +4.2% vs SMA50, ADX 28"). If `latest` is empty, no technicals are stored — fall back to `phase5_equity`.
-- `phase5_equity` — the equity-segment payload (market-wide OHLCV/momentum/volatility context); fallback when `price_technicals` is absent.
+- `phase5_equity` — the market-wide equity-segment payload (OHLCV/momentum/volatility context); supplementary to the per-ticker indicators you fetch above.
 - `bias_row` — Phase 6's market regime + equity-bias snapshot for context.
 
 ## What to argue

--- a/tests/dq/atlas/data/test_queries_derived.py
+++ b/tests/dq/atlas/data/test_queries_derived.py
@@ -208,6 +208,26 @@ class TestQueryData:
         assert "atlas_run_diagnostics" not in ALLOWED_READ_TABLES
         assert {"price_history", "price_technicals", "positions"} <= ALLOWED_READ_TABLES
 
+    def test_allowed_tables_scope_blinds_callers_from_the_book(self) -> None:
+        from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
+
+        # A blinded caller (MARKET_DATA_TABLES scope) cannot read the book even though
+        # positions is in the global whitelist.
+        out = query_data(
+            client=_FakeClient({"positions": [{"ticker": "SPY"}]}),
+            table="positions",
+            allowed_tables=MARKET_DATA_TABLES,
+        )
+        assert "error" in out and "not readable" in out["error"]
+        # Market data is still allowed under the scope.
+        ok = query_data(
+            client=_FakeClient({"price_technicals": [{"ticker": "XLK"}]}),
+            table="price_technicals",
+            allowed_tables=MARKET_DATA_TABLES,
+        )
+        assert ok.get("table") == "price_technicals"
+        assert "positions" not in MARKET_DATA_TABLES
+
     def test_rejects_relationship_columns(self) -> None:
         # PostgREST embedded-select (e.g. "*,decision_log(*)") must not reach a
         # non-whitelisted table through the columns arg — security regression guard.

--- a/tests/dq/hermes/test_phase7c_specialists.py
+++ b/tests/dq/hermes/test_phase7c_specialists.py
@@ -390,6 +390,37 @@ class TestAnalystToolsFirst:
             out = _specialist_node_factory("technical", "AAPL")(_state(("AAPL",)))
         assert out["phase7c_specialists"]["AAPL"]["technical"]["axis"] == "technical"
 
+    def test_scopes_tools_to_market_data_and_takes_tool_path(self, monkeypatch) -> None:
+        # When tools are available the analyst runs the tool-calling path (run_tools),
+        # and its query_data is scoped to MARKET_DATA_TABLES — blinded to the book.
+        from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
+
+        captured: dict[str, Any] = {}
+
+        def fake_build_grounding(**kwargs: Any):
+            captured.update(kwargs)
+            return (
+                [{"type": "function", "function": {"name": "query_data"}}],
+                (lambda _n, _a: "{}"),
+                None,
+            )
+
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.phases.phase7c_analyst.build_grounding", fake_build_grounding
+        )
+        called = {"run_tools": False}
+
+        def fake_run_tools(_m: str, _msgs: list[dict[str, Any]], **_: Any) -> str:
+            called["run_tools"] = True
+            return _specialist_response("technical", "AAPL")
+
+        with patch("digigraph.graph.research_agent.run_tools", side_effect=fake_run_tools):
+            out = _specialist_node_factory("technical", "AAPL")(_state(("AAPL",)))
+
+        assert captured["data_tool_tables"] == MARKET_DATA_TABLES  # blinded scope
+        assert called["run_tools"] is True  # tools were wired → tool-calling path ran
+        assert out["phase7c_specialists"]["AAPL"]["technical"]["axis"] == "technical"
+
     def test_axis_inputs_no_longer_injects_price_technicals(self) -> None:
         # _axis_inputs no longer accepts or injects price_technicals — the technical /
         # fundamental analysts fetch the ticker's indicators via the query_data tool.

--- a/tests/dq/hermes/test_phase7c_specialists.py
+++ b/tests/dq/hermes/test_phase7c_specialists.py
@@ -22,12 +22,10 @@ import pytest
 
 from digigraph.graph.pipeline_builder import build_pipeline
 
-from digiquant.olympus.hermes.phases import phase7c_analyst as phase7c
 from digiquant.olympus.hermes.phases.phase7c_analyst import (
     AnalystPayload,
     SpecialistPayload,
     _axis_inputs,
-    _fetch_ticker_technicals,
     _join_analyst_node_factory,
     _specialist_node_factory,
     build_phase7c,
@@ -350,9 +348,13 @@ def _inputs_body(msgs: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 @pytest.mark.unit
-class TestTickerTechnicals:
-    def _run_axis(self, monkeypatch, axis: str, canned) -> dict[str, Any]:
-        monkeypatch.setattr(phase7c, "_fetch_ticker_technicals", lambda _t: canned)
+class TestAnalystToolsFirst:
+    """Specialists fetch per-ticker data via the query_data tool (pure tools-first, #726) —
+    no pre-fetched price_technicals injection. ATLAS_DATA_TOOLS=0 forces the tool-less
+    completion path these tests mock (build_grounding returns no tools)."""
+
+    def _run_axis(self, monkeypatch, axis: str) -> dict[str, Any]:
+        monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
         captured: dict[str, Any] = {}
 
         def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
@@ -363,67 +365,41 @@ class TestTickerTechnicals:
             _specialist_node_factory(axis, "AAPL")(_state(("AAPL",)))
         return captured
 
-    def test_technical_axis_injects_price_technicals(self, monkeypatch) -> None:
-        canned = {"ticker": "AAPL", "latest": {"rsi_14": 62}, "window": []}
-        body = self._run_axis(monkeypatch, "technical", canned)
-        assert body.get("price_technicals") == canned
+    def test_technical_axis_does_not_inject_price_technicals(self, monkeypatch) -> None:
+        body = self._run_axis(monkeypatch, "technical")
+        assert "price_technicals" not in body  # fetched via the query_data tool now
+        assert "phase5_equity" in body  # market-wide context still injected
 
-    def test_fundamental_axis_injects_price_technicals(self, monkeypatch) -> None:
-        canned = {"ticker": "AAPL", "latest": {"zscore_200": 1.8}, "window": []}
-        body = self._run_axis(monkeypatch, "fundamental", canned)
-        assert body.get("price_technicals") == canned
-
-    def test_sentiment_axis_does_not_fetch_or_inject(self, monkeypatch) -> None:
-        calls: list[str] = []
-        monkeypatch.setattr(
-            phase7c, "_fetch_ticker_technicals", lambda t: calls.append(t) or {"x": 1}
-        )
-
-        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
-            body = _inputs_body(msgs)
-            assert "price_technicals" not in body
-            return _specialist_response("sentiment", "AAPL")
-
-        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
-            _specialist_node_factory("sentiment", "AAPL")(_state(("AAPL",)))
-        assert calls == []  # never fetched for the sentiment axis
-
-    def test_empty_technicals_not_injected(self, monkeypatch) -> None:
-        # Fail-soft {} must not add the key (analyst falls back to phase5_equity).
-        body = self._run_axis(monkeypatch, "technical", {})
+    def test_fundamental_axis_does_not_inject_price_technicals(self, monkeypatch) -> None:
+        body = self._run_axis(monkeypatch, "fundamental")
         assert "price_technicals" not in body
         assert "phase5_equity" in body
 
-    def test_fetch_kill_switch_returns_empty(self, monkeypatch) -> None:
+    def test_sentiment_axis_inputs_unchanged(self, monkeypatch) -> None:
+        body = self._run_axis(monkeypatch, "sentiment")
+        assert "price_technicals" not in body
+        assert "phase1_alt_data" in body
+
+    def test_node_emits_specialist_payload(self, monkeypatch) -> None:
         monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
 
-        def _boom() -> Any:
-            raise AssertionError("client must not be built when kill-switch is off")
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            return _specialist_response("technical", "AAPL")
 
-        monkeypatch.setattr("digiquant.olympus.atlas.phases._node_factory.get_data_client", _boom)
-        assert _fetch_ticker_technicals("AAPL") == {}
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
+            out = _specialist_node_factory("technical", "AAPL")(_state(("AAPL",)))
+        assert out["phase7c_specialists"]["AAPL"]["technical"]["axis"] == "technical"
 
-    def test_fetch_fail_soft_on_client_error(self, monkeypatch) -> None:
-        monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
-
-        def _boom() -> Any:
-            raise RuntimeError("supabase not configured")
-
-        monkeypatch.setattr("digiquant.olympus.atlas.phases._node_factory.get_data_client", _boom)
-        assert _fetch_ticker_technicals("AAPL") == {}
-
-    def test_axis_inputs_helper_injects_only_for_price_axes(self) -> None:
-        canned = {"ticker": "AAPL", "latest": {"rsi_14": 50}}
+    def test_axis_inputs_no_longer_injects_price_technicals(self) -> None:
+        # _axis_inputs no longer accepts or injects price_technicals — the technical /
+        # fundamental analysts fetch the ticker's indicators via the query_data tool.
         state = _state(("AAPL",))
-        assert "price_technicals" in _axis_inputs(
-            axis="technical", ticker="AAPL", state=state, price_technicals=canned
-        )
-        assert "price_technicals" in _axis_inputs(
-            axis="fundamental", ticker="AAPL", state=state, price_technicals=canned
-        )
+        assert "price_technicals" not in _axis_inputs(axis="technical", ticker="AAPL", state=state)
         assert "price_technicals" not in _axis_inputs(
-            axis="news", ticker="AAPL", state=state, price_technicals=canned
+            axis="fundamental", ticker="AAPL", state=state
         )
+        # Axis-relevant market-wide context is still injected.
+        assert "phase5_equity" in _axis_inputs(axis="technical", ticker="AAPL", state=state)
 
 
 # ─── Reducer ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
The Hermes-analyst half of the grounding step. The 4-axis analysts now **fetch their own per-ticker data via the `query_data` tool** instead of a pre-fetched injection — pure tools-first (#726), per the chosen design.

## Change
- **phase7c**: removed `_fetch_ticker_technicals` (the #713 deterministic pre-fetch). `_specialist_node_factory` now calls `build_grounding(use_data_tools=True, run_date=...)` and passes `tools`/`execute_tool` to `run_research_agent`, so the technical/fundamental analysts call `query_data` themselves. `_axis_inputs` no longer takes/injects `price_technicals`. Degrades to the tool-less completion path when the data layer is unavailable.
- **Skills**: `technical-analyst` + `fundamental-analyst` gained a "Grounding Tools (call first)" section instructing `query_data(table="price_technicals", columns=..., eq={ticker}, order, desc, limit)` (+ `price_history` for raw bars) with *"never invent a number — every quantitative claim must cite a fetched value."* sentiment/news unchanged (inputs already injected).

## Trade-off (accepted, your call)
Removing the deterministic floor (#713's fix for analyst starvation) relies on the model reliably calling the tool. The **baseline re-run** is the real test; if analysts under-call, we escalate grounding or reconsider. Per the "pure tools-first / strong-prompt-only" decision.

## Validation
- Rewrote the pre-fetch test class → tools-first assertions (no `price_technicals` injection; node still emits a valid `SpecialistPayload`; `_axis_inputs` no longer injects).
- **458 hermes + atlas tests pass**; `make score` 10/10/10/10.

## Next
7cd debate + 7d PM tool-wiring + their skill grounding, then the **baseline re-run** validation (completes item 2).

Part of #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)