### PR TITLE
feat(hermes): asset-class / sector map for whole-book concentration control (P2)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -710,6 +710,30 @@ contract — the only symbol Hermes imports from Atlas runtime.
 - Schemas under `digiquant/src/digiquant/olympus/hermes/templates/schemas/`. Loaded via
   `digiquant.olympus.hermes.schemas.load_schema`.
 
+#### Risk-sizing layer (Pillar 2)
+
+Implements the FinPos direction/sizing split: the PM (`phase7d_pm`) owns *direction +
+conviction + narrative*; deterministic code owns *sizing, caps, and risk*, so the book's
+risk profile is reproducible and auditable rather than LLM-eyeballed.
+
+- `digiquant.olympus.hermes.sizing.size_portfolio(...)` — pure, I/O-free. Turns per-ticker
+  conviction + stance into final target weights: select (conv ≥ bar, buy/hold) → raw
+  weights (conviction-∝ × inverse-vol, or fractional-Kelly) → position caps → sector caps
+  → correlation de-dup → ex-ante vol-target (√(wᵀΣw), pure-Python) → drawdown-breaker scale
+  → round-DOWN to grid → cash residual. Every reduction is **reduce-only / cash-first**:
+  freed weight becomes cash, never redistributed up (re-breaching the cap). Unknown
+  correlations default to ρ=1.0 (conservative). `SizingCaps.from_preferences` reads
+  `config/portfolio.json` constraints.
+- `digiquant.olympus.hermes.sector_map` — buckets every holdable ticker for concentration
+  control + exposure roll-ups, unifying GICS equity sectors (`config/sectors.yaml`) with the
+  cross-asset sleeves (`config/asset_classes.yaml`: fixed-income / commodity / crypto / fx /
+  international / equity-broad / cash). `asset_classes.yaml` is authoritative on conflict
+  (true risk exposure beats research fan-out — e.g. USO is `commodity`, not Energy equity).
+  `sector_bucket(t)` → fine-grained concentration slug; `asset_class(t)` → coarse class.
+- The `phase7e` enforcement node (between `publish` and `materialize` in `chain.py`) reads
+  vol/correlation, calls `size_portfolio`, and overwrites `phase7d_rebalance.recommended_portfolio`
+  with enforced weights that `portfolio_materialize` then books verbatim.
+
 ### Persistence
 
 Per ADR-0009: writes to Supabase `documents` / `daily_snapshots` /

--- a/digiquant/src/digiquant/olympus/atlas/config/asset_classes.yaml
+++ b/digiquant/src/digiquant/olympus/atlas/config/asset_classes.yaml
@@ -1,0 +1,57 @@
+# Asset-class buckets for the WHOLE book — the non-equity sleeves that GICS
+# `sectors.yaml` does not cover, plus the broad-equity / international / cash sleeves.
+#
+# Consumed by `olympus/hermes/sector_map.py`. Equity single-names and GICS sector
+# ETFs (XLK, XLV, …) are bucketed from `sectors.yaml`; this file covers everything
+# else. Tickers are matched case-insensitively. Lists need not be exhaustive — an
+# unlisted ticker resolves to the "unknown" bucket (a conservative default that the
+# sizer treats as its own concentration bucket).
+#
+# Each entry: a coarse `asset_class` (for exposure roll-ups) and the `sector_bucket`
+# slug used for concentration control (max_sector_pct). Keep both kebab/UPPER-stable;
+# downstream code and stored rows key off these exact strings.
+
+asset_classes:
+  equity-broad:
+    asset_class: EQUITY
+    label: US Broad Equity
+    tickers: [SPY, VOO, IVV, VTI, QQQ, QQQM, DIA, IWM, IWB, IJH, IJR, MDY, RSP, VT, SPLG, SCHX, SCHB]
+
+  international:
+    asset_class: INTERNATIONAL
+    label: International / EM Equity
+    tickers:
+      [EFA, VEA, IEFA, VXUS, VWO, EEM, IEMG, EWJ, EWA, EWG, EWU, EWY, EWT, EWZ,
+       FXI, MCHI, ASHR, CSI, INDA, VGK, EWC, EWH, EWP, EWQ, EWL, EZU, EWW, EPP]
+
+  fixed-income:
+    asset_class: FIXED_INCOME
+    label: Fixed Income
+    tickers:
+      [BIL, SHV, SHY, SGOV, VGSH, IEF, VGIT, TLT, VGLT, GOVT, EDV, BND, AGG, SCHZ,
+       LQD, VCIT, VCSH, HYG, JNK, USHY, TIP, VTIP, SCHP, MBB, MUB, EMB, BNDX, TLH, IEI]
+
+  commodity:
+    asset_class: COMMODITY
+    label: Commodities
+    tickers:
+      [IAU, GLD, GLDM, SGOL, SLV, SIVR, PPLT, PALL, CPER, USO, BNO, DBO, UNG, DBC,
+       PDBC, DJP, GSG, DBA, CORN, WEAT, URA, COMT]
+
+  crypto:
+    asset_class: CRYPTO
+    label: Crypto
+    tickers:
+      [IBIT, FBTC, GBTC, BITO, BITB, ARKB, HODL, ETHA, ETHE, FETH, ETH-USD, BTC-USD,
+       SOL-USD, ADA-USD, AVAX-USD, BCH-USD, DOGE-USD, DOT-USD, LINK-USD, LTC-USD,
+       NEAR-USD, TRX-USD, XMR-USD, XRP-USD, ATOM-USD, BNB-USD, BTC, ETH, SOL, BNB, XRP]
+
+  fx:
+    asset_class: FX
+    label: Currency
+    tickers: [UUP, UDN, FXE, FXY, FXB, FXF, FXC, FXA, CYB]
+
+  cash:
+    asset_class: CASH
+    label: Cash
+    tickers: [CASH]

--- a/digiquant/src/digiquant/olympus/hermes/sector_map.py
+++ b/digiquant/src/digiquant/olympus/hermes/sector_map.py
@@ -1,0 +1,114 @@
+"""Asset-class / sector bucketing for the whole book (Pillar 2).
+
+The sizer's concentration control (``max_sector_pct``) and the exposure roll-ups need
+to bucket *every* ticker the PM can hold — not just the GICS equity sectors that
+``config/sectors.yaml`` covers, but the fixed-income, commodity, crypto, FX,
+international, and cash sleeves too. This module unifies both sources:
+
+- Equity single-names + GICS sector ETFs resolve to their sector slug (via
+  :func:`~digiquant.olympus.atlas.sectors_config.load_sectors`), coarse class ``EQUITY``.
+- Everything else resolves via ``config/asset_classes.yaml``.
+
+**Authority on conflict:** ``sectors.yaml`` drives the *research* fan-out (what Atlas
+studies), while ``asset_classes.yaml`` reflects a ticker's *true risk exposure*. The
+latter therefore wins when both list a ticker — e.g. ``USO`` is researched under the
+Energy sector but is a crude-oil-futures ETF, so for risk bucketing it is ``commodity``;
+``QQQ`` is a broad multi-sector index, so it is ``equity-broad`` rather than a pure
+Technology bet.
+
+Two granularities are exposed:
+
+- :func:`sector_bucket` — the fine-grained concentration bucket (a GICS slug like
+  ``sector-technology`` for equities, or a sleeve slug like ``fixed-income`` /
+  ``commodity`` / ``crypto`` / ``fx`` / ``international`` / ``equity-broad`` / ``cash``).
+  Fed into ``TickerRisk.sector`` so ``max_sector_pct`` controls concentration.
+- :func:`asset_class` — the coarse class (``EQUITY`` / ``INTERNATIONAL`` /
+  ``FIXED_INCOME`` / ``COMMODITY`` / ``CRYPTO`` / ``FX`` / ``CASH``) for exposure
+  roll-ups.
+
+Both default to ``"unknown"`` / ``"UNKNOWN"`` for unlisted tickers — a conservative
+default the sizer treats as its own concentration bucket. Lookups are case-insensitive;
+the built map is cached (config is static per process — call ``_bucket_map.cache_clear()``
+in tests that patch the YAML).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+from digiquant.olympus.atlas.sectors_config import load_sectors
+
+UNKNOWN_BUCKET = "unknown"
+UNKNOWN_CLASS = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class Bucket:
+    """Where a ticker sits for concentration (``sector``) and exposure (``asset_class``)."""
+
+    sector: str
+    asset_class: str
+
+
+def _norm(ticker: str) -> str:
+    return str(ticker).strip().upper()
+
+
+def _asset_classes_path() -> Path:
+    # this file: …/olympus/hermes/sector_map.py → …/olympus/atlas/config/asset_classes.yaml
+    return Path(__file__).resolve().parents[1] / "atlas" / "config" / "asset_classes.yaml"
+
+
+@lru_cache(maxsize=1)
+def _bucket_map() -> dict[str, Bucket]:
+    """Build the ticker → :class:`Bucket` map from sectors.yaml + asset_classes.yaml.
+
+    Equity sectors fill first; ``asset_classes.yaml`` is layered on top so it wins on the
+    documented overlaps (true-exposure correction), keeping the cross-asset config
+    authoritative for risk bucketing.
+    """
+    out: dict[str, Bucket] = {}
+    # 1) GICS equity sectors → sector slug + coarse EQUITY.
+    for sector in load_sectors():
+        for ticker in (*sector.etfs, *sector.top_tickers):
+            out[_norm(ticker)] = Bucket(sector=sector.slug, asset_class="EQUITY")
+    # 2) Cross-asset / broad-equity / international / cash sleeves (override on conflict).
+    data = yaml.safe_load(_asset_classes_path().read_text(encoding="utf-8")) or {}
+    buckets = data.get("asset_classes")
+    if not isinstance(buckets, dict) or not buckets:
+        raise ValueError(f"{_asset_classes_path()} must declare a non-empty 'asset_classes' map")
+    for slug, spec in buckets.items():
+        spec = spec or {}
+        klass = str(spec.get("asset_class") or UNKNOWN_CLASS)
+        for ticker in spec.get("tickers") or []:
+            out[_norm(ticker)] = Bucket(sector=str(slug), asset_class=klass)
+    return out
+
+
+def bucket(ticker: str) -> Bucket:
+    """Full :class:`Bucket` for ``ticker`` (case-insensitive); UNKNOWN when unlisted."""
+    return _bucket_map().get(_norm(ticker), Bucket(UNKNOWN_BUCKET, UNKNOWN_CLASS))
+
+
+def sector_bucket(ticker: str) -> str:
+    """Fine-grained concentration bucket (GICS slug or sleeve slug); ``"unknown"`` default."""
+    return bucket(ticker).sector
+
+
+def asset_class(ticker: str) -> str:
+    """Coarse asset class for exposure roll-ups; ``"UNKNOWN"`` default."""
+    return bucket(ticker).asset_class
+
+
+__all__ = [
+    "UNKNOWN_BUCKET",
+    "UNKNOWN_CLASS",
+    "Bucket",
+    "asset_class",
+    "bucket",
+    "sector_bucket",
+]

--- a/tests/dq/hermes/test_sector_map.py
+++ b/tests/dq/hermes/test_sector_map.py
@@ -72,6 +72,17 @@ def test_asset_classes_yaml_wins_on_documented_conflicts() -> None:
     assert bucket("QQQ") == Bucket(sector="equity-broad", asset_class="EQUITY")
 
 
+def test_dual_listed_ticker_resolves_deterministically() -> None:
+    # GOOGL is listed in BOTH Technology and Communication Services in sectors.yaml (per
+    # real GICS). The build layers sectors in file order with last-wins, so the later
+    # sector (Communication Services) is authoritative. Pin the concrete outcome: this
+    # locks determinism — a non-deterministic build or a sectors.yaml reorder breaks it.
+    listing = {s.slug for s in load_sectors() if "GOOGL" in {t.upper() for t in s.top_tickers}}
+    assert listing == {"sector-technology", "sector-comms"}, listing
+    assert bucket("GOOGL").sector == "sector-comms"
+    assert asset_class("GOOGL") == "EQUITY"
+
+
 def test_unknown_ticker_falls_back() -> None:
     assert bucket("ZZZZ") == Bucket(UNKNOWN_BUCKET, UNKNOWN_CLASS)
     assert sector_bucket("not-a-ticker") == "unknown"

--- a/tests/dq/hermes/test_sector_map.py
+++ b/tests/dq/hermes/test_sector_map.py
@@ -1,0 +1,105 @@
+"""Asset-class / sector bucketing (Pillar 2).
+
+``sector_map`` buckets every holdable ticker for concentration control + exposure
+roll-ups, unifying the GICS equity sectors (sectors.yaml) with the cross-asset sleeves
+(asset_classes.yaml). asset_classes.yaml is authoritative on conflict (true risk
+exposure beats research fan-out): USO is a commodity, QQQ is broad equity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.atlas.sectors_config import load_sectors
+from digiquant.olympus.hermes import sector_map
+from digiquant.olympus.hermes.sector_map import (
+    UNKNOWN_BUCKET,
+    UNKNOWN_CLASS,
+    Bucket,
+    asset_class,
+    bucket,
+    sector_bucket,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_equity_single_name_maps_to_its_gics_sector() -> None:
+    assert sector_bucket("AAPL") == "sector-technology"
+    assert asset_class("AAPL") == "EQUITY"
+
+
+def test_sector_etf_maps_to_its_sector() -> None:
+    assert sector_bucket("XLV") == "sector-healthcare"
+    assert asset_class("XLV") == "EQUITY"
+
+
+def test_broad_equity_etf_is_equity_broad() -> None:
+    assert bucket("SPY") == Bucket(sector="equity-broad", asset_class="EQUITY")
+    assert sector_bucket("VTI") == "equity-broad"
+
+
+def test_fixed_income_bucket() -> None:
+    for t in ("BIL", "SHY", "TLT", "AGG", "HYG"):
+        assert bucket(t) == Bucket(sector="fixed-income", asset_class="FIXED_INCOME"), t
+
+
+def test_commodity_bucket() -> None:
+    for t in ("IAU", "GLD", "SLV"):
+        assert bucket(t) == Bucket(sector="commodity", asset_class="COMMODITY"), t
+
+
+def test_crypto_bucket() -> None:
+    assert bucket("IBIT") == Bucket(sector="crypto", asset_class="CRYPTO")
+    assert bucket("BTC-USD") == Bucket(sector="crypto", asset_class="CRYPTO")
+
+
+def test_international_bucket() -> None:
+    assert bucket("EFA") == Bucket(sector="international", asset_class="INTERNATIONAL")
+    assert asset_class("VWO") == "INTERNATIONAL"
+
+
+def test_fx_and_cash_buckets() -> None:
+    assert bucket("UUP") == Bucket(sector="fx", asset_class="FX")
+    assert bucket("CASH") == Bucket(sector="cash", asset_class="CASH")
+
+
+def test_asset_classes_yaml_wins_on_documented_conflicts() -> None:
+    # USO is researched under the Energy sector (sectors.yaml) but is a crude-oil-futures
+    # ETF → commodity for risk. QQQ is a broad multi-sector index → equity-broad, not a
+    # pure Technology bet. asset_classes.yaml is authoritative for both.
+    assert bucket("USO") == Bucket(sector="commodity", asset_class="COMMODITY")
+    assert bucket("QQQ") == Bucket(sector="equity-broad", asset_class="EQUITY")
+
+
+def test_unknown_ticker_falls_back() -> None:
+    assert bucket("ZZZZ") == Bucket(UNKNOWN_BUCKET, UNKNOWN_CLASS)
+    assert sector_bucket("not-a-ticker") == "unknown"
+    assert asset_class("") == "UNKNOWN"
+
+
+def test_lookup_is_case_and_whitespace_insensitive() -> None:
+    assert sector_bucket("aapl") == "sector-technology"
+    assert sector_bucket("  spy  ") == "equity-broad"
+    assert asset_class("bil") == "FIXED_INCOME"
+
+
+def test_every_sector_single_name_is_equity() -> None:
+    # Single names are never overridden by the cross-asset config, so each GICS sector's
+    # representative tickers stay EQUITY. A ticker dual-listed across sectors (e.g. GOOGL
+    # in Technology *and* Communication Services, per real GICS) resolves deterministically
+    # to one of the sectors that lists it.
+    listing_slugs: dict[str, set[str]] = {}
+    for sector in load_sectors():
+        for ticker in sector.top_tickers:
+            listing_slugs.setdefault(ticker.upper(), set()).add(sector.slug)
+    for ticker, slugs in listing_slugs.items():
+        b = bucket(ticker)
+        assert b.sector in slugs, f"{ticker} → {b.sector}, expected one of {slugs}"
+        assert b.asset_class == "EQUITY", ticker
+
+
+def test_module_exports_are_callable() -> None:
+    assert callable(sector_map.bucket)
+    assert callable(sector_map.sector_bucket)
+    assert callable(sector_map.asset_class)


### PR DESCRIPTION
## Pillar 2 · PR 2 — asset-class / sector bucketing

The sizer (#744) controls concentration via `max_sector_pct` and needs to bucket **every** ticker the PM can hold. GICS `config/sectors.yaml` only covers equity sectors — it has nothing for the fixed-income, commodity, crypto, FX, international, broad-equity, or cash sleeves that show up in the book. This PR fills that gap.

### What it adds

- **`config/asset_classes.yaml`** — the cross-asset sleeves (fixed-income / commodity / crypto / fx / international / equity-broad / cash) with representative ticker lists drawn from the live `watchlist.md` + cross-asset skills.
- **`digiquant/src/digiquant/olympus/hermes/sector_map.py`** — unifies both sources into a ticker → bucket map:
  - Equity single-names + GICS sector ETFs → their sector slug (via the existing `load_sectors`), coarse class `EQUITY`.
  - Everything else → `asset_classes.yaml`.
  - Two granularities: `sector_bucket(t)` (fine-grained concentration slug, e.g. `sector-technology` / `fixed-income`) and `asset_class(t)` (coarse class for exposure roll-ups). Both default to `unknown`/`UNKNOWN`; case-insensitive; cached.

### Authority on conflict (documented + tested)

`sectors.yaml` drives the **research** fan-out (what Atlas studies); `asset_classes.yaml` reflects **true risk exposure** and wins when both list a ticker:
- `USO` — a crude-oil-futures ETF researched under Energy → buckets as **commodity**.
- `QQQ` — a broad multi-sector index → **equity-broad**, not a pure Technology bet.

A ticker dual-listed across sectors (e.g. `GOOGL` in Technology *and* Communication Services, per real GICS) resolves deterministically (locked by a test).

### Tests / gate

- 13 unit tests (`tests/dq/hermes/test_sector_map.py`): every sleeve, the USO/QQQ overrides, dual-listed-GOOGL determinism, case/whitespace-insensitivity, unknown fallback, and an invariant that every GICS single-name stays `EQUITY`. **All pass** (34 with the sizer suite).
- `ruff` clean; `make score` (staged): **Security 10 · Quality 10 · Optimization 10 · Accuracy 10**.
- `ARCHITECTURE.md` documents the Pillar 2 risk-sizing layer (sizer + map + the upcoming phase7e node).

### Scope

Pure config + lookup; no behavior wired yet. The **phase7e enforcement node** (next PR) feeds `sector_bucket(t)` into `TickerRisk.sector` so the sizer's sector caps and exposure roll-ups operate on the whole book.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)