### PR TITLE
fix(deploy): install @next/swc Linux binary in CF build scripts

### DIFF
--- a/scripts/build-digiquant.sh
+++ b/scripts/build-digiquant.sh
@@ -20,8 +20,12 @@ npm install --prefer-offline --no-audit --no-fund --include=optional
 
 # GHA/npm cache can omit platform optional deps (npm/cli#4828); Next + Tailwind v4 need these on Linux.
 if [ "$(uname -s)" = "Linux" ]; then
-  echo "--- installing Linux native bindings (Tailwind/PostCSS) ---"
+  echo "--- installing Linux native bindings (Next SWC + Tailwind/PostCSS) ---"
+  # @next/swc must match the pinned next version exactly; if it's absent, next
+  # tries to download it at build time via `yarn config get registry`, which
+  # crashes in the yarn-less CF image ("Failed to get registry from yarn").
   npm install \
+    @next/swc-linux-x64-gnu@16.2.4 \
     lightningcss-linux-x64-gnu@1.32.0 \
     @tailwindcss/oxide-linux-x64-gnu@4.2.2 \
     --no-save --no-audit --no-fund

--- a/scripts/build-digithings.sh
+++ b/scripts/build-digithings.sh
@@ -14,11 +14,14 @@ cd "$(dirname "$0")/.."
 echo "--- installing workspaces ---"
 npm install --prefer-offline --no-audit --no-fund --include=optional
 
-# GHA/npm cache can omit platform optional deps (npm/cli#4828); the Tailwind v4
-# build needs these on Linux (same guard as build-digiquant.sh).
+# GHA/npm cache can omit platform optional deps (npm/cli#4828); Next + Tailwind v4
+# need these on Linux (same guard as build-digiquant.sh). @next/swc must match the
+# pinned next version exactly; if it's absent, next tries to download it at build
+# time via `yarn config get registry`, which crashes in the yarn-less CF image.
 if [ "$(uname -s)" = "Linux" ]; then
-  echo "--- installing Linux native bindings (Tailwind/PostCSS) ---"
+  echo "--- installing Linux native bindings (Next SWC + Tailwind/PostCSS) ---"
   npm install \
+    @next/swc-linux-x64-gnu@16.2.4 \
     lightningcss-linux-x64-gnu@1.32.0 \
     @tailwindcss/oxide-linux-x64-gnu@4.2.2 \
     --no-save --no-audit --no-fund


### PR DESCRIPTION
## Summary

Cloudflare Pages production builds of `develop` are **failing** for both digiquant.io and digithings.ai:

```
Downloading swc package @next/swc-linux-x64-gnu...
unhandledRejection Error: Failed to get registry from "yarn".
  [cause]: Command failed: yarn config get registry
npm error command failed: next build
```

## Root cause

`package-lock.json` was generated on macOS, so only `@next/swc-darwin-*` is tracked in the lockfile — the Linux glibc binary `@next/swc-linux-x64-gnu` is **absent**. On the CF Linux image `npm ci` omits the missing platform optional dep (npm/cli#4828), so `next build` falls back to downloading it at build time via `yarn config get registry`. Yarn isn't installed in the CF image, so that lookup crashes and the whole build fails.

## Fix

Install `@next/swc-linux-x64-gnu@16.2.4` (matching the repo-pinned `next` version) in the existing Linux native-bindings block of both `scripts/build-digiquant.sh` and `scripts/build-digithings.sh` — exactly the pattern already used for `lightningcss-linux-x64-gnu` and `@tailwindcss/oxide-linux-x64-gnu`. Guarded by `uname -s = Linux`, so local macOS builds are unaffected.

This covers all three Next apps built by these scripts (digiquant-web, digithings-web, olympus).

## Verification

- Confirmed `@next/swc-linux-x64-gnu` is a declared optional dep of `next@16.2.4` and that version exists on the registry.
- Confirmed it is missing from `package-lock.json` (only darwin binary present) — the exact omission that breaks CF.
- `bash -n` clean on both scripts; `make score` 10/10 across all dimensions.

Fixes #752
🤖 Generated with [Claude Code](https://claude.com/claude-code)