### PR TITLE
feat(hermes): wire query_data into debate + risk + PM nodes (finish grounding)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
@@ -32,8 +32,25 @@ from typing import Any, Literal
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
+from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
 from digiquant.olympus.hermes.state import HermesState
+
+
+def _debate_tools(state: HermesState):
+    """query_data + computed tools for the debaters, scoped to market data only.
+
+    Bull/bear/manager argue on the analyst's thesis and may cite real price/level
+    numbers — but stay blinded to the book (positions/nav_history/theses), like the
+    analysts, so the debate isn't anchored to current weights.
+    """
+    return build_grounding(
+        use_data_tools=True,
+        live_search=False,
+        run_date=state.run_date,
+        data_tool_tables=MARKET_DATA_TABLES,
+    )
+
 
 logger = logging.getLogger(__name__)
 
@@ -137,12 +154,15 @@ def _bull_node_factory(ticker: str):
             "prior_rounds": _prior_rounds(state, ticker, role="bull"),
             "bias_row": state.phase6_bias_row or {},
         }
+        tools, execute_tool, _ = _debate_tools(state)
         result = run_research_agent(
             skill_text=skill_text,
             phase_inputs=phase_inputs,
             shared_context=_shared_context(state, context_keys=(f"analyst/{ticker}",)),
             output_model=DebateRoundContribution,
             phase_slug=f"bull-researcher-{ticker}",
+            tools=tools,
+            execute_tool=execute_tool,
         )
         debate["pending"] = {
             "round_number": result.round_number,
@@ -175,12 +195,15 @@ def _bear_node_factory(ticker: str):
             "prior_rounds": _prior_rounds(state, ticker, role="bear"),
             "bias_row": state.phase6_bias_row or {},
         }
+        tools, execute_tool, _ = _debate_tools(state)
         result = run_research_agent(
             skill_text=skill_text,
             phase_inputs=phase_inputs,
             shared_context=_shared_context(state, context_keys=(f"analyst/{ticker}",)),
             output_model=DebateRoundContribution,
             phase_slug=f"bear-researcher-{ticker}",
+            tools=tools,
+            execute_tool=execute_tool,
         )
         completed = list(debate.get("rounds") or [])
         completed.append(
@@ -226,12 +249,15 @@ def _research_manager_node_factory(ticker: str):
             "analyst_payload": _analyst_for(state, ticker),
             "bias_row": state.phase6_bias_row or {},
         }
+        tools, execute_tool, _ = _debate_tools(state)
         result = run_research_agent(
             skill_text=skill_text,
             phase_inputs=phase_inputs,
             shared_context=_shared_context(state, context_keys=(f"analyst/{ticker}",)),
             output_model=DebateSummary,
             phase_slug=f"research-manager-{ticker}",
+            tools=tools,
+            execute_tool=execute_tool,
         )
         # The skill is told to return rounds verbatim; if it doesn't, we
         # overwrite with the deterministic record from state to keep

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
@@ -25,8 +25,26 @@ from typing import Any, Literal  # noqa: F401 — used for JSON-derived dict sha
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
+from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
 from digiquant.olympus.hermes.state import HermesState
+
+
+def _pm_tools(state: HermesState):
+    """Full-scope query_data + computed tools for the PM. As the decision-maker it MAY
+    read the book (positions/nav_history/theses) for rebalance + sizing context — it is
+    not blinded like the analysts/debaters."""
+    return build_grounding(use_data_tools=True, live_search=False, run_date=state.run_date)
+
+
+def _risk_tools(state: HermesState):
+    """Market-data-scoped tools for the risk debaters (blinded to the book)."""
+    return build_grounding(
+        use_data_tools=True,
+        live_search=False,
+        run_date=state.run_date,
+        data_tool_tables=MARKET_DATA_TABLES,
+    )
 
 
 class TargetWeight(BaseModel):
@@ -96,6 +114,7 @@ def _risk_aggressive_node(state: HermesState) -> dict[str, Any]:
     from digiquant.olympus.hermes.skills import load_skill
 
     skill_text = load_skill("risk-aggressive")
+    tools, execute_tool, _ = _risk_tools(state)
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=_build_risk_phase_inputs(state, role="aggressive"),
@@ -104,6 +123,8 @@ def _risk_aggressive_node(state: HermesState) -> dict[str, Any]:
         ),
         output_model=RiskCase,
         phase_slug="risk-aggressive",
+        tools=tools,
+        execute_tool=execute_tool,
     )
     # Prior summary (if any) is None on first debate node; conservative
     # node fills in its half + key_tension.
@@ -132,6 +153,7 @@ def _risk_conservative_node(state: HermesState) -> dict[str, Any]:
     inputs["aggressive_case"] = aggressive
 
     skill_text = load_skill("risk-conservative")
+    tools, execute_tool, _ = _risk_tools(state)
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=inputs,
@@ -140,6 +162,8 @@ def _risk_conservative_node(state: HermesState) -> dict[str, Any]:
         ),
         output_model=RiskDebateSummary,
         phase_slug="risk-conservative",
+        tools=tools,
+        execute_tool=execute_tool,
     )
     return {"phase7d_risk_debate": result.model_dump(mode="json")}
 
@@ -184,6 +208,7 @@ def _pm_node(state: HermesState) -> dict[str, Any]:
         # the lesson shape.
         "past_context": list(state.prior_context.decision_lessons),
     }
+    tools, execute_tool, _ = _pm_tools(state)
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=phase_inputs,
@@ -192,6 +217,8 @@ def _pm_node(state: HermesState) -> dict[str, Any]:
         ),
         output_model=RebalanceDecision,
         phase_slug="pm-rebalance",
+        tools=tools,
+        execute_tool=execute_tool,
     )
     # An empty recommended_portfolio is a valid 100% CASH stance; Phase 9D books
     # it as a CASH position (#713). No cash-proxy padding here.

--- a/digiquant/src/digiquant/olympus/hermes/skills/pm-rebalance-decision/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/pm-rebalance-decision/SKILL.md
@@ -12,7 +12,13 @@ description: >
 
 You are the Portfolio Manager. In ONE response you (B) construct the ideal clean-slate book
 from research conviction, then (C) compare it against the current book to produce actions.
-Everything you need is in `phase_inputs` — there are NO files to read and NO tools to call.
+
+The analyst payloads, debate summaries, risk debate, and current weights are in `phase_inputs`.
+You ALSO have **data tools** — call `query_data` (e.g. `table="price_history"` for a name's
+recent prices, `table="positions"` / `table="nav_history"` for the live book, or
+`table="macro_series_observations"` for rates/vol), plus `get_market_breadth` and
+`get_vix_term_structure` — to verify a level or size a position on real numbers before you
+decide. Ground sizing and regime claims in fetched values; never invent a number.
 
 ## Inputs (all in `phase_inputs`)
 

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -38,6 +38,13 @@ from digiquant.olympus.atlas.state import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_data_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deterministic tool-less completion path for completion_text mocks regardless of the
+    # developer's Supabase env (the debate nodes now wire data tools when available).
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+
+
 def _state(
     tickers: tuple[str, ...] = ("AAPL",), *, debate_rounds: int | None = None
 ) -> AtlasResearchState:

--- a/tests/dq/hermes/test_phase7d_pm_skill.py
+++ b/tests/dq/hermes/test_phase7d_pm_skill.py
@@ -21,6 +21,14 @@ from digiquant.olympus.hermes.skills import SkillNotFoundError
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _no_data_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default to the tool-less completion path so completion_text mocks are deterministic
+    # regardless of the developer's Supabase env. The explicit tool-path test monkeypatches
+    # build_grounding directly, so it is unaffected by this.
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+
+
 # ── skill selection ──────────────────────────────────────────────────────────
 
 

--- a/tests/dq/hermes/test_phase7d_pm_skill.py
+++ b/tests/dq/hermes/test_phase7d_pm_skill.py
@@ -108,3 +108,30 @@ class TestPmNodeContract:
             for w in update["phase7d_rebalance"]["recommended_portfolio"]
         }
         assert book == {"SPY": 40.0}  # residual left as implicit cash, no BIL injected
+
+    def test_pm_uses_full_scope_data_tools(self, monkeypatch) -> None:
+        # The PM is the decision-maker — full query_data scope (may read the book),
+        # NOT blinded like the analysts/debaters; and the tools are actually wired.
+        captured: dict = {}
+
+        def fake_build_grounding(**kwargs):
+            captured.update(kwargs)
+            return (
+                [{"type": "function", "function": {"name": "query_data"}}],
+                (lambda _n, _a: "{}"),
+                None,
+            )
+
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.phases.phase7d_pm.build_grounding", fake_build_grounding
+        )
+        called = {"run_tools": False}
+
+        def fake_run_tools(_m, _msgs, **_):
+            called["run_tools"] = True
+            return json.dumps({"recommended_portfolio": [], "actions": [], "notes": "cash"})
+
+        with patch("digigraph.graph.research_agent.run_tools", side_effect=fake_run_tools):
+            _pm_node(_pm_state())
+        assert called["run_tools"] is True  # tools wired → tool-calling path ran
+        assert captured.get("data_tool_tables") is None  # full scope, not market-data-restricted

--- a/tests/dq/hermes/test_phase7d_risk_debate.py
+++ b/tests/dq/hermes/test_phase7d_risk_debate.py
@@ -23,6 +23,13 @@ from digiquant.olympus.atlas.state import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_data_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deterministic tool-less completion path for completion_text mocks regardless of the
+    # developer's Supabase env (the risk/PM nodes now wire data tools when available).
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+
+
 def _state_for_debate() -> AtlasResearchState:
     """Minimal state with phase 6 bias + phase 7C analyst payload."""
     state = AtlasResearchState(


### PR DESCRIPTION
## What
Finishes the Hermes-side tools-first wiring (after the phase7c analysts in #739). The bull/bear debaters, risk-temperament debaters, and the PM now ground in **tool-fetched** numbers via `query_data` + the computed signal tools.

## Change
- **phase7cd** bull / bear / research-manager: `build_grounding(..., data_tool_tables=MARKET_DATA_TABLES)` — may cite real price/level numbers, but **blinded to the book** (positions/nav_history/theses), like the analysts, so the debate isn't anchored to current weights.
- **phase7d** risk-aggressive / risk-conservative: same blinded market-data scope.
- **phase7d PM** (`pm-rebalance`): **full scope** `build_grounding` — as the decision-maker it MAY read the book (`positions`/`nav_history`) to size on real numbers. The `pm-rebalance-decision` skill is updated from *"NO tools to call"* → call `query_data` / `get_market_breadth` / `get_vix_term_structure` to verify a level or size a position; never invent a number.
- `research-debate` skill gains a market-data grounding line.

## Scope distinction (security-relevant)
Analysts + debaters are **blinded** (MARKET_DATA_TABLES — no book); the PM is **full-scope** (decision-maker). Locked by a test asserting the PM's `build_grounding` gets no `data_tool_tables` restriction and the tool-calling path runs.

## Validation
- **109 hermes tests pass** (existing debate/risk/PM tests degrade to the tool-less path in the test env; new PM full-scope test added). `make score` 10/10/10/10.

This completes the grounding step. **Next: the baseline re-run validation** — the real test of whether the models reliably call the tools now that the deterministic floors are gone (completes item 2).

Part of #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)