### PR TITLE
feat(cost): bound OpenRouter auto-selection to cheap models (~$1/day) (Fixes #774)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -84,6 +84,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Cost controls (#774): keep OpenRouter auto-selection, but bound it to a cheap-model
+          # allowlist (auto-fallback) + price-sorted endpoints + a hard price ceiling so
+          # flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY PRICE, not by name.
+          # Tune these to taste; verify slugs/prices on the OpenRouter dashboard.
+          OPENROUTER_FALLBACK_MODELS: "deepseek/deepseek-v4-flash,google/gemini-3.1-flash-lite,x-ai/grok-build-0.1"
+          OPENROUTER_SORT: "price"
+          OPENROUTER_MAX_PROMPT_PRICE: "1.5"
+          OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -81,6 +81,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Cost controls (#774): keep OpenRouter auto-selection, but bound it to a cheap-model
+          # allowlist (auto-fallback) + price-sorted endpoints + a hard price ceiling so
+          # flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY PRICE, not by name.
+          # Tune these to taste; verify slugs/prices on the OpenRouter dashboard.
+          OPENROUTER_FALLBACK_MODELS: "deepseek/deepseek-v4-flash,google/gemini-3.1-flash-lite,x-ai/grok-build-0.1"
+          OPENROUTER_SORT: "price"
+          OPENROUTER_MAX_PROMPT_PRICE: "1.5"
+          OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           DRY_RUN: ${{ inputs.dry_run }}

--- a/digigraph/src/digigraph/usage.py
+++ b/digigraph/src/digigraph/usage.py
@@ -45,10 +45,17 @@ def record(
     model: str,
     prompt_tokens: int = 0,
     completion_tokens: int = 0,
+    cached_tokens: int = 0,
     sources: int = 0,
     ok: bool = True,
+    **_ignored: Any,
 ) -> None:
-    """Record one LLM/search call. No-op unless capture is active."""
+    """Record one LLM/search call. No-op unless capture is active.
+
+    ``cached_tokens`` is the prompt-cache-hit portion of ``prompt_tokens`` (OpenRouter
+    ``prompt_tokens_details.cached_tokens``) — surfaced so a run can show how much of the
+    repeated shared-context prefix was billed at the cheaper cached rate. ``**_ignored`` keeps
+    the observer forward-compatible with future digillm fields."""
     if not _ACTIVE:
         return
     with _LOCK:
@@ -58,6 +65,7 @@ def record(
                 "model": model,
                 "prompt_tokens": int(prompt_tokens or 0),
                 "completion_tokens": int(completion_tokens or 0),
+                "cached_tokens": int(cached_tokens or 0),
                 "sources": int(sources or 0),
                 "ok": bool(ok),
             }
@@ -72,19 +80,29 @@ def snapshot() -> dict[str, Any]:
     search = [c for c in calls if c["kind"] in _SEARCH_KINDS]
     prompt = sum(c["prompt_tokens"] for c in chat)
     completion = sum(c["completion_tokens"] for c in chat)
+    cached = sum(c.get("cached_tokens", 0) for c in chat)
     by_kind: dict[str, dict[str, int]] = {}
     for c in calls:
         b = by_kind.setdefault(
-            c["kind"], {"calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "sources": 0}
+            c["kind"],
+            {
+                "calls": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "cached_tokens": 0,
+                "sources": 0,
+            },
         )
         b["calls"] += 1
         b["prompt_tokens"] += c["prompt_tokens"]
         b["completion_tokens"] += c["completion_tokens"]
+        b["cached_tokens"] += c.get("cached_tokens", 0)
         b["sources"] += c["sources"]
     return {
         "llm_calls": len(chat),
         "prompt_tokens": prompt,
         "completion_tokens": completion,
+        "cached_tokens": cached,
         "total_tokens": prompt + completion,
         "search_calls": len(search),
         "sources_used": sum(c["sources"] for c in search),

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -531,26 +531,68 @@ def _is_empty_completion(resp: Any) -> bool:
 
 
 def _openrouter_fallback_models() -> list[str]:
-    """``OPENROUTER_FALLBACK_MODELS`` (comma-separated) — cheap models to fall back to."""
+    """``OPENROUTER_FALLBACK_MODELS`` (comma-separated) — the cheap-model allowlist OpenRouter
+    routes/falls-back across (keeps automatic selection, but only among affordable models)."""
     raw = os.environ.get("OPENROUTER_FALLBACK_MODELS", "").strip()
     return [m.strip() for m in raw.split(",") if m.strip()]
 
 
-def _with_openrouter_fallback(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
-    """Add OpenRouter provider-fallback routing (``extra_body.models`` + ``route=fallback``)
-    for an ``openrouter/`` model when ``OPENROUTER_FALLBACK_MODELS`` is set; a no-op for any
-    other provider or when no fallbacks are configured."""
+def _openrouter_provider_prefs() -> dict[str, Any]:
+    """OpenRouter ``provider`` routing preferences from env (all opt-in; empty when unset):
+
+    - ``OPENROUTER_SORT`` → ``provider.sort`` (e.g. ``price`` routes to the cheapest endpoint).
+    - ``OPENROUTER_MAX_PROMPT_PRICE`` / ``OPENROUTER_MAX_COMPLETION_PRICE`` (USD per 1M tokens)
+      → ``provider.max_price``, a hard ceiling that structurally excludes flagship-tier models
+      *by price* without naming them — the requested "exclude expensive, keep auto" control.
+    """
+    prefs: dict[str, Any] = {}
+    sort = os.environ.get("OPENROUTER_SORT", "").strip()
+    if sort:
+        prefs["sort"] = sort
+    max_price: dict[str, float] = {}
+    for key, env_name in (
+        ("prompt", "OPENROUTER_MAX_PROMPT_PRICE"),
+        ("completion", "OPENROUTER_MAX_COMPLETION_PRICE"),
+    ):
+        raw = os.environ.get(env_name, "").strip()
+        if not raw:
+            continue
+        try:
+            max_price[key] = float(raw)
+        except ValueError:
+            logger.warning("ignoring non-numeric %s=%r", env_name, raw)
+    if max_price:
+        prefs["max_price"] = max_price
+    return prefs
+
+
+def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
+    """Merge OpenRouter cost controls into ``extra_body`` for an ``openrouter/`` request:
+    a cheap-model allowlist with fallback routing (``OPENROUTER_FALLBACK_MODELS`` →
+    ``models`` + ``route=fallback``), price-sorted endpoints, and an optional hard price
+    ceiling (``provider.max_price``). Keeps OpenRouter's automatic selection but bounds it to
+    affordable models — flagships are excluded by price, not by name. No-op for non-OpenRouter
+    providers and when nothing is configured. Merges with (never clobbers) an existing
+    ``extra_body`` (e.g. the xAI ``search_parameters`` branch)."""
     if provider != "openrouter":
         return kwargs
     fallbacks = _openrouter_fallback_models()
-    if not fallbacks:
+    prefs = _openrouter_provider_prefs()
+    if not fallbacks and not prefs:
         return kwargs
     merged = dict(kwargs)
     extra = dict(merged.get("extra_body") or {})
-    extra["models"] = fallbacks
-    extra["route"] = "fallback"
+    if fallbacks:
+        extra["models"] = fallbacks
+        extra["route"] = "fallback"
+    if prefs:
+        extra["provider"] = {**(extra.get("provider") or {}), **prefs}
     merged["extra_body"] = extra
     return merged
+
+
+# Back-compat alias: the empty-retry path historically called the fallback-only form.
+_with_openrouter_fallback = _with_openrouter_cost_controls
 
 
 # ── Public API: chat_completion ────────────────────────────────────────────────
@@ -632,6 +674,10 @@ def completion(
     elif search_parameters is not None:
         logger.debug("search_parameters ignored for non-xAI model %s", effective_model)
 
+    # Bound OpenRouter's automatic selection to affordable models on the PRIMARY request
+    # (cheap-model allowlist + price ceiling); a no-op unless the OPENROUTER_* env is set.
+    kwargs = _with_openrouter_cost_controls(kwargs, provider)
+
     try:
         r: ChatCompletion = _create_with_retry(client, **kwargs)
     except Exception as exc:  # noqa: BLE001 — only the 410 case is soft; everything else re-raises
@@ -668,11 +714,15 @@ def completion(
         r = _create_with_retry(client, **retry_kwargs)
 
     _u = getattr(r, "usage", None)
+    _cached_tokens = getattr(getattr(_u, "prompt_tokens_details", None), "cached_tokens", 0) or 0
     _record_usage(
         kind="chat",
-        model=effective_model,
+        # Record the model OpenRouter actually served (``r.model``), not the request string
+        # ("auto" / the allowlist), so cost telemetry reflects what was really billed.
+        model=getattr(r, "model", None) or effective_model,
         prompt_tokens=getattr(_u, "prompt_tokens", 0) or 0,
         completion_tokens=getattr(_u, "completion_tokens", 0) or 0,
+        cached_tokens=_cached_tokens,
     )
     # Cache the serialized response (tool-free, non-BYOK, non-empty content) so a
     # future hit rehydrates a ChatCompletion — keeping the return type consistent.

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -586,7 +586,16 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
         extra["models"] = fallbacks
         extra["route"] = "fallback"
     if prefs:
-        extra["provider"] = {**(extra.get("provider") or {}), **prefs}
+        provider_prefs = {**(extra.get("provider") or {})}
+        for key, value in prefs.items():
+            # Deep-merge the nested max_price dict so a caller-set ceiling key (e.g. only
+            # ``completion``) survives when env sets the other (``prompt``), rather than the
+            # whole sub-dict being overwritten.
+            if key == "max_price" and isinstance(provider_prefs.get("max_price"), dict):
+                provider_prefs["max_price"] = {**provider_prefs["max_price"], **value}
+            else:
+                provider_prefs[key] = value
+        extra["provider"] = provider_prefs
     merged["extra_body"] = extra
     return merged
 

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -30,6 +30,10 @@ def _clean_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "XAI_API_KEY",
         "GEMINI_API_KEY",
         "OPENROUTER_API_KEY",
+        "OPENROUTER_FALLBACK_MODELS",
+        "OPENROUTER_SORT",
+        "OPENROUTER_MAX_PROMPT_PRICE",
+        "OPENROUTER_MAX_COMPLETION_PRICE",
         "DIGI_LLM_CACHE_TTL_SECONDS",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -197,8 +201,57 @@ def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.Monkey
     # Non-openrouter providers (and the default client) are untouched.
     assert client_mod._with_openrouter_fallback(base, "xai") == base
     assert client_mod._with_openrouter_fallback(base, None) == base
-    monkeypatch.delenv("OPENROUTER_FALLBACK_MODELS", raising=False)
-    assert client_mod._with_openrouter_fallback(base, "openrouter") == base  # no env → no-op
+
+
+def test_openrouter_provider_prefs_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Unset → empty (fully opt-in, no behavior change by default).
+    assert client_mod._openrouter_provider_prefs() == {}
+    monkeypatch.setenv("OPENROUTER_SORT", "price")
+    monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", "1.5")
+    monkeypatch.setenv("OPENROUTER_MAX_COMPLETION_PRICE", "4")
+    assert client_mod._openrouter_provider_prefs() == {
+        "sort": "price",
+        "max_price": {"prompt": 1.5, "completion": 4.0},
+    }
+
+
+def test_openrouter_provider_prefs_ignores_non_numeric_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", "cheap")  # garbage → dropped, not crash
+    assert client_mod._openrouter_provider_prefs() == {}
+
+
+def test_cost_controls_combine_allowlist_and_price_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "a/x,b/y")
+    monkeypatch.setenv("OPENROUTER_SORT", "price")
+    monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", "1.5")
+    out = client_mod._with_openrouter_cost_controls(
+        {"model": "openrouter/auto", "messages": []}, "openrouter"
+    )
+    assert out["extra_body"]["models"] == ["a/x", "b/y"]
+    assert out["extra_body"]["route"] == "fallback"
+    assert out["extra_body"]["provider"] == {"sort": "price", "max_price": {"prompt": 1.5}}
+
+
+def test_cost_controls_noop_when_unconfigured() -> None:
+    base = {"model": "openrouter/auto", "messages": []}
+    assert client_mod._with_openrouter_cost_controls(base, "openrouter") == base
+
+
+def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The xAI search_parameters branch is openrouter-gated out, but a pre-existing extra_body
+    # (and any pre-set provider keys) must be preserved/merged, not clobbered.
+    monkeypatch.setenv("OPENROUTER_SORT", "price")
+    base = {
+        "model": "openrouter/auto",
+        "messages": [],
+        "extra_body": {"provider": {"order": ["x"]}, "foo": 1},
+    }
+    out = client_mod._with_openrouter_cost_controls(base, "openrouter")
+    assert out["extra_body"]["foo"] == 1
+    assert out["extra_body"]["provider"] == {"order": ["x"], "sort": "price"}
+    assert base["extra_body"]["provider"] == {"order": ["x"]}  # input not mutated
 
 
 def test_empty_response_retries_then_heals(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -226,9 +279,14 @@ def test_empty_response_gives_up_gracefully(monkeypatch: pytest.MonkeyPatch) -> 
     assert fake_client.chat.completions.create.call_count == 1 + client_mod._EMPTY_RETRY_MAX
 
 
-def test_openrouter_fallback_injected_on_first_empty_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openrouter_cost_controls_applied_on_primary_and_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Cost controls (#774) now apply on the PRIMARY request (cheap allowlist + price ceiling),
+    # not only on the empty-retry path — so every OpenRouter call is bounded to cheap models.
     monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
     monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "openrouter/cheap-a,openrouter/cheap-b")
+    monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", "1.5")
     monkeypatch.setattr(client_mod, "_EMPTY_RETRY_MAX", 2)  # deterministic regardless of env
     monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
     fake_client = MagicMock()
@@ -236,11 +294,13 @@ def test_openrouter_fallback_injected_on_first_empty_retry(monkeypatch: pytest.M
     with patch.object(client_mod, "get_client_for_model", return_value=fake_client):
         digillm.completion("openrouter/primary/model", [{"role": "user", "content": "hi"}])
     calls = fake_client.chat.completions.create.call_args_list
-    assert "extra_body" not in calls[0].kwargs  # primary attempt: no fallback routing
-    assert calls[1].kwargs["extra_body"] == {
+    expected = {
         "models": ["openrouter/cheap-a", "openrouter/cheap-b"],
         "route": "fallback",
+        "provider": {"max_price": {"prompt": 1.5}},
     }
+    assert calls[0].kwargs["extra_body"] == expected  # primary already bounded to cheap models
+    assert calls[1].kwargs["extra_body"] == expected  # retry keeps the controls
 
 
 def test_chat_completion_response_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -254,6 +254,19 @@ def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.M
     assert base["extra_body"]["provider"] == {"order": ["x"]}  # input not mutated
 
 
+def test_cost_controls_deep_merge_max_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A caller-set max_price key (completion) must survive when env sets only the other
+    # (prompt) — deep-merge the nested dict, don't clobber it.
+    monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", "1.5")
+    base = {
+        "model": "openrouter/auto",
+        "messages": [],
+        "extra_body": {"provider": {"max_price": {"completion": 9.0}}},
+    }
+    out = client_mod._with_openrouter_cost_controls(base, "openrouter")
+    assert out["extra_body"]["provider"]["max_price"] == {"completion": 9.0, "prompt": 1.5}
+
+
 def test_empty_response_retries_then_heals(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "sk")
     monkeypatch.setattr(client_mod, "_EMPTY_RETRY_MAX", 2)  # deterministic regardless of env

--- a/digiquant/src/digiquant/olympus/atlas/config/ai_portfolio_accounts.yaml
+++ b/digiquant/src/digiquant/olympus/atlas/config/ai_portfolio_accounts.yaml
@@ -36,4 +36,5 @@ accounts:
     weight: low
 
 recency_days: 7
-max_search_results: 16
+# Per-source live-search billing; 16 -> 8 halves this pre-pass's search cost.
+max_search_results: 8

--- a/digiquant/src/digiquant/olympus/atlas/config/search_domains.yaml
+++ b/digiquant/src/digiquant/olympus/atlas/config/search_domains.yaml
@@ -61,4 +61,6 @@ per_segment:
     - ft.com
 
 recency_days: 7
-max_search_results: 8
+# Live search is billed per source; 8 -> 4 roughly halves the per-search spend with minimal
+# grounding loss (top results dominate). Tune up if grounding quality regresses.
+max_search_results: 4

--- a/digiquant/src/digiquant/olympus/atlas/diagnostics.py
+++ b/digiquant/src/digiquant/olympus/atlas/diagnostics.py
@@ -170,6 +170,13 @@ def _row(
     models = usage.get("models")
     if models:
         breakdown["models"] = models
+    # Surface the per-kind token/cost detail (incl. cached_tokens) in the breakdown JSONB so
+    # cost attribution is visible without a new column (no migration). cached_tokens is the
+    # prompt-cache-hit portion billed at the cheaper rate.
+    if usage.get("by_kind"):
+        breakdown["by_kind"] = usage["by_kind"]
+    if usage.get("cached_tokens"):
+        breakdown["cached_tokens"] = usage["cached_tokens"]
     # Fall back to the model(s) the usage observer actually saw when none was passed in.
     resolved_model = model or (",".join(map(str, models)) if models else None)
     return {

--- a/tests/dg/test_usage.py
+++ b/tests/dg/test_usage.py
@@ -48,6 +48,34 @@ def test_aggregates_chat_and_search():
 
 
 @pytest.mark.unit
+def test_aggregates_cached_tokens_and_tolerates_unknown_fields():
+    usage.start()
+    # cached_tokens (prompt-cache hits) aggregates into totals + by_kind; an unknown future
+    # field is tolerated (forward-compatible observer) rather than raising.
+    usage.record(
+        kind="chat",
+        model="deepseek/deepseek-v4-flash",
+        prompt_tokens=1000,
+        completion_tokens=50,
+        cached_tokens=700,
+    )
+    usage.record(
+        kind="chat",
+        model="deepseek/deepseek-v4-flash",
+        prompt_tokens=200,
+        completion_tokens=10,
+        cached_tokens=100,
+        some_future_field="ignored",
+    )
+    snap = usage.snapshot()
+    assert snap["cached_tokens"] == 800
+    assert snap["by_kind"]["chat"]["cached_tokens"] == 800
+    # Calls that never report cached_tokens default to 0 (no KeyError).
+    usage.record(kind="web_search", model="xai/grok-4-fast", sources=4, ok=True)
+    assert usage.snapshot()["cached_tokens"] == 800
+
+
+@pytest.mark.unit
 def test_reset_clears_and_deactivates():
     usage.start()
     usage.record(kind="chat", model="x", prompt_tokens=1, completion_tokens=1)


### PR DESCRIPTION
## Goal
Cut Olympus daily-run spend from ~$4–10 to **≤ ~$1/day** by excluding expensive flagships from OpenRouter's automatic selection — **without** pinning per-phase models (keep the Auto Router's "fusion" behavior, just over a cheap pool).

## Forensics (prod `atlas_run_diagnostics`)
Runs route via `openrouter/openrouter/auto`; the Auto Router picked flagship-tier models (GPT-5.x / grok-4.3-class). Cost is **input-token-bound** (06-13 baseline: 1.24M prompt vs 26K completion → $4.25; 06-12 deltas ~$9.5–9.7) plus 328–348 live-search sources/run. The cost-control plumbing (`extra_body.models`+`route:fallback`) already existed but only fired on the empty-retry path.

## Changes
1. **Cost controls on the primary request** (`digillm/client.py`): `_with_openrouter_fallback` → `_with_openrouter_cost_controls`, applied to every OpenRouter call:
   - `models:[cheap allowlist]` + `route:"fallback"` (auto-fallback among cheap models),
   - `provider.sort` (price-sorted endpoints),
   - `provider.max_price` ceiling — **excludes flagships by price, not by name**.
   - Opt-in via env; deep-merges with existing `extra_body` (preserves the xAI search branch).
2. **Trustworthy cost telemetry** (`usage.py` + `diagnostics.py`): record the model OpenRouter **actually served** (`r.model`, not the `auto` request string) and `cached_tokens` (prompt-cache hits); surface per-kind detail + cached totals in the breakdown JSONB (no migration).
3. **Live-search cap**: `max_search_results` 8→4 (news) and 16→8 (ai-portfolios).
4. **Workflow env** (`atlas-baseline` + `atlas-delta`): cheap default allowlist (`deepseek-v4-flash` / `gemini-3.1-flash-lite` / `grok-build-0.1`) + `max_price` $1.5/$4 + `sort:price` — all tunable, slugs/prices verified against the OpenRouter API.

## Projected cost
~**$0.15–0.45/day** (the model swap alone clears <$1; caching + search cap add margin). Verify post-merge via `usage.snapshot()`: `models` no longer contains a flagship and est cost ≤ $1.

## Deferred (deliberate)
The `_node_factory._shared_context` per-segment trim — a risky hot-path change that's **not needed** to hit <$1 (prompt caching on the cheap providers already addresses the repeated prefix, now visible via `cached_tokens`). Filed as a fast-follow.

## Verification
digillm cost-control tests (allowlist + ceiling + merge + primary/retry), usage `cached_tokens` aggregation — 45 digillm + 15 usage/diagnostics pass; ruff clean; `make score` 10/10. No live run (cost-gated).

Fixes #774.