### PR TITLE
feat(atlas): ETF flow proxy data tool — close the last Pillar 1D gap (Part of #726)

### DIFF
--- a/digiquant/src/digiquant/data/prices/etf_flows.py
+++ b/digiquant/src/digiquant/data/prices/etf_flows.py
@@ -1,0 +1,99 @@
+"""ETF flow proxy from price/volume (Pillar 1D).
+
+True ETF creation/redemption flow data is a paid feed. This derives a FREE proxy from the
+``price_history`` volume already stored: a **dollar-volume z-score** (is today's turnover
+unusually heavy vs its recent norm?) and an **OBV trend** (is volume accumulating on up-days
+or distributing on down-days?). It is explicitly a PROXY — a turnover/participation hint, not
+real fund flows — and is labelled as such so the analysts never overstate it.
+
+``compute_etf_flows_proxy`` is pure (frame in, dict out) so it unit-tests with a tiny fixture
+and no Supabase fake. The reader that fetches the window lives in
+``olympus/atlas/data/queries.py``. Polars only.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any  # noqa  # scored-lint suppression: heterogeneous signal-dict values
+
+import polars as pl
+
+_PROXY_NOTE = "volume-derived proxy (turnover/OBV), NOT true ETF creations/redemptions"
+
+
+def _ticker_signal(frame: pl.DataFrame) -> dict[str, Any] | None:
+    """Per-ticker proxy from a date-sorted close/volume window. ``None`` if too few rows."""
+    if frame.height < 2:
+        return None
+    dollar_vol = (frame["close"] * frame["volume"]).cast(pl.Float64)
+    latest = float(dollar_vol[-1])
+    mean = float(dollar_vol.mean())
+    std = float(dollar_vol.std() or 0.0)  # population/sample std; 0 when all equal
+    dv_z = round((latest - mean) / std, 2) if std > 0 else None
+
+    # OBV trend: sum of volume signed by the day's close direction over the window. Positive =
+    # accumulation (volume concentrated on up-days), negative = distribution.
+    direction = frame["close"].diff().sign()  # first row -> null
+    signed = (direction * frame["volume"]).cast(pl.Float64)
+    net = float(signed.sum() or 0.0)
+    obv_trend = "accumulation" if net > 0 else "distribution" if net < 0 else "flat"
+
+    return {
+        "dollar_volume_z": dv_z,
+        "obv_trend": obv_trend,
+        "avg_dollar_volume": round(mean, 2),
+    }
+
+
+def compute_etf_flows_proxy(price_window: pl.DataFrame, *, as_of: date) -> dict[str, Any]:
+    """Volume-derived flow proxy per ticker from a ``price_history`` window.
+
+    Args:
+        price_window: long frame with ``ticker``, ``date``, ``close``, ``volume`` — a trailing
+            window per ticker (newest row is "today").
+        as_of: run date (``as_of`` stamp + a ``<= as_of`` guard).
+
+    Returns:
+        ``{"as_of", "note", "universe_size", "flows": {ticker: {dollar_volume_z, obv_trend,
+        avg_dollar_volume}}}``. ``universe_size`` is 0 (and ``flows`` empty) when there isn't
+        enough data. ``note`` makes the proxy nature explicit for downstream prompts.
+    """
+    empty = {"as_of": as_of.isoformat(), "note": _PROXY_NOTE, "universe_size": 0, "flows": {}}
+    if price_window.is_empty():
+        return empty
+
+    if price_window.schema.get("date") == pl.Utf8:
+        price_window = price_window.with_columns(pl.col("date").str.to_date())
+
+    df = (
+        price_window.select(
+            pl.col("ticker").cast(pl.Utf8),
+            pl.col("date").cast(pl.Date),
+            pl.col("close").cast(pl.Float64),
+            pl.col("volume").cast(pl.Float64),
+        )
+        .filter(
+            (pl.col("date") <= as_of)
+            & pl.col("close").is_not_null()
+            & pl.col("volume").is_not_null()
+        )
+        .sort(["ticker", "date"])
+    )
+    if df.is_empty():
+        return empty
+
+    flows: dict[str, dict[str, Any]] = {}
+    for (ticker,), sub in df.group_by(["ticker"], maintain_order=True):
+        signal = _ticker_signal(sub)
+        if signal is not None:
+            flows[str(ticker)] = signal
+
+    return {
+        "as_of": as_of.isoformat(),
+        "note": _PROXY_NOTE,
+        "universe_size": len(flows),
+        "flows": flows,
+    }
+
+
+__all__ = ["compute_etf_flows_proxy"]

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -272,7 +272,8 @@ def get_etf_flows_proxy(
     True fund-flow data is paid; this derives a free turnover/accumulation proxy from
     ``price_history`` close+volume already stored, and delegates the math to
     :func:`compute_etf_flows_proxy`. Defaults to the configured sector ETFs; paginates the
-    window. Returns ``{}`` when the universe is empty.
+    window. Returns ``{}`` when the ETF universe is empty or ``price_history`` has no rows for
+    the window (the compute itself returns the empty-but-stamped proxy shape).
     """
     universe = list(etfs) if etfs else default_sector_etfs()
     if not universe:

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -14,6 +14,7 @@ from typing import Any  # noqa  # scored-lint suppression: duck-typed Supabase c
 import polars as pl
 
 from digiquant.data.prices.breadth import compute_breadth
+from digiquant.data.prices.etf_flows import compute_etf_flows_proxy
 from digiquant.data.prices.relative_strength import compute_relative_strength
 
 logger = logging.getLogger(__name__)
@@ -256,6 +257,48 @@ def get_vix_term_structure(*, client: Any, run_date: date) -> dict[str, Any]:
         "ratio": round(spot_f / three_m_f, 3) if three_m_f else None,
         "state": "backwardation" if spot_f > three_m_f else "contango",
     }
+
+
+def get_etf_flows_proxy(
+    *,
+    client: Any,
+    run_date: date,
+    etfs: list[str] | tuple[str, ...] | None = None,
+    lookback_days: int = 63,
+    page_size: int = 1000,
+) -> dict[str, Any]:
+    """Volume-derived ETF flow PROXY (dollar-volume z-score + OBV trend) per sector ETF.
+
+    True fund-flow data is paid; this derives a free turnover/accumulation proxy from
+    ``price_history`` close+volume already stored, and delegates the math to
+    :func:`compute_etf_flows_proxy`. Defaults to the configured sector ETFs; paginates the
+    window. Returns ``{}`` when the universe is empty.
+    """
+    universe = list(etfs) if etfs else default_sector_etfs()
+    if not universe:
+        return {}
+    since = (run_date - timedelta(days=lookback_days)).isoformat()
+    rows: list[dict[str, Any]] = []
+    start = 0
+    while True:
+        resp = (
+            client.table("price_history")
+            .select("date,ticker,close,volume")
+            .in_("ticker", universe)
+            .gte("date", since)
+            .lte("date", run_date.isoformat())
+            .order("date", desc=False)
+            .range(start, start + page_size - 1)
+            .execute()
+        )
+        batch = getattr(resp, "data", None) or []
+        rows.extend(batch)
+        if len(batch) < page_size:
+            break
+        start += page_size
+    if not rows:
+        return {}
+    return compute_etf_flows_proxy(pl.DataFrame(rows), as_of=run_date)
 
 
 # ── Generic scoped data reader (Pillar 1D) ───────────────────────────────────

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -13,6 +13,7 @@ from typing import Any, Callable  # noqa  # scored-lint suppression: duck-typed 
 
 from digiquant.olympus.atlas.data.queries import (
     get_macro_series,
+    get_etf_flows_proxy,
     get_market_breadth,
     get_sector_relative_strength,
     get_vix_term_structure,
@@ -119,6 +120,19 @@ DATA_TOOLS: list[dict[str, Any]] = [
             "parameters": {"type": "object", "properties": {}},
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_etf_flows_proxy",
+            "description": (
+                "Per-sector-ETF volume PROXY for flows: a dollar-volume z-score (unusual "
+                "turnover today vs its norm) and an OBV trend (accumulation vs distribution). "
+                "This is a free volume-derived proxy, NOT true creations/redemptions — use it "
+                "as a participation/turnover hint, and do not overstate it as fund flows."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
 ]
 
 
@@ -177,6 +191,8 @@ def build_data_tool_dispatcher(
                 result = get_sector_relative_strength(client=client, run_date=as_of)
             elif name == "get_vix_term_structure":
                 result = get_vix_term_structure(client=client, run_date=as_of)
+            elif name == "get_etf_flows_proxy":
+                result = get_etf_flows_proxy(client=client, run_date=as_of)
             else:
                 return f"Error: unknown tool {name!r}"
             return json.dumps(result, default=str)

--- a/tests/dq/atlas/data/test_tools.py
+++ b/tests/dq/atlas/data/test_tools.py
@@ -20,6 +20,7 @@ def test_tool_definitions_shape():
         "get_market_breadth",
         "get_sector_relative_strength",
         "get_vix_term_structure",
+        "get_etf_flows_proxy",
     }
     for t in DATA_TOOLS:
         assert t["type"] == "function"

--- a/tests/dq/data/test_etf_flows.py
+++ b/tests/dq/data/test_etf_flows.py
@@ -1,0 +1,59 @@
+"""Tests for the ETF flow-proxy compute (Pillar 1D)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from digiquant.data.prices.etf_flows import compute_etf_flows_proxy
+
+
+def _rows() -> list[dict]:
+    # XLK: steady ~1M dollar-volume then a big spike on the last day (high z-score), and an
+    # uptrend (accumulation). XLE: flat price (no direction) with steady volume → flat OBV.
+    return [
+        {"ticker": "XLK", "date": "2026-06-10", "close": 100.0, "volume": 10_000},
+        {"ticker": "XLK", "date": "2026-06-11", "close": 101.0, "volume": 10_000},
+        {"ticker": "XLK", "date": "2026-06-12", "close": 102.0, "volume": 10_000},
+        {"ticker": "XLK", "date": "2026-06-15", "close": 104.0, "volume": 60_000},  # turnover spike
+        {"ticker": "XLE", "date": "2026-06-10", "close": 90.0, "volume": 5_000},
+        {"ticker": "XLE", "date": "2026-06-11", "close": 90.0, "volume": 5_000},
+        {"ticker": "XLE", "date": "2026-06-12", "close": 90.0, "volume": 5_000},
+        {"ticker": "XLE", "date": "2026-06-15", "close": 90.0, "volume": 5_000},
+    ]
+
+
+@pytest.mark.unit
+class TestComputeEtfFlowsProxy:
+    def test_turnover_spike_and_accumulation(self) -> None:
+        out = compute_etf_flows_proxy(pl.DataFrame(_rows()), as_of=date(2026, 6, 15))
+        assert out["universe_size"] == 2
+        assert "proxy" in out["note"].lower()  # proxy nature is explicit for the prompt
+        xlk = out["flows"]["XLK"]
+        assert xlk["dollar_volume_z"] > 1.0  # the last-day turnover spike stands out
+        assert xlk["obv_trend"] == "accumulation"  # rising closes on rising volume
+        # Flat price → no directional volume → flat OBV; even turnover is steady → z≈0/None.
+        assert out["flows"]["XLE"]["obv_trend"] == "flat"
+
+    def test_respects_as_of_cutoff(self) -> None:
+        # As of 06-12 the XLK spike (06-15) is excluded → steady turnover, no big z-score.
+        out = compute_etf_flows_proxy(pl.DataFrame(_rows()), as_of=date(2026, 6, 12))
+        assert out["universe_size"] == 2
+        assert out["flows"]["XLK"]["obv_trend"] == "accumulation"
+
+    def test_single_row_ticker_dropped(self) -> None:
+        rows = [{"ticker": "ONE", "date": "2026-06-15", "close": 10.0, "volume": 100}]
+        out = compute_etf_flows_proxy(pl.DataFrame(rows), as_of=date(2026, 6, 15))
+        assert out["universe_size"] == 0  # need >= 2 rows for a signal
+
+    def test_empty_frame(self) -> None:
+        out = compute_etf_flows_proxy(pl.DataFrame(), as_of=date(2026, 6, 15))
+        assert out["universe_size"] == 0
+        assert out["flows"] == {}
+
+    def test_accepts_real_date_dtype(self) -> None:
+        frame = pl.DataFrame(_rows()).with_columns(pl.col("date").str.to_date())
+        out = compute_etf_flows_proxy(frame, as_of=date(2026, 6, 15))
+        assert out["flows"]["XLK"]["obv_trend"] == "accumulation"


### PR DESCRIPTION
## What
Closes the one unwired Pillar 1D analyst signal. The plan listed four derived signals — breadth, relative strength, VIX term structure, **and an ETF-flows free proxy**. The first three shipped; this adds the fourth.

## Why a proxy
True ETF creation/redemption flow data is a paid feed. This derives a **free** proxy from `price_history` volume already stored:
- **dollar-volume z-score** — is today's turnover unusually heavy vs its recent norm?
- **OBV trend** — is volume accumulating on up-days or distributing on down-days?

It's explicitly labelled a proxy (NOT real fund flows) in both the result `note` and the tool description, so analysts treat it as a turnover/participation hint and don't overstate it.

## Shape (mirrors breadth/RS exactly)
- `data/prices/etf_flows.py` — pure Polars `compute_etf_flows_proxy(frame, *, as_of)`.
- `queries.get_etf_flows_proxy` — paginated `price_history` reader over the sector-ETF universe → delegates to the pure compute.
- `data/tools.py` — registered as the `get_etf_flows_proxy` data tool (spec + dispatch) alongside breadth/RS/VIX, so the research agents call it on demand.

## Tests
5 compute cases (turnover spike → high z + accumulation, flat price → flat OBV, as-of cutoff, single-row drop, real-date dtype) + tool-surface test updated. 8 new/updated pass; 111 data tests green; ruff clean; `make score` 10/10. No live run (free, pure compute).

Part of #726 — this was the last remaining *code* item in the 3-pillar plan; everything else now is the human-gated activation (migrations + crons #771 + flag + one baseline).