### PR TITLE
feat(olympus): observability dashboard + curated run-health view (Pillar 3D, migration 041)

### DIFF
--- a/digiquant/supabase/migrations/041_atlas_run_health_view.sql
+++ b/digiquant/supabase/migrations/041_atlas_run_health_view.sql
@@ -1,0 +1,49 @@
+-- 041_atlas_run_health_view.sql — Curated anon-readable run-health view (Pillar 3D, #726).
+--
+-- Run with:  supabase db push   (or paste into the Supabase SQL editor / apply via MCP)
+--
+-- HUMAN GATE: migration 033 deliberately revoked anon SELECT on `atlas_run_diagnostics`
+-- (#706/#707) because that table carries operator-internal spend telemetry — `est_cost_usd`,
+-- token counts, `error_summary`, and the per-phase `breakdown` JSONB. The Olympus
+-- observability dashboard needs *run health* (status, segment success/carry/fail counts,
+-- model, timing) but must NEVER see spend. This view is the curation boundary: it projects
+-- ONLY the safe columns and is the sole anon-readable surface over the diagnostics table.
+--
+-- Security model — intentional security-DEFINER view (security_invoker = false):
+--   * `atlas_run_diagnostics` has RLS ENABLED with NO anon policy (033) → anon reads of the
+--     base table return zero rows. A `security_invoker = true` view would inherit that and
+--     also return nothing, so it is explicitly false here: the view runs with its owner's
+--     (postgres) rights and bypasses the base-table RLS.
+--   * Because the SELECT list omits every sensitive column, anon can read run health through
+--     the view yet can never reach cost/tokens/error_summary/breakdown — the projection IS
+--     the allowlist. anon still cannot read the base table directly (RLS denies).
+--   * Supabase's advisor will flag this as `security_definer_view`; that is expected and
+--     accepted here — a curated projection of an RLS-protected table is exactly this pattern.
+-- Idempotent (CREATE OR REPLACE).
+
+CREATE OR REPLACE VIEW public.atlas_run_health
+WITH (security_invoker = false) AS
+SELECT
+    run_id,
+    run_date,
+    run_type,
+    model,
+    status,
+    started_at,
+    finished_at,
+    duration_s,
+    segments_total,
+    segments_ok,
+    segments_carried,
+    segments_failed,
+    created_at
+FROM public.atlas_run_diagnostics;
+
+COMMENT ON VIEW public.atlas_run_health IS
+  'Curated, anon-readable projection of atlas_run_diagnostics for the Olympus observability '
+  'dashboard: run status, segment success/carry/fail counts, model, and timing ONLY. '
+  'Deliberately excludes est_cost_usd, token counts, error_summary, and the breakdown JSONB '
+  '(operator-internal spend telemetry revoked from anon in migration 033). Security-definer by '
+  'design so it bypasses the base-table RLS while the column projection enforces the allowlist.';
+
+GRANT SELECT ON public.atlas_run_health TO anon, authenticated;

--- a/frontend/olympus/app/observability/page.tsx
+++ b/frontend/olympus/app/observability/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Activity, BarChart3, ShieldAlert, Target } from 'lucide-react';
+import AtlasLoader from '@/components/AtlasLoader';
+import { SUBPAGE_MAX, SubpageStickyTabBar, subpageTabButtonClass } from '@/components/subpage-tab-bar';
+import AttributionTab from '@/components/observability/AttributionTab';
+import DecisionScorecardTab from '@/components/observability/DecisionScorecardTab';
+import PositionRiskTab from '@/components/observability/PositionRiskTab';
+import RunHealthTab from '@/components/observability/RunHealthTab';
+import { EmptyState } from '@/components/observability/shared';
+import { fetchObservabilityData, type ObservabilityData } from '@/lib/observability-queries';
+
+type ObservabilityTab = 'scorecard' | 'health' | 'attribution' | 'risk';
+
+const TABS: { id: ObservabilityTab; label: string; icon: typeof Target }[] = [
+  { id: 'scorecard', label: 'Decision Scorecard', icon: Target },
+  { id: 'attribution', label: 'Attribution', icon: BarChart3 },
+  { id: 'risk', label: 'Position Risk', icon: ShieldAlert },
+  { id: 'health', label: 'Run Health', icon: Activity },
+];
+
+export default function ObservabilityPage() {
+  const [data, setData] = useState<ObservabilityData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<ObservabilityTab>('scorecard');
+
+  useEffect(() => {
+    let alive = true;
+    fetchObservabilityData()
+      .then((d) => {
+        if (alive) setData(d);
+      })
+      .catch((e: unknown) => {
+        if (alive) setError(e instanceof Error ? e.message : 'Failed to load observability data');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-full flex-col">
+      <SubpageStickyTabBar aria-label="Observability sections">
+        {TABS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setActiveTab(id)}
+            className={subpageTabButtonClass(activeTab === id)}
+          >
+            <Icon size={16} />
+            {label}
+          </button>
+        ))}
+      </SubpageStickyTabBar>
+
+      <div className={`${SUBPAGE_MAX} flex-1 space-y-6 py-4 md:py-6`}>
+        <div className="flex flex-col gap-1">
+          <h1 className="text-lg font-semibold text-text-primary">Observability</h1>
+          <p className="text-sm text-text-muted">
+            Does the agent make money, and is it well-calibrated? Decision track record, performance
+            attribution, per-position risk, and pipeline health.
+          </p>
+        </div>
+
+        {loading ? (
+          <AtlasLoader fullScreen={false} />
+        ) : error || !data ? (
+          <EmptyState
+            title="Couldn't load observability data"
+            message={error ?? 'No data is available right now. Try again shortly.'}
+          />
+        ) : (
+          <>
+            {activeTab === 'scorecard' && <DecisionScorecardTab decisions={data.decisions} />}
+            {activeTab === 'attribution' && (
+              <AttributionTab attribution={data.attribution} date={data.attributionDate} />
+            )}
+            {activeTab === 'risk' && (
+              <PositionRiskTab positions={data.positions} date={data.positionsDate} />
+            )}
+            {activeTab === 'health' && (
+              <RunHealthTab runHealth={data.runHealth} available={data.runHealthAvailable} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/olympus/components/observability/AttributionTab.tsx
+++ b/frontend/olympus/components/observability/AttributionTab.tsx
@@ -51,8 +51,10 @@ export default function AttributionTab({
     );
   }
 
+  // Exclude the synthetic CASH row (contribution 0; its cash drag is in allocation/total) so the
+  // "by position" chart stays aligned with the rest of the tab's holdings-only framing.
   const chartData = [...attribution]
-    .filter((r) => r.contribution_pct != null)
+    .filter((r) => r.ticker !== 'CASH' && r.contribution_pct != null)
     .sort((a, b) => Math.abs(b.contribution_pct ?? 0) - Math.abs(a.contribution_pct ?? 0))
     .slice(0, TOP_N)
     .map((r) => ({ ticker: r.ticker, contribution: r.contribution_pct as number }));

--- a/frontend/olympus/components/observability/AttributionTab.tsx
+++ b/frontend/olympus/components/observability/AttributionTab.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { TableRow } from '@/lib/database.types';
+import { EmptyState, SectionCard, StatTile, fmtPct, signColorClass } from './shared';
+
+const FIN_GREEN = '#3fb984';
+const FIN_RED = '#e0654b';
+const AXIS = '#71717a';
+const TOP_N = 14;
+
+function sum(values: Array<number | null | undefined>): number {
+  return values.reduce<number>((acc, v) => acc + (v ?? 0), 0);
+}
+
+export default function AttributionTab({
+  attribution,
+  date,
+}: {
+  attribution: TableRow<'position_attribution'>[];
+  date: string | null;
+}) {
+  const summary = useMemo(() => {
+    if (!attribution.length) return null;
+    const activeReturn = sum(attribution.map((r) => r.total_attribution_pct));
+    const benchmarkReturn = attribution.find((r) => r.benchmark_return_pct != null)?.benchmark_return_pct ?? null;
+    const portfolioReturn = benchmarkReturn != null ? activeReturn + benchmarkReturn : null;
+    const holdings = attribution.filter((r) => r.ticker !== 'CASH');
+    // Unpriced holdings (no window return) carry null attribution; the sums then under-count and
+    // the active-return identity no longer reconciles — surface that rather than show a false total.
+    const unpriced = holdings.filter((r) => r.total_attribution_pct == null).length;
+    return { activeReturn, benchmarkReturn, portfolioReturn, holdings: holdings.length, unpriced };
+  }, [attribution]);
+
+  if (!summary) {
+    return (
+      <EmptyState
+        title="No attribution rows yet"
+        message="Per-position attribution is computed daily by refresh_attribution.py after EOD prices land, once the paper book holds positions. It will appear here after the next attribution run."
+      />
+    );
+  }
+
+  const chartData = [...attribution]
+    .filter((r) => r.contribution_pct != null)
+    .sort((a, b) => Math.abs(b.contribution_pct ?? 0) - Math.abs(a.contribution_pct ?? 0))
+    .slice(0, TOP_N)
+    .map((r) => ({ ticker: r.ticker, contribution: r.contribution_pct as number }));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatTile label="As of" value={date ?? '—'} sub={`${summary.holdings} holdings`} />
+        <StatTile
+          label="Portfolio return"
+          value={fmtPct(summary.portfolioReturn)}
+          sub="window total"
+          color={signColorClass(summary.portfolioReturn)}
+        />
+        <StatTile label="Benchmark (SPY)" value={fmtPct(summary.benchmarkReturn)} color={signColorClass(summary.benchmarkReturn)} />
+        <StatTile
+          label="Active return"
+          value={fmtPct(summary.activeReturn)}
+          sub={summary.unpriced > 0 ? `partial · ${summary.unpriced} unpriced` : 'Σ attribution'}
+          color={signColorClass(summary.activeReturn)}
+        />
+      </div>
+
+      {summary.unpriced > 0 ? (
+        <p className="text-xs text-fin-amber">
+          {summary.unpriced} holding{summary.unpriced === 1 ? '' : 's'} lack a priced window, so the
+          active-return total is partial and does not fully reconcile to portfolio − benchmark.
+        </p>
+      ) : null}
+
+      <SectionCard
+        title="Contribution by position"
+        subtitle="Each holding's share of the portfolio's window return (weight × return). Top contributors and detractors."
+      >
+        {chartData.length ? (
+          <div className="h-[300px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                <XAxis dataKey="ticker" tick={{ fill: AXIS, fontSize: 10 }} interval={0} angle={-30} textAnchor="end" height={50} />
+                <YAxis tick={{ fill: AXIS, fontSize: 11 }} tickFormatter={(v: number) => `${v}%`} />
+                <Tooltip
+                  cursor={{ fill: 'rgba(255,255,255,0.04)' }}
+                  contentStyle={{
+                    background: 'rgba(13,17,23,0.95)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: 8,
+                    fontSize: 12,
+                  }}
+                  formatter={(value: number) => [`${value}%`, 'Contribution']}
+                />
+                <Bar dataKey="contribution" radius={[3, 3, 0, 0]} isAnimationActive={false}>
+                  {chartData.map((d) => (
+                    <Cell key={d.ticker} fill={d.contribution >= 0 ? FIN_GREEN : FIN_RED} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">No priced contributions to chart.</p>
+        )}
+      </SectionCard>
+
+      <SectionCard
+        title="Decomposition"
+        subtitle="Single-benchmark attribution: contribution (weight × return), selection (weight × excess vs SPY), and total active. Sums reconcile to active return when every holding is priced."
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm tabular-nums">
+            <thead>
+              <tr className="text-left text-xs text-text-muted border-b border-border-subtle">
+                <th className="py-2 pr-4 font-medium">Ticker</th>
+                <th className="py-2 pr-4 font-medium">Sector</th>
+                <th className="py-2 pr-4 font-medium text-right">Weight</th>
+                <th className="py-2 pr-4 font-medium text-right">Return</th>
+                <th className="py-2 pr-4 font-medium text-right">Contribution</th>
+                <th className="py-2 pr-4 font-medium text-right">Selection</th>
+                <th className="py-2 font-medium text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {attribution.map((r) => (
+                <tr key={r.id} className="border-b border-border-subtle/50">
+                  <td className="py-2 pr-4 text-text-primary">{r.ticker}</td>
+                  <td className="py-2 pr-4 text-text-muted truncate max-w-[160px]">{r.sector_bucket ?? '—'}</td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">{fmtPct(r.weight_pct, 1)}</td>
+                  <td className={`py-2 pr-4 text-right ${signColorClass(r.position_return_pct)}`}>
+                    {fmtPct(r.position_return_pct)}
+                  </td>
+                  <td className={`py-2 pr-4 text-right ${signColorClass(r.contribution_pct)}`}>
+                    {fmtPct(r.contribution_pct)}
+                  </td>
+                  <td className={`py-2 pr-4 text-right ${signColorClass(r.selection_effect_pct)}`}>
+                    {fmtPct(r.selection_effect_pct)}
+                  </td>
+                  <td className={`py-2 text-right ${signColorClass(r.total_attribution_pct)}`}>
+                    {fmtPct(r.total_attribution_pct)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/frontend/olympus/components/observability/DecisionScorecardTab.tsx
+++ b/frontend/olympus/components/observability/DecisionScorecardTab.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { computeDecisionScorecard } from '@/lib/decision-scorecard';
+import type { TableRow } from '@/lib/database.types';
+import { EmptyState, SectionCard, StatTile, fmtPct, signColorClass } from './shared';
+
+const FIN_GREEN = '#3fb984';
+const FIN_RED = '#e0654b';
+const AXIS = '#71717a';
+const BUCKET_LABEL: Record<string, string> = { low: 'Low (<2)', medium: 'Med (2–3)', high: 'High (≥4)' };
+
+export default function DecisionScorecardTab({
+  decisions,
+}: {
+  decisions: TableRow<'decision_log'>[];
+}) {
+  const scorecard = useMemo(() => computeDecisionScorecard(decisions), [decisions]);
+
+  if (!scorecard) {
+    return (
+      <EmptyState
+        title="No resolved decisions yet"
+        message="The scorecard scores each analyst call once its holding window elapses and the resolver records realized alpha vs SPY. Decisions are still pending — check back after the next resolution run."
+      />
+    );
+  }
+
+  const chartData = scorecard.buckets.map((b) => ({
+    bucket: BUCKET_LABEL[b.bucket] ?? b.bucket,
+    meanAlphaPct: b.meanAlphaPct,
+    n: b.n,
+  }));
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatTile label="Resolved" value={scorecard.nResolved} sub={`${scorecard.nPending} pending`} />
+        <StatTile
+          label="Hit rate"
+          value={`${scorecard.hitRatePct.toFixed(1)}%`}
+          sub="positive alpha"
+          color={scorecard.hitRatePct >= 50 ? 'text-fin-green' : 'text-fin-red'}
+        />
+        <StatTile
+          label="Mean alpha"
+          value={fmtPct(scorecard.meanAlphaPct)}
+          sub="vs SPY, per call"
+          color={signColorClass(scorecard.meanAlphaPct)}
+        />
+        <StatTile
+          label="Median alpha"
+          value={fmtPct(scorecard.medianAlphaPct)}
+          color={signColorClass(scorecard.medianAlphaPct)}
+        />
+        <StatTile
+          label="Calibration"
+          value={scorecard.buckets.length < 2 ? 'n/a' : scorecard.calibrated ? 'Aligned' : 'Inverted'}
+          sub="conviction → alpha"
+          color={
+            scorecard.buckets.length < 2
+              ? 'text-text-secondary'
+              : scorecard.calibrated
+                ? 'text-fin-green'
+                : 'text-fin-amber'
+          }
+        />
+        <StatTile label="Buckets" value={scorecard.buckets.length} sub="with data" />
+      </div>
+
+      <SectionCard
+        title="Conviction calibration"
+        subtitle="Mean realized alpha (vs SPY) by conviction bucket. A well-calibrated book earns more alpha where it was more confident."
+      >
+        {chartData.length ? (
+          <div className="h-[280px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.05)" vertical={false} />
+                <XAxis dataKey="bucket" tick={{ fill: AXIS, fontSize: 11 }} />
+                <YAxis
+                  tick={{ fill: AXIS, fontSize: 11 }}
+                  tickFormatter={(v: number) => `${v}%`}
+                />
+                <Tooltip
+                  cursor={{ fill: 'rgba(255,255,255,0.04)' }}
+                  contentStyle={{
+                    background: 'rgba(13,17,23,0.95)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: 8,
+                    fontSize: 12,
+                  }}
+                  formatter={(value: number, _name, item) => [
+                    `${value}% (n=${item?.payload?.n})`,
+                    'Mean alpha',
+                  ]}
+                />
+                <Bar dataKey="meanAlphaPct" radius={[3, 3, 0, 0]} isAnimationActive={false}>
+                  {chartData.map((d) => (
+                    <Cell key={d.bucket} fill={d.meanAlphaPct >= 0 ? FIN_GREEN : FIN_RED} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">
+            Resolved decisions exist but none carry a recorded conviction, so calibration buckets
+            cannot be formed.
+          </p>
+        )}
+      </SectionCard>
+
+      <SectionCard title="By conviction bucket" subtitle="Per-bucket sample size, hit rate, and mean conviction.">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm tabular-nums">
+            <thead>
+              <tr className="text-left text-xs text-text-muted border-b border-border-subtle">
+                <th className="py-2 pr-4 font-medium">Bucket</th>
+                <th className="py-2 pr-4 font-medium text-right">N</th>
+                <th className="py-2 pr-4 font-medium text-right">Mean alpha</th>
+                <th className="py-2 pr-4 font-medium text-right">Hit rate</th>
+                <th className="py-2 font-medium text-right">Mean conviction</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scorecard.buckets.map((b) => (
+                <tr key={b.bucket} className="border-b border-border-subtle/50">
+                  <td className="py-2 pr-4 text-text-primary">{BUCKET_LABEL[b.bucket] ?? b.bucket}</td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">{b.n}</td>
+                  <td className={`py-2 pr-4 text-right ${signColorClass(b.meanAlphaPct)}`}>
+                    {fmtPct(b.meanAlphaPct)}
+                  </td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">{b.hitRatePct.toFixed(1)}%</td>
+                  <td className="py-2 text-right text-text-secondary">{b.meanConviction.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/frontend/olympus/components/observability/PositionRiskTab.tsx
+++ b/frontend/olympus/components/observability/PositionRiskTab.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { TableRow } from '@/lib/database.types';
+import { EmptyState, SectionCard, StatTile, fmtNum, fmtPct, signColorClass } from './shared';
+
+const RISK_KEYS = ['stop_loss_pct', 'target_pct_gain', 'horizon_days', 'conviction'] as const;
+
+function hasAnyRiskField(p: TableRow<'positions'>): boolean {
+  return RISK_KEYS.some((k) => p[k] != null);
+}
+
+export default function PositionRiskTab({
+  positions,
+  date,
+}: {
+  positions: TableRow<'positions'>[];
+  date: string | null;
+}) {
+  const holdings = useMemo(
+    () => positions.filter((p) => p.ticker !== 'CASH'),
+    [positions]
+  );
+  const riskPopulated = useMemo(() => holdings.some(hasAnyRiskField), [holdings]);
+
+  if (!holdings.length) {
+    return (
+      <EmptyState
+        title="No holdings to show"
+        message="The paper book currently holds no non-cash positions, so there are no per-position risk fields to display."
+      />
+    );
+  }
+
+  if (!riskPopulated) {
+    return (
+      <EmptyState
+        title="Advisory risk fields not populated"
+        message="Per-position stops, targets, horizons, and conviction are written when the OLYMPUS_POSITION_RISK_FIELDS flag is enabled (migration 039). The book holds positions, but these advisory fields are not yet populated."
+      />
+    );
+  }
+
+  const avgConviction =
+    holdings.filter((p) => p.conviction != null).reduce((a, p) => a + (p.conviction ?? 0), 0) /
+    Math.max(1, holdings.filter((p) => p.conviction != null).length);
+  const withStops = holdings.filter((p) => p.stop_loss_pct != null).length;
+  const withTargets = holdings.filter((p) => p.target_pct_gain != null).length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatTile label="As of" value={date ?? '—'} sub={`${holdings.length} holdings`} />
+        <StatTile label="Avg conviction" value={avgConviction.toFixed(2)} sub="−5 to +5 scale" />
+        <StatTile label="With stop-loss" value={`${withStops}/${holdings.length}`} />
+        <StatTile label="With target" value={`${withTargets}/${holdings.length}`} />
+      </div>
+
+      <SectionCard
+        title="Per-position risk"
+        subtitle="Advisory display fields derived from ATR + conviction — NOT orders and not sent to any broker. The book is paper-only."
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm tabular-nums">
+            <thead>
+              <tr className="text-left text-xs text-text-muted border-b border-border-subtle">
+                <th className="py-2 pr-4 font-medium">Ticker</th>
+                <th className="py-2 pr-4 font-medium">Sector</th>
+                <th className="py-2 pr-4 font-medium text-right">Weight</th>
+                <th className="py-2 pr-4 font-medium text-right">Conviction</th>
+                <th className="py-2 pr-4 font-medium text-right">Entry</th>
+                <th className="py-2 pr-4 font-medium text-right">Stop-loss</th>
+                <th className="py-2 pr-4 font-medium text-right">Target</th>
+                <th className="py-2 font-medium text-right">Horizon</th>
+              </tr>
+            </thead>
+            <tbody>
+              {holdings.map((p) => (
+                <tr key={p.id} className="border-b border-border-subtle/50">
+                  <td className="py-2 pr-4 text-text-primary">{p.ticker}</td>
+                  <td className="py-2 pr-4 text-text-muted truncate max-w-[160px]">
+                    {p.sector_bucket ?? p.category ?? '—'}
+                  </td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">{fmtPct(p.weight_pct, 1)}</td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">
+                    {p.conviction != null ? p.conviction.toFixed(1) : '—'}
+                  </td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">
+                    {p.entry_price != null ? p.entry_price.toFixed(2) : '—'}
+                  </td>
+                  <td className={`py-2 pr-4 text-right ${p.stop_loss_pct != null ? 'text-fin-red' : 'text-text-muted'}`}>
+                    {fmtPct(p.stop_loss_pct, 1)}
+                  </td>
+                  <td className={`py-2 pr-4 text-right ${p.target_pct_gain != null ? 'text-fin-green' : 'text-text-muted'}`}>
+                    {fmtPct(p.target_pct_gain, 1)}
+                  </td>
+                  <td className="py-2 text-right text-text-secondary">
+                    {p.horizon_days != null ? `${fmtNum(p.horizon_days)}d` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/frontend/olympus/components/observability/PositionRiskTab.tsx
+++ b/frontend/olympus/components/observability/PositionRiskTab.tsx
@@ -41,9 +41,11 @@ export default function PositionRiskTab({
     );
   }
 
-  const avgConviction =
-    holdings.filter((p) => p.conviction != null).reduce((a, p) => a + (p.conviction ?? 0), 0) /
-    Math.max(1, holdings.filter((p) => p.conviction != null).length);
+  const convictionVals = holdings.filter((p) => p.conviction != null).map((p) => p.conviction ?? 0);
+  // null (not 0) when no holding carries a conviction, so we render "—" rather than a false 0.00.
+  const avgConviction = convictionVals.length
+    ? convictionVals.reduce((a, c) => a + c, 0) / convictionVals.length
+    : null;
   const withStops = holdings.filter((p) => p.stop_loss_pct != null).length;
   const withTargets = holdings.filter((p) => p.target_pct_gain != null).length;
 
@@ -51,7 +53,11 @@ export default function PositionRiskTab({
     <div className="flex flex-col gap-6">
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
         <StatTile label="As of" value={date ?? '—'} sub={`${holdings.length} holdings`} />
-        <StatTile label="Avg conviction" value={avgConviction.toFixed(2)} sub="−5 to +5 scale" />
+        <StatTile
+          label="Avg conviction"
+          value={avgConviction != null ? avgConviction.toFixed(2) : '—'}
+          sub="−5 to +5 scale"
+        />
         <StatTile label="With stop-loss" value={`${withStops}/${holdings.length}`} />
         <StatTile label="With target" value={`${withTargets}/${holdings.length}`} />
       </div>

--- a/frontend/olympus/components/observability/RunHealthTab.tsx
+++ b/frontend/olympus/components/observability/RunHealthTab.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { ViewRow } from '@/lib/database.types';
+import { EmptyState, SectionCard, StatTile, fmtNum } from './shared';
+
+function statusColor(status: string | null): string {
+  const s = (status ?? '').toLowerCase();
+  if (s.includes('ok') || s.includes('success') || s === 'complete' || s === 'completed')
+    return 'text-fin-green';
+  if (s.includes('fail') || s.includes('error') || s.includes('abort')) return 'text-fin-red';
+  if (s) return 'text-fin-amber';
+  return 'text-text-secondary';
+}
+
+function fmtDuration(s: number | null): string {
+  if (s == null) return '—';
+  if (s < 90) return `${s.toFixed(0)}s`;
+  return `${(s / 60).toFixed(1)}m`;
+}
+
+export default function RunHealthTab({
+  runHealth,
+  available,
+}: {
+  runHealth: ViewRow<'atlas_run_health'>[];
+  available: boolean;
+}) {
+  if (!available) {
+    return (
+      <EmptyState
+        title="Run-health view not yet enabled"
+        message="The curated atlas_run_health view (migration 041) exposes run status, segment success/carry/fail counts, model, and timing — but never spend telemetry. It requires owner sign-off before it goes live, so this panel stays empty until the migration is applied."
+      />
+    );
+  }
+  if (!runHealth.length) {
+    return (
+      <EmptyState
+        title="No runs recorded yet"
+        message="The pipeline writes a diagnostics row at the end of each Atlas/Hermes run. Once a baseline or delta run completes, its health will appear here."
+      />
+    );
+  }
+
+  const latest = runHealth[0];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatTile
+          label="Latest status"
+          value={latest.status ?? '—'}
+          sub={latest.run_date ?? undefined}
+          color={statusColor(latest.status)}
+        />
+        <StatTile label="Run type" value={latest.run_type ?? '—'} />
+        <StatTile
+          label="Segments OK"
+          value={`${fmtNum(latest.segments_ok)}/${fmtNum(latest.segments_total)}`}
+          color="text-fin-green"
+        />
+        <StatTile label="Carried" value={fmtNum(latest.segments_carried)} color="text-fin-amber" />
+        <StatTile
+          label="Failed"
+          value={fmtNum(latest.segments_failed)}
+          color={(latest.segments_failed ?? 0) > 0 ? 'text-fin-red' : 'text-text-secondary'}
+        />
+        <StatTile label="Duration" value={fmtDuration(latest.duration_s)} sub={latest.model ?? undefined} />
+      </div>
+
+      <SectionCard
+        title="Recent runs"
+        subtitle="Health of the last 30 pipeline runs — status, segment outcomes, model, and timing. Spend telemetry is intentionally excluded from this surface."
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm tabular-nums">
+            <thead>
+              <tr className="text-left text-xs text-text-muted border-b border-border-subtle">
+                <th className="py-2 pr-4 font-medium">Date</th>
+                <th className="py-2 pr-4 font-medium">Type</th>
+                <th className="py-2 pr-4 font-medium">Status</th>
+                <th className="py-2 pr-4 font-medium text-right">OK</th>
+                <th className="py-2 pr-4 font-medium text-right">Carried</th>
+                <th className="py-2 pr-4 font-medium text-right">Failed</th>
+                <th className="py-2 pr-4 font-medium text-right">Total</th>
+                <th className="py-2 pr-4 font-medium">Model</th>
+                <th className="py-2 font-medium text-right">Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runHealth.map((r) => (
+                <tr key={r.run_id} className="border-b border-border-subtle/50">
+                  <td className="py-2 pr-4 text-text-primary">{r.run_date ?? '—'}</td>
+                  <td className="py-2 pr-4 text-text-secondary">{r.run_type ?? '—'}</td>
+                  <td className={`py-2 pr-4 ${statusColor(r.status)}`}>{r.status ?? '—'}</td>
+                  <td className="py-2 pr-4 text-right text-fin-green">{fmtNum(r.segments_ok)}</td>
+                  <td className="py-2 pr-4 text-right text-fin-amber">{fmtNum(r.segments_carried)}</td>
+                  <td
+                    className={`py-2 pr-4 text-right ${(r.segments_failed ?? 0) > 0 ? 'text-fin-red' : 'text-text-secondary'}`}
+                  >
+                    {fmtNum(r.segments_failed)}
+                  </td>
+                  <td className="py-2 pr-4 text-right text-text-secondary">{fmtNum(r.segments_total)}</td>
+                  <td className="py-2 pr-4 text-text-muted truncate max-w-[180px]">{r.model ?? '—'}</td>
+                  <td className="py-2 text-right text-text-secondary">{fmtDuration(r.duration_s)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/frontend/olympus/components/observability/shared.tsx
+++ b/frontend/olympus/components/observability/shared.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+/** Percent points → "+3.20%" / "-1.50%" / "—" for null. */
+export function fmtPct(v: number | null | undefined, digits = 2): string {
+  if (v == null || Number.isNaN(v)) return '—';
+  const s = v.toFixed(digits);
+  return `${v > 0 ? '+' : ''}${s}%`;
+}
+
+export function fmtNum(v: number | null | undefined, digits = 0): string {
+  if (v == null || Number.isNaN(v)) return '—';
+  return v.toLocaleString('en-US', { minimumFractionDigits: digits, maximumFractionDigits: digits });
+}
+
+/** Green for gains, red for losses, muted for flat/missing — the fin-* convention. */
+export function signColorClass(v: number | null | undefined): string {
+  if (v == null || Number.isNaN(v) || v === 0) return 'text-text-secondary';
+  return v > 0 ? 'text-fin-green' : 'text-fin-red';
+}
+
+export function StatTile({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  color?: string;
+}) {
+  return (
+    <div className="glass-card p-4 flex flex-col gap-1">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className={`text-xl font-semibold tabular-nums ${color ?? 'text-text-primary'}`}>
+        {value}
+      </span>
+      {sub ? <span className="text-xs text-text-muted">{sub}</span> : null}
+    </div>
+  );
+}
+
+export function SectionCard({
+  title,
+  subtitle,
+  children,
+  className,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`glass-card p-5 flex flex-col gap-4 ${className ?? ''}`}>
+      <div className="flex flex-col gap-0.5">
+        <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+        {subtitle ? <p className="text-xs text-text-muted">{subtitle}</p> : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function EmptyState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="glass-card p-8 flex flex-col items-center justify-center gap-2 text-center">
+      <p className="text-sm font-medium text-text-secondary">{title}</p>
+      <p className="text-xs text-text-muted max-w-md">{message}</p>
+    </div>
+  );
+}

--- a/frontend/olympus/components/sidebar.tsx
+++ b/frontend/olympus/components/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 import { ElementType } from 'react';
-import { LayoutDashboard, PieChart, BookOpen, ChevronLeft, ChevronRight } from 'lucide-react';
+import { LayoutDashboard, PieChart, BookOpen, Activity, ChevronLeft, ChevronRight } from 'lucide-react';
 import { AtlasMark } from '@/components/atlas-mark';
 import { useAppShell } from '@/components/app-shell-context';
 import SidebarSettings from '@/components/sidebar-settings';
@@ -19,6 +19,7 @@ const NAV: NavItem[] = [
   { href: '/', label: 'Overview', icon: LayoutDashboard },
   { href: '/portfolio', label: 'Portfolio', icon: PieChart },
   { href: '/research', label: 'Research', icon: BookOpen },
+  { href: '/observability', label: 'Observability', icon: Activity },
 ];
 
 function routeActive(pathname: string, base: string, href: string): boolean {

--- a/frontend/olympus/lib/database.types.ts
+++ b/frontend/olympus/lib/database.types.ts
@@ -188,11 +188,73 @@ export interface Database {
         Insert: Omit<Database['public']['Tables']['trading_calendar']['Row'], 'created_at'> & { created_at?: string };
         Update: Partial<Database['public']['Tables']['trading_calendar']['Insert']>;
       };
+      decision_log: {
+        // Per-ticker analyst decisions, resolved against realized prices (migration 026).
+        // Feeds the Observability Decision Scorecard: conviction vs realized alpha.
+        Row: {
+          id: string;
+          run_id: string;
+          run_date: string;
+          ticker: string;
+          stance: string;                 // 'buy' | 'hold' | 'sell' | 'trim' | ...
+          conviction: number | null;      // 0..5 effective conviction
+          thesis: string | null;
+          benchmark: string;              // default 'SPY'
+          holding_days: number;
+          status: 'pending' | 'resolved';
+          actual_return: number | null;   // ticker total return over the window
+          alpha: number | null;           // actual_return − benchmark_return (NULL while pending)
+          reflection: string | null;
+          resolved_at: string | null;
+          created_at: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['decision_log']['Row'], 'id' | 'created_at'> & { id?: string; created_at?: string };
+        Update: Partial<Database['public']['Tables']['decision_log']['Insert']>;
+      };
+      position_attribution: {
+        // Single-benchmark active-return decomposition per (date, ticker) (migration 040).
+        Row: {
+          id: string;
+          date: string;
+          ticker: string;
+          sector_bucket: string | null;
+          weight_pct: number | null;
+          position_return_pct: number | null;
+          benchmark_return_pct: number | null;
+          contribution_pct: number | null;       // weight × position return
+          selection_effect_pct: number | null;   // weight × (position − benchmark)
+          allocation_effect_pct: number | null;  // cash-drag effect (CASH row)
+          total_attribution_pct: number | null;  // selection + allocation; sums to active return
+          metrics_as_of: string | null;
+          created_at: string | null;
+        };
+        Insert: Omit<Database['public']['Tables']['position_attribution']['Row'], 'id' | 'created_at'> & { id?: string; created_at?: string };
+        Update: Partial<Database['public']['Tables']['position_attribution']['Insert']>;
+      };
     };
     Views: {
       price_history_tickers: {
         Row: {
           ticker: string;
+        };
+      };
+      // Curated, anon-readable run health (migration 041): status / segment counts / model /
+      // timing ONLY — spend telemetry (cost, tokens, error_summary, breakdown) is excluded.
+      atlas_run_health: {
+        Row: {
+          run_id: string;
+          run_date: string | null;
+          run_type: string | null;
+          model: string | null;
+          status: string | null;
+          started_at: string | null;
+          finished_at: string | null;
+          duration_s: number | null;
+          segments_total: number | null;
+          segments_ok: number | null;
+          segments_carried: number | null;
+          segments_failed: number | null;
+          created_at: string | null;
         };
       };
     };
@@ -204,3 +266,7 @@ export interface Database {
 /** Helpers for table row types */
 export type TableRow<T extends keyof Database['public']['Tables']> =
   Database['public']['Tables'][T]['Row'];
+
+/** Helper for view row types */
+export type ViewRow<T extends keyof Database['public']['Views']> =
+  Database['public']['Views'][T]['Row'];

--- a/frontend/olympus/lib/decision-scorecard.test.ts
+++ b/frontend/olympus/lib/decision-scorecard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bucketFor,
+  computeDecisionScorecard,
+  convictionBucketCalibration,
+  type DecisionRecord,
+} from './decision-scorecard';
+
+function rec(conviction: number | null, alpha: number | null, status = 'resolved'): DecisionRecord {
+  return { conviction, alpha, status, stance: 'buy' };
+}
+
+describe('bucketFor', () => {
+  it('thresholds match the Python backtest (high≥4, medium≥2, low otherwise)', () => {
+    expect(bucketFor(5)).toBe('high');
+    expect(bucketFor(4)).toBe('high');
+    expect(bucketFor(3)).toBe('medium');
+    expect(bucketFor(2)).toBe('medium');
+    expect(bucketFor(1)).toBe('low');
+    expect(bucketFor(0)).toBe('low');
+  });
+});
+
+describe('computeDecisionScorecard', () => {
+  it('returns null when there are no resolved decisions', () => {
+    expect(computeDecisionScorecard([])).toBeNull();
+    expect(computeDecisionScorecard([rec(5, 0.1, 'pending')])).toBeNull();
+  });
+
+  it('computes hit rate, mean/median alpha in percent points, and counts pending', () => {
+    const sc = computeDecisionScorecard([
+      rec(5, 0.1), // +10% alpha
+      rec(4, 0.02), // +2%
+      rec(2, -0.03), // −3%
+      rec(3, null), // resolved but unpriced → excluded
+      rec(5, 0.05, 'pending'), // pending → excluded, counted as pending
+    ]);
+    expect(sc).not.toBeNull();
+    expect(sc!.nResolved).toBe(3);
+    expect(sc!.nPending).toBe(1);
+    expect(sc!.hitRatePct).toBeCloseTo((2 / 3) * 100, 3); // 2 of 3 positive
+    expect(sc!.meanAlphaPct).toBeCloseTo(3, 3); // (10+2−3)/3
+    expect(sc!.medianAlphaPct).toBeCloseTo(2, 3);
+  });
+
+  it('excludes rows missing conviction from calibration but the scorecard still scores alpha', () => {
+    const sc = computeDecisionScorecard([rec(null, 0.1), rec(4, 0.05)]);
+    expect(sc!.nResolved).toBe(2);
+    // only the conviction-bearing row lands in a bucket
+    expect(sc!.buckets.reduce((n, b) => n + b.n, 0)).toBe(1);
+  });
+
+  it('flags a well-calibrated book when higher conviction earns higher alpha', () => {
+    const sc = computeDecisionScorecard([
+      rec(1, -0.02),
+      rec(1, 0.0),
+      rec(3, 0.02),
+      rec(3, 0.03),
+      rec(5, 0.08),
+      rec(5, 0.1),
+    ]);
+    expect(sc!.calibrated).toBe(true);
+    const byBucket = Object.fromEntries(sc!.buckets.map((b) => [b.bucket, b]));
+    expect(byBucket.high.meanAlphaPct).toBeGreaterThan(byBucket.low.meanAlphaPct);
+  });
+
+  it('flags a mis-calibrated book when high conviction underperforms', () => {
+    const sc = computeDecisionScorecard([
+      rec(1, 0.1), // low conviction, big win
+      rec(5, -0.05), // high conviction, loss
+    ]);
+    expect(sc!.calibrated).toBe(false);
+  });
+});
+
+describe('convictionBucketCalibration', () => {
+  it('returns present buckets in ascending conviction order with per-bucket hit rate', () => {
+    const decisions = [rec(1, -0.01), rec(2, 0.02), rec(5, 0.06), rec(5, -0.01)];
+    const buckets = convictionBucketCalibration(decisions);
+    expect(buckets.map((b) => b.bucket)).toEqual(['low', 'medium', 'high']);
+    const high = buckets.find((b) => b.bucket === 'high')!;
+    expect(high.n).toBe(2);
+    expect(high.hitRatePct).toBeCloseTo(50, 3); // 1 of 2 positive
+  });
+});

--- a/frontend/olympus/lib/decision-scorecard.ts
+++ b/frontend/olympus/lib/decision-scorecard.ts
@@ -1,0 +1,131 @@
+/**
+ * Decision scorecard — conviction calibration for the Observability dashboard (Pillar 3D).
+ *
+ * Pure functions over resolved `decision_log` rows. The central question: do **higher-
+ * conviction** calls earn **higher alpha**? `alpha` is the realized excess return over the
+ * benchmark (SPY) computed at resolution time, stored as a FRACTION (0.05 = +5%); we surface
+ * percent points. Conviction is the 0..5 effective conviction recorded with each decision.
+ *
+ * Buckets mirror the Python backtest core (digiquant/src/digiquant/olympus/atlas/backtest.py):
+ * high ≥ 4, medium ≥ 2, low otherwise — so the in-graph backtest and this dashboard agree.
+ */
+
+/** Conviction thresholds — kept in sync with backtest.py `_HIGH_CONVICTION` / `_MED_CONVICTION`. */
+const HIGH_CONVICTION = 4;
+const MED_CONVICTION = 2;
+
+export type ConvictionBucket = 'low' | 'medium' | 'high';
+
+/** Minimal shape consumed from a `decision_log` row (alpha is a fraction). */
+export interface DecisionRecord {
+  conviction: number | null;
+  alpha: number | null;
+  status: string;
+  stance?: string | null;
+}
+
+export interface BucketCalibration {
+  bucket: ConvictionBucket;
+  n: number;
+  meanAlphaPct: number;
+  hitRatePct: number; // share of decisions with alpha > 0 (0..100)
+  meanConviction: number;
+}
+
+export interface DecisionScorecard {
+  nResolved: number;
+  nPending: number;
+  hitRatePct: number; // overall share with positive alpha (0..100)
+  meanAlphaPct: number;
+  medianAlphaPct: number;
+  buckets: BucketCalibration[]; // present buckets, ascending conviction (low → high)
+  /** True when mean alpha is non-decreasing across present buckets (the calibration we want). */
+  calibrated: boolean;
+}
+
+function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+}
+
+function median(xs: number[]): number {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function round4(x: number): number {
+  return Math.round(x * 1e4) / 1e4;
+}
+
+export function bucketFor(conviction: number): ConvictionBucket {
+  if (conviction >= HIGH_CONVICTION) return 'high';
+  if (conviction >= MED_CONVICTION) return 'medium';
+  return 'low';
+}
+
+/** A resolved decision with a realized alpha scores the overall track record (conviction optional). */
+function hasResolvedAlpha(d: DecisionRecord): d is DecisionRecord & { alpha: number } {
+  return d.status === 'resolved' && d.alpha != null;
+}
+
+/** Calibration additionally needs a recorded conviction to place the row in a bucket. */
+function isCalibratable(
+  d: DecisionRecord
+): d is DecisionRecord & { conviction: number; alpha: number } {
+  return hasResolvedAlpha(d) && d.conviction != null;
+}
+
+/** Per-bucket calibration over resolved decisions, ascending conviction; empty buckets omitted. */
+export function convictionBucketCalibration(decisions: DecisionRecord[]): BucketCalibration[] {
+  const order: ConvictionBucket[] = ['low', 'medium', 'high'];
+  const grouped: Record<ConvictionBucket, { alphas: number[]; convs: number[] }> = {
+    low: { alphas: [], convs: [] },
+    medium: { alphas: [], convs: [] },
+    high: { alphas: [], convs: [] },
+  };
+  for (const d of decisions) {
+    if (!isCalibratable(d)) continue;
+    const g = grouped[bucketFor(d.conviction)];
+    g.alphas.push(d.alpha);
+    g.convs.push(d.conviction);
+  }
+  const out: BucketCalibration[] = [];
+  for (const bucket of order) {
+    const { alphas, convs } = grouped[bucket];
+    if (!alphas.length) continue;
+    out.push({
+      bucket,
+      n: alphas.length,
+      meanAlphaPct: round4(mean(alphas) * 100),
+      hitRatePct: round4((alphas.filter((a) => a > 0).length / alphas.length) * 100),
+      meanConviction: round4(mean(convs)),
+    });
+  }
+  return out;
+}
+
+/** Overall scorecard; null when there are no resolved decisions to score. */
+export function computeDecisionScorecard(decisions: DecisionRecord[]): DecisionScorecard | null {
+  const scored = decisions.filter(hasResolvedAlpha);
+  if (!scored.length) return null;
+  const alphas = scored.map((d) => d.alpha);
+  const buckets = convictionBucketCalibration(decisions);
+  // Calibrated = mean alpha never falls as conviction rises across the present buckets.
+  let calibrated = true;
+  for (let i = 1; i < buckets.length; i++) {
+    if (buckets[i].meanAlphaPct < buckets[i - 1].meanAlphaPct) {
+      calibrated = false;
+      break;
+    }
+  }
+  return {
+    nResolved: scored.length,
+    nPending: decisions.filter((d) => d.status === 'pending').length,
+    hitRatePct: round4((alphas.filter((a) => a > 0).length / alphas.length) * 100),
+    meanAlphaPct: round4(mean(alphas) * 100),
+    medianAlphaPct: round4(median(alphas) * 100),
+    buckets,
+    calibrated,
+  };
+}

--- a/frontend/olympus/lib/observability-queries.ts
+++ b/frontend/olympus/lib/observability-queries.ts
@@ -1,0 +1,104 @@
+/**
+ * Observability dashboard data access (Pillar 3D).
+ *
+ * Reads the four read-only surfaces the observability route needs — `decision_log`,
+ * `position_attribution`, the curated `atlas_run_health` view, and the latest `positions`
+ * (with advisory risk fields). Kept separate from `getFullDashboardData` so the main Morning
+ * Read bundle stays lean; this fires only when the observability route mounts.
+ *
+ * Every query is FAIL-SOFT: a missing/forbidden source (e.g. the `atlas_run_health` view
+ * before migration 041 is applied, or an empty book) resolves to an empty result rather than
+ * throwing, so the dashboard renders a clean empty state instead of an error wall.
+ */
+
+import { supabase } from './supabase';
+import type { TableRow, ViewRow } from './database.types';
+
+const RUN_HEALTH_LIMIT = 30;
+const DECISION_LIMIT = 1000;
+const ATTRIBUTION_LIMIT = 600;
+const POSITIONS_LIMIT = 400;
+
+export interface ObservabilityData {
+  decisions: TableRow<'decision_log'>[];
+  runHealth: ViewRow<'atlas_run_health'>[];
+  attribution: TableRow<'position_attribution'>[]; // latest date only
+  attributionDate: string | null;
+  positions: TableRow<'positions'>[]; // latest date only
+  positionsDate: string | null;
+  runHealthAvailable: boolean; // false when the 041 view isn't applied yet
+}
+
+/** Run a single-table read, logging + swallowing any error into an empty array. */
+async function safeSelect<T>(
+  label: string,
+  run: (sb: NonNullable<typeof supabase>) => PromiseLike<{ data: T[] | null; error: unknown }>
+): Promise<{ rows: T[]; ok: boolean }> {
+  if (!supabase) return { rows: [], ok: false };
+  try {
+    const { data, error } = await run(supabase);
+    if (error) {
+      console.error(`Supabase ${label} query:`, error);
+      return { rows: [], ok: false };
+    }
+    return { rows: data ?? [], ok: true };
+  } catch (err) {
+    console.error(`Supabase ${label} query threw:`, err);
+    return { rows: [], ok: false };
+  }
+}
+
+/** Keep only the rows belonging to the most-recent `date` present (the latest snapshot). */
+function latestDateRows<T extends { date: string | null }>(rows: T[]): { rows: T[]; date: string | null } {
+  let max: string | null = null;
+  for (const r of rows) {
+    if (r.date && (max === null || r.date > max)) max = r.date;
+  }
+  return { rows: max === null ? [] : rows.filter((r) => r.date === max), date: max };
+}
+
+export async function fetchObservabilityData(): Promise<ObservabilityData> {
+  const [decisionsRes, runHealthRes, attributionRes, positionsRes] = await Promise.all([
+    safeSelect<TableRow<'decision_log'>>('decision_log', (sb) =>
+      sb
+        .from('decision_log')
+        .select(
+          'id,run_id,run_date,ticker,stance,conviction,thesis,benchmark,holding_days,status,actual_return,alpha,reflection,resolved_at,created_at'
+        )
+        .order('run_date', { ascending: false })
+        .limit(DECISION_LIMIT)
+    ),
+    safeSelect<ViewRow<'atlas_run_health'>>('atlas_run_health', (sb) =>
+      sb
+        .from('atlas_run_health')
+        .select(
+          'run_id,run_date,run_type,model,status,started_at,finished_at,duration_s,segments_total,segments_ok,segments_carried,segments_failed,created_at'
+        )
+        .order('run_date', { ascending: false })
+        .limit(RUN_HEALTH_LIMIT)
+    ),
+    safeSelect<TableRow<'position_attribution'>>('position_attribution', (sb) =>
+      sb
+        .from('position_attribution')
+        .select('*')
+        .order('date', { ascending: false })
+        .limit(ATTRIBUTION_LIMIT)
+    ),
+    safeSelect<TableRow<'positions'>>('positions', (sb) =>
+      sb.from('positions').select('*').order('date', { ascending: false }).limit(POSITIONS_LIMIT)
+    ),
+  ]);
+
+  const attribution = latestDateRows(attributionRes.rows);
+  const positions = latestDateRows(positionsRes.rows);
+
+  return {
+    decisions: decisionsRes.rows,
+    runHealth: runHealthRes.rows,
+    attribution: attribution.rows,
+    attributionDate: attribution.date,
+    positions: positions.rows,
+    positionsDate: positions.date,
+    runHealthAvailable: runHealthRes.ok,
+  };
+}

--- a/frontend/olympus/lib/observability-queries.ts
+++ b/frontend/olympus/lib/observability-queries.ts
@@ -11,7 +11,7 @@
  * throwing, so the dashboard renders a clean empty state instead of an error wall.
  */
 
-import { supabase } from './supabase';
+import { supabase, isSupabaseConfigured } from './supabase';
 import type { TableRow, ViewRow } from './database.types';
 
 const RUN_HEALTH_LIMIT = 30;
@@ -58,6 +58,15 @@ function latestDateRows<T extends { date: string | null }>(rows: T[]): { rows: T
 }
 
 export async function fetchObservabilityData(): Promise<ObservabilityData> {
+  // Distinguish a total misconfiguration (no Supabase env) from a configured-but-empty book:
+  // throw so the page shows a clear error, matching the main data layer (lib/queries.ts).
+  // Per-query failures below still fail-soft (a missing 041 view degrades, not errors).
+  if (!isSupabaseConfigured() || !supabase) {
+    throw new Error(
+      'Supabase is not configured (NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY). ' +
+        'Observability data cannot be loaded.'
+    );
+  }
   const [decisionsRes, runHealthRes, attributionRes, positionsRes] = await Promise.all([
     safeSelect<TableRow<'decision_log'>>('decision_log', (sb) =>
       sb
@@ -74,7 +83,9 @@ export async function fetchObservabilityData(): Promise<ObservabilityData> {
         .select(
           'run_id,run_date,run_type,model,status,started_at,finished_at,duration_s,segments_total,segments_ok,segments_carried,segments_failed,created_at'
         )
-        .order('run_date', { ascending: false })
+        // Order by created_at (NOT NULL, DEFAULT now()): run_date is nullable, so ordering by
+        // it could surface a NULL-dated row first and make runHealth[0] point at the wrong run.
+        .order('created_at', { ascending: false })
         .limit(RUN_HEALTH_LIMIT)
     ),
     safeSelect<TableRow<'position_attribution'>>('position_attribution', (sb) =>


### PR DESCRIPTION
## Pillar 3D — Observability dashboard (#726)

Final code pillar of the Olympus "hedge-fund-in-a-box" overhaul. Adds an **Observability** route that answers: *does the agent make money, and is it well-calibrated?*

### Tabs (all read-only, fail-soft)
- **Decision Scorecard** — conviction calibration over resolved `decision_log` rows: do higher-conviction calls earn higher alpha? Pure `lib/decision-scorecard.ts` (+ vitest), bucket thresholds mirror the Python `backtest.py` (high≥4 / medium≥2 / low). Resolved-but-unconvictioned rows still score the overall track record; only bucketing needs conviction.
- **Attribution** — per-position contribution / selection over `position_attribution` (migration 040, already merged). Surfaces a **partial** caveat when a holding is unpriced so the active-return total is never shown as falsely reconciled.
- **Position Risk** — advisory stops / targets / horizon / conviction from `positions` (migration 039), explicitly labelled **not orders** (paper-only); empty-states when the `OLYMPUS_POSITION_RISK_FIELDS` flag hasn't populated them.
- **Run Health** — status / segment ok·carry·fail counts / model / timing via the new curated view.

### ⚠️ Human gate — migration `041_atlas_run_health_view.sql`
Creates `atlas_run_health`, an **anon-readable, security-definer view** over `atlas_run_diagnostics`. Migration 033 deliberately revoked anon access to that table because it carries spend telemetry (`est_cost_usd`, token counts, `error_summary`, `breakdown`). This view re-exposes **only** safe operational columns — that projection **is** the allowlist; the sensitive columns are never selected. `security_invoker=false` so it bypasses the base RLS (which denies anon), while the column list bounds what anon can read. **Requires owner sign-off before apply.** Not applied by CI; held for the final batched migration step.

Security review: PASS 10/10 — zero sensitive columns leaked, security-definer reasoning sound, no pivot path from view to base table.

### Data contract
Adds `decision_log` + `position_attribution` Tables and the `atlas_run_health` View to `database.types.ts` (matched column-for-column against migrations 026 / 040 / 032). Observability entry added to the sidebar.

### Verification (no baseline run — all free)
- vitest **95/95** (7 new scorecard tests), eslint clean, `next build` (TypeScript + static export) green — `/observability` prerendered.
- `make score` **10/10** all dimensions.
- Adversarial security + correctness reviews run pre-PR; both Important/critical findings fixed (conviction scale label −5..+5; partial-attribution caveat; calibration n/a for <2 buckets).

Part of #726.
