### PR TITLE
feat(atlas): zero-LLM backtest of recorded decisions (Pillar 3C)

### DIFF
--- a/digiquant/scripts/atlas/backtest_decisions.py
+++ b/digiquant/scripts/atlas/backtest_decisions.py
@@ -28,7 +28,10 @@ import sys
 from dataclasses import asdict
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+from typing import TYPE_CHECKING, Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+if TYPE_CHECKING:  # build_trades returns Trades; keep the dep import lazy (see _ensure_importable)
+    from digiquant.olympus.atlas.backtest import Trade
 
 # repo root: .../digiquant/scripts/atlas/backtest_decisions.py → up 4 (atlas → scripts →
 # digiquant → repo root).
@@ -67,13 +70,15 @@ def _read_decisions(client: Any, since_iso: str) -> list[dict]:
     return list(getattr(resp, "data", None) or [])
 
 
-def build_trades(*, client: Any, decisions: list[dict], default_benchmark: str = "SPY") -> list:
+def build_trades(
+    *, client: Any, decisions: list[dict], default_benchmark: str = "SPY"
+) -> list[Trade]:
     """Turn decision_log rows into realized :class:`Trade`s, skipping non-long stances and
     decisions whose price window isn't available yet (look-ahead-safe)."""
     from digiquant.olympus.atlas.backtest import Trade
     from digiquant.olympus.atlas.supabase_io import query_returns_window
 
-    trades = []
+    trades: list[Trade] = []
     for row in decisions:
         stance = str(row.get("stance") or "").strip().lower()
         ticker = row.get("ticker")
@@ -83,8 +88,11 @@ def build_trades(*, client: Any, decisions: list[dict], default_benchmark: str =
             decision_date = _parse_date(row["run_date"])
         except (KeyError, ValueError, TypeError):
             continue
-        holding_days = int(row.get("holding_days") or 5)
-        benchmark = row.get("benchmark") or default_benchmark
+        try:
+            holding_days = int(row.get("holding_days") or 5)
+        except (TypeError, ValueError):
+            holding_days = 5  # a malformed holding_days shouldn't drop an otherwise-valid decision
+        benchmark = str(row.get("benchmark") or default_benchmark).strip() or default_benchmark
         ticker_win = query_returns_window(
             client=client, ticker=ticker, start_date=decision_date, holding_days=holding_days
         )
@@ -101,6 +109,7 @@ def build_trades(*, client: Any, decisions: list[dict], default_benchmark: str =
                 benchmark_frac=bench_win[0],
                 conviction=_opt_float(row.get("conviction")),
                 stance=stance,
+                end_date=ticker_win[2],  # window close → lets same-run decisions annualize
             )
         )
     return trades

--- a/digiquant/scripts/atlas/backtest_decisions.py
+++ b/digiquant/scripts/atlas/backtest_decisions.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Backtest the agent's recorded decisions (Pillar 3C, #726).
+
+Zero LLM cost. Reads ``decision_log`` (the agent's calls), computes each long-side
+decision's realized return over its holding window + the benchmark's return over the same
+window from ``price_history`` (look-ahead-safe via ``query_returns_window`` — only prices
+inside the window are used), and runs the pure
+:func:`digiquant.olympus.atlas.backtest.backtest_decisions` to print a decision-level tear
+sheet: hit-rate, mean/median alpha, compounded return vs benchmark, max drawdown,
+information / Sortino ratios, and **conviction-bucket calibration** (do higher-conviction
+calls earn higher alpha?).
+
+Read-only — no writes, no LLM, no schema change. Run weekly / on demand.
+
+Usage::
+
+    python digiquant/scripts/atlas/backtest_decisions.py [--start YYYY-MM-DD] [--benchmark SPY]
+
+Env: ``SUPABASE_URL`` + ``SUPABASE_SERVICE_ROLE_KEY``. Exit 0 = clean; 1 = hard failure;
+2 = bad ``--start``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
+
+# repo root: .../digiquant/scripts/atlas/backtest_decisions.py → up 4 (atlas → scripts →
+# digiquant → repo root).
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+_DEFAULT_LOOKBACK_DAYS = 365
+_LONG_STANCES = ("buy", "hold")
+
+
+def _ensure_importable() -> None:
+    for rel in ("digiquant/src", "digigraph/src", "digibase/src", "digismith/src"):
+        path = str(_REPO_ROOT / rel)
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+def _parse_date(value: str) -> date:
+    return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+
+
+def _opt_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_decisions(client: Any, since_iso: str) -> list[dict]:
+    resp = (
+        client.table("decision_log")
+        .select("run_date,ticker,stance,conviction,holding_days,benchmark")
+        .gte("run_date", since_iso)
+        .order("run_date", desc=False)
+        .execute()
+    )
+    return list(getattr(resp, "data", None) or [])
+
+
+def build_trades(*, client: Any, decisions: list[dict], default_benchmark: str = "SPY") -> list:
+    """Turn decision_log rows into realized :class:`Trade`s, skipping non-long stances and
+    decisions whose price window isn't available yet (look-ahead-safe)."""
+    from digiquant.olympus.atlas.backtest import Trade
+    from digiquant.olympus.atlas.supabase_io import query_returns_window
+
+    trades = []
+    for row in decisions:
+        stance = str(row.get("stance") or "").strip().lower()
+        ticker = row.get("ticker")
+        if stance not in _LONG_STANCES or not isinstance(ticker, str) or not ticker:
+            continue
+        try:
+            decision_date = _parse_date(row["run_date"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        holding_days = int(row.get("holding_days") or 5)
+        benchmark = row.get("benchmark") or default_benchmark
+        ticker_win = query_returns_window(
+            client=client, ticker=ticker, start_date=decision_date, holding_days=holding_days
+        )
+        bench_win = query_returns_window(
+            client=client, ticker=benchmark, start_date=decision_date, holding_days=holding_days
+        )
+        if ticker_win is None or bench_win is None:
+            continue  # insufficient price data → skip (the window hasn't fully landed)
+        trades.append(
+            Trade(
+                date=decision_date,
+                ticker=ticker,
+                return_frac=ticker_win[0],
+                benchmark_frac=bench_win[0],
+                conviction=_opt_float(row.get("conviction")),
+                stance=stance,
+            )
+        )
+    return trades
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backtest recorded Atlas decisions (zero LLM).")
+    parser.add_argument("--start", default=None, help="Earliest decision run_date YYYY-MM-DD.")
+    parser.add_argument("--benchmark", default="SPY", help="Default benchmark ticker.")
+    args = parser.parse_args(argv)
+
+    since = (
+        args.start
+        or (datetime.now(timezone.utc).date() - timedelta(days=_DEFAULT_LOOKBACK_DAYS)).isoformat()
+    )
+    try:
+        _parse_date(since)
+    except ValueError:
+        print(f"error: bad --start {args.start!r} (expected YYYY-MM-DD)", file=sys.stderr)
+        return 2
+
+    _ensure_importable()
+    from digiquant.olympus.atlas.backtest import backtest_decisions
+    from digiquant.olympus.atlas.supabase_io import SupabaseConfig, build_client
+
+    try:
+        client = build_client(SupabaseConfig.from_env())
+    except Exception as exc:  # noqa: BLE001 — config/connectivity failure is a hard error
+        print(f"error: Supabase client unavailable: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        decisions = _read_decisions(client, since)
+        trades = build_trades(client=client, decisions=decisions, default_benchmark=args.benchmark)
+        result = backtest_decisions(trades)
+    except Exception as exc:  # noqa: BLE001 — surface a hard failure as a non-zero exit
+        print(f"error: backtest failed: {exc}", file=sys.stderr)
+        return 1
+
+    payload = asdict(result)
+    payload["since"] = since
+    payload["decisions_scanned"] = len(decisions)
+    print(json.dumps(payload, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/digiquant/src/digiquant/olympus/atlas/backtest.py
+++ b/digiquant/src/digiquant/olympus/atlas/backtest.py
@@ -12,8 +12,10 @@ same window — both computed look-ahead-safely from ``price_history``) and this
 
 This is a *decision-sequence* tear sheet (each decision = one trade), not a daily
 overlapping-portfolio NAV simulation — the honest, well-defined quantity given the
-decision-level data. Metric formulas mirror frontend/olympus/lib/portfolio-risk-metrics.ts
-(ported to Python; the pandas ``tearsheet.py`` is intentionally NOT imported).
+decision-level data. Metric formulas mirror the frontend's TypeScript: Sharpe/Sortino/vol
+from frontend/olympus/lib/portfolio-risk-metrics.ts, max-drawdown + information ratio from
+frontend/olympus/components/portfolio/advanced-stats-panel.tsx (ported to Python; the pandas
+``tearsheet.py`` is intentionally NOT imported).
 """
 
 from __future__ import annotations
@@ -37,6 +39,7 @@ class Trade:
     benchmark_frac: float
     conviction: float | None = None
     stance: str | None = None
+    end_date: date | None = None  # holding-window close; lets same-run decisions still annualize
 
 
 @dataclass(frozen=True)
@@ -60,7 +63,7 @@ class BacktestResult:
     annualized_return_pct: float | None  # total compounded, annualized over the decision span
     max_drawdown_pct: float  # worst peak-to-trough of the decision equity curve
     information_ratio: float  # mean(alpha) / std(alpha) — per-decision, NOT annualized
-    sortino_ratio: float  # mean(alpha) / downside-std(alpha)
+    sortino_ratio: float  # mean(alpha)/downside-std; falls back to info ratio if no downside
     conviction_buckets: list[BucketStat]
 
 
@@ -164,7 +167,14 @@ def backtest_decisions(trades: Sequence[Trade]) -> BacktestResult:
     alphas = [r - b for r, b in zip(rets, bench, strict=True)]
 
     total_return = _compound(rets)
-    span_days = (ordered[-1].date - ordered[0].date).days
+    # Span the sequence entry→holding-window-close, not entry→entry: decision_log records many
+    # tickers under a single run_date, so an entry-to-entry span collapses to 0 days for a
+    # single-run book and would null out annualization even with many trades. Fall back to
+    # entry-to-entry when no window-close dates are carried (e.g. legacy callers).
+    first_day = ordered[0].date
+    ends = [t.end_date for t in ordered if t.end_date is not None]
+    last_day = max(ends) if ends else ordered[-1].date
+    span_days = (last_day - first_day).days
     annualized = (
         round(((1.0 + total_return) ** (365.0 / span_days) - 1.0) * 100.0, 4)
         if span_days > 0 and total_return > -1.0
@@ -172,6 +182,11 @@ def backtest_decisions(trades: Sequence[Trade]) -> BacktestResult:
     )
     std_a = _std(alphas)
     dstd_a = _downside_std(alphas)
+    info_ratio = round(_mean(alphas) / std_a, 4) if std_a > 0 else 0.0
+    # No downside deviation (every alpha ≥ 0 — the best case) leaves Sortino undefined; fall
+    # back to the information ratio (its Sharpe analogue here), mirroring advanced-stats-panel's
+    # downside-zero handling, rather than reporting a misleading 0.0.
+    sortino = round(_mean(alphas) / dstd_a, 4) if dstd_a > 0 else info_ratio
 
     return BacktestResult(
         n_trades=len(ordered),
@@ -182,8 +197,8 @@ def backtest_decisions(trades: Sequence[Trade]) -> BacktestResult:
         benchmark_total_return_pct=round(_compound(bench) * 100.0, 4),
         annualized_return_pct=annualized,
         max_drawdown_pct=_max_drawdown_pct(rets),
-        information_ratio=round(_mean(alphas) / std_a, 4) if std_a > 0 else 0.0,
-        sortino_ratio=round(_mean(alphas) / dstd_a, 4) if dstd_a > 0 else 0.0,
+        information_ratio=info_ratio,
+        sortino_ratio=sortino,
         conviction_buckets=_bucket_stats(ordered),
     )
 

--- a/digiquant/src/digiquant/olympus/atlas/backtest.py
+++ b/digiquant/src/digiquant/olympus/atlas/backtest.py
@@ -1,0 +1,191 @@
+"""Backtest of the agent's recorded decisions (Pillar 3C).
+
+Zero LLM cost: replays the realized outcome of each ``decision_log`` decision — the
+ticker's return over its holding window vs the benchmark (alpha) — into a decision-level
+tear sheet. The point is to measure the *track record* of the agent's calls: do they beat
+the benchmark, and do **higher-conviction** calls earn **higher alpha** (calibration)?
+
+Pure-functional (no I/O, no pandas): the caller assembles realized :class:`Trade` records
+(entry date, conviction, stance, the holding-window return + the benchmark return over the
+same window — both computed look-ahead-safely from ``price_history``) and this returns a
+:class:`BacktestResult`. The script half does the Supabase reads.
+
+This is a *decision-sequence* tear sheet (each decision = one trade), not a daily
+overlapping-portfolio NAV simulation — the honest, well-defined quantity given the
+decision-level data. Metric formulas mirror frontend/olympus/lib/portfolio-risk-metrics.ts
+(ported to Python; the pandas ``tearsheet.py`` is intentionally NOT imported).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+
+# Conviction buckets (effective conviction is −5..+5; decisions booked are long-side ≥ ~2).
+_HIGH_CONVICTION = 4.0
+_MED_CONVICTION = 2.0
+
+
+@dataclass(frozen=True)
+class Trade:
+    """One realized decision: its holding-window return + the benchmark's, as fractions."""
+
+    date: date
+    ticker: str
+    return_frac: float
+    benchmark_frac: float
+    conviction: float | None = None
+    stance: str | None = None
+
+
+@dataclass(frozen=True)
+class BucketStat:
+    """Calibration stats for one conviction bucket."""
+
+    bucket: str
+    n: int
+    mean_alpha_pct: float
+    hit_rate: float
+
+
+@dataclass(frozen=True)
+class BacktestResult:
+    n_trades: int
+    hit_rate: float  # share of decisions with positive alpha
+    mean_alpha_pct: float
+    median_alpha_pct: float
+    total_return_pct: float  # compounded over the decision sequence
+    benchmark_total_return_pct: float
+    annualized_return_pct: float | None  # total compounded, annualized over the decision span
+    max_drawdown_pct: float  # worst peak-to-trough of the decision equity curve
+    information_ratio: float  # mean(alpha) / std(alpha) — per-decision, NOT annualized
+    sortino_ratio: float  # mean(alpha) / downside-std(alpha)
+    conviction_buckets: list[BucketStat]
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _median(xs: Sequence[float]) -> float:
+    if not xs:
+        return 0.0
+    s = sorted(xs)
+    mid = len(s) // 2
+    return s[mid] if len(s) % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+
+def _std(xs: Sequence[float]) -> float:
+    if len(xs) < 2:
+        return 0.0
+    m = _mean(xs)
+    return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
+
+
+def _downside_std(xs: Sequence[float]) -> float:
+    if len(xs) < 2:
+        return 0.0
+    downs = [min(0.0, x) for x in xs]
+    return (sum(d * d for d in downs) / len(xs)) ** 0.5
+
+
+def _max_drawdown_pct(returns: Sequence[float]) -> float:
+    """Worst peak-to-trough (%) of the equity curve built by compounding ``returns``."""
+    nav = 1.0
+    peak = 1.0
+    worst = 0.0
+    for r in returns:
+        nav *= 1.0 + r
+        peak = max(peak, nav)
+        if peak > 0:
+            worst = min(worst, nav / peak - 1.0)
+    return round(worst * 100.0, 4)
+
+
+def _compound(returns: Sequence[float]) -> float:
+    nav = 1.0
+    for r in returns:
+        nav *= 1.0 + r
+    return nav - 1.0
+
+
+def _bucket_for(conviction: float | None) -> str:
+    if conviction is None:
+        return "unknown"
+    if conviction >= _HIGH_CONVICTION:
+        return "high"
+    if conviction >= _MED_CONVICTION:
+        return "medium"
+    return "low"
+
+
+def _bucket_stats(trades: Sequence[Trade]) -> list[BucketStat]:
+    order = ["high", "medium", "low", "unknown"]
+    grouped: dict[str, list[float]] = {b: [] for b in order}
+    for t in trades:
+        grouped[_bucket_for(t.conviction)].append(t.return_frac - t.benchmark_frac)
+    out: list[BucketStat] = []
+    for bucket in order:
+        alphas = grouped[bucket]
+        if not alphas:
+            continue
+        out.append(
+            BucketStat(
+                bucket=bucket,
+                n=len(alphas),
+                mean_alpha_pct=round(_mean(alphas) * 100.0, 4),
+                hit_rate=round(sum(a > 0 for a in alphas) / len(alphas), 4),
+            )
+        )
+    return out
+
+
+def backtest_decisions(trades: Sequence[Trade]) -> BacktestResult:
+    """Decision-level tear sheet over realized ``trades`` (chronological by entry date)."""
+    if not trades:
+        return BacktestResult(
+            n_trades=0,
+            hit_rate=0.0,
+            mean_alpha_pct=0.0,
+            median_alpha_pct=0.0,
+            total_return_pct=0.0,
+            benchmark_total_return_pct=0.0,
+            annualized_return_pct=None,
+            max_drawdown_pct=0.0,
+            information_ratio=0.0,
+            sortino_ratio=0.0,
+            conviction_buckets=[],
+        )
+
+    ordered = sorted(trades, key=lambda t: t.date)
+    rets = [t.return_frac for t in ordered]
+    bench = [t.benchmark_frac for t in ordered]
+    alphas = [r - b for r, b in zip(rets, bench, strict=True)]
+
+    total_return = _compound(rets)
+    span_days = (ordered[-1].date - ordered[0].date).days
+    annualized = (
+        round(((1.0 + total_return) ** (365.0 / span_days) - 1.0) * 100.0, 4)
+        if span_days > 0 and total_return > -1.0
+        else None
+    )
+    std_a = _std(alphas)
+    dstd_a = _downside_std(alphas)
+
+    return BacktestResult(
+        n_trades=len(ordered),
+        hit_rate=round(sum(a > 0 for a in alphas) / len(alphas), 4),
+        mean_alpha_pct=round(_mean(alphas) * 100.0, 4),
+        median_alpha_pct=round(_median(alphas) * 100.0, 4),
+        total_return_pct=round(total_return * 100.0, 4),
+        benchmark_total_return_pct=round(_compound(bench) * 100.0, 4),
+        annualized_return_pct=annualized,
+        max_drawdown_pct=_max_drawdown_pct(rets),
+        information_ratio=round(_mean(alphas) / std_a, 4) if std_a > 0 else 0.0,
+        sortino_ratio=round(_mean(alphas) / dstd_a, 4) if dstd_a > 0 else 0.0,
+        conviction_buckets=_bucket_stats(ordered),
+    )
+
+
+__all__ = ["BacktestResult", "BucketStat", "Trade", "backtest_decisions"]

--- a/tests/dq/atlas/test_backtest.py
+++ b/tests/dq/atlas/test_backtest.py
@@ -1,0 +1,81 @@
+"""Decision backtest core (Pillar 3C).
+
+backtest_decisions turns realized per-decision trades into a tear sheet: hit-rate, alpha,
+compounded return vs benchmark, max drawdown, information/Sortino ratios, and conviction-
+bucket calibration (do higher-conviction calls earn higher alpha?).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.atlas.backtest import Trade, backtest_decisions
+
+pytestmark = pytest.mark.unit
+
+
+def _t(day: int, ticker: str, ret: float, bench: float, conviction: float | None) -> Trade:
+    return Trade(
+        date=date(2026, 6, day),
+        ticker=ticker,
+        return_frac=ret,
+        benchmark_frac=bench,
+        conviction=conviction,
+        stance="buy",
+    )
+
+
+def test_empty_is_zeroed() -> None:
+    r = backtest_decisions([])
+    assert r.n_trades == 0
+    assert r.hit_rate == 0.0
+    assert r.annualized_return_pct is None
+    assert r.conviction_buckets == []
+
+
+def test_hit_rate_and_alpha() -> None:
+    # A +5% alpha, B +3% alpha, C −3% alpha → 2/3 hit, mean alpha = +5/3 %.
+    r = backtest_decisions(
+        [
+            _t(1, "A", 0.10, 0.05, 5),
+            _t(2, "B", 0.08, 0.05, 4),
+            _t(3, "C", 0.02, 0.05, 2),
+        ]
+    )
+    assert r.n_trades == 3
+    assert r.hit_rate == pytest.approx(2 / 3, abs=1e-3)
+    assert r.mean_alpha_pct == pytest.approx(5 / 3, abs=1e-3)
+    assert r.information_ratio > 0  # positive mean alpha
+    # Compounded: (1.10)(1.08)(1.02) − 1 ≈ 21.18%; benchmark (1.05)³ − 1 ≈ 15.76%.
+    assert r.total_return_pct == pytest.approx(21.176, abs=0.01)
+    assert r.benchmark_total_return_pct == pytest.approx(15.7625, abs=0.01)
+
+
+def test_conviction_calibration_buckets() -> None:
+    r = backtest_decisions(
+        [
+            _t(1, "A", 0.10, 0.05, 5),  # high, +5%
+            _t(2, "B", 0.08, 0.05, 4),  # high, +3%
+            _t(3, "C", 0.02, 0.05, 2),  # medium, −3%
+        ]
+    )
+    buckets = {b.bucket: b for b in r.conviction_buckets}
+    assert buckets["high"].n == 2
+    assert buckets["high"].mean_alpha_pct == pytest.approx(4.0)  # (5+3)/2
+    assert buckets["medium"].mean_alpha_pct == pytest.approx(-3.0)
+    assert buckets["high"].mean_alpha_pct > buckets["medium"].mean_alpha_pct  # calibrated
+
+
+def test_max_drawdown_of_equity_curve() -> None:
+    # returns 10% / −20% / 5% → nav 1.10 → 0.88 → 0.924; worst dd = 0.88/1.10 − 1 = −20%.
+    r = backtest_decisions(
+        [_t(1, "A", 0.10, 0.0, 3), _t(2, "B", -0.20, 0.0, 3), _t(3, "C", 0.05, 0.0, 3)]
+    )
+    assert r.max_drawdown_pct == pytest.approx(-20.0, abs=0.01)
+
+
+def test_unknown_conviction_bucket() -> None:
+    r = backtest_decisions([_t(1, "A", 0.03, 0.01, None)])
+    assert {b.bucket for b in r.conviction_buckets} == {"unknown"}

--- a/tests/dq/atlas/test_backtest.py
+++ b/tests/dq/atlas/test_backtest.py
@@ -79,3 +79,28 @@ def test_max_drawdown_of_equity_curve() -> None:
 def test_unknown_conviction_bucket() -> None:
     r = backtest_decisions([_t(1, "A", 0.03, 0.01, None)])
     assert {b.bucket for b in r.conviction_buckets} == {"unknown"}
+
+
+def test_annualizes_same_run_decisions_via_window_end() -> None:
+    # Many tickers booked under one run_date (the decision_log norm): entry→entry span is 0,
+    # but carrying each holding-window close lets the sequence still annualize.
+    entry = date(2026, 6, 1)
+    close = date(2026, 7, 1)  # ~30-day holding window
+    trades = [
+        Trade(date=entry, ticker="A", return_frac=0.05, benchmark_frac=0.02, end_date=close),
+        Trade(date=entry, ticker="B", return_frac=0.03, benchmark_frac=0.02, end_date=close),
+    ]
+    r = backtest_decisions(trades)
+    assert r.annualized_return_pct is not None
+    assert r.annualized_return_pct > 0
+    # Without a window close (legacy callers) a same-day book has no span → no annualization.
+    bare = [Trade(date=entry, ticker="A", return_frac=0.05, benchmark_frac=0.02)]
+    assert backtest_decisions(bare).annualized_return_pct is None
+
+
+def test_sortino_falls_back_to_info_ratio_when_no_downside() -> None:
+    # All-positive alpha → downside deviation is 0; Sortino reports the info ratio (its Sharpe
+    # analogue), not a misleading 0.0.
+    r = backtest_decisions([_t(1, "A", 0.10, 0.05, 4), _t(2, "B", 0.07, 0.05, 4)])
+    assert r.information_ratio > 0
+    assert r.sortino_ratio == pytest.approx(r.information_ratio)

--- a/tests/dq/atlas/test_backtest_decisions.py
+++ b/tests/dq/atlas/test_backtest_decisions.py
@@ -1,0 +1,102 @@
+"""Decision-backtest runner (Pillar 3C).
+
+build_trades turns decision_log rows into realized trades via query_returns_window (mocked
+here — no live prices), skipping non-long stances + decisions whose window isn't available.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "scripts"
+    / "atlas"
+    / "backtest_decisions.py"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("backtest_decisions_script", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backtest_mod = _load_script()
+
+
+def _fake_returns_window(returns_by_ticker):
+    def _qrw(*, client, ticker, start_date, holding_days, lookback_days=21):
+        value = returns_by_ticker.get(ticker)
+        return (value, start_date, start_date) if value is not None else None
+
+    return _qrw
+
+
+def test_build_trades_filters_and_maps(monkeypatch) -> None:
+    import digiquant.olympus.atlas.supabase_io as sio
+
+    monkeypatch.setattr(
+        sio,
+        "query_returns_window",
+        _fake_returns_window({"AAPL": 0.10, "TLT": 0.02, "SPY": 0.05}),
+    )
+    decisions = [
+        {
+            "run_date": "2026-05-01",
+            "ticker": "AAPL",
+            "stance": "buy",
+            "conviction": 5,
+            "holding_days": 5,
+        },
+        {
+            "run_date": "2026-05-02",
+            "ticker": "XOM",
+            "stance": "sell",
+            "conviction": 3,
+            "holding_days": 5,
+        },
+        {
+            "run_date": "2026-05-03",
+            "ticker": "TLT",
+            "stance": "hold",
+            "conviction": 2,
+            "holding_days": 5,
+        },
+    ]
+    trades = backtest_mod.build_trades(client=object(), decisions=decisions)
+    # sell is dropped (not long-side); buy + hold kept.
+    assert {t.ticker for t in trades} == {"AAPL", "TLT"}
+    aapl = next(t for t in trades if t.ticker == "AAPL")
+    assert aapl.return_frac == pytest.approx(0.10)
+    assert aapl.benchmark_frac == pytest.approx(0.05)  # SPY default benchmark
+    assert aapl.conviction == 5
+
+
+def test_build_trades_skips_unpriced_window(monkeypatch) -> None:
+    import digiquant.olympus.atlas.supabase_io as sio
+
+    # AAPL has a window but SPY (benchmark) does not → the decision is skipped.
+    monkeypatch.setattr(sio, "query_returns_window", _fake_returns_window({"AAPL": 0.10}))
+    decisions = [
+        {
+            "run_date": "2026-05-01",
+            "ticker": "AAPL",
+            "stance": "buy",
+            "conviction": 5,
+            "holding_days": 5,
+        }
+    ]
+    assert backtest_mod.build_trades(client=object(), decisions=decisions) == []
+
+
+def test_bad_start_returns_2(capsys) -> None:
+    assert backtest_mod.main(["--start", "nope"]) == 2
+    assert "bad --start" in capsys.readouterr().err


### PR DESCRIPTION
## Pillar 3C — decision backtest (zero LLM)

Measures the **track record of the agent's calls** — read-only, zero LLM cost. Do the decisions beat the benchmark, and do **higher-conviction** calls earn **higher alpha** (calibration)?

### What it adds

- **`olympus/atlas/backtest.py`** — pure `backtest_decisions(trades)` → `BacktestResult`: a **decision-level tear sheet** — hit-rate, mean/median alpha, compounded return vs benchmark, max drawdown of the decision equity curve, information + Sortino ratios, and **conviction-bucket calibration** (high/medium/low → mean alpha + hit-rate). Pure Python, no pandas; formulas ported from `portfolio-risk-metrics.ts` (the pandas `tearsheet.py` is intentionally not imported).
- **`scripts/atlas/backtest_decisions.py`** — reads `decision_log`, computes each long-side decision's realized holding-window return + the benchmark's return over the same window via `query_returns_window` (**look-ahead-safe** — only in-window prices), runs the core, prints the tear sheet as JSON.

### Scope + safety

A **decision-sequence** tear sheet (each decision = one trade), not a daily overlapping-portfolio NAV — the honest, well-defined quantity given decision-level data. **Read-only**: no writes, no LLM, no migration, not croned → fully safe to merge; runnable weekly / on demand.

### Tests / gate

8 tests: core (empty, hit-rate+alpha, **conviction calibration buckets**, equity-curve max drawdown, unknown bucket) + runner (build_trades filters non-long stances & maps returns, skips unpriced windows, bad `--start` → exit 2). `ruff` clean; `make score` **10/10**.

Part of #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)