### PR TITLE
feat(hermes): drawdown circuit breaker — scale gross down as drawdown deepens (P2)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -738,8 +738,15 @@ risk profile is reproducible and auditable rather than LLM-eyeballed.
   `chain.py` via `ChainDeps.risk_sizing`, it runs **before** `publish` + `materialize` so the
   published `pm-rebalance` document and the booked `positions` reflect the same sized book.
   Fail-soft: a data or sizing error keeps the PM's book; a no-op when the PM never ran.
-  Correlation + the drawdown breaker are stubbed (`corr=None`, `breaker_scale=1.0`) pending
-  follow-up Pillar 2 PRs.
+  Correlation is stubbed (`corr=None`) pending a follow-up PR.
+- `digiquant.olympus.hermes.risk_controls` — the drawdown circuit breaker. Pure
+  `compute_breaker_scale(navs)` maps the book's drawdown from its recent NAV peak to a
+  gross-exposure `scale ∈ [1 − max_reduction, 1.0]` (1.0 above the soft drawdown, ramping
+  to the floor at the hard drawdown — only ever *reduces* gross, never levers up);
+  `breaker_scale_from_nav_history` reads the recent `nav_history` window (look-ahead-guarded,
+  fail-soft → 1.0). phase7e feeds the scale into `size_portfolio`. Thresholds come from
+  `BreakerConfig.from_preferences` (`breaker_soft_dd_pct` / `breaker_hard_dd_pct` /
+  `breaker_max_reduction`; defaults −8% / −20% / 0.5).
 
 ### Persistence
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -26,9 +26,11 @@ never crashes and the book is never silently emptied). No-op when the PM produce
 rebalance (``None``) — distinct from a deliberate 100%-cash stance (empty
 ``recommended_portfolio``), which the sizer simply returns as empty.
 
-Correlation + the drawdown breaker are not wired yet (``corr=None`` → the sizer's
-conservative full-correlation default; ``breaker_scale=1.0``); both arrive in follow-up
-Pillar 2 PRs without changing this node's contract.
+The drawdown circuit breaker is wired (``risk_controls.breaker_scale_from_nav_history``):
+a deepening drawdown from the NAV peak scales gross exposure down (raises cash); a shallow
+or freshly launched book leaves it at 1.0. Correlation is still stubbed (``corr=None`` →
+the sizer's conservative full-correlation default), arriving in a follow-up PR without
+changing this node's contract.
 """
 
 from __future__ import annotations
@@ -42,6 +44,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 
 from digiquant.olympus.atlas.state import AtlasResearchState, RebalancePayload
 from digiquant.olympus.atlas.supabase_io import SupabaseClient
+from digiquant.olympus.hermes.risk_controls import BreakerConfig, breaker_scale_from_nav_history
 from digiquant.olympus.hermes.sector_map import sector_bucket
 from digiquant.olympus.hermes.sizing import SizingCaps, TickerRisk, size_portfolio
 
@@ -240,13 +243,20 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
                 default_conviction=caps.min_conviction,
             )
             risk = _load_ticker_risk(deps.client, pm_tickers, state.run_date)
+            # Drawdown circuit breaker: deepening drawdown from the NAV peak scales gross
+            # down (raises cash); shallow / fresh book → 1.0 (no cut). Fail-soft to 1.0.
+            breaker = breaker_scale_from_nav_history(
+                deps.client,
+                state.run_date,
+                config=BreakerConfig.from_preferences(state.config.preferences),
+            )
             result = size_portfolio(
                 convictions=convictions,
                 stances=stances,
                 risk=risk,
                 corr=None,
                 caps=caps,
-                breaker_scale=1.0,
+                breaker_scale=breaker.scale,
             )
         except Exception as exc:  # noqa: BLE001 — sizing must never crash the run; keep PM book
             logger.warning("phase7e: risk sizing failed (%s); keeping PM book", exc)
@@ -259,9 +269,10 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
         ]
         updated["actions"] = _rebuild_actions(rebalance.get("actions") or [], pm_targets, sized)
         prior_notes = str(rebalance.get("notes") or "").strip()
+        breaker_note = f" Drawdown breaker: {breaker.reason}." if breaker.scale < 1.0 else ""
         updated["notes"] = (
             f"{prior_notes}\n\n" if prior_notes else ""
-        ) + f"Risk-sizing (Phase 7E): {result.explanation}"
+        ) + f"Risk-sizing (Phase 7E): {result.explanation}{breaker_note}"
 
         logger.info(
             "phase7e: sized %d→%d holdings, %.1f%% invested / %.1f%% cash, ex-ante vol ~%s%% (%s)",

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -235,6 +235,21 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
         pm_tickers = list(pm_targets)
         caps = SizingCaps.from_preferences(state.config.preferences)
 
+        # Drawdown circuit breaker — computed in its OWN fail-soft scope (separate from the
+        # sizing try) so a breaker problem can never abort sizing: the worst case is a
+        # neutral 1.0 scale (no cut). Deepening drawdown from the NAV peak scales gross down.
+        try:
+            breaker = breaker_scale_from_nav_history(
+                deps.client,
+                state.run_date,
+                config=BreakerConfig.from_preferences(state.config.preferences),
+            )
+            breaker_scale = breaker.scale
+            breaker_note = f" Drawdown breaker: {breaker.reason}." if breaker.scale < 1.0 else ""
+        except Exception as exc:  # noqa: BLE001 — breaker is best-effort; neutral on failure
+            logger.warning("phase7e: drawdown breaker failed (%s); neutral scale", exc)
+            breaker_scale, breaker_note = 1.0, ""
+
         try:
             convictions, stances = _effective_inputs(
                 pm_tickers,
@@ -243,20 +258,13 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
                 default_conviction=caps.min_conviction,
             )
             risk = _load_ticker_risk(deps.client, pm_tickers, state.run_date)
-            # Drawdown circuit breaker: deepening drawdown from the NAV peak scales gross
-            # down (raises cash); shallow / fresh book → 1.0 (no cut). Fail-soft to 1.0.
-            breaker = breaker_scale_from_nav_history(
-                deps.client,
-                state.run_date,
-                config=BreakerConfig.from_preferences(state.config.preferences),
-            )
             result = size_portfolio(
                 convictions=convictions,
                 stances=stances,
                 risk=risk,
                 corr=None,
                 caps=caps,
-                breaker_scale=breaker.scale,
+                breaker_scale=breaker_scale,
             )
         except Exception as exc:  # noqa: BLE001 — sizing must never crash the run; keep PM book
             logger.warning("phase7e: risk sizing failed (%s); keeping PM book", exc)
@@ -269,7 +277,6 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
         ]
         updated["actions"] = _rebuild_actions(rebalance.get("actions") or [], pm_targets, sized)
         prior_notes = str(rebalance.get("notes") or "").strip()
-        breaker_note = f" Drawdown breaker: {breaker.reason}." if breaker.scale < 1.0 else ""
         updated["notes"] = (
             f"{prior_notes}\n\n" if prior_notes else ""
         ) + f"Risk-sizing (Phase 7E): {result.explanation}{breaker_note}"

--- a/digiquant/src/digiquant/olympus/hermes/risk_controls.py
+++ b/digiquant/src/digiquant/olympus/hermes/risk_controls.py
@@ -1,0 +1,167 @@
+"""Drawdown circuit breaker (Pillar 2).
+
+A defensive overlay on the sizer: as the paper book's drawdown from its recent peak
+deepens, the breaker returns a ``scale ≤ 1.0`` that the sizer applies to gross exposure
+— it only ever *reduces* gross / raises cash and can never lever up (paper-safe). Below
+the ``soft`` drawdown the book is untouched (scale 1.0); at/below the ``hard`` drawdown
+the cut reaches its configured maximum; between the two it ramps linearly.
+
+The pure half — :func:`compute_breaker_scale` — takes a chronological NAV series and the
+config; the I/O half — :func:`breaker_scale_from_nav_history` — reads the recent
+``nav_history`` window (fail-soft → a neutral 1.0 scale) and computes it. The phase7e
+enforcement node calls the I/O half and passes ``scale`` to
+:func:`~digiquant.olympus.hermes.sizing.size_portfolio`.
+
+NAV is the base-100 paper index written by ``portfolio_materialize`` (``nav_history.nav``);
+drawdown is measured against the peak within a bounded lookback window so a single ancient
+peak can't pin the breaker on forever.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LOOKBACK_DAYS = 365  # calendar window for the peak (≈ 1y of the paper index)
+
+
+@dataclass(frozen=True)
+class BreakerConfig:
+    """Drawdown-breaker thresholds (all drawdowns are negative %)."""
+
+    soft_dd_pct: float = -8.0  # reduction begins once drawdown is worse than this
+    hard_dd_pct: float = -20.0  # full reduction reached at/below this
+    max_reduction: float = 0.5  # deepest cut: scale floor = 1 − max_reduction
+    lookback_days: int = _DEFAULT_LOOKBACK_DAYS
+
+    @classmethod
+    def from_preferences(cls, prefs: Mapping[str, Any]) -> BreakerConfig:
+        """Build from the investor ``preferences`` dict; absent keys keep defaults.
+
+        Reads ``breaker_soft_dd_pct`` / ``breaker_hard_dd_pct`` / ``breaker_max_reduction``
+        / ``breaker_lookback_days``. Drawdown thresholds are normalized to negative.
+        """
+
+        def _num(key: str, default: float) -> float:
+            try:
+                val = prefs.get(key)
+                return float(val) if val is not None else default
+            except (TypeError, ValueError):
+                return default
+
+        soft = -abs(_num("breaker_soft_dd_pct", cls.soft_dd_pct))
+        hard = -abs(_num("breaker_hard_dd_pct", cls.hard_dd_pct))
+        reduction = min(1.0, max(0.0, _num("breaker_max_reduction", cls.max_reduction)))
+        lookback = int(_num("breaker_lookback_days", float(cls.lookback_days)))
+        return cls(
+            soft_dd_pct=soft,
+            hard_dd_pct=min(hard, soft),  # hard must be at least as deep as soft
+            max_reduction=reduction,
+            lookback_days=max(1, lookback),
+        )
+
+
+@dataclass(frozen=True)
+class BreakerState:
+    """Outcome of one breaker evaluation (scale + the drawdown that drove it)."""
+
+    scale: float
+    drawdown_pct: float  # current NAV vs peak, ≤ 0
+    peak_nav: float | None
+    current_nav: float | None
+    reason: str
+
+
+def compute_breaker_scale(
+    navs: Sequence[float], *, config: BreakerConfig | None = None
+) -> BreakerState:
+    """Map a chronological NAV series to a gross-exposure ``scale`` in [floor, 1.0].
+
+    Fewer than two points (a freshly launched book) → 1.0 (nothing to measure yet). The
+    drawdown is ``(current − peak) / peak``; ``scale`` ramps linearly from 1.0 at
+    ``soft_dd_pct`` to ``1 − max_reduction`` at ``hard_dd_pct`` (and stays at the floor
+    below it). Never exceeds 1.0 — the breaker only reduces.
+    """
+    config = config or BreakerConfig()
+    clean = [float(n) for n in navs if n is not None and float(n) > 0.0]
+    if len(clean) < 2:
+        return BreakerState(
+            1.0, 0.0, None, (clean[-1] if clean else None), "insufficient NAV history"
+        )
+
+    peak = max(clean)
+    current = clean[-1]
+    drawdown = (current - peak) / peak * 100.0 if peak > 0 else 0.0
+
+    soft, hard = config.soft_dd_pct, config.hard_dd_pct
+    if drawdown >= soft:
+        scale, reason = 1.0, f"drawdown {drawdown:.1f}% shallower than soft {soft:.0f}% — no cut"
+    elif drawdown <= hard:
+        scale = 1.0 - config.max_reduction
+        reason = f"drawdown {drawdown:.1f}% at/below hard {hard:.0f}% — gross cut to {scale:.0%}"
+    else:
+        # Linear ramp between soft (frac 0) and hard (frac 1).
+        frac = (soft - drawdown) / (soft - hard) if soft != hard else 1.0
+        scale = 1.0 - config.max_reduction * frac
+        reason = f"drawdown {drawdown:.1f}% between soft/hard — gross scaled to {scale:.0%}"
+
+    return BreakerState(
+        scale=round(max(0.0, min(1.0, scale)), 4),
+        drawdown_pct=round(drawdown, 2),
+        peak_nav=round(peak, 4),
+        current_nav=round(current, 4),
+        reason=reason,
+    )
+
+
+def _recent_navs(client: Any, as_of: date, lookback_days: int) -> list[float]:
+    """Chronological NAV values in ``(as_of − lookback, as_of]``; ``[]`` on any read error.
+
+    Look-ahead-guarded (``.lte(as_of)``): a future NAV row can never enter the window.
+    """
+    since = (as_of - timedelta(days=max(1, lookback_days))).isoformat()
+    resp = (
+        client.table("nav_history")
+        .select("date,nav")
+        .lte("date", as_of.isoformat())
+        .gte("date", since)
+        .order("date", desc=False)  # ascending → chronological, current = last
+        .limit(lookback_days + 8)
+        .execute()
+    )
+    navs: list[float] = []
+    for row in getattr(resp, "data", None) or []:
+        value = row.get("nav")
+        if value is not None:
+            try:
+                navs.append(float(value))
+            except (TypeError, ValueError):
+                continue
+    return navs
+
+
+def breaker_scale_from_nav_history(
+    client: Any, as_of: date, *, config: BreakerConfig | None = None
+) -> BreakerState:
+    """Read the recent ``nav_history`` window and compute the breaker. Fail-soft: a
+    read error degrades to a neutral 1.0 scale (the breaker never blocks a run)."""
+    config = config or BreakerConfig()
+    try:
+        navs = _recent_navs(client, as_of, config.lookback_days)
+    except Exception as exc:  # noqa: BLE001 — breaker is best-effort; never fail the run
+        logger.warning("breaker: nav_history read failed (%s); neutral scale", exc)
+        return BreakerState(1.0, 0.0, None, None, f"nav_history read failed: {exc}")
+    return compute_breaker_scale(navs, config=config)
+
+
+__all__ = [
+    "BreakerConfig",
+    "BreakerState",
+    "breaker_scale_from_nav_history",
+    "compute_breaker_scale",
+]

--- a/digiquant/src/digiquant/olympus/hermes/risk_controls.py
+++ b/digiquant/src/digiquant/olympus/hermes/risk_controls.py
@@ -120,9 +120,11 @@ def compute_breaker_scale(
 
 
 def _recent_navs(client: Any, as_of: date, lookback_days: int) -> list[float]:
-    """Chronological NAV values in ``(as_of − lookback, as_of]``; ``[]`` on any read error.
+    """Chronological NAV values in ``(as_of − lookback, as_of]``.
 
     Look-ahead-guarded (``.lte(as_of)``): a future NAV row can never enter the window.
+    A query error is *propagated* — the public :func:`breaker_scale_from_nav_history`
+    catches it and degrades to a neutral scale.
     """
     since = (as_of - timedelta(days=max(1, lookback_days))).isoformat()
     resp = (

--- a/tests/dq/hermes/test_phase7e_risk_sizing.py
+++ b/tests/dq/hermes/test_phase7e_risk_sizing.py
@@ -121,6 +121,29 @@ def test_single_name_position_capped_to_thirty() -> None:
     assert _weights(rebal) == {"SPY": pytest.approx(30.0)}
 
 
+def test_drawdown_breaker_halves_gross() -> None:
+    # nav_history shows a −25% drawdown (peak 100 → 75) → breaker scale 0.5. The single
+    # name caps at 30%, then the breaker halves gross → 15% (the rest to cash).
+    client = FakeSupabaseClient(
+        canned_reads={
+            "price_technicals": _tech_rows({"SPY": 15}),
+            "nav_history": [
+                {"date": "2026-06-01", "nav": 100.0},
+                {"date": "2026-06-10", "nav": 75.0},
+            ],
+        }
+    )
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        client,
+    )
+    assert _weights(rebal) == {"SPY": pytest.approx(15.0)}
+    assert "Drawdown breaker" in rebal["notes"]
+
+
 def test_effective_conviction_applies_debate_delta() -> None:
     # Equal analyst conviction (3); a +2 debate delta lifts A to 5 → A outweighs B ~5:3.
     rebal = _run(

--- a/tests/dq/hermes/test_risk_controls.py
+++ b/tests/dq/hermes/test_risk_controls.py
@@ -1,0 +1,147 @@
+"""Drawdown circuit breaker (Pillar 2).
+
+``compute_breaker_scale`` maps a NAV series → a gross-exposure scale in [floor, 1.0]:
+1.0 above the soft drawdown, a linear ramp to ``1 − max_reduction`` at the hard
+drawdown. It only ever reduces (never levers up). ``breaker_scale_from_nav_history``
+reads the recent ``nav_history`` window (look-ahead-guarded) and is fail-soft.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.hermes.risk_controls import (
+    BreakerConfig,
+    breaker_scale_from_nav_history,
+    compute_breaker_scale,
+)
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+pytestmark = pytest.mark.unit
+
+AS_OF = date(2026, 6, 12)
+_CFG = BreakerConfig()  # soft -8%, hard -20%, max_reduction 0.5
+
+
+# --------------------------------------------------------------------------- pure compute
+
+
+def test_fresh_book_has_no_cut() -> None:
+    assert compute_breaker_scale([], config=_CFG).scale == 1.0
+    assert compute_breaker_scale([100.0], config=_CFG).scale == 1.0
+
+
+def test_shallow_drawdown_no_cut() -> None:
+    # -5% drawdown is shallower than the -8% soft threshold → full exposure.
+    state = compute_breaker_scale([100.0, 95.0], config=_CFG)
+    assert state.scale == 1.0
+    assert state.drawdown_pct == pytest.approx(-5.0)
+
+
+def test_soft_threshold_boundary_no_cut() -> None:
+    # Exactly at soft (-8%) → still no cut (ramp starts strictly beyond it).
+    assert compute_breaker_scale([100.0, 92.0], config=_CFG).scale == 1.0
+
+
+def test_hard_drawdown_takes_max_cut() -> None:
+    # -25% (≤ hard -20%) → gross scaled to 1 − max_reduction = 0.5.
+    state = compute_breaker_scale([100.0, 75.0], config=_CFG)
+    assert state.scale == pytest.approx(0.5)
+    assert state.drawdown_pct == pytest.approx(-25.0)
+
+
+def test_linear_ramp_midpoint() -> None:
+    # -14% is the midpoint of [-8, -20] → frac 0.5 → scale 1 − 0.5·0.5 = 0.75.
+    state = compute_breaker_scale([100.0, 86.0], config=_CFG)
+    assert state.scale == pytest.approx(0.75)
+
+
+def test_peak_is_window_max_not_last_point() -> None:
+    # Peak is the interior high (120), not the latest (90): dd = (90−120)/120 = −25%.
+    state = compute_breaker_scale([100.0, 120.0, 90.0], config=_CFG)
+    assert state.peak_nav == pytest.approx(120.0)
+    assert state.scale == pytest.approx(0.5)
+
+
+def test_new_high_is_full_exposure() -> None:
+    state = compute_breaker_scale([100.0, 110.0, 120.0], config=_CFG)
+    assert state.drawdown_pct == pytest.approx(0.0)
+    assert state.scale == 1.0
+
+
+def test_scale_never_exceeds_one() -> None:
+    for navs in ([100.0, 130.0], [100.0, 100.0], [50.0, 200.0]):
+        assert compute_breaker_scale(navs, config=_CFG).scale <= 1.0
+
+
+def test_invalid_navs_filtered() -> None:
+    # None / 0 / negative are dropped → clean series [100, 80] → −20% → 0.5.
+    state = compute_breaker_scale([100.0, None, 0.0, -5.0, 80.0], config=_CFG)  # type: ignore[list-item]
+    assert state.scale == pytest.approx(0.5)
+
+
+# --------------------------------------------------------------------------- config
+
+
+def test_from_preferences_normalizes_and_overrides() -> None:
+    cfg = BreakerConfig.from_preferences(
+        {
+            "breaker_soft_dd_pct": 5,  # positive input → normalized to −5
+            "breaker_hard_dd_pct": 15,
+            "breaker_max_reduction": 0.8,
+            "breaker_lookback_days": 90,
+        }
+    )
+    assert cfg.soft_dd_pct == -5.0
+    assert cfg.hard_dd_pct == -15.0
+    assert cfg.max_reduction == 0.8
+    assert cfg.lookback_days == 90
+
+
+def test_from_preferences_defaults_when_absent() -> None:
+    assert BreakerConfig.from_preferences({}) == BreakerConfig()
+
+
+def test_max_reduction_clamped_to_unit_interval() -> None:
+    assert BreakerConfig.from_preferences({"breaker_max_reduction": 5}).max_reduction == 1.0
+    assert BreakerConfig.from_preferences({"breaker_max_reduction": -1}).max_reduction == 0.0
+
+
+# --------------------------------------------------------------------------- I/O reader
+
+
+def _nav_rows(pairs: list[tuple[str, float]]) -> list[dict]:
+    return [{"date": d, "nav": n} for d, n in pairs]
+
+
+def test_reads_window_and_computes_scale() -> None:
+    client = FakeSupabaseClient(
+        canned_reads={"nav_history": _nav_rows([("2026-06-01", 100.0), ("2026-06-10", 80.0)])}
+    )
+    state = breaker_scale_from_nav_history(client, AS_OF, config=_CFG)
+    assert state.drawdown_pct == pytest.approx(-20.0)
+    assert state.scale == pytest.approx(0.5)
+
+
+def test_reader_look_ahead_guard_excludes_future_nav() -> None:
+    # A future spike (after as_of) would create a 500 peak → huge drawdown if included.
+    # The .lte(as_of) guard excludes it, so the peak stays 100 and dd is 0.
+    client = FakeSupabaseClient(
+        canned_reads={"nav_history": _nav_rows([("2026-06-10", 100.0), ("2026-06-20", 500.0)])}
+    )
+    state = breaker_scale_from_nav_history(client, AS_OF, config=_CFG)
+    assert state.current_nav == pytest.approx(100.0)
+    assert state.scale == 1.0
+
+
+def test_reader_is_fail_soft_on_error() -> None:
+    class _Raising:
+        def table(self, _name: str):
+            raise RuntimeError("supabase down")
+
+    state = breaker_scale_from_nav_history(_Raising(), AS_OF, config=_CFG)
+    assert state.scale == 1.0
+    assert "failed" in state.reason


### PR DESCRIPTION
## Pillar 2 · PR 4 — drawdown circuit breaker

A defensive overlay on the sizer: as the paper book's drawdown from its recent NAV peak deepens, the breaker scales **gross exposure down** (raises cash). It can **only ever reduce** — never levers up — so the worst case is an over-conservative paper book.

### What it adds

New **`digiquant/src/digiquant/olympus/hermes/risk_controls.py`**:

- **`compute_breaker_scale(navs)`** (pure) → `BreakerState`: maps drawdown `(current − peak) / peak` to a gross scale —
  - shallower than the **soft** threshold (−8%) → `1.0` (no cut),
  - at/below the **hard** threshold (−20%) → `1 − max_reduction` (floor `0.5`),
  - linear ramp between.
  - Peak is the max within a bounded lookback window, so an ancient high can't pin the breaker on permanently. A freshly launched book (<2 NAV points) → `1.0`.
- **`breaker_scale_from_nav_history(client, as_of)`** (I/O) — reads the recent `nav_history` window, **look-ahead-guarded** (`.lte(as_of)`), **fail-soft** (a read error → neutral `1.0`; the breaker never blocks a run).
- **`BreakerConfig.from_preferences`** — `breaker_soft_dd_pct` / `breaker_hard_dd_pct` / `breaker_max_reduction` / `breaker_lookback_days` (positive inputs normalized to negative; `max_reduction` clamped to `[0,1]`; defaults −8% / −20% / 0.5 / 365d).

### Wiring

phase7e now replaces its stubbed `breaker_scale=1.0` with the computed scale and surfaces the breaker reason in the published `pm-rebalance` notes when it cuts. (`corr=None` remains stubbed — a follow-up PR.)

### Tests / gate

- 15 `risk_controls` unit tests: fresh book, shallow/soft-boundary/hard-max-cut/linear-midpoint, interior-peak, new-high, never-exceeds-1, invalid-NAV filtering, `from_preferences` normalize+clamp, reader window + **look-ahead guard**, fail-soft.
- 1 phase7e integration test: a −25% drawdown halves gross (30% → 15%) and notes the breaker.
- **192 hermes + supabase tests pass**; `ruff` clean; `make score` **10/10/10/10**; `ARCHITECTURE.md` updated.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)