### PR TITLE
feat(atlas): data-quality contract + suppress degenerate documents (Pillar 1E)

### DIFF
--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -43,7 +43,8 @@ Principles:
 - Cite. When citing a source, use the url or identifier provided in the user block. If the evidence is in the data bundle, reference the field name.
 - Quantify when possible. Percent moves, basis points, date ranges, dollar flows — prefer numbers over adjectives.
 - Flag uncertainty. If evidence is thin or conflicting, say so in the output's uncertainty/notes field; do not paper over it.
-- Refuse to hallucinate. If the scope cannot be answered from the provided context, return the schema with empty findings and a note explaining what is missing.
+- Grade your evidence. When the schema has a `data_quality` field, set it honestly: 'high'/'medium'/'low' when real data (prices, technicals, macro, retrieved sources) backs the read, and 'absent' when no material data was available. Optionally set `confidence` (0.0–1.0).
+- Refuse to hallucinate. If the scope cannot be answered from the provided context, return the schema with empty findings, bias 'neutral', `data_quality` set to 'absent', and a note explaining what is missing — do NOT write a confident brief on no data.
 
 Output format:
 - Respond with a single JSON object that validates against the schema named in the user block.

--- a/digiquant/docs/schemas/atlas_snapshot.v1.json
+++ b/digiquant/docs/schemas/atlas_snapshot.v1.json
@@ -58,6 +58,36 @@
           "title": "Bias",
           "type": "string"
         },
+        "confidence": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "data_quality": {
+          "anyOf": [
+            {
+              "enum": [
+                "high",
+                "medium",
+                "low",
+                "absent"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Quality"
+        },
         "date": {
           "format": "date",
           "title": "Date",

--- a/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
@@ -64,6 +64,16 @@ def _is_degenerate(body: Any) -> bool:
     return body.get("data_quality") == "absent" and not (body.get("material_findings") or [])
 
 
+def _log_suppressed(slug: str, body: dict[str, Any]) -> None:
+    """Emit a per-segment line when a degenerate segment is dropped (observability)."""
+    logger.info(
+        "publish: suppressing degenerate segment %s (data_quality=%r, %d findings)",
+        slug,
+        body.get("data_quality"),
+        len(body.get("material_findings") or []),
+    )
+
+
 def _publish_segment_bag(
     *,
     client: SupabaseClient,
@@ -77,13 +87,7 @@ def _publish_segment_bag(
         if slot.payload.source != "today":
             continue
         if _is_degenerate(slot.payload.body):
-            body = slot.payload.body
-            logger.info(
-                "publish: suppressing degenerate segment %s (data_quality=%r, %d findings)",
-                slug,
-                body.get("data_quality"),
-                len(body.get("material_findings") or []),
-            )
+            _log_suppressed(slug, slot.payload.body)
             continue
         artifact = publish_document(
             client=client,
@@ -120,24 +124,24 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                 )
             )
 
-        if (
-            state.phase3_output is not None
-            and state.phase3_output.payload.source == "today"
-            and not _is_degenerate(state.phase3_output.payload.body)
-        ):
-            artifacts.append(
-                publish_document(
-                    client=deps.client,
-                    document_key="macro",
-                    payload=dict(state.phase3_output.payload.body),
-                    doc_type=None,
-                    run_type=run_type,
-                    title=f"macro {date_str}",
-                    date_str=date_str,
-                    category="macro",
-                    segment="macro",
+        macro_slot = state.phase3_output
+        if macro_slot is not None and macro_slot.payload.source == "today":
+            if _is_degenerate(macro_slot.payload.body):
+                _log_suppressed("macro", macro_slot.payload.body)
+            else:
+                artifacts.append(
+                    publish_document(
+                        client=deps.client,
+                        document_key="macro",
+                        payload=dict(macro_slot.payload.body),
+                        doc_type=None,
+                        run_type=run_type,
+                        title=f"macro {date_str}",
+                        date_str=date_str,
+                        category="macro",
+                        segment="macro",
+                    )
                 )
-            )
 
         if state.phase7_digest is not None:
             # Custom research routing (#313). A one-off user prompt routes

--- a/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/publish_phase.py
@@ -5,6 +5,7 @@ Skips carried slots. Monthly runs omit this phase.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -16,6 +17,8 @@ from digiquant.olympus.atlas.supabase_io import (
     publish_daily_snapshot,
     publish_document,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,16 @@ def _segment_category(slug: str) -> str:
     return "output"
 
 
+def _is_degenerate(body: Any) -> bool:
+    """A content-free segment: the analyst graded the evidence ``data_quality == "absent"``
+    AND produced no material findings (Pillar 1E). Publishing it would surface a
+    confident-looking empty document, so it is suppressed. A segment with findings — or one
+    graded high/medium/low (or ungraded ``None``) — always publishes."""
+    if not isinstance(body, dict):
+        return False
+    return body.get("data_quality") == "absent" and not (body.get("material_findings") or [])
+
+
 def _publish_segment_bag(
     *,
     client: SupabaseClient,
@@ -58,10 +71,19 @@ def _publish_segment_bag(
     run_type: str,
     date_str: str,
 ) -> list[PublishedArtifact]:
-    """Publish all fresh ('today') slots in a phase output dict."""
+    """Publish all fresh ('today') slots in a phase output dict (skipping degenerate ones)."""
     published: list[PublishedArtifact] = []
     for slug, slot in bag.items():
         if slot.payload.source != "today":
+            continue
+        if _is_degenerate(slot.payload.body):
+            body = slot.payload.body
+            logger.info(
+                "publish: suppressing degenerate segment %s (data_quality=%r, %d findings)",
+                slug,
+                body.get("data_quality"),
+                len(body.get("material_findings") or []),
+            )
             continue
         artifact = publish_document(
             client=client,
@@ -98,7 +120,11 @@ def build_publish_node(deps: PublishDeps) -> Callable[[AtlasResearchState], dict
                 )
             )
 
-        if state.phase3_output is not None and state.phase3_output.payload.source == "today":
+        if (
+            state.phase3_output is not None
+            and state.phase3_output.payload.source == "today"
+            and not _is_degenerate(state.phase3_output.payload.body)
+        ):
             artifacts.append(
                 publish_document(
                     client=deps.client,

--- a/digiquant/src/digiquant/olympus/atlas/segments.py
+++ b/digiquant/src/digiquant/olympus/atlas/segments.py
@@ -31,6 +31,13 @@ Bias = Literal[
     "mixed",
 ]
 
+# Honest grade of the evidence behind a segment read (Pillar 1E). "absent" means no
+# material data was available — the analyst should set it (with bias "neutral") instead of
+# writing a confident "no data" brief; publish suppresses an absent + finding-free segment,
+# and Phase 7 synthesis / the PM can discount thin ones.
+DataQuality = Literal["high", "medium", "low", "absent"]
+
+
 # LLM synonym → canonical Bias value. Applied before Pydantic validates the
 # Literal so models never hard-fail on reasonable paraphrases (e.g. Gemini
 # Flash returning "positive" instead of "bullish").
@@ -98,6 +105,19 @@ class SegmentReport(BaseModel):
         default="",
         description="Free-form analyst notes — uncertainty, contradictions, regime caveats.",
     )
+    data_quality: DataQuality | None = Field(
+        default=None,
+        description=(
+            "Honest grade of the evidence behind this read: 'high'/'medium'/'low' when real "
+            "data (prices, technicals, macro, retrieved sources) backs it; 'absent' when no "
+            "material data was available — set 'absent' with bias 'neutral' rather than "
+            "writing a confident brief on nothing."
+        ),
+    )
+    confidence: float | None = Field(
+        default=None,
+        description="Optional self-rated confidence in the bias/findings, 0.0–1.0.",
+    )
 
     @field_validator("bias", mode="before")
     @classmethod
@@ -105,3 +125,25 @@ class SegmentReport(BaseModel):
         if isinstance(v, str):
             return _BIAS_SYNONYMS.get(v.lower(), v)
         return v
+
+    @field_validator("data_quality", mode="before")
+    @classmethod
+    def _normalize_data_quality(cls, v: object) -> object:
+        """Lower/strip the LLM's grade; an unrecognized value degrades to None so a
+        malformed grade never hard-fails the run (it just publishes ungraded), mirroring
+        the soft-validation on ``bias`` / ``confidence``."""
+        if isinstance(v, str):
+            cleaned = v.strip().lower()
+            return cleaned if cleaned in ("high", "medium", "low", "absent") else None
+        return v
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def _clamp_confidence(cls, v: object) -> object:
+        """Clamp to [0, 1]; a non-numeric value degrades to None (never hard-fail a run)."""
+        if v is None:
+            return None
+        try:
+            return max(0.0, min(1.0, float(v)))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None

--- a/digiquant/src/digiquant/olympus/atlas/segments.py
+++ b/digiquant/src/digiquant/olympus/atlas/segments.py
@@ -130,8 +130,9 @@ class SegmentReport(BaseModel):
     @classmethod
     def _normalize_data_quality(cls, v: object) -> object:
         """Lower/strip the LLM's grade; an unrecognized value degrades to None so a
-        malformed grade never hard-fails the run (it just publishes ungraded), mirroring
-        the soft-validation on ``bias`` / ``confidence``."""
+        malformed grade never hard-fails the run (it just publishes ungraded). This is
+        fully fail-soft — unlike ``bias`` normalization, which only maps known synonyms and
+        still rejects truly unknown values."""
         if isinstance(v, str):
             cleaned = v.strip().lower()
             return cleaned if cleaned in ("high", "medium", "low", "absent") else None

--- a/digiquant/src/digiquant/olympus/atlas/snapshot.py
+++ b/digiquant/src/digiquant/olympus/atlas/snapshot.py
@@ -121,6 +121,9 @@ Bias = Literal[
     "mixed",
 ]
 
+# Evidence grade — kept in sync with digiquant.olympus.atlas.segments.DataQuality.
+DataQuality = Literal["high", "medium", "low", "absent"]
+
 
 # ─── DigestPayload — local mirror of phase7_synthesis.DigestSnapshot ────────
 
@@ -147,6 +150,8 @@ class DigestPayload(BaseModel):
     material_findings: list[Finding] = Field(default_factory=list)
     sources: list[Source] = Field(default_factory=list)
     notes: str = Field(default="")
+    data_quality: DataQuality | None = Field(default=None)
+    confidence: float | None = Field(default=None)
 
     # ── Digest-specific narrative sections ────────────────────────────────
     market_regime_snapshot: str = Field()

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -276,6 +276,8 @@ class Phase7DigestPayload(TypedDict, total=False):
     material_findings: list[dict[str, Any]]
     sources: list[dict[str, Any]]
     notes: str
+    data_quality: str | None
+    confidence: float | None
     # DigestSnapshot extensions.
     market_regime_snapshot: str
     alt_data_dashboard: str

--- a/tests/dq/atlas/test_publish_phase.py
+++ b/tests/dq/atlas/test_publish_phase.py
@@ -301,3 +301,71 @@ class TestGraphDepsWiring:
         )
         graph = build_atlas_graph("baseline", deps=deps, watchlist=("AAPL",))
         assert graph is not None
+
+
+@pytest.mark.unit
+class TestSuppressDegenerate:
+    """Pillar 1E — a fresh segment graded data_quality='absent' with no material findings is
+    suppressed at publish (a confident-looking empty doc helps no one). Findings present, or
+    any other grade (incl. ungraded None), always publish."""
+
+    def _state_with(self, **phase1: SegmentSlot) -> AtlasResearchState:
+        state = AtlasResearchState(
+            run_type="baseline",
+            run_date=date(2026, 4, 26),
+            baseline_date=None,
+            config=AtlasConfigBundle(watchlist=["AAPL"]),
+        )
+        state.phase1_outputs = dict(phase1)
+        state.phase7_digest = {"market_regime_snapshot": "r"}  # so a snapshot/digest still writes
+        return state
+
+    def _published_keys(self, state: AtlasResearchState) -> set[str]:
+        client = FakeSupabaseClient()
+        build_publish_node(PublishDeps(client=client))(state)
+        return {r["document_key"] for r in client.store["documents"]}
+
+    def test_absent_with_no_findings_is_suppressed(self) -> None:
+        keys = self._published_keys(
+            self._state_with(
+                dead=_slot("dead", data_quality="absent", material_findings=[]),
+                live=_slot("live", data_quality="high"),
+            )
+        )
+        assert "dead" not in keys
+        assert "live" in keys
+
+    def test_absent_but_with_findings_still_publishes(self) -> None:
+        # 'absent' grade but the analyst still surfaced a finding → not content-free.
+        keys = self._published_keys(
+            self._state_with(
+                kept=_slot("kept", data_quality="absent", material_findings=[{"label": "x"}]),
+            )
+        )
+        assert "kept" in keys
+
+    def test_ungraded_segment_publishes(self) -> None:
+        # No data_quality field at all (legacy / ungraded) → always publishes (backward-compat).
+        keys = self._published_keys(self._state_with(legacy=_slot("legacy")))
+        assert "legacy" in keys
+
+    def test_degenerate_macro_phase3_is_suppressed(self) -> None:
+        state = self._state_with()
+        state.phase3_output = _slot("macro", data_quality="absent", material_findings=[])
+        keys = self._published_keys(state)
+        assert "macro" not in keys
+
+    def test_mixed_phases_only_degenerate_suppressed(self) -> None:
+        # A degenerate macro + degenerate phase1 leg are dropped; healthy legs across
+        # phases 1/2/4/5 still publish — suppression is per-segment, not all-or-nothing.
+        state = self._state_with(
+            dead=_slot("dead", data_quality="absent", material_findings=[]),
+            alive=_slot("alive", data_quality="high"),
+        )
+        state.phase3_output = _slot("macro", data_quality="absent", material_findings=[])
+        state.phase2_outputs = {"inst-flows": _slot("inst-flows", data_quality="medium")}
+        state.phase4_outputs = {"bonds": _slot("bonds")}  # ungraded → publishes
+        keys = self._published_keys(state)
+        assert "dead" not in keys
+        assert "macro" not in keys
+        assert {"alive", "inst-flows", "bonds"} <= keys

--- a/tests/dq/atlas/test_segments.py
+++ b/tests/dq/atlas/test_segments.py
@@ -1,0 +1,67 @@
+"""SegmentReport data-quality contract (Pillar 1E).
+
+``data_quality`` + ``confidence`` are optional (backward-compatible: old bodies without
+them validate and default to None). ``confidence`` is clamped to [0,1]; a non-numeric
+value degrades to None rather than hard-failing a run.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.segments import SegmentReport
+
+pytestmark = pytest.mark.unit
+
+
+def _report(**over: object) -> SegmentReport:
+    base: dict[str, object] = {
+        "segment": "macro",
+        "date": date(2026, 6, 12),
+        "bias": "neutral",
+        "headline": "h",
+    }
+    base.update(over)
+    return SegmentReport(**base)  # type: ignore[arg-type]
+
+
+def test_data_quality_defaults_to_none() -> None:
+    r = _report()
+    assert r.data_quality is None
+    assert r.confidence is None
+
+
+def test_data_quality_accepts_grades() -> None:
+    for grade in ("high", "medium", "low", "absent"):
+        assert _report(data_quality=grade).data_quality == grade
+
+
+def test_confidence_clamped_to_unit_interval() -> None:
+    assert _report(confidence=1.5).confidence == 1.0
+    assert _report(confidence=-0.2).confidence == 0.0
+    assert _report(confidence="0.7").confidence == pytest.approx(0.7)
+
+
+def test_confidence_non_numeric_degrades_to_none() -> None:
+    assert _report(confidence="high").confidence is None
+    assert _report(confidence=None).confidence is None
+
+
+def test_data_quality_normalizes_case_and_whitespace() -> None:
+    # LLM case/whitespace variants normalize rather than hard-fail the run.
+    assert _report(data_quality="ABSENT").data_quality == "absent"
+    assert _report(data_quality=" High ").data_quality == "high"
+    assert _report(data_quality="Medium").data_quality == "medium"
+
+
+def test_data_quality_unrecognized_degrades_to_none() -> None:
+    # An out-of-vocab grade degrades to None (publishes ungraded) instead of ValidationError.
+    assert _report(data_quality="unknown").data_quality is None
+    assert _report(data_quality="n/a").data_quality is None
+
+
+def test_bias_synonym_still_normalizes() -> None:
+    # The new fields don't disturb the existing bias-synonym normalization.
+    assert _report(bias="positive").bias == "bullish"

--- a/tests/dq/atlas/test_snapshot.py
+++ b/tests/dq/atlas/test_snapshot.py
@@ -215,6 +215,17 @@ class TestParityWithPipelineDigest:
             f"only-upstream: {upstream_fields - local_fields}"
         )
 
+    def test_data_quality_enum_parity(self) -> None:
+        """The snapshot DataQuality literal mirrors segments.DataQuality on purpose (the
+        snapshot module never imports the pipeline). Guard against ENUM drift (the field-name
+        parity test only checks names) — adding/removing a grade in one must match the other."""
+        from typing import get_args
+
+        from digiquant.olympus.atlas.segments import DataQuality as SegmentsDataQuality
+        from digiquant.olympus.atlas.snapshot import DataQuality as SnapshotDataQuality
+
+        assert set(get_args(SnapshotDataQuality)) == set(get_args(SegmentsDataQuality))
+
     def test_actionable_item_field_parity(self) -> None:
         DigestSnapshot = self._digest_snapshot_class()
         from digiquant.olympus.atlas.snapshot import ActionableItem as LocalActionableItem


### PR DESCRIPTION
## Pillar 1E — data-quality contract

Segments now carry an honest **evidence grade**, so Olympus stops publishing confident-looking "No data available" documents and the PM / digest can discount thin segments. With 1C/1D shipped (real data tools + empty-response self-heal) segments now *have* data — this is the quality guard that keeps degenerate output from leaking through.

### What it does

- **`SegmentReport`** (segments.py) gains optional `data_quality` (`high`/`medium`/`low`/`absent`) + `confidence` (0–1). **Backward-compatible** (default `None`; old stored bodies validate). All phase sub-classes inherit. Two soft validators keep it **fail-soft**:
  - `data_quality` is stripped/lowercased; an out-of-vocab grade → `None` (publishes ungraded) instead of a `ValidationError` that would carry the segment.
  - `confidence` is clamped to `[0,1]`; non-numeric → `None`.
  - (mirrors the existing `bias`-synonym normalization pattern.)
- **`ANALYST_SYSTEM`** prompt: grade evidence honestly; on no data, set `data_quality="absent"` + bias `neutral` + empty findings rather than writing a confident brief on nothing.
- **`publish_phase`** suppresses degenerate segments (`data_quality=="absent"` **and** no `material_findings`), including the macro slot — observable via a log line with the actual grade + finding count. A segment with findings, or graded high/medium/low (or ungraded `None`), always publishes.

### Parity fix (found by an adversarial review pass before this PR)

`DigestSnapshot` inherits the new fields from `SegmentReport`, so the deliberately-mirrored `DigestPayload` (snapshot.py, `extra="forbid"`) and the `Phase7DigestPayload` TypedDict (state.py) had to gain them too, and the exported `docs/schemas/atlas_snapshot.v1.json` was regenerated. Without this, the snapshot **parity test** + **schema-drift test** fail and frontend deserialization of digest snapshots would raise on the extra fields. (This is exactly the drift those guard-tests exist to catch.)

### Tests / gate

- 13 new/updated tests: data_quality defaults/grades/**case+whitespace normalization**/degrade-to-none; confidence clamp; publish **suppress** absent-no-findings (incl. macro); absent-**with**-findings still publishes; ungraded publishes; **mixed-phase** per-segment suppression.
- **551 atlas + hermes tests pass** (incl. the snapshot parity + schema-drift guards); `ruff` clean; `make score` **10/10/10/10**.

No DB migration; no schema change to stored tables (optional body fields only).

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)