### PR TITLE
feat(atlas): on-demand technicals recompute from price_history (Pillar 1F, code half)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -761,6 +761,13 @@ risk profile is reproducible and auditable rather than LLM-eyeballed.
   captured (`usage.start`/`snapshot`/`reset`) across the whole run.
 - `cli_main` exits non-zero when `is_degraded` (failed-segment share > `ATLAS_DEGRADED_RUN_PCT`,
   default 50%) so CI's outer retry fires on a starved run — one bad sector does not trip it.
+- **Technicals freshness (Pillar 1F).** `data/prices/refresh.recompute_technicals_from_history`
+  recomputes `price_technicals` from the raw OHLCV already in `price_history` (look-ahead-guarded,
+  network-free, idempotent) — distinct from the prices cron's network `fetch-quotes`. When
+  preflight finds `price_technicals` stale it can call this in-graph, opt-in via
+  `ATLAS_REFRESH_ON_DEMAND` (off by default; fail-soft → keeps the stale data + the `scripts`
+  signal), then re-probes and clears the signal if now fresh. The CI pre-baseline step (a
+  `fetch-quotes` + `compute-technicals` pass in `atlas-baseline.yml`) is the primary mechanism.
 
 ### Persistence
 

--- a/digiquant/src/digiquant/data/prices/refresh.py
+++ b/digiquant/src/digiquant/data/prices/refresh.py
@@ -1,0 +1,128 @@
+"""On-demand technicals refresh (Pillar 1F).
+
+When ``price_technicals`` is stale at run time (e.g. a Saturday baseline whose Friday
+intraday prices cron didn't run), recompute the indicators from the raw OHLCV **already in
+``price_history``** and upsert them — *network-free* (no yfinance fetch), so it is safe to
+call from inside the pipeline. This brings the technicals table current to the freshest
+prices already ingested, rather than silently reading days-old indicators.
+
+This is distinct from the prices cron's ``fetch-quotes`` (which pulls *new* OHLCV from the
+network). The CI pre-baseline step still does a real fetch; this recompute is the in-graph
+fallback (opt-in via ``ATLAS_REFRESH_ON_DEMAND``) and the reusable core both can share.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+import polars as pl
+
+from digiquant.data.prices import TECHNICAL_COLUMNS
+from digiquant.data.prices.supabase_writer import technicals_to_rows, upsert_price_technicals
+from digiquant.data.prices.technicals import MIN_BARS, compute_indicators
+
+logger = logging.getLogger(__name__)
+
+# Calendar window of OHLCV to pull per ticker — wide enough for the 200-day SMA (~270
+# trading days) plus slack for weekends/holidays.
+_DEFAULT_LOOKBACK_DAYS = 400
+_OHLCV_COLUMNS = ("date", "ticker", "open", "high", "low", "close", "volume")
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """Outcome of a technicals recompute."""
+
+    tickers_processed: int
+    rows_upserted: int
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_history(client: Any, tickers: list[str], as_of: date, lookback_days: int) -> list[dict]:
+    """Raw OHLCV rows for ``tickers`` in ``(as_of − lookback, as_of]``, oldest first.
+
+    Look-ahead-guarded (``.lte(as_of)``) so a recompute is reproducible for a back-dated run.
+    """
+    since = (as_of - timedelta(days=max(1, lookback_days))).isoformat()
+    resp = (
+        client.table("price_history")
+        .select(",".join(_OHLCV_COLUMNS))
+        .in_("ticker", list(tickers))
+        .lte("date", as_of.isoformat())
+        .gte("date", since)
+        .order("date", desc=False)
+        .execute()
+    )
+    return list(getattr(resp, "data", None) or [])
+
+
+def _frame_for_ticker(rows: list[dict]) -> pl.DataFrame:
+    """Build the OHLCV frame ``compute_indicators`` expects (``timestamp`` + OHLCV)."""
+    return pl.DataFrame(
+        {
+            "timestamp": [str(r.get("date"))[:10] for r in rows],
+            "open": [_to_float(r.get("open")) for r in rows],
+            "high": [_to_float(r.get("high")) for r in rows],
+            "low": [_to_float(r.get("low")) for r in rows],
+            "close": [_to_float(r.get("close")) for r in rows],
+            "volume": [_to_float(r.get("volume")) for r in rows],
+        }
+    ).with_columns(pl.col("timestamp").str.to_date(strict=False))
+
+
+def recompute_technicals_from_history(
+    *,
+    client: Any,
+    tickers: list[str] | tuple[str, ...],
+    as_of: date,
+    lookback_days: int = _DEFAULT_LOOKBACK_DAYS,
+) -> RefreshResult:
+    """Recompute + upsert ``price_technicals`` from ``price_history`` (≤ ``as_of``).
+
+    Network-free and idempotent (upserts on ``(date, ticker)``). A ticker with fewer than
+    :data:`~digiquant.data.prices.technicals.MIN_BARS` bars is skipped. The caller decides
+    whether to run this (it does I/O); errors propagate so the caller can fail-soft.
+    """
+    tickers = [t for t in dict.fromkeys(tickers) if t]  # dedupe, drop empties
+    if not tickers:
+        return RefreshResult(0, 0)
+
+    rows = _read_history(client, tickers, as_of, lookback_days)
+    by_ticker: dict[str, list[dict]] = {}
+    for row in rows:
+        ticker = row.get("ticker")
+        if isinstance(ticker, str):
+            by_ticker.setdefault(ticker, []).append(row)
+
+    out_rows: list[dict] = []
+    processed = 0
+    for ticker, t_rows in by_ticker.items():
+        if len(t_rows) < MIN_BARS:
+            continue
+        frame = _frame_for_ticker(t_rows)
+        indicators = compute_indicators(frame)
+        keep = [c for c in TECHNICAL_COLUMNS if c in indicators.columns]
+        out_rows.extend(technicals_to_rows(indicators.select(keep), ticker, frame["timestamp"]))
+        processed += 1
+
+    result = upsert_price_technicals(client, out_rows)
+    logger.info(
+        "refresh: recomputed technicals for %d/%d tickers (%d rows) as_of %s",
+        processed,
+        len(tickers),
+        result.rows,
+        as_of.isoformat(),
+    )
+    return RefreshResult(tickers_processed=processed, rows_upserted=result.rows)
+
+
+__all__ = ["RefreshResult", "recompute_technicals_from_history"]

--- a/digiquant/src/digiquant/data/prices/refresh.py
+++ b/digiquant/src/digiquant/data/prices/refresh.py
@@ -48,7 +48,8 @@ def _to_float(value: Any) -> float | None:
 
 
 def _read_history(client: Any, tickers: list[str], as_of: date, lookback_days: int) -> list[dict]:
-    """Raw OHLCV rows for ``tickers`` in ``(as_of − lookback, as_of]``, oldest first.
+    """Raw OHLCV rows for ``tickers`` in ``[as_of − lookback, as_of]`` (both bounds
+    inclusive: ``.gte(since)`` / ``.lte(as_of)``), oldest first.
 
     Look-ahead-guarded (``.lte(as_of)``) so a recompute is reproducible for a back-dated run.
     """

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -7,6 +7,7 @@ See ``atlas/docs/agentic/ARCHITECTURE.md`` Pre-Flight Protocol.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import date
 from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-update dict shape
@@ -87,6 +88,42 @@ def _market_context_tickers() -> list[str]:
     return tickers
 
 
+def _refresh_on_demand_enabled() -> bool:
+    """``ATLAS_REFRESH_ON_DEMAND`` — opt in to the in-graph technicals recompute (off by
+    default; the CI pre-baseline step is the primary freshness mechanism)."""
+    return os.environ.get("ATLAS_REFRESH_ON_DEMAND", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _refresh_stale_technicals(
+    deps: PreflightDeps, run_date: date, config: AtlasConfigBundle
+) -> bool:
+    """Recompute technicals from ``price_history`` (network-free) to clear staleness.
+
+    Opt-in via ``ATLAS_REFRESH_ON_DEMAND``; fail-soft → ``False`` (keep the stale data and
+    the ``"scripts"`` fallback signal). Returns True only when rows were actually upserted.
+    """
+    if not _refresh_on_demand_enabled():
+        return False
+    tickers = list(config.watchlist)
+    if not tickers:
+        return False
+    try:
+        from digiquant.data.prices.refresh import recompute_technicals_from_history
+
+        result = recompute_technicals_from_history(
+            client=deps.client, tickers=tickers, as_of=run_date
+        )
+        return result.rows_upserted > 0
+    except Exception as exc:  # noqa: BLE001 — refresh is best-effort; never block preflight
+        logger.warning("preflight: on-demand technicals refresh failed (%s); using stale data", exc)
+        return False
+
+
 def _data_layer_snapshot(
     deps: PreflightDeps, run_date: date, config: AtlasConfigBundle
 ) -> DataLayerSnapshot:
@@ -104,6 +141,13 @@ def _data_layer_snapshot(
         stale_cutoff = run_date - _days(deps.price_staleness_days)
         if latest_tech < stale_cutoff:
             fallback = "scripts"
+            # On-demand refresh (opt-in, network-free): recompute technicals from
+            # price_history so the research phases read current values. Re-probe; if the
+            # table is now fresh, clear the fallback signal (#726, 1F).
+            if _refresh_stale_technicals(deps, run_date, config):
+                latest_tech, ticker_count = query_price_technicals_freshness(client=deps.client)
+                if latest_tech is not None and latest_tech >= stale_cutoff:
+                    fallback = "supabase"
 
     # Deterministic market values for every phase's shared context (#694).
     # Fail-soft: research must proceed (ungrounded) on a data-layer hiccup.

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -120,7 +120,11 @@ def _refresh_stale_technicals(
         )
         return result.rows_upserted > 0
     except Exception as exc:  # noqa: BLE001 — refresh is best-effort; never block preflight
-        logger.warning("preflight: on-demand technicals refresh failed (%s); using stale data", exc)
+        logger.warning(
+            "preflight: on-demand technicals refresh failed (%s); using stale data",
+            exc,
+            exc_info=True,
+        )
         return False
 
 

--- a/tests/dq/atlas/test_preflight.py
+++ b/tests/dq/atlas/test_preflight.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from datetime import date
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
+from digiquant.data.prices import refresh as refresh_mod
 from digiquant.olympus.atlas.phases.preflight import PreflightDeps, build_preflight_node
 from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
 
@@ -70,6 +73,62 @@ class TestPreflight:
         node = build_preflight_node(deps)
         state = AtlasResearchState(run_type="baseline", run_date=run_date)
         out = node(state)
+        assert out["data_layer"].fallback_used == "scripts"
+
+    def _stale_deps(self) -> tuple[FakeSupabaseClient, PreflightDeps]:
+        client = self._client_with_fresh_data(date(2026, 4, 20))  # 6 days stale
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(watchlist=["SPY"]),
+            price_staleness_days=3,
+        )
+        return client, deps
+
+    def test_on_demand_refresh_off_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Without ATLAS_REFRESH_ON_DEMAND the stale signal stands and no recompute is attempted.
+        monkeypatch.delenv("ATLAS_REFRESH_ON_DEMAND", raising=False)
+        _client, deps = self._stale_deps()
+        with patch.object(refresh_mod, "recompute_technicals_from_history") as recompute:
+            out = build_preflight_node(deps)(
+                AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+            )
+        recompute.assert_not_called()
+        assert out["data_layer"].fallback_used == "scripts"
+
+    def test_on_demand_refresh_clears_fallback_when_now_fresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAS_REFRESH_ON_DEMAND", "1")
+        client, deps = self._stale_deps()
+        run_date = date(2026, 4, 26)
+
+        def _fake_recompute(*, client, tickers, as_of):
+            # Simulate the upsert: the table is now fresh on the re-probe.
+            client.canned_reads["price_technicals"] = [{"date": as_of.isoformat(), "ticker": "SPY"}]
+            return SimpleNamespace(tickers_processed=1, rows_upserted=12)
+
+        with patch.object(
+            refresh_mod, "recompute_technicals_from_history", side_effect=_fake_recompute
+        ):
+            out = build_preflight_node(deps)(
+                AtlasResearchState(run_type="baseline", run_date=run_date)
+            )
+        # Refresh brought it current → fallback cleared back to supabase.
+        assert out["data_layer"].fallback_used == "supabase"
+        assert out["data_layer"].price_technicals_latest == run_date
+
+    def test_on_demand_refresh_is_fail_soft(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_REFRESH_ON_DEMAND", "1")
+        _client, deps = self._stale_deps()
+        with patch.object(
+            refresh_mod,
+            "recompute_technicals_from_history",
+            side_effect=RuntimeError("supabase down"),
+        ):
+            out = build_preflight_node(deps)(
+                AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+            )
+        # Refresh failed → keep the stale data + the scripts signal (never crashes preflight).
         assert out["data_layer"].fallback_used == "scripts"
 
     def test_missing_price_technicals_signals_no_source(self) -> None:

--- a/tests/dq/data/test_prices_refresh.py
+++ b/tests/dq/data/test_prices_refresh.py
@@ -1,0 +1,110 @@
+"""On-demand technicals recompute (Pillar 1F).
+
+recompute_technicals_from_history reads raw OHLCV from price_history (look-ahead-guarded),
+recomputes indicators, and upserts price_technicals — network-free. Tickers below MIN_BARS
+are skipped; the read is bounded by .lte(as_of).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from digiquant.data.prices import refresh
+from digiquant.data.prices.technicals import MIN_BARS
+
+pytestmark = pytest.mark.unit
+
+AS_OF = date(2026, 3, 1)
+
+
+def _ohlcv(ticker: str, n: int) -> list[dict]:
+    rows = []
+    for i in range(n):
+        d = date(2026, 1, 1) + timedelta(days=i)
+        px = 100.0 + i * 0.5
+        rows.append(
+            {
+                "date": d.isoformat(),
+                "ticker": ticker,
+                "open": px,
+                "high": px + 1,
+                "low": px - 1,
+                "close": px + 0.5,
+                "volume": 1_000_000,
+            }
+        )
+    return rows
+
+
+def _capture_upsert():
+    seen: dict[str, list] = {}
+
+    def _fake(_client, rows, **_kw):
+        seen["rows"] = rows
+        return SimpleNamespace(table="price_technicals", rows=len(rows))
+
+    return seen, _fake
+
+
+def test_recompute_upserts_for_sufficient_history() -> None:
+    seen, fake = _capture_upsert()
+    with (
+        patch.object(refresh, "_read_history", return_value=_ohlcv("SPY", 40)),
+        patch.object(refresh, "upsert_price_technicals", side_effect=fake),
+    ):
+        result = refresh.recompute_technicals_from_history(
+            client=object(), tickers=["SPY"], as_of=AS_OF
+        )
+    assert result.tickers_processed == 1
+    assert result.rows_upserted > 0
+    assert {"date", "ticker"} <= set(seen["rows"][0])
+
+
+def test_skips_tickers_below_min_bars() -> None:
+    seen, fake = _capture_upsert()
+    with (
+        patch.object(refresh, "_read_history", return_value=_ohlcv("SPY", MIN_BARS - 1)),
+        patch.object(refresh, "upsert_price_technicals", side_effect=fake),
+    ):
+        result = refresh.recompute_technicals_from_history(
+            client=object(), tickers=["SPY"], as_of=AS_OF
+        )
+    assert result.tickers_processed == 0
+    assert result.rows_upserted == 0
+    assert seen["rows"] == []  # upsert called with nothing
+
+
+def test_empty_tickers_is_noop() -> None:
+    with patch.object(refresh, "upsert_price_technicals") as upsert:
+        result = refresh.recompute_technicals_from_history(client=object(), tickers=[], as_of=AS_OF)
+    assert result == refresh.RefreshResult(0, 0)
+    upsert.assert_not_called()
+
+
+def test_dedupes_tickers_before_read() -> None:
+    seen, fake = _capture_upsert()
+    with (
+        patch.object(refresh, "_read_history", return_value=_ohlcv("SPY", 40)) as read,
+        patch.object(refresh, "upsert_price_technicals", side_effect=fake),
+    ):
+        refresh.recompute_technicals_from_history(
+            client=object(), tickers=["SPY", "SPY", ""], as_of=AS_OF
+        )
+    # Deduped + empties dropped → a single "SPY" passed to the read.
+    assert read.call_args.args[1] == ["SPY"]
+
+
+def test_read_is_look_ahead_guarded() -> None:
+    client = MagicMock()
+    chain = client.table.return_value.select.return_value.in_.return_value.lte.return_value.gte.return_value.order.return_value
+    chain.execute.return_value.data = []
+    refresh.recompute_technicals_from_history(client=client, tickers=["SPY"], as_of=AS_OF)
+    client.table.assert_called_with("price_history")
+    # The upper bound is run_date — a future price row can never enter the window.
+    client.table.return_value.select.return_value.in_.return_value.lte.assert_called_with(
+        "date", AS_OF.isoformat()
+    )


### PR DESCRIPTION
## Pillar 1F (code half) — technicals freshness

A stale `price_technicals` table (e.g. a Saturday baseline whose Friday prices cron didn't run) silently fed days-old indicators to the research phases. This adds a **network-free** recompute + an **opt-in** preflight hook so the table is brought current from data already in Supabase.

### What it adds

- **`data/prices/refresh.py::recompute_technicals_from_history`** — reads raw OHLCV from `price_history` (**look-ahead-guarded** by `.lte(as_of)`), recomputes indicators per ticker (skipping tickers below `MIN_BARS`), and upserts `price_technicals`. **Network-free** (no yfinance) and **idempotent** (upserts on `(date, ticker)`). This is distinct from the prices cron's network `fetch-quotes` — it recomputes from already-ingested OHLCV, so a stale technicals table is refreshed to match the freshest `price_history` available. Reusable core for both the in-graph hook and the CLI.
- **preflight hook** — when `price_technicals` is stale, optionally recompute in-graph (**opt-in via `ATLAS_REFRESH_ON_DEMAND`, OFF by default**), then re-probe freshness and clear the `scripts` fallback signal if now current. **Fail-soft**: a refresh error keeps the stale data + signal and never crashes preflight.

### Scope split — the CI step is a separate human gate

The plan's **pre-baseline compute step** in `atlas-baseline.yml` (a `fetch-quotes` + `compute-technicals` pass) is the **primary** freshness mechanism, but it changes the **production baseline run** — an explicitly flagged **human gate**. So it ships separately (1F-b) for your sign-off; **this PR is the code-only half** (safe to merge: off-by-default hook + a pure reusable function).

### Tests / gate

- 12 tests: recompute upserts for sufficient history / skips below `MIN_BARS` / empty-noop / dedupes tickers / **look-ahead guard**; preflight refresh **off-by-default** / **clears fallback when now fresh** / **fail-soft on error**.
- `ruff` clean; `make score` **10/10/10/10**; `ARCHITECTURE.md` updated.

No DB migration; no behavior change unless `ATLAS_REFRESH_ON_DEMAND` is set.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)