### PR TITLE
feat(digichat): serve under digithings.ai/chat (env-gated basePath)

### DIFF
--- a/docs/adr/0018-digichat-path-routing.md
+++ b/docs/adr/0018-digichat-path-routing.md
@@ -1,0 +1,32 @@
+# ADR 0018 — DigiChat served at `digithings.ai/chat` (path), not a separate `chat.` deploy
+
+Status: Accepted · Supersedes the `chat.digithings.ai` subdomain decision in [ADR-0002](0002-domain-unification.md)
+
+## Context
+
+ADR-0002 planned DigiChat as `chat.digithings.ai` — a separate production deployment target. In practice this reads as "DigiChat has its own pipeline / its own site," which is not desired: DigiChat should be part of the digithings.ai surface, reachable at **`digithings.ai/chat`**, with a single web presence.
+
+DigiChat is, however, a **stateful Next.js standalone server** (`output: "standalone"`, a Dockerfile running `node server.js`): NextAuth sessions, a Postgres/Drizzle database, streaming LLM responses through its BFF, and an `/embed` route. It therefore **cannot** be a static page under the Cloudflare-Pages static digithings.ai — it needs a server runtime.
+
+## Decision
+
+Serve DigiChat under the path **`digithings.ai/chat`** via a Cloudflare route to the DigiChat container, rather than a `chat.` subdomain:
+
+- digithings.ai stays a static Cloudflare Pages site (`frontend/digithings-web`); a Cloudflare route forwards `digithings.ai/chat/*` to the DigiChat container origin.
+- DigiChat runs as the existing container/service in the monorepo stack (`make up-digichat`) — **not** a separate website pipeline or domain.
+- DigiChat gains an **env-gated `basePath`** so it serves correctly under the subpath:
+  - `next.config.ts` → `basePath: process.env.DIGICHAT_BASE_PATH || undefined`.
+  - `src/lib/base-path.ts` exposes `BASE_PATH`/`p()`; raw `fetch("/api/...")`, NextAuth `SessionProvider basePath`, and `signIn`/`signOut`/`window.location` callbacks are prefixed (Next `<Link>`/router and server `redirect()` apply basePath automatically — verified).
+  - Unset env → root (self-host, local dev, and the legacy deploy are unchanged: zero regression).
+
+## Production configuration (Cloudflare + env)
+
+- Cloudflare route: `digithings.ai/chat/*` → DigiChat container origin.
+- DigiChat build/runtime env for that deploy: `DIGICHAT_BASE_PATH=/chat`, `NEXT_PUBLIC_DIGICHAT_BASE_PATH=/chat`, `AUTH_URL=https://digithings.ai/chat`.
+- The marketing site's "Try Chat" link points at `/chat`.
+
+## Consequences
+
+- One domain, one website pipeline; DigiChat is a service behind a path, not a second site.
+- DigiChat still requires a server host for its container (inherent to an auth + DB + streaming app) — this is a stack service, not a separate product deploy.
+- Verified: with `basePath=/chat`, `GET /chat` → 307 `/chat/login`, `/chat/login` → 200, `/login` → 404; default build stays at root.

--- a/frontend/digichat/next.config.ts
+++ b/frontend/digichat/next.config.ts
@@ -7,6 +7,10 @@ import {
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Serve under a subpath when set (e.g. /chat for digithings.ai/chat). Unset →
+  // root, so self-host (`make up-digichat`), local dev, and the legacy deploy are
+  // unchanged. Must match NEXT_PUBLIC_DIGICHAT_BASE_PATH (see src/lib/base-path.ts).
+  basePath: process.env.DIGICHAT_BASE_PATH || undefined,
   // Pin the tracing root to the monorepo root so the standalone tree is always
   // .next/standalone/frontend/digichat/server.js — without this Next infers the
   // root from surrounding lockfiles, which breaks in git worktrees and would

--- a/frontend/digichat/src/app/login/login-form.tsx
+++ b/frontend/digichat/src/app/login/login-form.tsx
@@ -4,6 +4,7 @@ import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { p } from "@/lib/base-path";
 
 export function LoginForm({
   oidcEnabled,
@@ -26,7 +27,7 @@ export function LoginForm({
       </p>
       <div className="flex flex-col gap-3">
         {oidcEnabled ? (
-          <Button type="button" className="w-full" onClick={() => signIn("oidc", { callbackUrl: "/" })}>
+          <Button type="button" className="w-full" onClick={() => signIn("oidc", { callbackUrl: p("/") })}>
             Continue with SSO
           </Button>
         ) : (
@@ -64,10 +65,10 @@ export function LoginForm({
               const res = await signIn("dev", {
                 password,
                 redirect: false,
-                callbackUrl: "/",
+                callbackUrl: p("/"),
               });
               if (res?.error) setErr("Invalid dev password.");
-              else if (res?.ok) window.location.href = "/";
+              else if (res?.ok) window.location.href = p("/");
             }}
           >
             <label className="text-xs font-medium text-muted-foreground">

--- a/frontend/digichat/src/components/byok-settings-panel.tsx
+++ b/frontend/digichat/src/components/byok-settings-panel.tsx
@@ -5,6 +5,7 @@ import { Eye, EyeOff, Key, Loader2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { p } from "@/lib/base-path";
 import {
   Sheet,
   SheetContent,
@@ -70,7 +71,7 @@ function ByokSettingsForm({
     setTesting(true);
     setTestResult(null);
     try {
-      const resp = await fetch("/api/byok/test", {
+      const resp = await fetch(p("/api/byok/test"), {
         method: "POST",
         credentials: "include",
         headers: {

--- a/frontend/digichat/src/components/chat-shell.tsx
+++ b/frontend/digichat/src/components/chat-shell.tsx
@@ -37,6 +37,7 @@ import {
   type ChatThreadState,
 } from "@/lib/thread-local";
 import { cn } from "@/lib/utils";
+import { p } from "@/lib/base-path";
 
 type RemoteSummary = { id: string; title: string; updatedAt: string };
 
@@ -104,7 +105,7 @@ export function ChatShell({
       if (!t) return;
 
       if (!t.remote) {
-        const cr = await fetch("/api/conversations", {
+        const cr = await fetch(p("/api/conversations"), {
           method: "POST",
           credentials: "include",
           headers: { "content-type": "application/json" },
@@ -116,7 +117,7 @@ export function ChatShell({
       }
 
       const snap = threadsRef.current.find((x) => x.id === threadId) ?? t;
-      await fetch(`/api/conversations/${threadId}`, {
+      await fetch(p(`/api/conversations/${threadId}`), {
         method: "PUT",
         credentials: "include",
         headers: { "content-type": "application/json" },
@@ -146,7 +147,7 @@ export function ChatShell({
       let remote: RemoteSummary[] = [];
       let pers = false;
       try {
-        const r = await fetch("/api/conversations", { credentials: "include" });
+        const r = await fetch(p("/api/conversations"), { credentials: "include" });
         if (r.ok) {
           const j = (await r.json()) as {
             serverPersistence?: boolean;
@@ -194,7 +195,7 @@ export function ChatShell({
       const t = threads.find((x) => x.id === id);
       if (t?.remote && !t.hydrated) {
         try {
-          const r = await fetch(`/api/conversations/${id}`, { credentials: "include" });
+          const r = await fetch(p(`/api/conversations/${id}`), { credentials: "include" });
           if (r.ok) {
             const j = (await r.json()) as { title: string; messages: UIMessage[] };
             setThreads((prev) =>
@@ -247,7 +248,7 @@ export function ChatShell({
       const t = threadsRef.current.find((x) => x.id === id);
       if (t?.remote && serverPersistence) {
         try {
-          await fetch(`/api/conversations/${id}`, { method: "DELETE", credentials: "include" });
+          await fetch(p(`/api/conversations/${id}`), { method: "DELETE", credentials: "include" });
         } catch {
           /* ignore */
         }
@@ -473,7 +474,7 @@ export function ChatShell({
               type="button"
               className="dc-sidebar-cmd"
               style={{ width: "100%", background: "transparent", border: "none", cursor: "pointer" }}
-              onClick={() => signOut({ callbackUrl: "/login" })}
+              onClick={() => signOut({ callbackUrl: p("/login") })}
             >
               <span>sign out</span>
               <span aria-hidden>⏻</span>

--- a/frontend/digichat/src/components/connections-sheet.tsx
+++ b/frontend/digichat/src/components/connections-sheet.tsx
@@ -14,6 +14,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import type { EcosystemEndpoints } from "@/lib/ecosystem";
+import { p } from "@/lib/base-path";
 
 type HealthChecks = Record<string, string>;
 
@@ -32,7 +33,7 @@ export function ConnectionsSheet() {
     setLoading(true);
     setErr(null);
     try {
-      const r = await fetch("/api/ecosystem/config", { credentials: "include" });
+      const r = await fetch(p("/api/ecosystem/config"), { credentials: "include" });
       if (!r.ok) {
         setErr(`Config ${r.status}: ${await r.text()}`);
         return;
@@ -47,7 +48,7 @@ export function ConnectionsSheet() {
       setForm(data.effective);
       setHasCustom(data.hasCustomEndpoints);
       setPersistence(data.persistence ?? null);
-      const h = await fetch("/api/health", { credentials: "include" });
+      const h = await fetch(p("/api/health"), { credentials: "include" });
       if (h.ok) {
         const hj = (await h.json()) as { checks?: HealthChecks };
         setHealth(hj.checks ?? null);
@@ -70,7 +71,7 @@ export function ConnectionsSheet() {
     setSaving(true);
     setErr(null);
     try {
-      const r = await fetch("/api/ecosystem/config", {
+      const r = await fetch(p("/api/ecosystem/config"), {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -92,7 +93,7 @@ export function ConnectionsSheet() {
     setSaving(true);
     setErr(null);
     try {
-      const r = await fetch("/api/ecosystem/config", {
+      const r = await fetch(p("/api/ecosystem/config"), {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },

--- a/frontend/digichat/src/components/providers.tsx
+++ b/frontend/digichat/src/components/providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
 import { LocalBootstrapGate } from "@/components/local-bootstrap-gate";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { BASE_PATH } from "@/lib/base-path";
 
 export function Providers({
   children,
@@ -16,7 +17,7 @@ export function Providers({
   localBootstrapEnabled: boolean;
 }) {
   return (
-    <SessionProvider session={session}>
+    <SessionProvider session={session} basePath={`${BASE_PATH}/api/auth`}>
       <LocalBootstrapGate
         enabled={localBootstrapEnabled}
         hasServerSession={!!session?.user}

--- a/frontend/digichat/src/lib/base-path.ts
+++ b/frontend/digichat/src/lib/base-path.ts
@@ -1,0 +1,15 @@
+/**
+ * Base path prefix for serving DigiChat under a subpath (e.g. digithings.ai/chat).
+ *
+ * Empty by default → the app serves at root (self-host `make up-digichat`, local
+ * dev, and the legacy chat.digithings.ai deploy are all unaffected). Set
+ * NEXT_PUBLIC_DIGICHAT_BASE_PATH=/chat at build time (alongside DIGICHAT_BASE_PATH
+ * for next.config's basePath) to serve under /chat.
+ *
+ * Next's <Link>/router auto-prefix basePath, but raw fetch() to "/api/..." and
+ * next-auth/react's signIn/signOut callbackUrls do NOT — prefix those with BASE_PATH.
+ */
+export const BASE_PATH = process.env.NEXT_PUBLIC_DIGICHAT_BASE_PATH ?? "";
+
+/** Prefix an app-absolute path with the base path. `p("/api/x")` → "/api/x" or "/chat/api/x". */
+export const p = (path: string): string => `${BASE_PATH}${path}`;


### PR DESCRIPTION
## Summary
Serves DigiChat at **digithings.ai/chat** (Cloudflare path route → the DigiChat container) instead of a separate `chat.digithings.ai` deploy, so there's one website pipeline. DigiChat remains a Next.js **standalone server** (auth + Postgres + streaming) — it can't be a static page; this just serves it under a subpath. Supersedes ADR-0002's subdomain decision. Fixes #746.

## Change (env-gated → zero regression)
- `next.config.ts`: `basePath: process.env.DIGICHAT_BASE_PATH || undefined`.
- `src/lib/base-path.ts` (`BASE_PATH`/`p()`): prefix the 10 absolute `fetch("/api/...")` calls, NextAuth `SessionProvider basePath`, and `signIn`/`signOut`/`window.location` callbacks. Next `<Link>`/router + server `redirect()` apply basePath automatically (verified).
- **Unset env → root** — self-host (`make up-digichat`), local dev, and the current deploy are unaffected.
- ADR-0018 documents routing + the Cloudflare route + build env.

## Verification
- With `DIGICHAT_BASE_PATH=/chat` (ran the standalone server): `GET /chat` → 307 `/chat/login`, `/chat/login` → 200, `/login` → 404.
- Default build (no env): stays at root, 0 `/chat` refs — no regression.
- `make score` 10/10; `make doc-check` OK.

## Infra (dashboard, separate)
- Cloudflare route `digithings.ai/chat/*` → DigiChat container origin.
- DigiChat deploy env: `DIGICHAT_BASE_PATH=/chat`, `NEXT_PUBLIC_DIGICHAT_BASE_PATH=/chat`, `AUTH_URL=https://digithings.ai/chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)