### PR TITLE
feat(digillm): empty-response self-heal + OpenRouter fallback routing (Pillar 1C)

### DIFF
--- a/digillm/ARCHITECTURE.md
+++ b/digillm/ARCHITECTURE.md
@@ -61,6 +61,12 @@ chat_completion(
   any other string is passed through unchanged. There is **no hidden env/YAML
   model substitution** (that was a digigraph deployment behavior; here mode
   selection is the explicit, opt-in `resolve_model`).
+- **Empty-response self-heal.** A 200-OK with no usable output (empty `choices` /
+  blank content and no `tool_calls`) is treated as a transient provider hiccup and
+  retried with a short backoff (`DIGILLM_EMPTY_RETRY_MAX` / `DIGILLM_EMPTY_RETRY_DELAY`).
+  For an `openrouter/` model the first retry adds provider-fallback routing
+  (`extra_body.models` + `route=fallback`) from `OPENROUTER_FALLBACK_MODELS`; other
+  providers just re-ask. A persistent blank is returned unchanged (callers stay graceful).
 
 ### `chat_completion_with_tools`
 
@@ -191,6 +197,8 @@ digismith on the path) plus `LANGSMITH_API_KEY` to enable spans.
 | `XAI_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY` | provider clients | Keys for the corresponding `provider/` prefixes. |
 | `DIGI_LLM_CACHE_TTL_SECONDS` | response cache | Response-cache TTL (default 3600). |
 | `DIGI_TOOL_MESSAGE_MAX_CHARS` | tool loop | Cap on tool-result text injected into the next turn (default 12000). |
+| `DIGILLM_EMPTY_RETRY_MAX` / `DIGILLM_EMPTY_RETRY_DELAY` | `completion` | Empty-response self-heal: retry count (default 2) + backoff seconds (default 2.0). |
+| `OPENROUTER_FALLBACK_MODELS` | `completion` | Comma-separated cheap models for OpenRouter provider-fallback routing on an empty retry. |
 
 ## Monorepo integration (follow-ups for the integrator)
 

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -510,6 +510,49 @@ def _create_with_retry(client: OpenAI, **kwargs: Any) -> Any:
     raise RuntimeError("chat completion failed after all retry attempts")  # pragma: no cover
 
 
+# Empty-response self-heal: a 200-OK with no usable output (empty ``choices`` / blank
+# content and no tool_calls) is a transient provider hiccup — the one that aborted the
+# #726 baseline. Retry the create a few times with a short backoff before giving up; if
+# still empty, the response is returned unchanged (callers stay graceful: completion_text
+# → "" and the node/chain fail-soft handles a persistent blank).
+_EMPTY_RETRY_MAX = int(os.environ.get("DIGILLM_EMPTY_RETRY_MAX", "2") or 2)
+_EMPTY_RETRY_DELAY = float(os.environ.get("DIGILLM_EMPTY_RETRY_DELAY", "2.0") or 2.0)
+
+
+def _is_empty_completion(resp: Any) -> bool:
+    """A completion with no usable output: no choices, or blank content AND no tool_calls."""
+    choices = getattr(resp, "choices", None)
+    if not choices:
+        return True
+    message = getattr(choices[0], "message", None)
+    content = (getattr(message, "content", None) or "").strip()
+    tool_calls = getattr(message, "tool_calls", None)
+    return not content and not tool_calls
+
+
+def _openrouter_fallback_models() -> list[str]:
+    """``OPENROUTER_FALLBACK_MODELS`` (comma-separated) — cheap models to fall back to."""
+    raw = os.environ.get("OPENROUTER_FALLBACK_MODELS", "").strip()
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _with_openrouter_fallback(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
+    """Add OpenRouter provider-fallback routing (``extra_body.models`` + ``route=fallback``)
+    for an ``openrouter/`` model when ``OPENROUTER_FALLBACK_MODELS`` is set; a no-op for any
+    other provider or when no fallbacks are configured."""
+    if provider != "openrouter":
+        return kwargs
+    fallbacks = _openrouter_fallback_models()
+    if not fallbacks:
+        return kwargs
+    merged = dict(kwargs)
+    extra = dict(merged.get("extra_body") or {})
+    extra["models"] = fallbacks
+    extra["route"] = "fallback"
+    merged["extra_body"] = extra
+    return merged
+
+
 # ── Public API: chat_completion ────────────────────────────────────────────────
 
 
@@ -603,6 +646,27 @@ def completion(
             r = _create_with_retry(client, **kwargs)
         else:
             raise
+
+    # Empty-response self-heal. An empty body is transient; retry with backoff. The first
+    # retry also adds OpenRouter provider-fallback routing for openrouter/ models (a flaky
+    # primary is swapped out); other providers just re-ask the same model. A persistent
+    # blank falls through unchanged so downstream stays graceful (no crash).
+    empty_attempts = 0
+    while _is_empty_completion(r) and empty_attempts < _EMPTY_RETRY_MAX:
+        empty_attempts += 1
+        retry_kwargs = (
+            _with_openrouter_fallback(kwargs, provider) if empty_attempts == 1 else kwargs
+        )
+        logger.warning(
+            "empty completion from %s (empty-retry %d/%d); backing off %.1fs",
+            effective_model,
+            empty_attempts,
+            _EMPTY_RETRY_MAX,
+            _EMPTY_RETRY_DELAY,
+        )
+        time.sleep(_EMPTY_RETRY_DELAY)  # noqa: S110 — intentional short backoff on empty
+        r = _create_with_retry(client, **retry_kwargs)
+
     _u = getattr(r, "usage", None)
     _record_usage(
         kind="chat",

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -71,7 +71,10 @@ def _real_completion(content: str = "") -> ChatCompletion:
 
 
 def test_parse_provider_prefix_known_and_unknown() -> None:
-    assert client_mod._parse_provider_prefix("openrouter/mistral/mistral-7b") == ("openrouter", "mistral/mistral-7b")
+    assert client_mod._parse_provider_prefix("openrouter/mistral/mistral-7b") == (
+        "openrouter",
+        "mistral/mistral-7b",
+    )
     assert client_mod._parse_provider_prefix("gpt-4o-mini") == (None, "gpt-4o-mini")
     # Unregistered prefix is treated as a plain model (default client handles it).
     assert client_mod._parse_provider_prefix("ollama/qwen2.5") == (None, "ollama/qwen2.5")
@@ -163,6 +166,78 @@ def test_chat_completion_passes_model_as_given_no_prefix(monkeypatch: pytest.Mon
         digillm.completion("gpt-4o-mini", [{"role": "user", "content": "hi"}])
     _, kwargs = fake_client.chat.completions.create.call_args
     assert kwargs["model"] == "gpt-4o-mini"  # used verbatim, no env substitution
+
+
+# ── Empty-response self-heal (#726, 1C) ──────────────────────────────────────
+
+
+def test_is_empty_completion_detects_blank_and_no_tool_calls() -> None:
+    assert client_mod._is_empty_completion(_mock_response("")) is True
+    assert client_mod._is_empty_completion(_mock_response("   ")) is True
+    assert client_mod._is_empty_completion(_mock_response("hi")) is False
+    # Blank content but tool_calls present is NOT empty.
+    assert client_mod._is_empty_completion(_mock_response("", tool_calls=[object()])) is False
+    no_choices = MagicMock()
+    no_choices.choices = []
+    assert client_mod._is_empty_completion(no_choices) is True
+
+
+def test_openrouter_fallback_models_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", " a/x , b/y ,")
+    assert client_mod._openrouter_fallback_models() == ["a/x", "b/y"]
+    monkeypatch.delenv("OPENROUTER_FALLBACK_MODELS", raising=False)
+    assert client_mod._openrouter_fallback_models() == []
+
+
+def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "a/x,b/y")
+    base = {"model": "m", "messages": []}
+    out = client_mod._with_openrouter_fallback(base, "openrouter")
+    assert out["extra_body"] == {"models": ["a/x", "b/y"], "route": "fallback"}
+    # Non-openrouter providers (and the default client) are untouched.
+    assert client_mod._with_openrouter_fallback(base, "xai") == base
+    assert client_mod._with_openrouter_fallback(base, None) == base
+    monkeypatch.delenv("OPENROUTER_FALLBACK_MODELS", raising=False)
+    assert client_mod._with_openrouter_fallback(base, "openrouter") == base  # no env → no-op
+
+
+def test_empty_response_retries_then_heals(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)  # no backoff wait
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = [_mock_response(""), _mock_response("healed")]
+    with patch.object(client_mod, "get_client_for_model", return_value=fake_client):
+        resp = digillm.completion("gpt-4o-mini", [{"role": "user", "content": "hi"}])
+    assert resp.choices[0].message.content == "healed"
+    assert fake_client.chat.completions.create.call_count == 2  # initial empty + one retry
+
+
+def test_empty_response_gives_up_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = _mock_response("")  # always empty
+    with patch.object(client_mod, "get_client_for_model", return_value=fake_client):
+        resp = digillm.completion("gpt-4o-mini", [{"role": "user", "content": "hi"}])
+    assert client_mod._is_empty_completion(resp)  # returned unchanged, no crash
+    # 1 initial + _EMPTY_RETRY_MAX retries.
+    assert fake_client.chat.completions.create.call_count == 1 + client_mod._EMPTY_RETRY_MAX
+
+
+def test_openrouter_fallback_injected_on_first_empty_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+    monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "openrouter/cheap-a,openrouter/cheap-b")
+    monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.side_effect = [_mock_response(""), _mock_response("ok")]
+    with patch.object(client_mod, "get_client_for_model", return_value=fake_client):
+        digillm.completion("openrouter/primary/model", [{"role": "user", "content": "hi"}])
+    calls = fake_client.chat.completions.create.call_args_list
+    assert "extra_body" not in calls[0].kwargs  # primary attempt: no fallback routing
+    assert calls[1].kwargs["extra_body"] == {
+        "models": ["openrouter/cheap-a", "openrouter/cheap-b"],
+        "route": "fallback",
+    }
 
 
 def test_chat_completion_response_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -203,6 +203,7 @@ def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.Monkey
 
 def test_empty_response_retries_then_heals(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setattr(client_mod, "_EMPTY_RETRY_MAX", 2)  # deterministic regardless of env
     monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)  # no backoff wait
     fake_client = MagicMock()
     fake_client.chat.completions.create.side_effect = [_mock_response(""), _mock_response("healed")]
@@ -214,6 +215,7 @@ def test_empty_response_retries_then_heals(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_empty_response_gives_up_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setattr(client_mod, "_EMPTY_RETRY_MAX", 2)  # deterministic regardless of env
     monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
     fake_client = MagicMock()
     fake_client.chat.completions.create.return_value = _mock_response("")  # always empty
@@ -227,6 +229,7 @@ def test_empty_response_gives_up_gracefully(monkeypatch: pytest.MonkeyPatch) -> 
 def test_openrouter_fallback_injected_on_first_empty_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
     monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "openrouter/cheap-a,openrouter/cheap-b")
+    monkeypatch.setattr(client_mod, "_EMPTY_RETRY_MAX", 2)  # deterministic regardless of env
     monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
     fake_client = MagicMock()
     fake_client.chat.completions.create.side_effect = [_mock_response(""), _mock_response("ok")]


### PR DESCRIPTION
## Pillar 1C — empty-response self-heal

The failure that started #726 was an **empty OpenRouter body** (a 200-OK with no usable output) in one sector that aborted the whole baseline. `_create_with_retry` only retries transient *exceptions* — an empty `choices`/blank body isn't an exception, so it sailed straight through to the node and crashed it. 1A/1B made that crash fail-soft at the node/chain level; **1C fixes the root cause** so the empty rarely reaches them.

### What it does

`digillm.completion` now self-heals after the create:
- **Detects** an empty response — no `choices`, or blank `content` **and** no `tool_calls` (`_is_empty_completion`).
- **Retries** with a short backoff (`DIGILLM_EMPTY_RETRY_MAX`=2, `DIGILLM_EMPTY_RETRY_DELAY`=2.0s). **Provider-agnostic** — helps xAI/Grok (the active provider) and any OpenAI-compatible endpoint, since a transient empty body is a provider-side hiccup.
- **OpenRouter fallback** — for an `openrouter/` model the *first* retry also injects provider-fallback routing (`extra_body={"models": OPENROUTER_FALLBACK_MODELS, "route": "fallback"}`) so a flaky primary model is swapped out. Other providers just re-ask the same model (`_with_openrouter_fallback` is a no-op for them).
- **Graceful fallthrough** — a persistent blank is returned unchanged, so callers stay graceful (`completion_text` → `""`, and the 1A/1B node/chain fail-soft handles a persistent blank). No new exception type, no contract change.

### Why digillm-layer (not research_agent)

The cheap, same-prompt retry at the client layer heals transient empties before the agent ever sees one — avoiding an expensive full agent-turn re-run. If retries are exhausted, the existing fail-soft path takes over (carry + `PhaseError` + the degraded gate from 1B).

### Tests / gate

- 6 new tests: empty detection (incl. `tool_calls` present / no choices), env parsing, fallback only-for-OpenRouter, retry-then-heal (2 creates), give-up-gracefully (1 + max creates, no crash), fallback injected on first retry only.
- **40 digillm tests pass** (caching/routing/tool-loop unaffected).
- `ruff` clean; `make score` **10/10/9/10** — the lone Opt-9 note (`time.sleep`) matches the existing `_sleep_transient_retry` blocking-backoff pattern in this sync module.
- `ARCHITECTURE.md` + env-var table updated.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)