### PR TITLE
feat(digichat): unify DigiChat with the new design language (cyan + Geist)

### DIFF
--- a/frontend/digichat/src/app/globals.css
+++ b/frontend/digichat/src/app/globals.css
@@ -68,77 +68,89 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --background: #fbfbf9;
+  --foreground: #14181b;
+  --card: #ffffff;
+  --card-foreground: #14181b;
+  --popover: #ffffff;
+  --popover-foreground: #14181b;
+  --primary: #0e8c7f;
+  --primary-foreground: #ffffff;
+  --secondary: #f4f4f1;
+  --secondary-foreground: #14181b;
+  --muted: #f4f4f1;
+  --muted-foreground: #5c636a;
+  --accent: #efeee9;
+  --accent-foreground: #14181b;
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
+  --border: #e4e0d8;
+  --input: #e4e0d8;
+  --ring: #0e8c7f;
+  --chart-1: #0e8c7f;
+  --chart-2: #3dd6c4;
+  --chart-3: #8a9097;
+  --chart-4: #2f9e70;
+  --chart-5: #c9533b;
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: #f4f4f1;
+  --sidebar-foreground: #14181b;
+  --sidebar-primary: #0e8c7f;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #efeee9;
+  --sidebar-accent-foreground: #14181b;
+  --sidebar-border: #e4e0d8;
+  --sidebar-ring: #0e8c7f;
 }
 
 /*
- * Dark theme aligned with digithings.ai marketing site (website/style.css):
- * --bg-secondary #0a0a0a, --bg-primary #121212, --border-color #2a2a2a,
- * --text-primary #e6e6e6, --text-secondary #a3a3a3. No starfield in app chrome.
+ * Dark theme — unified DigiThings design language (terminal-phosphor cyan on a
+ * neutral near-black, matching digithings.ai / digiquant.io / Olympus).
+ * shadcn `--primary`/`--ring` carry the cyan accent; `--accent` stays a neutral
+ * hover gray. Brand cyan for the DigiChat chrome is scoped in `.app-shell`.
  */
 .dark {
-  --background: #0a0a0a;
-  --foreground: #e6e6e6;
-  --card: #121212;
-  --card-foreground: #e6e6e6;
-  --popover: #121212;
-  --popover-foreground: #e6e6e6;
-  --primary: #ffffff;
-  --primary-foreground: #0a0a0a;
-  --secondary: #1a1a1a;
-  --secondary-foreground: #e6e6e6;
-  --muted: #1a1a1a;
-  --muted-foreground: #a3a3a3;
-  --accent: #1f1f1f;
-  --accent-foreground: #e6e6e6;
+  --background: #0b0c0e;
+  --foreground: #eceef0;
+  --card: #121417;
+  --card-foreground: #eceef0;
+  --popover: #121417;
+  --popover-foreground: #eceef0;
+  --primary: #3dd6c4;
+  --primary-foreground: #04201c;
+  --secondary: #171a1e;
+  --secondary-foreground: #eceef0;
+  --muted: #171a1e;
+  --muted-foreground: #9aa0a6;
+  --accent: #1f2226;
+  --accent-foreground: #eceef0;
   --destructive: oklch(0.704 0.191 22.216);
-  --border: #2a2a2a;
-  --input: #2a2a2a;
-  --ring: #525252;
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: #0f0f0f;
-  --sidebar-foreground: #e6e6e6;
-  --sidebar-primary: #ffffff;
-  --sidebar-primary-foreground: #0a0a0a;
-  --sidebar-accent: #1a1a1a;
-  --sidebar-accent-foreground: #e6e6e6;
-  --sidebar-border: #2a2a2a;
-  --sidebar-ring: #525252;
+  --border: #23262b;
+  --input: #23262b;
+  --ring: #3dd6c4;
+  --chart-1: #3dd6c4;
+  --chart-2: #6fe3d4;
+  --chart-3: #9aa0a6;
+  --chart-4: #3fb984;
+  --chart-5: #e0654b;
+  --sidebar: #0e0e10;
+  --sidebar-foreground: #eceef0;
+  --sidebar-primary: #3dd6c4;
+  --sidebar-primary-foreground: #04201c;
+  --sidebar-accent: #171a1e;
+  --sidebar-accent-foreground: #eceef0;
+  --sidebar-border: #23262b;
+  --sidebar-ring: #3dd6c4;
+
+  /* Align the legacy @digithings/design tokens (consumed by the imported
+     terminal + app-shell primitives and the .dc-term-* chrome) to the new
+     palette, and unify the brand accent to cyan. */
+  --bg-primary: #0b0c0e;
+  --bg-secondary: #08090b;
+  --text-primary: #eceef0;
+  --text-secondary: #9aa0a6;
+  --border-color: #23262b;
+  --fg: #eceef0;
+  --accent-digichat: #3dd6c4;
 }
 
 @layer base {
@@ -162,8 +174,11 @@
  * rows, tool chips, sources accordion, streaming caret) on top of the
  * primitive palette.
  * ------------------------------------------------------------------------- */
+/* Brand accent for the DigiChat chrome — unified terminal-phosphor cyan
+   (was the per-module lavender). Scoped to .app-shell so shadcn's neutral
+   --accent hover stays authoritative elsewhere. */
 .app-shell {
-  --accent: var(--accent-digichat);
+  --accent: #3dd6c4;
 }
 
 .dc-term-pane {

--- a/frontend/digichat/src/app/layout.tsx
+++ b/frontend/digichat/src/app/layout.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { auth } from "@/auth";
 import { Providers } from "@/components/providers";
 
-const inter = Inter({
+// Unified with the rest of the stack (self-hosted by next/font → CSP-safe).
+const geistSans = Geist({
   variable: "--font-sans",
+  subsets: ["latin"],
+});
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
   subsets: ["latin"],
 });
 
@@ -24,7 +29,7 @@ export default async function RootLayout({
     process.env.NODE_ENV !== "production" &&
     !!process.env.DIGICHAT_LOCAL_AUTH_KEY?.trim();
   return (
-    <html lang="en" className={`${inter.variable} dark h-full antialiased`}>
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} dark h-full antialiased`}>
       <body className="accent-digichat flex min-h-full flex-col bg-background font-sans text-foreground">
         <Providers session={session} localBootstrapEnabled={localBootstrapEnabled}>
           <div className="flex min-h-dvh w-full flex-1 flex-col">{children}</div>


### PR DESCRIPTION
## Summary
Brings **DigiChat** into the unified DigiThings design language so all four surfaces match — not just share a stack. **Presentational only**: fonts + color tokens. No changes to auth, the BFF, data, or any logic. Fixes #742.

## Changes
- **Fonts**: Inter → Geist Sans + Geist Mono (`next/font`, self-hosted → CSP-safe).
- **Palette**: shadcn `.dark` (the active theme) + `:root` (light) remapped to the neutral near-black + terminal-phosphor cyan used across digithings.ai / digiquant.io / Olympus; `--primary`/`--ring` carry the cyan accent.
- **Brand accent**: `.app-shell` brand `--accent` and the legacy `@digithings/design` tokens consumed by the imported terminal/app-shell primitives + `.dc-term-*` chrome → cyan (was lavender).

Dark-only behavior preserved (app renders `.dark`); light tokens updated for parity.

## Verification
- `make score` ✅ 10/10 all dimensions.
- `next build` ✅ (all routes compile); built CSS contains the new cyan `#3dd6c4` + neutral `#0b0c0e`; 11 self-hosted Geist woff2 in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)