### PR TITLE
feat(atlas): close the learning loop — standalone decision resolver + due-window fix (Pillar 3A)

### DIFF
--- a/digiquant/scripts/atlas/resolve_decisions.py
+++ b/digiquant/scripts/atlas/resolve_decisions.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Standalone Atlas decision resolver (Pillar 3A, #726).
+
+Resolves every *due* ``decision_log`` row — computes realized alpha vs the benchmark and
+writes the reflection lesson — by calling
+:func:`digiquant.olympus.atlas.decision_log.resolve_pending`. This decouples resolution
+from the research pipeline so it can run on its own cron (daily, after EOD prices land),
+independent of a baseline/delta run. The in-graph ``preflight_reflect`` stays as a
+belt-and-suspenders path; this script is the authoritative, schedulable resolver.
+
+Resolution is idempotent (only ``status='pending'`` rows are touched) and gracefully skips
+a due row whose price window hasn't landed yet (it stays pending for the next run).
+
+Usage::
+
+    python digiquant/scripts/atlas/resolve_decisions.py [--run-date YYYY-MM-DD]
+
+Env: ``SUPABASE_URL`` + ``SUPABASE_SERVICE_ROLE_KEY`` (reads/writes ``decision_log``);
+``OPENROUTER_API_KEY`` for the reflector LLM (~1 cheap call per resolved decision).
+
+Exit codes: 0 = clean run (resolving 0 due rows is success); 1 = hard failure (Supabase
+unavailable / resolver crash); 2 = bad ``--run-date``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# repo root: .../digiquant/scripts/atlas/resolve_decisions.py → up 3 → repo root
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _ensure_importable() -> None:
+    """Add the monorepo ``*/src`` paths to sys.path so the atlas package imports."""
+    for rel in ("digiquant/src", "digigraph/src", "digibase/src", "digismith/src"):
+        path = str(_REPO_ROOT / rel)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _parse_run_date(value: str | None) -> date:
+    if value:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    return datetime.now(timezone.utc).date()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve due Atlas decision_log rows (alpha vs benchmark + reflection)."
+    )
+    parser.add_argument(
+        "--run-date",
+        default=None,
+        help="Resolution as-of date YYYY-MM-DD (default: today UTC).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        run_date = _parse_run_date(args.run_date)
+    except ValueError:
+        print(f"error: bad --run-date {args.run_date!r} (expected YYYY-MM-DD)", file=sys.stderr)
+        return 2
+
+    _ensure_importable()
+    from digiquant.olympus.atlas.decision_log import resolve_pending
+    from digiquant.olympus.atlas.supabase_io import (
+        SupabaseConfig,
+        build_client,
+        query_pending_decisions,
+    )
+
+    try:
+        client = build_client(SupabaseConfig.from_env())
+    except Exception as exc:  # noqa: BLE001 — a config/connectivity failure is a hard error
+        print(f"error: Supabase client unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        resolved = resolve_pending(client=client, run_date=run_date)
+        remaining = len(query_pending_decisions(client=client, run_date=run_date))
+    except Exception as exc:  # noqa: BLE001 — surface a hard failure as a non-zero exit
+        print(f"error: resolve_pending failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"resolve_decisions: resolved {resolved} decision(s) as of {run_date.isoformat()}; "
+        f"{remaining} still due-pending (awaiting price data)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/digiquant/scripts/atlas/resolve_decisions.py
+++ b/digiquant/scripts/atlas/resolve_decisions.py
@@ -29,7 +29,8 @@ import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# repo root: .../digiquant/scripts/atlas/resolve_decisions.py → up 3 → repo root
+# repo root: .../digiquant/scripts/atlas/resolve_decisions.py → up 4 (atlas → scripts →
+# digiquant → repo root).
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -514,7 +514,10 @@ def query_pending_decisions(
             "benchmark, holding_days, status"
         )
         .eq("status", "pending")
-        .lt("run_date", floor)
+        # ``<=`` not ``<``: a decision dated exactly ``floor`` (= run_date − holding_days_default)
+        # is due today (floor + holding_days_default == run_date), so it must be included.
+        # ``<`` dropped that boundary row, delaying its resolution by a day (#726, 3A).
+        .lte("run_date", floor)
         .order("run_date", desc=False)
         .execute()
     )

--- a/tests/dq/atlas/test_resolve_decisions.py
+++ b/tests/dq/atlas/test_resolve_decisions.py
@@ -33,7 +33,8 @@ def _patch_deps(monkeypatch, *, resolved: int, remaining: int) -> None:
     import digiquant.olympus.atlas.decision_log as dl
     import digiquant.olympus.atlas.supabase_io as sio
 
-    monkeypatch.setattr(sio.SupabaseConfig, "from_env", lambda: object())
+    # from_env is a classmethod; patch with staticmethod so it's invoked with no implicit cls.
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", staticmethod(lambda: object()))
     monkeypatch.setattr(sio, "build_client", lambda _cfg: object())
     monkeypatch.setattr(dl, "resolve_pending", lambda **_k: resolved)
     monkeypatch.setattr(sio, "query_pending_decisions", lambda **_k: [{}] * remaining)
@@ -66,7 +67,7 @@ def test_client_failure_returns_1(monkeypatch, capsys) -> None:
     def _boom():
         raise sio.SupabaseNotConfiguredError("missing SUPABASE_URL")
 
-    monkeypatch.setattr(sio.SupabaseConfig, "from_env", _boom)
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", staticmethod(_boom))
     assert resolve_decisions.main([]) == 1  # default run-date = today
     assert "Supabase client unavailable" in capsys.readouterr().err
 
@@ -75,7 +76,7 @@ def test_resolver_crash_returns_1(monkeypatch, capsys) -> None:
     import digiquant.olympus.atlas.decision_log as dl
     import digiquant.olympus.atlas.supabase_io as sio
 
-    monkeypatch.setattr(sio.SupabaseConfig, "from_env", lambda: object())
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", staticmethod(lambda: object()))
     monkeypatch.setattr(sio, "build_client", lambda _cfg: object())
 
     def _boom(**_k):

--- a/tests/dq/atlas/test_resolve_decisions.py
+++ b/tests/dq/atlas/test_resolve_decisions.py
@@ -1,0 +1,86 @@
+"""Standalone decision-resolver script (Pillar 3A).
+
+The script is a thin runner over decision_log.resolve_pending: builds a Supabase client,
+resolves due rows, reports counts. Loaded from its file path (it lives under scripts/, not
+the importable package) and exercised with monkeypatched deps — no live Supabase/LLM.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "digiquant" / "scripts" / "atlas" / "resolve_decisions.py"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("resolve_decisions_script", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+resolve_decisions = _load_script()
+
+
+def _patch_deps(monkeypatch, *, resolved: int, remaining: int) -> None:
+    import digiquant.olympus.atlas.decision_log as dl
+    import digiquant.olympus.atlas.supabase_io as sio
+
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", lambda: object())
+    monkeypatch.setattr(sio, "build_client", lambda _cfg: object())
+    monkeypatch.setattr(dl, "resolve_pending", lambda **_k: resolved)
+    monkeypatch.setattr(sio, "query_pending_decisions", lambda **_k: [{}] * remaining)
+
+
+def test_resolves_and_reports(monkeypatch, capsys) -> None:
+    _patch_deps(monkeypatch, resolved=3, remaining=2)
+    rc = resolve_decisions.main(["--run-date", "2026-06-12"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "resolved 3" in out
+    assert "2 still due-pending" in out
+    assert "2026-06-12" in out
+
+
+def test_zero_due_is_success(monkeypatch, capsys) -> None:
+    _patch_deps(monkeypatch, resolved=0, remaining=0)
+    assert resolve_decisions.main(["--run-date", "2026-06-12"]) == 0
+    assert "resolved 0" in capsys.readouterr().out
+
+
+def test_bad_run_date_returns_2(capsys) -> None:
+    assert resolve_decisions.main(["--run-date", "not-a-date"]) == 2
+    assert "bad --run-date" in capsys.readouterr().err
+
+
+def test_client_failure_returns_1(monkeypatch, capsys) -> None:
+    import digiquant.olympus.atlas.supabase_io as sio
+
+    def _boom():
+        raise sio.SupabaseNotConfiguredError("missing SUPABASE_URL")
+
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", _boom)
+    assert resolve_decisions.main([]) == 1  # default run-date = today
+    assert "Supabase client unavailable" in capsys.readouterr().err
+
+
+def test_resolver_crash_returns_1(monkeypatch, capsys) -> None:
+    import digiquant.olympus.atlas.decision_log as dl
+    import digiquant.olympus.atlas.supabase_io as sio
+
+    monkeypatch.setattr(sio.SupabaseConfig, "from_env", lambda: object())
+    monkeypatch.setattr(sio, "build_client", lambda _cfg: object())
+
+    def _boom(**_k):
+        raise RuntimeError("price_history unreachable")
+
+    monkeypatch.setattr(dl, "resolve_pending", _boom)
+    assert resolve_decisions.main(["--run-date", "2026-06-12"]) == 1
+    assert "resolve_pending failed" in capsys.readouterr().err

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, timedelta
 from typing import Any  # noqa: F401 — used for fake-client payload dict shape
 
 import pytest
@@ -15,6 +15,7 @@ from digiquant.olympus.atlas.supabase_io import (
     publish_daily_snapshot,
     publish_document,
     query_macro_series_freshness,
+    query_pending_decisions,
     query_price_deltas,
     query_price_technicals_freshness,
 )
@@ -446,3 +447,38 @@ class TestQueryPriceDeltas:
         )
         assert "QQQ" not in out
         assert "SPY" in out
+
+
+@pytest.mark.unit
+class TestQueryPendingDueWindow:
+    """Pillar 3A — the due-window lower bound is inclusive (``<=``): a decision dated exactly
+    run_date − holding_days_default is due today and must be returned (``<`` dropped it)."""
+
+    def _row(self, run_date_iso: str, ticker: str = "AAPL") -> dict:
+        return {
+            "id": f"d-{ticker}-{run_date_iso}",
+            "run_id": "run-1",
+            "run_date": run_date_iso,
+            "ticker": ticker,
+            "stance": "buy",
+            "conviction": 4,
+            "thesis": "t",
+            "benchmark": "SPY",
+            "holding_days": 5,
+            "status": "pending",
+        }
+
+    def test_boundary_run_date_is_due(self) -> None:
+        run_date = date(2026, 6, 20)
+        floor = (
+            run_date - timedelta(days=5)
+        ).isoformat()  # exactly run_date − holding_days_default
+        client = FakeSupabaseClient(canned_reads={"decision_log": [self._row(floor)]})
+        due = query_pending_decisions(client=client, run_date=run_date)
+        assert [d["id"] for d in due] == [self._row(floor)["id"]]  # boundary included
+
+    def test_future_decision_not_due(self) -> None:
+        run_date = date(2026, 6, 20)
+        too_recent = (run_date - timedelta(days=2)).isoformat()  # window not yet elapsed
+        client = FakeSupabaseClient(canned_reads={"decision_log": [self._row(too_recent)]})
+        assert query_pending_decisions(client=client, run_date=run_date) == []


### PR DESCRIPTION
## Pillar 3A — close the learning loop

Makes decision resolution **schedulable independently** of the research pipeline, and fixes an off-by-one that delayed resolutions by a day.

### What it adds

- **`scripts/atlas/resolve_decisions.py`** — a thin standalone runner over `decision_log.resolve_pending`: build client → resolve every due row (realized alpha vs benchmark + LLM reflection lesson) → report `resolved` + `still-due-pending` counts. Decoupled from baseline/delta so it can run daily after EOD prices land. The resolution math + the in-graph `preflight_reflect` path already existed and are reused; this is the authoritative, cron-able entry point. Exit 0 = clean (0 due rows = success), 1 = hard failure, 2 = bad `--run-date`.
- **Due-window fix** (`query_pending_decisions`): the lower bound was `<` (strict), so a decision dated **exactly** `run_date − holding_days_default` — which is due *today* — was dropped, delaying resolution by a day. Now `<=` (inclusive). Live-path correctness; no schema change.

### Lessons → PM: already wired

Verified the chain is intact: preflight hydrates `PriorContext.decision_lessons` (via `fetch_recent_lessons`), and `phase7d_pm` reads them as `past_context`. No change needed.

### Tests / gate

- 7 tests: resolver runner (resolves+reports, zero-due success, bad-date → exit 2, client failure → exit 1, resolver crash → exit 1) + **due-window boundary regression** (the boundary row IS due; a too-recent row is NOT).
- **43 atlas + reflection tests pass** (the `.lte` change doesn't regress existing resolution). `ruff` clean; `make score` **10/10**.

### Human gate (batched separately)

The `atlas-resolve-decisions.yml` cron (a new scheduled, LLM-invoking job — ~1 cheap reflection call per due decision) is a **human gate**; it ships in the batched wiring PR for your sign-off, alongside the other crons/migrations.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)