### PR TITLE
fix(web): theme-color follows active theme (black top bar) + center /chat hero

### DIFF
--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -8,7 +8,7 @@
 /* ── reset ──────────────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
 * { margin: 0; }
-html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; background: var(--bg); }
 @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
 
 body {
@@ -100,6 +100,14 @@ a { color: inherit; text-decoration: none; }
 .hero-stats div { display: flex; flex-direction: column; }
 .hero-stats dt { font-size: 1.9rem; font-weight: 600; letter-spacing: -0.04em; font-family: var(--font-mono); color: var(--ink); }
 .hero-stats dd { font-size: 0.82rem; color: var(--ink-mute); margin-top: 0.15rem; }
+
+/* Centered hero variant (e.g. /chat). The base hero pieces are tuned for the
+   asymmetric left-aligned grid: hero-title/lede cap their width and hero-actions
+   is a flex row, so a parent text-align:center alone leaves them left-aligned. */
+.hero.center .wrap { text-align: center; }
+.hero.center .hero-title,
+.hero.center .hero-lede { margin-inline: auto; }
+.hero.center .hero-actions { justify-content: center; }
 
 /* ── terminal block (always dark) ───────────────────────────────────── */
 .term { width: 100%; background: var(--term-bg); border: 1px solid var(--term-hair); border-radius: 14px; overflow: hidden; box-shadow: 0 44px 100px -50px rgba(0,0,0,0.45); }

--- a/frontend/digiquant-web/app/layout.tsx
+++ b/frontend/digiquant-web/app/layout.tsx
@@ -24,8 +24,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" data-theme="dark" className={`${GeistSans.variable} ${GeistMono.variable}`}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <meta name="theme-color" content="#0B0C0E" media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content="#FBFBF9" media="(prefers-color-scheme: light)" />
+        {/* Single fallback; themeInitScript sets it to the active theme pre-paint. */}
+        <meta name="theme-color" content="#0B0C0E" />
       </head>
       <body>
         <div className="grain" aria-hidden="true" />

--- a/frontend/digithings-web/app/chat/page.tsx
+++ b/frontend/digithings-web/app/chat/page.tsx
@@ -37,8 +37,8 @@ export default function ChatPage() {
     <>
       <Nav brand={<Brand />} links={NAV} />
       <main>
-        <section className="hero">
-          <div className="wrap" style={{ textAlign: "center" }}>
+        <section className="hero center">
+          <div className="wrap">
             <Reveal as="p" className="eyebrow"><span className="prompt">$</span> digichat · streams digigraph</Reveal>
             <Reveal as="h1" className="hero-title" delay={0.05} >Talk to your <em>stack.</em></Reveal>
             <Reveal as="p" className="hero-lede" delay={0.1}>Ask questions, run research, explore your data — with your keys, your models, and full audit on every response.</Reveal>

--- a/frontend/digithings-web/app/layout.tsx
+++ b/frontend/digithings-web/app/layout.tsx
@@ -28,8 +28,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" data-theme="dark" className={`${GeistSans.variable} ${GeistMono.variable} ${serif.variable}`}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <meta name="theme-color" content="#0B0C0E" media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content="#FBFBF9" media="(prefers-color-scheme: light)" />
+        {/* Single fallback; themeInitScript sets it to the active theme pre-paint. */}
+        <meta name="theme-color" content="#0B0C0E" />
       </head>
       <body>
         <div className="grain" aria-hidden="true" />

--- a/frontend/web/src/components/ThemeProvider.tsx
+++ b/frontend/web/src/components/ThemeProvider.tsx
@@ -10,9 +10,30 @@ import { createContext, useCallback, useContext, useEffect, useState, type React
 type Theme = "light" | "dark";
 const KEY = "dt-theme";
 
+/** Browser-chrome colour per theme; must match --bg in tokens.css. */
+const THEME_BG: Record<Theme, string> = { light: "#FBFBF9", dark: "#0B0C0E" };
+
+/**
+ * Point the single <meta name="theme-color"> at the active theme's --bg so the
+ * browser toolbar/status bar matches the page. Keying theme-color off
+ * prefers-color-scheme instead leaves a dark bar above a light page (and vice
+ * versa) whenever the OS scheme and the chosen site theme disagree.
+ */
+function applyThemeColor(t: Theme) {
+  try {
+    let m = document.querySelector('meta[name="theme-color"]');
+    if (!m) {
+      m = document.createElement("meta");
+      m.setAttribute("name", "theme-color");
+      document.head.appendChild(m);
+    }
+    m.setAttribute("content", THEME_BG[t]);
+  } catch {}
+}
+
 /** Inline in <head> before paint: <script dangerouslySetInnerHTML={{__html: themeInitScript}}/> */
 export const themeInitScript =
-  "try{var s=localStorage.getItem('dt-theme');document.documentElement.setAttribute('data-theme',s||(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'))}catch(e){document.documentElement.setAttribute('data-theme','dark')}";
+  "try{var s=localStorage.getItem('dt-theme');var t=s||(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);var c=t==='light'?'#FBFBF9':'#0B0C0E';var m=document.querySelector('meta[name=\"theme-color\"]');if(!m){m=document.createElement('meta');m.setAttribute('name','theme-color');document.head.appendChild(m)}m.setAttribute('content',c)}catch(e){document.documentElement.setAttribute('data-theme','dark')}";
 
 const ThemeCtx = createContext<{ theme: Theme; toggle: () => void } | null>(null);
 
@@ -33,6 +54,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       try { if (localStorage.getItem(KEY)) return; } catch {}
       const t = e.matches ? "light" : "dark";
       document.documentElement.setAttribute("data-theme", t);
+      applyThemeColor(t);
       setTheme(t);
     };
     mq.addEventListener("change", onOS);
@@ -43,6 +65,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setTheme((prev) => {
       const next: Theme = prev === "light" ? "dark" : "light";
       document.documentElement.setAttribute("data-theme", next);
+      applyThemeColor(next);
       try { localStorage.setItem(KEY, next); } catch {}
       return next;
     });


### PR DESCRIPTION
## Summary

Two visual issues reported on the live marketing sites.

### 1. Black gap at the top of both digithings.ai and digiquant.io

The `<meta name="theme-color">` tags were keyed to `prefers-color-scheme` (the OS setting), **not** the site's active `data-theme`. When the OS scheme and the chosen site theme disagree — e.g. macOS in dark mode while the site shows light (default or user-toggled) — the browser paints its toolbar `#0B0C0E` (dark) above a light page, which reads as a black bar at the top. It's browser chrome, not page content, so it doesn't appear in headless screenshots and shows on every page.

**Fix:** replace the two media-keyed metas with a single `theme-color` meta that:
- `themeInitScript` sets to the resolved theme's `--bg` pre-paint (no flash), and
- the theme toggle and the OS-change handler keep in sync.

Also paint `html { background: var(--bg) }` (previously only `<body>` was painted) so overscroll/rubber-band never exposes a bare canvas.

### 2. digithings.ai/chat hero not centered

The hero wrapper set `text-align:center`, but `.hero-title` (`max-width:16ch`), `.hero-lede` (`max-width:48ch`) and `.hero-actions` (`display:flex`) don't respond to `text-align`, so the heading, lede, and buttons stayed left-aligned while only the eyebrow centered. Added a reusable `.hero.center` modifier (`margin-inline:auto` on title/lede, `justify-content:center` on actions) and applied it on the chat page.

## Verification (local, both built apps)

- `theme-color` now tracks the active theme: dark→`#0B0C0E`, light→`#FBFBF9`, exactly one meta; verified via the init path, the toggle, and OS-change.
- `/chat` hero renders fully centered (heading + lede + buttons).
- Landing hero (asymmetric `hero-grid`, no `.center`) unaffected.
- `npm run build` green for both digithings-web and digiquant-web; `make score` 10/10.

Note: `digithings.ai/chat` currently serves the **static marketing landing page** (not the DigiChat app) — the Cloudflare route to the DigiChat container isn't wired yet. This PR fixes that marketing page's layout.

Fixes #756
🤖 Generated with [Claude Code](https://claude.com/claude-code)