### PR TITLE
feat(atlas): single-benchmark position attribution (Pillar 3B, migration 040)

### DIFF
--- a/digiquant/scripts/atlas/refresh_attribution.py
+++ b/digiquant/scripts/atlas/refresh_attribution.py
@@ -24,6 +24,7 @@ for the date is success); 1 = hard failure; 2 = bad ``--date``.
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -51,10 +52,13 @@ def _parse_date(value: str | None) -> date:
 
 
 def _opt_float(value: Any) -> float | None:
+    if value is None:
+        return None
     try:
-        return float(value) if value is not None else None
+        out = float(value)
     except (TypeError, ValueError):
         return None
+    return out if math.isfinite(out) else None  # reject NaN/inf (e.g. Postgres numeric 'NaN')
 
 
 def _window_return(client: Any, ticker: str, start_iso: str, end_iso: str) -> float | None:
@@ -72,10 +76,14 @@ def _window_return(client: Any, ticker: str, start_iso: str, end_iso: str) -> fl
         .limit(400)
         .execute()
     )
+    # Keep 0.0 (only drop None) so a bad non-positive close at either end trips the guard
+    # below rather than being silently skipped (which would compute a return off wrong rows).
     closes = [
-        c for c in (_opt_float(r.get("close")) for r in (getattr(resp, "data", None) or [])) if c
+        c
+        for c in (_opt_float(r.get("close")) for r in (getattr(resp, "data", None) or []))
+        if c is not None
     ]
-    if len(closes) < 2 or closes[0] <= 0:
+    if len(closes) < 2 or closes[0] <= 0 or closes[-1] <= 0:
         return None
     return closes[-1] / closes[0] - 1.0
 
@@ -103,13 +111,16 @@ def refresh_attribution(
         .eq("date", date_str)
         .execute()
     )
+    pos_rows = getattr(pos_resp, "data", None) or []
+    if not pos_rows:
+        return 0, True  # the date was never materialized → genuine no-op
+    # An all-cash day (only a CASH row) still gets a CASH attribution row: drop CASH here and
+    # let the core emit it from the cash residual (holdings=[]).
     holdings_raw = [
         row
-        for row in (getattr(pos_resp, "data", None) or [])
+        for row in pos_rows
         if isinstance(row.get("ticker"), str) and row["ticker"].strip().upper() != "CASH"
     ]
-    if not holdings_raw:
-        return 0, True  # no holdings (all-cash / no book) → nothing to attribute
 
     benchmark_return = _window_return(client, benchmark, start_iso, date_str)
     if benchmark_return is None:
@@ -126,9 +137,20 @@ def refresh_attribution(
     ]
     result = compute_position_attribution(holdings=holdings, benchmark_return_frac=benchmark_return)
     records = attribution_rows_to_records(result, date_str=date_str)
-    for record in records:
-        client.table("position_attribution").upsert(record, on_conflict="date,ticker").execute()
+    _upsert_attribution(client, records)
     return len(records), result.reconciles
+
+
+def _upsert_attribution(client: Any, records: list[dict[str, Any]]) -> None:
+    """Bulk-upsert attribution rows in one round-trip; fall back to per-row for clients (or
+    the test fake) whose ``upsert`` only accepts a single dict."""
+    if not records:
+        return
+    try:
+        client.table("position_attribution").upsert(records, on_conflict="date,ticker").execute()
+    except (TypeError, ValueError, AttributeError):
+        for record in records:
+            client.table("position_attribution").upsert(record, on_conflict="date,ticker").execute()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/digiquant/scripts/atlas/refresh_attribution.py
+++ b/digiquant/scripts/atlas/refresh_attribution.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Standalone per-position attribution refresh (Pillar 3B, #726).
+
+Computes the single-benchmark attribution decomposition for one date and upserts it to
+``position_attribution``: reads the booked ``positions`` weights, each holding's trailing-
+window return + the benchmark's return from ``price_history``, runs the pure
+:func:`digiquant.olympus.atlas.attribution.compute_position_attribution`, and writes the
+rows. Decoupled from the research pipeline so it can run on its own daily cron after EOD
+prices land. Idempotent (upsert on ``(date, ticker)``).
+
+A dedicated script (vs. wedging into ``refresh_performance_metrics.py``) keeps the
+attribution path importable + unit-testable and gives it a clean cron entry, mirroring
+``resolve_decisions.py``.
+
+Usage::
+
+    python digiquant/scripts/atlas/refresh_attribution.py [--date YYYY-MM-DD] [--window-days N]
+
+Env: ``SUPABASE_URL`` + ``SUPABASE_SERVICE_ROLE_KEY``. Reads positions + price_history,
+writes position_attribution (migration 040 must be applied). Exit 0 = clean (no positions
+for the date is success); 1 = hard failure; 2 = bad ``--date``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+# repo root: .../digiquant/scripts/atlas/refresh_attribution.py → up 4 (atlas → scripts →
+# digiquant → repo root).
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+_DEFAULT_WINDOW_DAYS = 21
+_BENCHMARK = "SPY"
+
+
+def _ensure_importable() -> None:
+    for rel in ("digiquant/src", "digigraph/src", "digibase/src", "digismith/src"):
+        path = str(_REPO_ROOT / rel)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _parse_date(value: str | None) -> date:
+    if value:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    return datetime.now(timezone.utc).date()
+
+
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _window_return(client: Any, ticker: str, start_iso: str, end_iso: str) -> float | None:
+    """Return over ``[start_iso, end_iso]`` from price_history (latest/earliest − 1).
+
+    Look-ahead-guarded (``.lte(end)``). ``None`` when fewer than two closes are available.
+    """
+    resp = (
+        client.table("price_history")
+        .select("date,close")
+        .eq("ticker", ticker)
+        .gte("date", start_iso)
+        .lte("date", end_iso)
+        .order("date", desc=False)
+        .limit(400)
+        .execute()
+    )
+    closes = [
+        c for c in (_opt_float(r.get("close")) for r in (getattr(resp, "data", None) or [])) if c
+    ]
+    if len(closes) < 2 or closes[0] <= 0:
+        return None
+    return closes[-1] / closes[0] - 1.0
+
+
+def refresh_attribution(
+    *,
+    client: Any,
+    as_of: date,
+    window_days: int = _DEFAULT_WINDOW_DAYS,
+    benchmark: str = _BENCHMARK,
+) -> tuple[int, bool]:
+    """Compute + upsert attribution rows for ``as_of``. Returns (rows_written, reconciles)."""
+    from digiquant.olympus.atlas.attribution import (
+        Holding,
+        attribution_rows_to_records,
+        compute_position_attribution,
+    )
+
+    date_str = as_of.isoformat()
+    start_iso = (as_of - timedelta(days=window_days)).isoformat()
+
+    pos_resp = (
+        client.table("positions")
+        .select("ticker,weight_pct,sector_bucket")
+        .eq("date", date_str)
+        .execute()
+    )
+    holdings_raw = [
+        row
+        for row in (getattr(pos_resp, "data", None) or [])
+        if isinstance(row.get("ticker"), str) and row["ticker"].strip().upper() != "CASH"
+    ]
+    if not holdings_raw:
+        return 0, True  # no holdings (all-cash / no book) → nothing to attribute
+
+    benchmark_return = _window_return(client, benchmark, start_iso, date_str)
+    if benchmark_return is None:
+        return 0, False  # no benchmark window yet → skip; the next run retries
+
+    holdings = [
+        Holding(
+            ticker=row["ticker"],
+            weight_frac=(_opt_float(row.get("weight_pct")) or 0.0) / 100.0,
+            return_frac=_window_return(client, row["ticker"], start_iso, date_str),
+            sector_bucket=row.get("sector_bucket"),
+        )
+        for row in holdings_raw
+    ]
+    result = compute_position_attribution(holdings=holdings, benchmark_return_frac=benchmark_return)
+    records = attribution_rows_to_records(result, date_str=date_str)
+    for record in records:
+        client.table("position_attribution").upsert(record, on_conflict="date,ticker").execute()
+    return len(records), result.reconciles
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Refresh per-position attribution for a date.")
+    parser.add_argument(
+        "--date", default=None, help="Attribution date YYYY-MM-DD (default: today UTC)."
+    )
+    parser.add_argument(
+        "--window-days", type=int, default=_DEFAULT_WINDOW_DAYS, help="Trailing return window."
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        as_of = _parse_date(args.date)
+    except ValueError:
+        print(f"error: bad --date {args.date!r} (expected YYYY-MM-DD)", file=sys.stderr)
+        return 2
+
+    _ensure_importable()
+    from digiquant.olympus.atlas.supabase_io import SupabaseConfig, build_client
+
+    try:
+        client = build_client(SupabaseConfig.from_env())
+    except Exception as exc:  # noqa: BLE001 — a config/connectivity failure is a hard error
+        print(f"error: Supabase client unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        written, reconciles = refresh_attribution(
+            client=client, as_of=as_of, window_days=max(1, args.window_days)
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a hard failure as a non-zero exit
+        print(f"error: refresh_attribution failed: {exc}", file=sys.stderr)
+        return 1
+
+    flag = "reconciles" if reconciles else "PARTIAL (some holding unpriced)"
+    print(f"refresh_attribution: wrote {written} row(s) for {as_of.isoformat()} — {flag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/digiquant/src/digiquant/olympus/atlas/attribution.py
+++ b/digiquant/src/digiquant/olympus/atlas/attribution.py
@@ -116,8 +116,11 @@ def compute_position_attribution(
             )
         )
 
-    cash_frac = max(0.0, 1.0 - invested)
-    if cash_frac > 1e-9:
+    # cash_frac = 1 − Σwᵢ — may be NEGATIVE for a net-invested (>100%) book; keeping the sign
+    # is what makes the identity reconcile at any invested level (clamping to ≥0 would drop
+    # the term and break it). Negative = a leverage/margin sleeve (still earns 0 vs r_b).
+    cash_frac = 1.0 - invested
+    if abs(cash_frac) > 1e-9:
         cash_drag = -cash_frac * r_b  # cash earns 0 while the benchmark moved r_b
         rows.append(
             AttributionRow(

--- a/digiquant/src/digiquant/olympus/atlas/attribution.py
+++ b/digiquant/src/digiquant/olympus/atlas/attribution.py
@@ -1,0 +1,176 @@
+"""Per-position performance attribution (Pillar 3B).
+
+A single-benchmark, reconcilable decomposition of the paper book's active return. We have
+each holding's return + a single benchmark (SPY), but **no benchmark sector weights**, so
+classic multi-sector Brinson allocation/selection is not computable. Instead we compute the
+honest quantities that *do* reconcile to the active return:
+
+    contribution_i = wᵢ · rᵢ                      (holding i's share of portfolio return)
+    selection_i    = wᵢ · (rᵢ − r_b)              (its return vs the benchmark, weighted)
+    cash drag      = −w_cash · r_b                 (holding cash while the benchmark moved)
+
+and the identity (when every holding is priced):
+
+    Σ selection_i + cash_drag  ==  Σ wᵢ·rᵢ − r_b  ==  portfolio_return − benchmark_return
+                                ==  active_return
+
+Pure-functional (no I/O, no pandas): the caller assembles per-holding weights + window
+returns (from price_history) and the benchmark return, and this returns the rows +
+reconciliation. The script half does the Supabase reads/writes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any  # noqa  # scored-lint: heterogeneous position_attribution record dicts
+
+_RECONCILE_TOL_PCT = 1e-6
+
+
+@dataclass(frozen=True)
+class Holding:
+    """One book holding for attribution: weight + window return (fractions, e.g. 0.03 = 3%)."""
+
+    ticker: str
+    weight_frac: float
+    return_frac: float | None  # None when the price window is unavailable → excluded
+    sector_bucket: str | None = None
+
+
+@dataclass(frozen=True)
+class AttributionRow:
+    """One attribution row (a holding, or the synthetic CASH drag row). Percent points."""
+
+    ticker: str
+    sector_bucket: str | None
+    weight_pct: float
+    position_return_pct: float | None
+    benchmark_return_pct: float
+    contribution_pct: float | None
+    selection_effect_pct: float | None
+    allocation_effect_pct: float
+    total_attribution_pct: float | None
+
+
+@dataclass(frozen=True)
+class AttributionResult:
+    rows: list[AttributionRow]
+    portfolio_return_pct: float
+    benchmark_return_pct: float
+    active_return_pct: float  # = Σ total_attribution_pct over priced rows + cash (identity)
+    reconciles: bool  # Σ total == active within tolerance (False if a holding was unpriced)
+
+
+def _pct(frac: float) -> float:
+    return round(frac * 100.0, 6)
+
+
+def compute_position_attribution(
+    *, holdings: Sequence[Holding], benchmark_return_frac: float
+) -> AttributionResult:
+    """Decompose active return per holding vs a single benchmark (see module doc).
+
+    Holdings with ``return_frac is None`` (no price window) are emitted with null effects
+    and excluded from the totals; ``reconciles`` then reports ``False`` so callers can flag
+    a partial attribution. Returns are fractions in, percent points out.
+    """
+    r_b = benchmark_return_frac
+    rows: list[AttributionRow] = []
+    port_return = 0.0
+    invested = 0.0
+    any_unpriced = False
+
+    for h in holdings:
+        invested += h.weight_frac
+        if h.return_frac is None:
+            any_unpriced = True
+            rows.append(
+                AttributionRow(
+                    ticker=h.ticker,
+                    sector_bucket=h.sector_bucket,
+                    weight_pct=round(h.weight_frac * 100.0, 4),
+                    position_return_pct=None,
+                    benchmark_return_pct=_pct(r_b),
+                    contribution_pct=None,
+                    selection_effect_pct=None,
+                    allocation_effect_pct=0.0,
+                    total_attribution_pct=None,
+                )
+            )
+            continue
+        contribution = h.weight_frac * h.return_frac
+        selection = h.weight_frac * (h.return_frac - r_b)
+        port_return += contribution
+        rows.append(
+            AttributionRow(
+                ticker=h.ticker,
+                sector_bucket=h.sector_bucket,
+                weight_pct=round(h.weight_frac * 100.0, 4),
+                position_return_pct=_pct(h.return_frac),
+                benchmark_return_pct=_pct(r_b),
+                contribution_pct=_pct(contribution),
+                selection_effect_pct=_pct(selection),
+                allocation_effect_pct=0.0,
+                total_attribution_pct=_pct(selection),
+            )
+        )
+
+    cash_frac = max(0.0, 1.0 - invested)
+    if cash_frac > 1e-9:
+        cash_drag = -cash_frac * r_b  # cash earns 0 while the benchmark moved r_b
+        rows.append(
+            AttributionRow(
+                ticker="CASH",
+                sector_bucket="cash",
+                weight_pct=round(cash_frac * 100.0, 4),
+                position_return_pct=0.0,
+                benchmark_return_pct=_pct(r_b),
+                contribution_pct=0.0,
+                selection_effect_pct=0.0,
+                allocation_effect_pct=_pct(cash_drag),
+                total_attribution_pct=_pct(cash_drag),
+            )
+        )
+
+    active = port_return - r_b
+    total_sum = sum(r.total_attribution_pct or 0.0 for r in rows)
+    reconciles = (not any_unpriced) and abs(total_sum - _pct(active)) <= _RECONCILE_TOL_PCT
+    return AttributionResult(
+        rows=rows,
+        portfolio_return_pct=_pct(port_return),
+        benchmark_return_pct=_pct(r_b),
+        active_return_pct=_pct(active),
+        reconciles=reconciles,
+    )
+
+
+def attribution_rows_to_records(
+    result: AttributionResult, *, date_str: str
+) -> list[dict[str, Any]]:
+    """Flatten :class:`AttributionResult` rows into ``position_attribution`` upsert dicts."""
+    return [
+        {
+            "date": date_str,
+            "ticker": row.ticker,
+            "sector_bucket": row.sector_bucket,
+            "weight_pct": row.weight_pct,
+            "position_return_pct": row.position_return_pct,
+            "benchmark_return_pct": row.benchmark_return_pct,
+            "contribution_pct": row.contribution_pct,
+            "selection_effect_pct": row.selection_effect_pct,
+            "allocation_effect_pct": row.allocation_effect_pct,
+            "total_attribution_pct": row.total_attribution_pct,
+            "metrics_as_of": date_str,
+        }
+        for row in result.rows
+    ]
+
+
+__all__ = [
+    "AttributionResult",
+    "AttributionRow",
+    "Holding",
+    "attribution_rows_to_records",
+    "compute_position_attribution",
+]

--- a/digiquant/supabase/migrations/040_position_attribution.sql
+++ b/digiquant/supabase/migrations/040_position_attribution.sql
@@ -1,0 +1,48 @@
+-- 040_position_attribution.sql — Per-position performance attribution (Pillar 3B, #726).
+--
+-- One row per (date, ticker) decomposing the paper book's active return vs the benchmark:
+-- contribution (wᵢ·rᵢ), selection (wᵢ·(rᵢ−r_b)), and a synthetic CASH row carrying the
+-- cash-drag allocation effect. A single-benchmark model (SPY) — full multi-sector Brinson
+-- needs benchmark sector weights we don't have. The dashboard reads this (anon SELECT,
+-- mirroring positions/nav_history) for the Attribution/Exposure tab. Computed by
+-- scripts/atlas/refresh_attribution.py; idempotent upsert on (date, ticker).
+
+CREATE TABLE IF NOT EXISTS public.position_attribution (
+    id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    date                   date NOT NULL,
+    ticker                 text NOT NULL,
+    sector_bucket          text,
+    weight_pct             numeric,
+    position_return_pct    numeric,
+    benchmark_return_pct   numeric,
+    contribution_pct       numeric,
+    selection_effect_pct   numeric,
+    allocation_effect_pct  numeric,
+    total_attribution_pct  numeric,
+    metrics_as_of          date,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (date, ticker)
+);
+
+COMMENT ON TABLE public.position_attribution IS
+  'Per-(date,ticker) single-benchmark attribution: contribution wi*ri, selection wi*(ri-rb), '
+  'plus a CASH row for cash drag. Sum(total_attribution_pct) reconciles to portfolio_return '
+  '- benchmark_return when every holding is priced (Pillar 3B, #726).';
+COMMENT ON COLUMN public.position_attribution.contribution_pct IS 'weight × position return (pct points).';
+COMMENT ON COLUMN public.position_attribution.selection_effect_pct IS 'weight × (position − benchmark) return.';
+COMMENT ON COLUMN public.position_attribution.allocation_effect_pct IS 'Cash-drag effect on the CASH row; 0 for holdings.';
+COMMENT ON COLUMN public.position_attribution.total_attribution_pct IS 'selection + allocation; sums to active return.';
+
+CREATE INDEX IF NOT EXISTS position_attribution_date_idx
+    ON public.position_attribution (date DESC);
+CREATE INDEX IF NOT EXISTS position_attribution_sector_idx
+    ON public.position_attribution (sector_bucket, date DESC);
+
+-- Anon SELECT only (read-only dashboard surface), mirroring positions / nav_history.
+ALTER TABLE public.position_attribution ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS position_attribution_anon_select ON public.position_attribution;
+CREATE POLICY position_attribution_anon_select
+    ON public.position_attribution
+    FOR SELECT TO anon
+    USING (true);

--- a/tests/dq/atlas/test_attribution.py
+++ b/tests/dq/atlas/test_attribution.py
@@ -83,6 +83,24 @@ def test_unpriced_holding_marks_partial() -> None:
     assert zzz.total_attribution_pct is None
 
 
+def test_net_invested_over_100_reconciles_with_negative_cash() -> None:
+    # Weights sum to 120% (a leveraged book). cash_frac = −0.20 must be kept (not clamped)
+    # so the identity still holds: Σ total == portfolio_return − benchmark.
+    result = compute_position_attribution(
+        holdings=[
+            Holding("AAA", 0.70, 0.10, "sector-technology"),
+            Holding("BBB", 0.50, 0.04, "fixed-income"),
+        ],
+        benchmark_return_frac=0.05,
+    )
+    cash = {r.ticker: r for r in result.rows}["CASH"]
+    assert cash.weight_pct == pytest.approx(-20.0)  # negative = leverage sleeve
+    assert result.reconciles is True
+    assert sum(r.total_attribution_pct for r in result.rows) == pytest.approx(
+        result.active_return_pct, abs=1e-6
+    )
+
+
 def test_records_flatten_with_date() -> None:
     result = compute_position_attribution(
         holdings=[Holding("AAA", 1.0, 0.05, "sector-technology")], benchmark_return_frac=0.05

--- a/tests/dq/atlas/test_attribution.py
+++ b/tests/dq/atlas/test_attribution.py
@@ -1,0 +1,102 @@
+"""Single-benchmark attribution core (Pillar 3B).
+
+compute_position_attribution decomposes active return into per-holding contribution +
+selection and a cash-drag allocation row. The defining property is the reconciliation
+identity: Σ total_attribution == portfolio_return − benchmark_return (when every holding is
+priced).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.atlas.attribution import (
+    Holding,
+    attribution_rows_to_records,
+    compute_position_attribution,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _by_ticker(result):
+    return {r.ticker: r for r in result.rows}
+
+
+def test_reconciliation_identity_fully_invested() -> None:
+    # 60% A (+10%) / 40% B (0%), benchmark +5%. port = 6%, active = +1%.
+    result = compute_position_attribution(
+        holdings=[
+            Holding("AAA", 0.60, 0.10, "sector-technology"),
+            Holding("BBB", 0.40, 0.00, "fixed-income"),
+        ],
+        benchmark_return_frac=0.05,
+    )
+    assert result.portfolio_return_pct == pytest.approx(6.0)
+    assert result.active_return_pct == pytest.approx(1.0)
+    assert result.reconciles is True
+    total = sum(r.total_attribution_pct for r in result.rows)
+    assert total == pytest.approx(result.active_return_pct, abs=1e-6)
+    rows = _by_ticker(result)
+    assert rows["AAA"].selection_effect_pct == pytest.approx(3.0)  # 0.6×(10−5)
+    assert rows["BBB"].selection_effect_pct == pytest.approx(-2.0)  # 0.4×(0−5)
+    assert rows["AAA"].contribution_pct == pytest.approx(6.0)  # 0.6×10
+
+
+def test_cash_drag_reconciles() -> None:
+    # 50% A (+10%) / 50% cash, benchmark +5%. port = 5%, active = 0%.
+    result = compute_position_attribution(
+        holdings=[Holding("AAA", 0.50, 0.10, "sector-technology")],
+        benchmark_return_frac=0.05,
+    )
+    assert result.active_return_pct == pytest.approx(0.0)
+    cash = _by_ticker(result)["CASH"]
+    assert cash.weight_pct == pytest.approx(50.0)
+    assert cash.allocation_effect_pct == pytest.approx(-2.5)  # −0.5×5
+    assert result.reconciles is True
+    assert sum(r.total_attribution_pct for r in result.rows) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_outperform_positive_underperform_negative_selection() -> None:
+    result = compute_position_attribution(
+        holdings=[Holding("WIN", 1.0, 0.08, None)], benchmark_return_frac=0.03
+    )
+    assert _by_ticker(result)["WIN"].selection_effect_pct == pytest.approx(5.0)  # beats benchmark
+    loser = compute_position_attribution(
+        holdings=[Holding("LOSE", 1.0, 0.01, None)], benchmark_return_frac=0.03
+    )
+    assert _by_ticker(loser)["LOSE"].selection_effect_pct == pytest.approx(-2.0)
+
+
+def test_unpriced_holding_marks_partial() -> None:
+    result = compute_position_attribution(
+        holdings=[
+            Holding("AAA", 0.50, 0.10, None),
+            Holding("ZZZ", 0.50, None, None),  # no price window
+        ],
+        benchmark_return_frac=0.05,
+    )
+    assert result.reconciles is False  # an unpriced holding breaks the exact identity
+    zzz = _by_ticker(result)["ZZZ"]
+    assert zzz.contribution_pct is None
+    assert zzz.selection_effect_pct is None
+    assert zzz.total_attribution_pct is None
+
+
+def test_records_flatten_with_date() -> None:
+    result = compute_position_attribution(
+        holdings=[Holding("AAA", 1.0, 0.05, "sector-technology")], benchmark_return_frac=0.05
+    )
+    records = attribution_rows_to_records(result, date_str="2026-06-12")
+    assert records[0]["date"] == "2026-06-12"
+    assert records[0]["ticker"] == "AAA"
+    assert records[0]["metrics_as_of"] == "2026-06-12"
+    assert "selection_effect_pct" in records[0]
+
+
+def test_empty_holdings_is_flat() -> None:
+    result = compute_position_attribution(holdings=[], benchmark_return_frac=0.05)
+    # No holdings → the whole book is cash; active = −benchmark (full cash drag).
+    assert result.rows[0].ticker == "CASH"
+    assert result.active_return_pct == pytest.approx(-5.0)
+    assert result.reconciles is True

--- a/tests/dq/atlas/test_refresh_attribution.py
+++ b/tests/dq/atlas/test_refresh_attribution.py
@@ -97,11 +97,32 @@ def test_missing_benchmark_skips() -> None:
 
 
 def test_no_positions_is_noop() -> None:
+    # The date was never materialized (no positions rows at all) → genuine no-op.
     client = FakeSupabaseClient(canned_reads={"positions": [], "price_history": _prices()})
     written, reconciles = refresh_attribution_mod.refresh_attribution(client=client, as_of=AS_OF)
     assert written == 0
     assert reconciles is True
     assert "position_attribution" not in client.store
+
+
+def test_all_cash_day_writes_cash_row() -> None:
+    # A fully-in-cash day (only a CASH position row) still produces a CASH attribution row
+    # with the cash-drag allocation effect (−1.0 × benchmark return).
+    client = FakeSupabaseClient(
+        canned_reads={
+            "positions": [{"date": "2026-06-12", "ticker": "CASH", "weight_pct": 100}],
+            "price_history": [
+                {"date": START, "ticker": "SPY", "close": 100.0},
+                {"date": "2026-06-12", "ticker": "SPY", "close": 105.0},
+            ],
+        }
+    )
+    written, reconciles = refresh_attribution_mod.refresh_attribution(client=client, as_of=AS_OF)
+    assert written == 1
+    assert reconciles is True
+    cash = client.store["position_attribution"][0]
+    assert cash["ticker"] == "CASH"
+    assert cash["allocation_effect_pct"] == pytest.approx(-5.0)  # −1.0 × 5% benchmark
 
 
 def test_bad_date_returns_2(capsys) -> None:

--- a/tests/dq/atlas/test_refresh_attribution.py
+++ b/tests/dq/atlas/test_refresh_attribution.py
@@ -1,0 +1,109 @@
+"""Attribution refresh runner (Pillar 3B).
+
+The script reads positions + price_history window returns, runs the pure attribution core,
+and upserts position_attribution. Loaded from its file path (lives under scripts/) and
+exercised with a FakeSupabaseClient — no live Supabase.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "scripts"
+    / "atlas"
+    / "refresh_attribution.py"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("refresh_attribution_script", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+refresh_attribution_mod = _load_script()
+AS_OF = date(2026, 6, 12)
+START = "2026-05-22"  # AS_OF − 21 days
+
+
+def _prices() -> list[dict]:
+    # Two closes per ticker bracketing the 21-day window: AAPL +10%, TLT flat, SPY +5%.
+    return [
+        {"date": START, "ticker": "AAPL", "close": 100.0},
+        {"date": "2026-06-12", "ticker": "AAPL", "close": 110.0},
+        {"date": START, "ticker": "TLT", "close": 100.0},
+        {"date": "2026-06-12", "ticker": "TLT", "close": 100.0},
+        {"date": START, "ticker": "SPY", "close": 100.0},
+        {"date": "2026-06-12", "ticker": "SPY", "close": 105.0},
+    ]
+
+
+def test_writes_reconciling_attribution() -> None:
+    client = FakeSupabaseClient(
+        canned_reads={
+            "positions": [
+                {
+                    "date": "2026-06-12",
+                    "ticker": "AAPL",
+                    "weight_pct": 60,
+                    "sector_bucket": "sector-technology",
+                },
+                {
+                    "date": "2026-06-12",
+                    "ticker": "TLT",
+                    "weight_pct": 40,
+                    "sector_bucket": "fixed-income",
+                },
+            ],
+            "price_history": _prices(),
+        }
+    )
+    written, reconciles = refresh_attribution_mod.refresh_attribution(client=client, as_of=AS_OF)
+    assert written == 2  # AAPL + TLT, fully invested → no cash row
+    assert reconciles is True
+    rows = {r["ticker"]: r for r in client.store["position_attribution"]}
+    assert rows["AAPL"]["selection_effect_pct"] == pytest.approx(3.0)  # 0.6×(10−5)
+    assert rows["AAPL"]["_on_conflict"] == "date,ticker"
+    assert rows["TLT"]["selection_effect_pct"] == pytest.approx(-2.0)  # 0.4×(0−5)
+
+
+def test_missing_benchmark_skips() -> None:
+    # No SPY price rows → benchmark return unknown → skip (retry next run), write nothing.
+    client = FakeSupabaseClient(
+        canned_reads={
+            "positions": [{"date": "2026-06-12", "ticker": "AAPL", "weight_pct": 100}],
+            "price_history": [
+                {"date": START, "ticker": "AAPL", "close": 100.0},
+                {"date": "2026-06-12", "ticker": "AAPL", "close": 110.0},
+            ],
+        }
+    )
+    written, reconciles = refresh_attribution_mod.refresh_attribution(client=client, as_of=AS_OF)
+    assert written == 0
+    assert reconciles is False
+    assert "position_attribution" not in client.store
+
+
+def test_no_positions_is_noop() -> None:
+    client = FakeSupabaseClient(canned_reads={"positions": [], "price_history": _prices()})
+    written, reconciles = refresh_attribution_mod.refresh_attribution(client=client, as_of=AS_OF)
+    assert written == 0
+    assert reconciles is True
+    assert "position_attribution" not in client.store
+
+
+def test_bad_date_returns_2(capsys) -> None:
+    assert refresh_attribution_mod.main(["--date", "nope"]) == 2
+    assert "bad --date" in capsys.readouterr().err


### PR DESCRIPTION
## Pillar 3B — per-position attribution

Decomposes the paper book's **active return** per holding vs the benchmark (SPY). The dashboard's Attribution/Exposure tab (3D) reads this.

### Why single-benchmark (not full Brinson)

We have each holding's return + a single benchmark, but **no benchmark sector weights**, so classic multi-sector Brinson allocation/selection isn't computable. Instead we compute the honest quantities that **reconcile** to active return:

```
contribution_i = wᵢ · rᵢ                  selection_i = wᵢ · (rᵢ − r_b)
cash drag      = −w_cash · r_b
Σ selection_i + cash_drag  ==  portfolio_return − benchmark_return  ==  active_return
```

(holds exactly when every holding is priced; otherwise the result is flagged `PARTIAL`).

### What it adds

- **`olympus/atlas/attribution.py`** — pure `compute_position_attribution(holdings, r_b)` → `AttributionResult` (rows + `reconciles`). I/O-free, no pandas, fully unit-testable.
- **`scripts/atlas/refresh_attribution.py`** — thin runner: reads `positions` weights + each holding's trailing-window return + the benchmark return from `price_history` (**look-ahead-guarded**), runs the core, upserts `position_attribution`. A **dedicated script** (rather than wedging into the import-fragile `refresh_performance_metrics.py`) keeps the path importable/testable and gives it a clean cron entry, mirroring `resolve_decisions.py`.
- **Migration 040** `position_attribution` (anon-read RLS, mirroring `positions`/`nav_history`).

### Tests / gate

- 10 tests: **reconciliation identity**, cash drag, over/under-perform selection sign, unpriced → PARTIAL, records flatten, empty → full-cash; runner: writes reconciling rows / missing-benchmark skip / no-positions noop / bad-date → exit 2.
- `ruff` clean; `make score` **10/10**.

### Human gates (batched separately)

The `atlas-attribution.yml` cron (new scheduled job) + applying **migration 040** to prod are human gates — they ship in the batched wiring PR. This code is **dormant** until then (the script isn't croned; merging is safe).

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)