### PR TITLE
fix(hermes): cash row category must satisfy chk_positions_category (Fixes #772)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -452,8 +452,17 @@ def build_materialize_node(deps: MaterializeDeps):
         ).execute()
 
         if cash_pct > 0.01:
+            # The cash sleeve's category must satisfy chk_positions_category (migration 002),
+            # whose vocabulary has no bare "cash" — "fixed_income_cash" is the cash bucket. A
+            # literal "cash" raises 23514 and (for an all-cash book) blocks the whole positions
+            # write. Cash is otherwise identified by ticker == "CASH".
             pos_rows.append(
-                {"date": date_str, "ticker": "CASH", "weight_pct": cash_pct, "category": "cash"}
+                {
+                    "date": date_str,
+                    "ticker": "CASH",
+                    "weight_pct": cash_pct,
+                    "category": "fixed_income_cash",
+                }
             )
         for row in pos_rows:
             client.table("positions").upsert(row, on_conflict="date,ticker").execute()

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -23,6 +23,27 @@ pytestmark = pytest.mark.unit
 
 RUN_DATE = date(2026, 6, 12)
 
+# Mirrors the chk_positions_category CHECK constraint (migration 002_schema_hardening.sql).
+# The FakeSupabaseClient does not enforce CHECK constraints, so we assert against this set
+# explicitly — a category outside it (e.g. a bare "cash") is rejected by Postgres and blocks
+# the positions write (#772).
+_POSITIONS_CATEGORY_ALLOWED = frozenset(
+    {
+        "commodity_gold",
+        "commodity_oil",
+        "commodity_broad",
+        "equity_sector",
+        "equity_broad",
+        "equity_international",
+        "fixed_income_cash",
+        "fixed_income_short",
+        "fixed_income_long",
+        "crypto",
+        "forex",
+        "other",
+    }
+)
+
 
 def _state(recommended) -> AtlasResearchState:
     state = AtlasResearchState(run_type="delta", run_date=RUN_DATE, baseline_date=date(2026, 6, 9))
@@ -85,6 +106,10 @@ class TestFreshSeed:
         positions = {r["ticker"]: r for r in client.store["positions"]}
         assert positions["CASH"]["weight_pct"] == 30.0
         assert client.store["nav_history"][0]["cash_pct"] == 30.0
+        # Regression (#772): the cash row's category must satisfy chk_positions_category —
+        # a bare "cash" is rejected by Postgres and blocks the positions write.
+        assert positions["CASH"]["category"] == "fixed_income_cash"
+        assert positions["CASH"]["category"] in _POSITIONS_CATEGORY_ALLOWED
 
 
 class TestNavChaining:


### PR DESCRIPTION
## Bug (prod-affecting)
`portfolio_materialize.py` wrote the CASH residual row with `category="cash"`, but `chk_positions_category` (migration `002_schema_hardening.sql`) only allows the fixed taxonomy (`fixed_income_cash`, `equity_*`, …) or NULL — **not** a bare `"cash"`. The upsert raised `23514 check constraint`, failing the terminal **materialize** phase. For a 100%-cash book this meant **no positions persisted** — a likely root cause of earlier baselines showing an empty/all-cash book.

**Confirmed identical constraint on prod** (read-only check), so this affected production, not just local.

## Fix
Write `category="fixed_income_cash"` (the cash bucket in that taxonomy). Cash is identified everywhere by `ticker == "CASH"` and the newer `sector_bucket` field; `category` isn't consumed by the frontend.

## Test
Adds a regression assertion: the cash row's `category` must be constraint-valid. The `FakeSupabaseClient` doesn't enforce CHECK constraints — which is exactly how this slipped past the existing tests — so the test asserts against a constant mirroring the constraint vocabulary. 26/26 materialize tests pass; ruff clean; `make score` 10/10.

## How it was found
A **free local baseline** (LM Studio `gemma-4-e4b` → throwaway Supabase, zero OpenRouter spend) run end-to-end while validating the Olympus #726 overhaul. The pipeline ran through every phase and failed only here, on the cash-row upsert.

Fixes #772.