### PR TITLE
feat(hermes): phase7e — wire deterministic risk-sizing into the live pipeline (P2)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -730,9 +730,16 @@ risk profile is reproducible and auditable rather than LLM-eyeballed.
   international / equity-broad / cash). `asset_classes.yaml` is authoritative on conflict
   (true risk exposure beats research fan-out — e.g. USO is `commodity`, not Energy equity).
   `sector_bucket(t)` → fine-grained concentration slug; `asset_class(t)` → coarse class.
-- The `phase7e` enforcement node (between `publish` and `materialize` in `chain.py`) reads
-  vol/correlation, calls `size_portfolio`, and overwrites `phase7d_rebalance.recommended_portfolio`
-  with enforced weights that `portfolio_materialize` then books verbatim.
+- `digiquant.olympus.hermes.phases.phase7e_risk_sizing` — the enforcement node. Reads each
+  PM-recommended ticker's effective conviction (analyst `conviction_score` + debate
+  `conviction_delta`, clamped −5..+5), per-ticker vol from the latest `price_technicals` row
+  ≤ `run_date` (look-ahead-guarded), and the `sector_map` bucket; calls `size_portfolio`; and
+  overwrites `phase7d_rebalance.recommended_portfolio` (+ rebuilds the action list). Wired in
+  `chain.py` via `ChainDeps.risk_sizing`, it runs **before** `publish` + `materialize` so the
+  published `pm-rebalance` document and the booked `positions` reflect the same sized book.
+  Fail-soft: a data or sizing error keeps the PM's book; a no-op when the PM never ran.
+  Correlation + the drawdown breaker are stubbed (`corr=None`, `breaker_scale=1.0`) pending
+  follow-up Pillar 2 PRs.
 
 ### Persistence
 

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -26,6 +26,10 @@ from digiquant.olympus.atlas.phases.preflight import (
     PreflightReflectDeps,
 )
 from digiquant.olympus.atlas.phases.publish_phase import PublishDeps, build_publish_phase
+from digiquant.olympus.hermes.phases.phase7e_risk_sizing import (
+    RiskSizingDeps,
+    build_risk_sizing_phase,
+)
 from digiquant.olympus.hermes.portfolio_materialize import (
     MaterializeDeps,
     build_materialize_phase,
@@ -57,6 +61,10 @@ class ChainDeps:
     atlas: AtlasGraphDeps
     hermes: HermesGraphDeps
     publish: PublishDeps | None = None
+    # Phase 7E deterministic risk-sizing enforcement (#726). None → no-op (legacy /
+    # dry-run / monthly). Runs BEFORE publish + materialize so the published
+    # pm-rebalance document and the booked positions share the same sized book.
+    risk_sizing: RiskSizingDeps | None = None
     # Phase 9D paper-portfolio materialization (#700). None → no-op (legacy /
     # dry-run / monthly). Wired on by ``cli_main`` for non-monthly runs so the
     # pipeline owns the book (owner decision 2026-06-13).
@@ -161,6 +169,16 @@ def run_atlas_then_hermes(
         checkpointer=checkpointer,
     )
     state = _invoke_resumable(hermes_graph, state, checkpointer, thread_base, "hermes")
+
+    # Phase 7E — deterministic risk-sizing enforcement (#726). Overwrites the PM's
+    # eyeballed candidate book with capped, vol-targeted, reduce-only weights. Runs
+    # BEFORE publish + materialize so the published pm-rebalance document and the booked
+    # positions reflect the SAME sized book. No-op when deps absent or the PM held cash.
+    if deps.risk_sizing is not None:
+        from digiquant.olympus.hermes.pipeline_builder import build_pipeline
+
+        risk_only = [build_risk_sizing_phase(deps.risk_sizing)]
+        state = build_pipeline(AtlasResearchState, risk_only).invoke(state)
 
     # Terminal publish — single pass over the fully populated state.
     if deps.publish is not None:
@@ -324,6 +342,8 @@ def cli_main(argv: list[str] | None = None) -> int:
         atlas=atlas_deps,
         hermes=hermes_deps,
         publish=PublishDeps(client=client) if atlas_input.run_type != "monthly" else None,
+        # Deterministic risk-sizing enforcement before publish/materialize (#726).
+        risk_sizing=(RiskSizingDeps(client=client) if atlas_input.run_type != "monthly" else None),
         # Pipeline owns the paper book on non-monthly runs (#700).
         materialize=(MaterializeDeps(client=client) if atlas_input.run_type != "monthly" else None),
     )

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -173,7 +173,9 @@ def run_atlas_then_hermes(
     # Phase 7E — deterministic risk-sizing enforcement (#726). Overwrites the PM's
     # eyeballed candidate book with capped, vol-targeted, reduce-only weights. Runs
     # BEFORE publish + materialize so the published pm-rebalance document and the booked
-    # positions reflect the SAME sized book. No-op when deps absent or the PM held cash.
+    # positions reflect the SAME sized book. Skipped entirely when deps are absent
+    # (legacy / dry-run / monthly); the node itself no-ops only when the PM never ran
+    # (``phase7d_rebalance is None``) — a deliberate cash book is still re-sized (→ empty).
     if deps.risk_sizing is not None:
         from digiquant.olympus.hermes.pipeline_builder import build_pipeline
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -156,14 +156,30 @@ def _load_ticker_risk(
     }
 
 
+def _verb(current: float | None, target: float) -> str:
+    """Rebalance verb from current → target weight. Unknown current ⇒ treat as 0."""
+    cur = current or 0.0
+    if cur <= 0 < target:
+        return "new"
+    if target <= 0 < cur:
+        return "exit"
+    if target > cur + 1e-9:
+        return "add"
+    if target < cur - 1e-9:
+        return "trim"
+    return "hold"
+
+
 def _rebuild_actions(
     original_actions: list[Any], pm_targets: dict[str, float], sized: dict[str, float]
 ) -> list[dict[str, Any]]:
     """Rebuild the advisory action list to match the SIZED book.
 
-    Preserves each PM action row (its verb / ``current_pct`` / rationale — the PM knew the
-    live book) and only updates ``target_pct`` to the sized weight. A PM name that sizing
-    dropped becomes an explicit exit-to-cash. ``materialize`` ignores ``actions`` (it books
+    For a retained ticker, updates ``target_pct`` to the sized weight AND recomputes the
+    verb from ``current_pct`` → sized target (so the published document doesn't say "add"
+    when sizing actually trimmed the position to a cap). When ``current_pct`` is unknown
+    the PM's verb is preserved (it can't be recomputed). A PM name that sizing dropped
+    becomes an explicit exit-to-cash. ``materialize`` ignores ``actions`` (it books
     ``recommended_portfolio``); these drive the published document only.
     """
     out: list[dict[str, Any]] = []
@@ -177,7 +193,11 @@ def _rebuild_actions(
         seen.add(ticker)
         row = dict(action)
         if ticker in sized:
-            row["target_pct"] = round(sized[ticker], 4)
+            new_target = round(sized[ticker], 4)
+            row["target_pct"] = new_target
+            current = _opt_float(action.get("current_pct"))
+            if current is not None:  # recompute verb only when we know the live weight
+                row["action"] = _verb(current, new_target)
         elif ticker in pm_targets:
             base = str(action.get("rationale") or "").strip()
             row["action"] = "exit"

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -1,0 +1,268 @@
+"""Phase 7E — deterministic risk-sizing enforcement (#726, Pillar 2).
+
+The PM (Phase 7D) proposes a candidate book: *which* tickers to hold (direction) with a
+per-ticker conviction + narrative. This terminal-side phase replaces the PM's eyeballed
+target weights with deterministic, risk-managed weights via
+:func:`~digiquant.olympus.hermes.sizing.size_portfolio` — the code half of the FinPos
+direction/sizing split. Sizing, position/sector caps, correlation de-dup, vol-targeting,
+and the drawdown-breaker scale become CODE, so the book's risk profile is reproducible
+and auditable.
+
+**Runs before publish + materialize** (not between them): ``publish_phase`` writes the
+``pm-rebalance`` document from ``state.phase7d_rebalance`` and ``portfolio_materialize``
+books ``recommended_portfolio`` — so to keep the *published* digest and the *booked*
+positions consistent, the sized book must be in state before either runs.
+
+Per ticker the PM recommended: effective conviction = analyst ``conviction_score`` +
+debate ``conviction_delta`` (clamped −5..+5); stance from the analyst (a carried holding
+with no fresh analyst payload defaults to the conviction floor + "hold" so it survives
+the select gate at minimal tilt rather than being dropped to cash for lack of new work).
+Per-ticker vol comes from the latest ``price_technicals`` row at-or-before ``run_date``
+(``hist_vol_21`` → ATR% → default); the concentration bucket from
+:func:`~digiquant.olympus.hermes.sector_map.sector_bucket`.
+
+Fail-soft: any data-layer or sizing error degrades to the PM's original book (the run
+never crashes and the book is never silently emptied). No-op when the PM produced no
+rebalance (``None``) — distinct from a deliberate 100%-cash stance (empty
+``recommended_portfolio``), which the sizer simply returns as empty.
+
+Correlation + the drawdown breaker are not wired yet (``corr=None`` → the sizer's
+conservative full-correlation default; ``breaker_scale=1.0``); both arrive in follow-up
+Pillar 2 PRs without changing this node's contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
+
+from digiquant.olympus.atlas.state import AtlasResearchState, RebalancePayload
+from digiquant.olympus.atlas.supabase_io import SupabaseClient
+from digiquant.olympus.hermes.sector_map import sector_bucket
+from digiquant.olympus.hermes.sizing import SizingCaps, TickerRisk, size_portfolio
+
+logger = logging.getLogger(__name__)
+
+# Calendar-day window to find the latest technicals row ≤ run_date. Wide enough to
+# clear weekends + holidays + a stale prices cron (the Saturday-baseline lag, #726).
+_VOL_LOOKBACK_DAYS = 40
+_CONVICTION_FLOOR, _CONVICTION_CAP = -5.0, 5.0
+
+
+@dataclass(frozen=True)
+class RiskSizingDeps:
+    """Wiring deps for the Phase 7E enforcement node (injected Supabase client)."""
+
+    client: SupabaseClient
+
+
+def _opt_float(val: Any) -> float | None:
+    try:
+        return float(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_cash(ticker: Any) -> bool:
+    return isinstance(ticker, str) and ticker.strip().upper() == "CASH"
+
+
+def _clamp_conviction(value: float) -> float:
+    return max(_CONVICTION_FLOOR, min(_CONVICTION_CAP, value))
+
+
+def _pm_direction(recommended: list[Any]) -> dict[str, float]:
+    """The PM's chosen names → its proposed weight (deduped, positive, non-CASH).
+
+    These are the *direction* the sizer re-sizes; the PM's actual weights are discarded
+    in favour of conviction-based sizing but kept here to rebuild the action list.
+    """
+    targets: dict[str, float] = {}
+    for row in recommended:
+        if not isinstance(row, dict):
+            continue
+        ticker = row.get("ticker")
+        if not isinstance(ticker, str) or not ticker or _is_cash(ticker):
+            continue
+        weight = _opt_float(row.get("target_pct")) or 0.0
+        if weight <= 0:
+            continue
+        targets[ticker] = targets.get(ticker, 0.0) + weight
+    return targets
+
+
+def _effective_inputs(
+    tickers: list[str],
+    analysts: dict[str, dict[str, Any]],
+    debates: dict[str, dict[str, Any]],
+    default_conviction: float,
+) -> tuple[dict[str, float], dict[str, str]]:
+    """Per ticker: effective conviction (analyst score + debate delta, clamped) + stance."""
+    convictions: dict[str, float] = {}
+    stances: dict[str, str] = {}
+    for ticker in tickers:
+        analyst = analysts.get(ticker) or {}
+        debate = debates.get(ticker) or {}
+        if analyst:
+            base = _opt_float(analyst.get("conviction_score")) or 0.0
+            stance = str(analyst.get("stance") or "hold")
+        else:
+            base = default_conviction
+            stance = "hold"
+        delta = _opt_float(debate.get("conviction_delta")) or 0.0
+        convictions[ticker] = _clamp_conviction(base + delta)
+        stances[ticker] = stance
+    return convictions, stances
+
+
+def _load_ticker_risk(
+    client: SupabaseClient, tickers: list[str], run_date: date
+) -> dict[str, TickerRisk]:
+    """Assemble ``{ticker: TickerRisk}`` — latest ``price_technicals`` row ≤ run_date for
+    vol, :func:`sector_bucket` for concentration. Fail-soft: a read error (or a missing
+    ticker) leaves vol unset so the sizer falls back to its default annualized vol."""
+    latest: dict[str, dict[str, Any]] = {}
+    if tickers:
+        try:
+            since = (run_date - timedelta(days=_VOL_LOOKBACK_DAYS)).isoformat()
+            resp = (
+                client.table("price_technicals")
+                .select("ticker,date,hist_vol_21,atr_pct")
+                .in_("ticker", list(tickers))
+                .lte("date", run_date.isoformat())  # look-ahead guard (no future rows)
+                .gte("date", since)
+                .order("date", desc=True)
+                .limit(len(tickers) * _VOL_LOOKBACK_DAYS)
+                .execute()
+            )
+            for row in getattr(resp, "data", None) or []:
+                ticker = row.get("ticker")
+                if ticker and ticker not in latest:  # desc order → first seen is freshest
+                    latest[ticker] = row
+        except Exception as exc:  # noqa: BLE001 — vol read is best-effort; default vol used
+            logger.warning("phase7e: price_technicals read failed (%s); using default vol", exc)
+    return {
+        ticker: TickerRisk(
+            ticker=ticker,
+            hist_vol_21=_opt_float((latest.get(ticker) or {}).get("hist_vol_21")),
+            atr_pct=_opt_float((latest.get(ticker) or {}).get("atr_pct")),
+            sector=sector_bucket(ticker),
+        )
+        for ticker in tickers
+    }
+
+
+def _rebuild_actions(
+    original_actions: list[Any], pm_targets: dict[str, float], sized: dict[str, float]
+) -> list[dict[str, Any]]:
+    """Rebuild the advisory action list to match the SIZED book.
+
+    Preserves each PM action row (its verb / ``current_pct`` / rationale — the PM knew the
+    live book) and only updates ``target_pct`` to the sized weight. A PM name that sizing
+    dropped becomes an explicit exit-to-cash. ``materialize`` ignores ``actions`` (it books
+    ``recommended_portfolio``); these drive the published document only.
+    """
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for action in original_actions:
+        if not isinstance(action, dict):
+            continue
+        ticker = action.get("ticker")
+        if not isinstance(ticker, str) or not ticker:
+            continue
+        seen.add(ticker)
+        row = dict(action)
+        if ticker in sized:
+            row["target_pct"] = round(sized[ticker], 4)
+        elif ticker in pm_targets:
+            base = str(action.get("rationale") or "").strip()
+            row["action"] = "exit"
+            row["target_pct"] = 0.0
+            row["rationale"] = (
+                f"{base} [removed by risk sizing — cap / correlation de-dup / conviction floor]"
+            ).strip()
+        out.append(row)
+    # Sized tickers the PM had no explicit action row for (rare) → minimal new rows.
+    for ticker, target in sized.items():
+        if ticker not in seen:
+            out.append(
+                {
+                    "ticker": ticker,
+                    "action": "new",
+                    "target_pct": round(target, 4),
+                    "rationale": "Position weight set by deterministic risk sizing.",
+                }
+            )
+    return out
+
+
+def build_risk_sizing_node(deps: RiskSizingDeps):
+    """Return the Phase 7E enforcement node bound to ``deps``."""
+
+    def risk_sizing(state: AtlasResearchState) -> dict[str, Any]:
+        rebalance = state.phase7d_rebalance
+        if rebalance is None:
+            return {}  # PM never ran (partial graph / dry-run) — don't fabricate a book.
+
+        pm_targets = _pm_direction(rebalance.get("recommended_portfolio") or [])
+        pm_tickers = list(pm_targets)
+        caps = SizingCaps.from_preferences(state.config.preferences)
+
+        try:
+            convictions, stances = _effective_inputs(
+                pm_tickers,
+                dict(state.phase7c_analysts),
+                dict(state.phase7cd_debates),
+                default_conviction=caps.min_conviction,
+            )
+            risk = _load_ticker_risk(deps.client, pm_tickers, state.run_date)
+            result = size_portfolio(
+                convictions=convictions,
+                stances=stances,
+                risk=risk,
+                corr=None,
+                caps=caps,
+                breaker_scale=1.0,
+            )
+        except Exception as exc:  # noqa: BLE001 — sizing must never crash the run; keep PM book
+            logger.warning("phase7e: risk sizing failed (%s); keeping PM book", exc)
+            return {}
+
+        sized = {p.ticker: p.target_pct for p in result.positions}
+        updated: RebalancePayload = dict(rebalance)  # type: ignore[assignment]
+        updated["recommended_portfolio"] = [
+            {"ticker": ticker, "target_pct": round(weight, 4)} for ticker, weight in sized.items()
+        ]
+        updated["actions"] = _rebuild_actions(rebalance.get("actions") or [], pm_targets, sized)
+        prior_notes = str(rebalance.get("notes") or "").strip()
+        updated["notes"] = (
+            f"{prior_notes}\n\n" if prior_notes else ""
+        ) + f"Risk-sizing (Phase 7E): {result.explanation}"
+
+        logger.info(
+            "phase7e: sized %d→%d holdings, %.1f%% invested / %.1f%% cash, ex-ante vol ~%s%% (%s)",
+            len(pm_tickers),
+            len(sized),
+            result.gross_pct,
+            result.cash_pct,
+            result.realized_portfolio_vol,
+            caps.sizing_mode,
+        )
+        return {"phase7d_rebalance": updated}
+
+    return risk_sizing
+
+
+def build_risk_sizing_phase(deps: RiskSizingDeps) -> PipelinePhase:
+    """Wrap the enforcement node into a single-node ``PipelinePhase``."""
+    return PipelinePhase(
+        name="risk-sizing",
+        nodes=[NodeSpec(name="phase7e-risk-sizing", run=build_risk_sizing_node(deps))],
+    )
+
+
+__all__ = ["RiskSizingDeps", "build_risk_sizing_node", "build_risk_sizing_phase"]

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -54,6 +54,10 @@ class _FakeQuery:
         self._filters.append(("lt", col, val))
         return self
 
+    def lte(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("lte", col, val))
+        return self
+
     def gte(self, col: str, val: Any) -> "_FakeQuery":
         self._filters.append(("gte", col, val))
         return self
@@ -101,6 +105,7 @@ class _FakeQuery:
                 if all(
                     (op == "eq" and row.get(col) == val)
                     or (op == "lt" and str(row.get(col, "")) < str(val))
+                    or (op == "lte" and str(row.get(col, "")) <= str(val))
                     or (op == "gte" and str(row.get(col, "")) >= str(val))
                     or (op == "in_" and row.get(col) in val)
                     for op, col, val in self._filters
@@ -112,6 +117,8 @@ class _FakeQuery:
         for op, col, val in self._filters:
             if op == "lt":
                 rows = [r for r in rows if str(r.get(col, "")) < str(val)]
+            elif op == "lte":
+                rows = [r for r in rows if str(r.get(col, "")) <= str(val)]
             elif op == "gte":
                 rows = [r for r in rows if str(r.get(col, "")) >= str(val)]
             elif op == "eq":

--- a/tests/dq/hermes/test_phase7e_risk_sizing.py
+++ b/tests/dq/hermes/test_phase7e_risk_sizing.py
@@ -224,6 +224,32 @@ def test_dropped_ticker_becomes_exit_action() -> None:
     assert "removed by risk sizing" in aaa_action["rationale"]
 
 
+def test_retained_position_verb_recomputed_to_trim() -> None:
+    # PM held SPY at 50% and proposed holding 50%; the 30% position cap trims the sized
+    # target to 30 < 50, so the published action must flip "hold" → "trim" (not stay
+    # "hold" with a 30% target, which would misdescribe the enforced book).
+    client = FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"SPY": 15})})
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 50}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+            actions=[
+                {
+                    "ticker": "SPY",
+                    "action": "hold",
+                    "current_pct": 50,
+                    "target_pct": 50,
+                    "rationale": "PM holds SPY.",
+                },
+            ],
+        ),
+        client,
+    )
+    spy_action = next(a for a in rebal["actions"] if a["ticker"] == "SPY")
+    assert spy_action["action"] == "trim"
+    assert spy_action["target_pct"] == pytest.approx(30.0)
+
+
 def test_carried_holding_without_analyst_is_retained() -> None:
     # The PM recommends a name with no fresh analyst payload (a carried holding); it
     # defaults to the conviction floor + hold and survives at minimal tilt, not dropped.

--- a/tests/dq/hermes/test_phase7e_risk_sizing.py
+++ b/tests/dq/hermes/test_phase7e_risk_sizing.py
@@ -1,0 +1,279 @@
+"""Phase 7E — deterministic risk-sizing enforcement (#726, Pillar 2).
+
+The node replaces the PM's eyeballed candidate book with sized, capped, reduce-only
+weights and rebuilds the advisory action list, reading per-ticker vol from
+``price_technicals`` (look-ahead-guarded) and sector buckets from ``sector_map``. It is
+fail-soft (errors keep the PM book) and a no-op when the PM never ran.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
+from digiquant.olympus.hermes.phases import phase7e_risk_sizing
+from digiquant.olympus.hermes.phases.phase7e_risk_sizing import (
+    RiskSizingDeps,
+    build_risk_sizing_node,
+)
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+pytestmark = pytest.mark.unit
+
+RUN_DATE = date(2026, 6, 12)
+# Caps relaxed so a *specific* constraint can be isolated per test (the default caps bind
+# at 30% position / 40% sector / 12% vol — exercised by the default-caps tests below).
+_RELAXED = {
+    "max_single_etf_pct": 100,
+    "max_sector_pct": 100,
+    "target_portfolio_vol": 1.0e6,
+    "weight_increment_pct": 0,
+}
+
+
+def _state(
+    recommended: list[dict],
+    analysts: dict | None = None,
+    debates: dict | None = None,
+    actions: list[dict] | None = None,
+    preferences: dict | None = None,
+) -> AtlasResearchState:
+    state = AtlasResearchState(
+        run_type="delta",
+        run_date=RUN_DATE,
+        baseline_date=date(2026, 6, 9),
+        config=AtlasConfigBundle(preferences=preferences or {}),
+    )
+    state.phase7d_rebalance = {
+        "recommended_portfolio": recommended,
+        "actions": actions or [],
+        "notes": "PM notes.",
+    }
+    state.phase7c_analysts = analysts or {}
+    state.phase7cd_debates = debates or {}
+    return state
+
+
+def _tech_rows(vols: dict[str, float], on: str = "2026-06-12") -> list[dict]:
+    return [{"ticker": t, "date": on, "hist_vol_21": v, "atr_pct": None} for t, v in vols.items()]
+
+
+def _run(state: AtlasResearchState, client: FakeSupabaseClient | None = None) -> dict | None:
+    client = client or FakeSupabaseClient()
+    out = build_risk_sizing_node(RiskSizingDeps(client=client))(state)
+    return out.get("phase7d_rebalance")
+
+
+def _weights(rebal: dict) -> dict[str, float]:
+    return {r["ticker"]: r["target_pct"] for r in rebal["recommended_portfolio"]}
+
+
+# --------------------------------------------------------------------------- no-op / cash
+
+
+def test_no_op_when_pm_never_ran() -> None:
+    state = _state([])
+    state.phase7d_rebalance = None
+    assert build_risk_sizing_node(RiskSizingDeps(client=FakeSupabaseClient()))(state) == {}
+
+
+def test_empty_book_stays_empty_cash() -> None:
+    rebal = _run(_state([]))
+    assert rebal is not None
+    assert rebal["recommended_portfolio"] == []
+
+
+# --------------------------------------------------------------------------- core enforcement
+
+
+def test_overwrites_pm_weights_with_position_capped_book() -> None:
+    # PM eyeballed 50/50; the 30% default position cap rewrites it to 30/30 with the freed
+    # 40% as cash (reduce-only). The PM's weights are discarded in favour of sizing.
+    client = FakeSupabaseClient(
+        canned_reads={"price_technicals": _tech_rows({"SPY": 15, "TLT": 15})}
+    )
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 50}, {"ticker": "TLT", "target_pct": 50}],
+            analysts={
+                "SPY": {"conviction_score": 5, "stance": "buy"},
+                "TLT": {"conviction_score": 5, "stance": "buy"},
+            },
+        ),
+        client,
+    )
+    w = _weights(rebal)
+    assert w == {"SPY": pytest.approx(30.0), "TLT": pytest.approx(30.0)}
+
+
+def test_single_name_position_capped_to_thirty() -> None:
+    client = FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"SPY": 15})})
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        client,
+    )
+    assert _weights(rebal) == {"SPY": pytest.approx(30.0)}
+
+
+def test_effective_conviction_applies_debate_delta() -> None:
+    # Equal analyst conviction (3); a +2 debate delta lifts A to 5 → A outweighs B ~5:3.
+    rebal = _run(
+        _state(
+            [{"ticker": "AAA", "target_pct": 50}, {"ticker": "BBB", "target_pct": 50}],
+            analysts={
+                "AAA": {"conviction_score": 3, "stance": "buy"},
+                "BBB": {"conviction_score": 3, "stance": "buy"},
+            },
+            debates={"AAA": {"conviction_delta": 2}, "BBB": {"conviction_delta": 0}},
+            preferences=_RELAXED,
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"AAA": 20, "BBB": 20})}),
+    )
+    w = _weights(rebal)
+    assert w["AAA"] > w["BBB"]
+    assert w["AAA"] / w["BBB"] == pytest.approx(5.0 / 3.0, rel=0.05)
+
+
+def test_sector_cap_enforced_via_real_buckets() -> None:
+    # Three Technology single-names (sector_map → sector-technology) → the 40% sector cap
+    # trims the bucket from 100% to 40%, the rest to cash.
+    techs = ["AAPL", "MSFT", "NVDA"]
+    rebal = _run(
+        _state(
+            [{"ticker": t, "target_pct": 33} for t in techs],
+            analysts={t: {"conviction_score": 4, "stance": "buy"} for t in techs},
+            preferences={
+                "max_single_etf_pct": 100,
+                "target_portfolio_vol": 1.0e6,
+                "weight_increment_pct": 0,
+            },
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({t: 20 for t in techs})}),
+    )
+    w = _weights(rebal)
+    assert sum(w.values()) == pytest.approx(40.0, abs=0.5)
+
+
+# --------------------------------------------------------------------------- look-ahead guard
+
+
+def test_look_ahead_guard_ignores_future_technicals() -> None:
+    # A future-dated row (after run_date) with absurd vol would, if not guarded, blow up
+    # vol-targeting and shrink the book to ~0. The .lte(run_date) guard excludes it, so the
+    # 15%-vol row at run_date is used and the position caps at 30%.
+    client = FakeSupabaseClient(
+        canned_reads={
+            "price_technicals": [
+                {"ticker": "SPY", "date": "2026-06-12", "hist_vol_21": 15, "atr_pct": None},
+                {"ticker": "SPY", "date": "2026-06-20", "hist_vol_21": 300, "atr_pct": None},
+            ]
+        }
+    )
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        client,
+    )
+    assert _weights(rebal) == {"SPY": pytest.approx(30.0)}
+
+
+# --------------------------------------------------------------------------- actions / carried
+
+
+def test_dropped_ticker_becomes_exit_action() -> None:
+    # AAA below the conviction floor (1 < 2) is dropped from the book; its PM action row
+    # flips to an explicit exit-to-cash, and it is absent from recommended_portfolio.
+    rebal = _run(
+        _state(
+            [{"ticker": "AAA", "target_pct": 50}, {"ticker": "BBB", "target_pct": 50}],
+            analysts={
+                "AAA": {"conviction_score": 1, "stance": "buy"},
+                "BBB": {"conviction_score": 5, "stance": "buy"},
+            },
+            actions=[
+                {
+                    "ticker": "AAA",
+                    "action": "add",
+                    "current_pct": 10,
+                    "target_pct": 50,
+                    "rationale": "PM liked AAA.",
+                },
+                {
+                    "ticker": "BBB",
+                    "action": "new",
+                    "current_pct": 0,
+                    "target_pct": 50,
+                    "rationale": "PM liked BBB.",
+                },
+            ],
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"BBB": 15})}),
+    )
+    assert "AAA" not in _weights(rebal)
+    aaa_action = next(a for a in rebal["actions"] if a["ticker"] == "AAA")
+    assert aaa_action["action"] == "exit"
+    assert aaa_action["target_pct"] == 0.0
+    assert "removed by risk sizing" in aaa_action["rationale"]
+
+
+def test_carried_holding_without_analyst_is_retained() -> None:
+    # The PM recommends a name with no fresh analyst payload (a carried holding); it
+    # defaults to the conviction floor + hold and survives at minimal tilt, not dropped.
+    rebal = _run(
+        _state(
+            [{"ticker": "GLD", "target_pct": 40}, {"ticker": "SPY", "target_pct": 60}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},  # GLD: none
+            preferences=_RELAXED,
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"SPY": 15, "GLD": 18})}),
+    )
+    assert "GLD" in _weights(rebal)
+
+
+def test_notes_carry_sizing_explanation() -> None:
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"SPY": 15})}),
+    )
+    assert "Risk-sizing (Phase 7E)" in rebal["notes"]
+    assert rebal["notes"].startswith("PM notes.")  # PM's note preserved
+
+
+# --------------------------------------------------------------------------- fail-soft
+
+
+def test_sizing_error_keeps_pm_book(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(**_kwargs):
+        raise RuntimeError("sizer exploded")
+
+    monkeypatch.setattr(phase7e_risk_sizing, "size_portfolio", _boom)
+    state = _state(
+        [{"ticker": "SPY", "target_pct": 50}],
+        analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+    )
+    # No update returned → the chain keeps state.phase7d_rebalance (the PM's book) intact.
+    assert build_risk_sizing_node(RiskSizingDeps(client=FakeSupabaseClient()))(state) == {}
+
+
+def test_missing_technicals_uses_default_vol() -> None:
+    # No price_technicals rows at all → the sizer falls back to its default vol; the book
+    # still materializes (position cap binds), never crashes.
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": []}),
+    )
+    assert _weights(rebal) == {"SPY": pytest.approx(30.0)}


### PR DESCRIPTION
## Pillar 2 · PR 3 — the enforcement node (sizer goes live)

This is the integrating PR for Pillar 2: it wires the deterministic sizer (#744) and the asset-class map (#745) into the live Olympus pipeline so the paper book is actually risk-managed, not LLM-eyeballed.

### What it does

New **`digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py`** — a deterministic `PipelinePhase` (the 7C-join precedent). For each ticker the PM recommended it:

1. computes **effective conviction** = analyst `conviction_score` + debate `conviction_delta`, clamped −5..+5 (a carried holding with no fresh analyst payload defaults to the conviction floor + `hold` so it survives at minimal tilt rather than being dropped for lack of new analysis);
2. reads per-ticker **vol** from the latest `price_technicals` row **≤ `run_date`** (look-ahead-guarded via `.lte`), `hist_vol_21` → ATR% → default;
3. resolves the **concentration bucket** via `sector_map.sector_bucket`;
4. calls **`size_portfolio`** and **overwrites `phase7d_rebalance.recommended_portfolio`** with the sized weights, rebuilding the advisory `actions` list (sizing-dropped names become explicit exits-to-cash).

`portfolio_materialize` then books the *sized* weights verbatim (its weight logic is unchanged).

### Insertion point — a deliberate deviation from the plan

The roadmap said "between publish and materialize." Building it revealed that **`publish_phase` writes the `pm-rebalance` document from `state.phase7d_rebalance`** (`publish_phase.py:201`). So phase7e must run **before publish** — otherwise the published Morning Read would show un-sized weights while `positions` shows sized ones. It's wired in `chain.py` via the new `ChainDeps.risk_sizing` dep, right after the Hermes graph and before publish, so the **published digest and the booked positions reflect the same sized book**.

### Fail-soft + safety

- A data-layer or sizing error **keeps the PM's book** (the run never crashes, the book is never silently emptied).
- **No-op** when the PM never ran (`phase7d_rebalance is None`) — distinct from a deliberate 100%-cash stance (empty book), which the sizer returns as empty.
- **Look-ahead guard** (`.lte(run_date)`) — a future-dated technicals row can't leak into a historical replay (regression-tested).
- Correlation + the drawdown breaker are **stubbed** (`corr=None` → the sizer's conservative full-correlation default; `breaker_scale=1.0`) pending follow-up Pillar 2 PRs — those land without changing this node's contract.

### Tests / gate

- 12 node tests (`tests/dq/hermes/test_phase7e_risk_sizing.py`): overwrites PM weights, position cap, **sector cap via real `sector_map` buckets**, effective-conviction (debate delta), look-ahead guard, dropped→exit action, carried-holding retention, notes/explanation, fail-soft on sizing error, empty-cash, missing-technicals default vol.
- Adds `.lte()` to the shared `FakeSupabaseClient` (mirrors the real client; the look-ahead guard needs it).
- **175 hermes + supabase-io tests pass** (chain test intact); `ruff` clean; `make score` **10/10/10/10**.
- `ARCHITECTURE.md` updated to reflect the implemented node + its before-publish position.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)