### PR TITLE
fix(digichat): prefix AI SDK chat transport endpoint with basePath

### DIFF
--- a/frontend/digichat/src/app/embed/page.tsx
+++ b/frontend/digichat/src/app/embed/page.tsx
@@ -30,6 +30,7 @@ import {
   type BYOKProvider,
 } from "@/hooks/use-byok-key";
 import { formatEmbedChatError } from "@/lib/embed-chat-error";
+import { p } from "@/lib/base-path";
 import {
   emit,
   useEmbedGate,
@@ -112,7 +113,7 @@ function EmbedChat({ accent }: { accent: Accent }) {
         // cookie on the host site; the free-tier gate here is purely a
         // client-side UX affordance (per #241 non-goals: no backend rate
         // limiting).
-        api: "/api/chat",
+        api: p("/api/chat"),
         prepareSendMessagesRequest: ({ messages, body }) => {
           const headers: Record<string, string> = {
             "content-type": "application/json",

--- a/frontend/digichat/src/components/chat-panel.tsx
+++ b/frontend/digichat/src/components/chat-panel.tsx
@@ -29,6 +29,7 @@ import {
 import { QuantComparisonStrip } from "@/components/quant-comparison-strip";
 import { EChartsCard } from "@/components/echarts-card";
 import { parseChartEnvelope } from "@/lib/chart-spec";
+import { p } from "@/lib/base-path";
 import type { DigigraphTracePayload } from "@/lib/stream-digigraph-trace";
 import { useBYOKKey } from "@/hooks/use-byok-key";
 import { cn } from "@/lib/utils";
@@ -305,7 +306,7 @@ export function ChatPanel({
   const transport = useMemo(
     () =>
       new DefaultChatTransport<UIMessage>({
-        api: "/api/chat",
+        api: p("/api/chat"),
         credentials: "include",
         prepareSendMessagesRequest: ({ messages, id, body, headers }) => {
           const h = new Headers(headers as HeadersInit | undefined);


### PR DESCRIPTION
## Summary

Follow-up to PR #747 (code-review finding). The basePath migration prefixed all 10 client `fetch("/api/...")` calls with `p()`, but missed the two Vercel AI SDK `DefaultChatTransport({ api: "/api/chat" })` sites — which are also client-side POSTs:

- `frontend/digichat/src/components/chat-panel.tsx`
- `frontend/digichat/src/app/embed/page.tsx`

Under `DIGICHAT_BASE_PATH=/chat` the chat route is served at `/chat/api/chat`, but the transport POSTed to `/api/chat` → **404**, breaking the core chat feature (sending a message) under the exact `/chat` deployment #747 enables. A raw-`fetch` grep missed these because `api` is a config string, not a `fetch()` call.

## Fix

`api: p("/api/chat")` in both files, importing `p` from `@/lib/base-path` — exactly the rule the PR's own `base-path.ts` documents. Unset env → root, unchanged (zero regression).

## Verification

- `make score`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10
- `tsc --noEmit`: no new errors in the touched files
- Confirmed `/api/chat` route handler lives at `app/api/chat/route.ts` (served at `<basePath>/api/chat`)

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)