### PR TITLE
ci(atlas): pre-baseline price + technicals freshness step (Pillar 1F) [HUMAN GATE]

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -77,6 +77,28 @@ jobs:
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
 
+      # Pre-baseline price freshness (#726, 1F). The intraday prices cron is MON-FRI, so a
+      # Saturday baseline would otherwise read Friday-stale technicals. Refresh prices +
+      # technicals right before the run (same commands as digiquant-prices.yml).
+      # Best-effort: continue-on-error so a yfinance/network hiccup never blocks the baseline
+      # — preflight's on-demand recompute + the stale-data fallback cover a skipped refresh.
+      - name: Refresh prices + technicals (pre-baseline freshness)
+        continue-on-error: true
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          pip install -e "./digiquant[prices]"
+          python -m digiquant prices fetch-quotes \
+            --watchlist digiquant/src/digiquant/olympus/atlas/config/watchlist.md \
+            --cache-dir data/price-history \
+            --period 1y \
+            --supabase
+          python -m digiquant prices compute-technicals \
+            --cache-dir data/price-history \
+            --days 365 \
+            --supabase
+
       - name: Run baseline
         id: run
         env:


### PR DESCRIPTION
## Pillar 1F (CI half) — pre-baseline freshness · ⚠️ HUMAN GATE

> **This changes the production `atlas baseline` workflow. Per the #726 program, the pre-baseline compute step is an explicit human gate — please review + merge yourself; I have not auto-merged it.**

### What it does

Adds one best-effort step to `atlas-baseline.yml`, between **Validate providers** and **Run baseline**:

```yaml
- name: Refresh prices + technicals (pre-baseline freshness)
  continue-on-error: true
  env: { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY }
  run: |
    pip install -e "./digiquant[prices]"
    python -m digiquant prices fetch-quotes  --watchlist .../watchlist.md --cache-dir data/price-history --period 1y --supabase
    python -m digiquant prices compute-technicals --cache-dir data/price-history --days 365 --supabase
```

These are the **same commands** the MON-FRI `digiquant-prices.yml` cron runs. Because that cron is weekday-only, a **Saturday baseline** would otherwise read Friday-stale technicals; this refreshes `price_history` + `price_technicals` right before the run.

### Safety

- **`continue-on-error: true`** — a yfinance/network hiccup must **never block the baseline**. preflight's on-demand recompute (#759) + the stale-data fallback cover a skipped/failed refresh.
- Uses only repo secrets + static strings — no untrusted `github.event.*` input (no injection surface).
- `actionlint` clean; `make score` 10/10.

### Why human-gated

It modifies the live daily baseline run (adds network calls + a Supabase write before the pipeline). That's an owner decision — once you're comfortable, merge it and the next baseline will self-refresh.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)