### PR TITLE
ci(atlas): wire Pillar 3 analytics crons + 1F freshness backstop (HUMAN GATE)

### DIFF
--- a/.github/workflows/atlas-attribution.yml
+++ b/.github/workflows/atlas-attribution.yml
@@ -1,0 +1,110 @@
+name: atlas attribution + backtest
+
+# Pillar 3B/3C — post-hoc analytics over the paper book. Two jobs, both zero-LLM:
+#   * attribution — daily at 21:30 UTC (after the EOD price ingest at 21:00) computes the
+#     single-benchmark active-return decomposition for today and upserts position_attribution
+#     (requires migration 040). Idempotent upsert on (date, ticker).
+#   * backtest    — weekly (SUN 13:00 UTC) replays recorded decision_log stances into a
+#     decision-level tear sheet using only look-ahead-safe prices. Read-only; prints JSON +
+#     uploads it as an artifact. No writes, no schema change.
+# Both are deterministic Polars/Python — effectively free; never a baseline run.
+
+on:
+  schedule:
+    - cron: "30 21 * * *"   # attribution (daily, post-EOD-prices)
+    - cron: "0 13 * * SUN"  # backtest (weekly)
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Which job to run"
+        required: true
+        default: "attribution"
+        type: choice
+        options: [attribution, backtest]
+      as_of:
+        description: "attribution: date (YYYY-MM-DD). Default today UTC."
+        required: false
+        default: ""
+      start:
+        description: "backtest: earliest decision run_date (YYYY-MM-DD). Default 1y back."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  attribution:
+    name: Refresh position attribution
+    if: |
+      github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'attribution' ||
+      github.event_name == 'schedule' && github.event.schedule == '30 21 * * *'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: atlas-attribution
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            digiquant/pyproject.toml
+      - name: Install Atlas
+        run: |
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
+      - name: Refresh attribution
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Via env (not inline ${{ }}) so the dispatch input can't inject shell.
+          AS_OF: ${{ inputs.as_of }}
+        run: |
+          ARGS=()
+          [ -n "$AS_OF" ] && ARGS+=(--date "$AS_OF")
+          python digiquant/scripts/atlas/refresh_attribution.py "${ARGS[@]}"
+
+  backtest:
+    name: Backtest recorded decisions
+    if: |
+      github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'backtest' ||
+      github.event_name == 'schedule' && github.event.schedule == '0 13 * * SUN'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            digiquant/pyproject.toml
+      - name: Install Atlas
+        run: |
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
+      - name: Backtest decisions (read-only tear sheet)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          START: ${{ inputs.start }}
+        run: |
+          mkdir -p artifacts
+          ARGS=()
+          [ -n "$START" ] && ARGS+=(--start "$START")
+          python digiquant/scripts/atlas/backtest_decisions.py "${ARGS[@]}" | tee artifacts/backtest.json
+      - name: Upload tear sheet
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: atlas-decision-backtest
+          path: artifacts/
+          retention-days: 30

--- a/.github/workflows/atlas-attribution.yml
+++ b/.github/workflows/atlas-attribution.yml
@@ -31,15 +31,14 @@ on:
         default: ""
 
 permissions:
-  contents: read
-  issues: write
+  contents: read  # read-only: neither job opens issues (least privilege)
 
 jobs:
   attribution:
     name: Refresh position attribution
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'attribution' ||
-      github.event_name == 'schedule' && github.event.schedule == '30 21 * * *'
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'attribution') ||
+      (github.event_name == 'schedule' && github.event.schedule == '30 21 * * *')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
@@ -73,8 +72,8 @@ jobs:
   backtest:
     name: Backtest recorded decisions
     if: |
-      github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'backtest' ||
-      github.event_name == 'schedule' && github.event.schedule == '0 13 * * SUN'
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'backtest') ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 13 * * SUN')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -97,6 +96,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           START: ${{ inputs.start }}
         run: |
+          set -o pipefail  # without this, a failing python is masked by tee → false-green run
           mkdir -p artifacts
           ARGS=()
           [ -n "$START" ] && ARGS+=(--start "$START")

--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -87,8 +87,8 @@ jobs:
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           # Pillar 1F backstop: the Saturday baseline runs after the MON-FRI prices cron, so
-          # opt preflight into the on-demand technicals recompute (fail-soft) to guarantee the
-          # analysts see fresh data even if Friday's compute was stale/missing.
+          # opt in to the on-demand technicals recompute in preflight (fail-soft) to guarantee
+          # the analysts see fresh data even if Friday's compute was stale/missing.
           ATLAS_REFRESH_ON_DEMAND: "true"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).

--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -86,6 +86,10 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
+          # Pillar 1F backstop: the Saturday baseline runs after the MON-FRI prices cron, so
+          # opt preflight into the on-demand technicals recompute (fail-soft) to guarantee the
+          # analysts see fresh data even if Friday's compute was stale/missing.
+          ATLAS_REFRESH_ON_DEMAND: "true"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).
           # Degrades to no-checkpointing if the secret/package is absent.

--- a/.github/workflows/atlas-resolve-decisions.yml
+++ b/.github/workflows/atlas-resolve-decisions.yml
@@ -1,0 +1,105 @@
+name: atlas resolve decisions
+
+# Pillar 3A — closed learning loop. Resolves every *due* decision_log row (realized alpha
+# vs benchmark + an LLM reflection lesson) on its own daily cron, decoupled from the
+# research pipeline. Runs at 22:00 UTC — after the EOD price ingest (digiquant-prices,
+# 21:00 UTC MON-FRI) lands the closing prices each window needs. Idempotent: only
+# status='pending' rows are touched, and a due row whose price window hasn't landed yet
+# stays pending for the next run. Cost: ~1 cheap reflector LLM call per resolved decision
+# (~10/day), no baseline.
+
+on:
+  schedule:
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+    inputs:
+      run_date:
+        description: "Resolution as-of date (YYYY-MM-DD). Defaults to today UTC."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: atlas-resolve-decisions
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            digiquant/pyproject.toml
+
+      - name: Install Atlas (reflector LLM needs the digigraph/digillm stack)
+        run: |
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
+
+      - name: Resolve due decisions
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Reflector LLM routes through OpenRouter (config/model_modes.yaml).
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Via env (not inline ${{ }}) so the dispatch input can't inject shell. The script
+          # also validates the format and exits 2 on a bad date.
+          RUN_DATE: ${{ inputs.run_date }}
+        run: |
+          ARGS=()
+          [ -n "$RUN_DATE" ] && ARGS+=(--run-date "$RUN_DATE")
+          python digiquant/scripts/atlas/resolve_decisions.py "${ARGS[@]}"
+
+      - name: Update persistent failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stamp  = new Date().toISOString().slice(0, 16);
+            const marker = '<!-- atlas-resolve-decisions-tracker -->';
+            const labels = ['ci-failure', 'component:digiquant', 'pipeline:reflection'];
+            const failLine = `- ${stamp} — [run ${context.runId}](${runUrl})`;
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'ci-failure', per_page: 100,
+            });
+            const tracker = existing.find(i => (i.body || '').includes(marker));
+            if (tracker) {
+              const MAX = 20;
+              const parts = (tracker.body || '').split('## Recent failures');
+              const tail = [failLine, ...((parts[1] || '').split('\n').filter(l => l.startsWith('- ')))]
+                .slice(0, MAX).join('\n');
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: tracker.number,
+                body: `${parts[0].trim()}\n\n## Recent failures (latest first)\n${tail}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: 'atlas-resolve-decisions — recurring failures',
+                labels,
+                body: [
+                  marker,
+                  '## Persistent tracker for the decision resolver cron',
+                  '',
+                  'Daily resolver (`0 22 * * *`) has been failing.',
+                  '**Likely causes:** Supabase outage, OpenRouter key rotated, decision_log schema drift.',
+                  '',
+                  '## Recent failures (latest first)',
+                  failLine,
+                ].join('\n'),
+              });
+            }

--- a/digiquant/src/digiquant/olympus/atlas/docs/OBSERVABILITY_ACTIVATION.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/OBSERVABILITY_ACTIVATION.md
@@ -1,0 +1,83 @@
+# Olympus Pillar 2/3 — Activation Checklist (Human Gate)
+
+The hedge-fund-in-a-box overhaul (#726) landed its code across many PRs. The remaining steps
+are **operator actions** — apply migrations, flip a flag, enable crons, and run the single
+baseline validation. None of this happens automatically; CI never applies migrations, and the
+crons + the curated anon view are deliberate human gates.
+
+> **Cost note.** Only the final baseline run spends LLM budget (~$8). Everything else here is
+> free: migrations are DDL, the flag is an env var, the attribution/backtest crons are
+> deterministic Polars, and the resolver makes ~1 cheap reflector call per due decision (~10/day).
+> Do **not** trigger extra baseline/delta runs while validating.
+
+## 1. Apply migrations (manual, in order)
+
+Apply against prod via the Supabase SQL editor or MCP `apply_migration`. All are idempotent.
+
+| Migration | What it adds | Notes |
+|-----------|--------------|-------|
+| `039_position_risk_fields.sql` | `positions` += stop/target/horizon/conviction/sector_bucket | Advisory display fields. Safe. |
+| `040_position_attribution.sql` | `position_attribution` table (anon-read) | Feeds the Attribution tab + the attribution cron. |
+| `041_atlas_run_health_view.sql` | **Curated `atlas_run_health` view (anon-read)** | ⚠️ Re-exposes run health that #707 revoked. Owner sign-off required. Exposes status/segment-counts/model/timing **only** — never cost/tokens/error_summary/breakdown. |
+
+Verify after apply:
+
+```sql
+select count(*) from position_attribution;          -- table exists (0 rows is fine)
+select * from atlas_run_health order by run_date desc limit 3;  -- view returns rows, no spend cols
+```
+
+## 2. Flip the per-position risk flag
+
+`OLYMPUS_POSITION_RISK_FIELDS` (read in `hermes/portfolio_materialize.py`) is **off by default**.
+To populate the advisory stop/target/horizon/conviction fields, set it on the runs that
+materialize the book — add to the `Run baseline` / `Run delta` step env in
+`.github/workflows/atlas-baseline.yml` and `atlas-delta.yml`:
+
+```yaml
+          OLYMPUS_POSITION_RISK_FIELDS: "true"
+```
+
+Until then the Position Risk tab shows its "advisory risk fields not populated" empty state — by
+design, not a bug.
+
+## 3. Enable the analytics crons
+
+These workflows ship dormant in the repo; they begin firing once merged to `develop` (and are
+runnable now via **workflow_dispatch**). Confirm the referenced secrets exist
+(`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENROUTER_API_KEY`):
+
+| Workflow | Schedule (UTC) | Does | Requires |
+|----------|----------------|------|----------|
+| `atlas-resolve-decisions.yml` | daily 22:00 | Resolves due `decision_log` rows (alpha + reflection) — closes the learning loop | migration 026 (live); OpenRouter |
+| `atlas-attribution.yml` (attribution job) | daily 21:30 | Upserts `position_attribution` for today | **migration 040 applied** |
+| `atlas-attribution.yml` (backtest job) | weekly SUN 13:00 | Zero-LLM decision tear sheet → artifact | read-only |
+
+Order matters: apply migration 040 **before** the attribution cron first fires, or its run fails
+on a missing table (fail-soft exit 1, noisy but harmless).
+
+## 4. Single baseline validation (the only spend)
+
+After 1–3 are done, run ONE baseline to prove the end-to-end book:
+
+```bash
+# via workflow_dispatch on atlas-baseline.yml, or locally:
+python -m digiquant.olympus.hermes.chain --run-type baseline --run-date "$(date -u +%F)"
+```
+
+Then verify (Supabase row counts > 0 and a spot-check):
+
+- `positions` for the run date is **non-empty** with sized/capped weights (Pillar 2) and, if the
+  flag is on, populated `stop_loss_pct`/`conviction`.
+- `nav_history`, `theses`, `decision_log` (pending) have rows; a sector document shows real
+  breadth/RS numbers (Pillar 1).
+- `atlas_run_diagnostics` has a row for the run (Pillar 1B).
+- Dashboard `/observability`: Run Health shows the run; after the next 22:00 resolver + 21:30
+  attribution, the Decision Scorecard and Attribution tabs populate.
+
+## Rollback
+
+- Crons: disable via the Actions UI or revert the workflow files.
+- Flag: unset `OLYMPUS_POSITION_RISK_FIELDS` (existing rows keep their values; new rows write NULL).
+- View: `DROP VIEW IF EXISTS public.atlas_run_health;` (re-closes anon run-health).
+- Tables 039/040 are additive; leaving them in place is harmless.


### PR DESCRIPTION
## Pillar 3 wiring — analytics crons + 1F freshness backstop (#726)

⚠️ **HUMAN GATE — do not merge until prod migrations are applied.** Once merged to `develop`, these crons fire on schedule; the attribution cron needs table `040` and the resolver makes (cheap) LLM calls. Merge order is documented in the activation checklist.

Schedules the standalone scripts already merged in 3A/3B/3C — they currently run **nowhere**, which is why the learning loop and attribution never populate.

| Workflow | Schedule (UTC) | Job | Cost |
|----------|----------------|-----|------|
| `atlas-resolve-decisions.yml` (3A) | daily 22:00 | resolve due `decision_log` rows → realized alpha + reflection (closes the loop) | ~10 cheap reflector calls/day |
| `atlas-attribution.yml` (3B) | daily 21:30 | upsert `position_attribution` (needs migration 040) | free (Polars) |
| `atlas-attribution.yml` (3C) | weekly SUN 13:00 | zero-LLM decision tear sheet → artifact | free |
| `atlas-baseline.yml` (1F) | — | sets `ATLAS_REFRESH_ON_DEMAND=true` so the Saturday baseline recomputes stale technicals (fail-soft) | free |

Timing: resolver/attribution run **after** the 21:00 EOD price ingest so each holding window has its closing prices.

### Security
All `workflow_dispatch` inputs are passed via `env:` (never inline `${{ }}` in `run:`), so a dispatch input can't inject shell. The resolver additionally validates `--run-date` and exits 2 on a bad value.

### Operator runbook
`digiquant/.../atlas/docs/OBSERVABILITY_ACTIVATION.md` — the final-gate checklist: apply migrations 039/040/041 (041 = curated anon `atlas_run_health` view, **owner sign-off**), flip `OLYMPUS_POSITION_RISK_FIELDS`, enable these crons, then run the **single** baseline validation (the only LLM spend).

`make score` 10/10. YAML validated. Part of #726.
