### PR TITLE
fix(cost,atlas): address 8 code-review findings on #775/#776 (Part of #726)

### DIFF
--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -37,6 +37,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -351,7 +352,12 @@ def _llm_cache_key(
     response_format: JsonSchemaResponseFormat | None,
     max_tokens: int | None,
 ) -> str:
-    """Return a stable SHA-256 cache key for the given completion parameters."""
+    """Return a stable SHA-256 cache key for the given completion parameters.
+
+    The OpenRouter cost-control env (allowlist + sort + price ceiling) is folded in: it changes
+    which model actually serves the request, so a response cached under one routing regime must
+    not be returned after those settings change.
+    """
     payload = json.dumps(
         {
             "model": model,
@@ -359,6 +365,12 @@ def _llm_cache_key(
             "temperature": temperature,
             "response_format": response_format,
             "max_tokens": max_tokens,
+            "cost_controls": [
+                os.environ.get("OPENROUTER_FALLBACK_MODELS", ""),
+                os.environ.get("OPENROUTER_SORT", ""),
+                os.environ.get("OPENROUTER_MAX_PROMPT_PRICE", ""),
+                os.environ.get("OPENROUTER_MAX_COMPLETION_PRICE", ""),
+            ],
         },
         sort_keys=True,
     )
@@ -518,6 +530,9 @@ def _create_with_retry(client: OpenAI, **kwargs: Any) -> Any:
 _EMPTY_RETRY_MAX = int(os.environ.get("DIGILLM_EMPTY_RETRY_MAX", "2") or 2)
 _EMPTY_RETRY_DELAY = float(os.environ.get("DIGILLM_EMPTY_RETRY_DELAY", "2.0") or 2.0)
 
+# Valid OpenRouter provider.sort values; an unknown value 400s (not transient), so we drop it.
+_OPENROUTER_SORTS = ("price", "throughput", "latency")
+
 
 def _is_empty_completion(resp: Any) -> bool:
     """A completion with no usable output: no choices, or blank content AND no tool_calls."""
@@ -548,7 +563,14 @@ def _openrouter_provider_prefs() -> dict[str, Any]:
     prefs: dict[str, Any] = {}
     sort = os.environ.get("OPENROUTER_SORT", "").strip()
     if sort:
-        prefs["sort"] = sort
+        # OpenRouter accepts a fixed sort enum; an invalid value would 400 (not a transient/410
+        # error, so it would crash the call). Drop an unknown value with a warning instead.
+        if sort in _OPENROUTER_SORTS:
+            prefs["sort"] = sort
+        else:
+            logger.warning(
+                "ignoring invalid OPENROUTER_SORT=%r (allowed: %s)", sort, _OPENROUTER_SORTS
+            )
     max_price: dict[str, float] = {}
     for key, env_name in (
         ("prompt", "OPENROUTER_MAX_PROMPT_PRICE"),
@@ -558,9 +580,15 @@ def _openrouter_provider_prefs() -> dict[str, Any]:
         if not raw:
             continue
         try:
-            max_price[key] = float(raw)
+            value = float(raw)
         except ValueError:
             logger.warning("ignoring non-numeric %s=%r", env_name, raw)
+            continue
+        # float() also accepts 'inf'/'nan'/negatives; a price ceiling must be finite and > 0.
+        if not math.isfinite(value) or value <= 0:
+            logger.warning("ignoring out-of-range %s=%r (need a finite price > 0)", env_name, raw)
+            continue
+        max_price[key] = value
     if max_price:
         prefs["max_price"] = max_price
     return prefs

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -222,6 +222,23 @@ def test_openrouter_provider_prefs_ignores_non_numeric_ceiling(
     assert client_mod._openrouter_provider_prefs() == {}
 
 
+def test_openrouter_provider_prefs_drops_invalid_sort(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An invalid sort would 400 (not transient) and crash the call — drop it instead of sending.
+    monkeypatch.setenv("OPENROUTER_SORT", "cheapest")  # not in the OpenRouter enum
+    assert client_mod._openrouter_provider_prefs() == {}
+    monkeypatch.setenv("OPENROUTER_SORT", "throughput")  # a valid value passes through
+    assert client_mod._openrouter_provider_prefs() == {"sort": "throughput"}
+
+
+def test_openrouter_provider_prefs_drops_nonpositive_or_nonfinite_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # float() accepts these, but a price ceiling must be finite and > 0.
+    for bad in ("0", "-1", "inf", "nan"):
+        monkeypatch.setenv("OPENROUTER_MAX_PROMPT_PRICE", bad)
+        assert client_mod._openrouter_provider_prefs() == {}, bad
+
+
 def test_cost_controls_combine_allowlist_and_price_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "a/x,b/y")
     monkeypatch.setenv("OPENROUTER_SORT", "price")

--- a/digiquant/src/digiquant/data/prices/etf_flows.py
+++ b/digiquant/src/digiquant/data/prices/etf_flows.py
@@ -13,12 +13,18 @@ and no Supabase fake. The reader that fetches the window lives in
 
 from __future__ import annotations
 
+import math
 from datetime import date
 from typing import Any  # noqa  # scored-lint suppression: heterogeneous signal-dict values
 
 import polars as pl
 
 _PROXY_NOTE = "volume-derived proxy (turnover/OBV), NOT true ETF creations/redemptions"
+_REQUIRED_COLUMNS = ("ticker", "date", "close", "volume")
+
+
+def _finite(x: float) -> bool:
+    return isinstance(x, float) and math.isfinite(x)
 
 
 def _ticker_signal(frame: pl.DataFrame) -> dict[str, Any] | None:
@@ -27,21 +33,37 @@ def _ticker_signal(frame: pl.DataFrame) -> dict[str, Any] | None:
         return None
     dollar_vol = (frame["close"] * frame["volume"]).cast(pl.Float64)
     latest = float(dollar_vol[-1])
-    mean = float(dollar_vol.mean())
-    std = float(dollar_vol.std() or 0.0)  # population/sample std; 0 when all equal
-    dv_z = round((latest - mean) / std, 2) if std > 0 else None
+
+    # Score the latest day against a LEAVE-ONE-OUT baseline (the prior rows only). Including
+    # today in its own mean/std lets a spike inflate its own baseline and self-damp — and on a
+    # short window the in-sample z is pinned near (n-1)/sqrt(n) regardless of spike size. A
+    # sample std needs >= 2 baseline points, so dv_z is None for a 2-row window. Non-finite
+    # inputs (inf/NaN close*volume) also yield None rather than a silent NaN.
+    baseline = dollar_vol.head(frame.height - 1)
+    base_mean = float(baseline.mean()) if baseline.len() else float("nan")
+    base_std = float(baseline.std()) if baseline.len() >= 2 else float("nan")
+    dv_z = (
+        round((latest - base_mean) / base_std, 2)
+        if _finite(latest) and _finite(base_mean) and _finite(base_std) and base_std > 0
+        else None
+    )
 
     # OBV trend: sum of volume signed by the day's close direction over the window. Positive =
     # accumulation (volume concentrated on up-days), negative = distribution.
     direction = frame["close"].diff().sign()  # first row -> null
     signed = (direction * frame["volume"]).cast(pl.Float64)
     net = float(signed.sum() or 0.0)
-    obv_trend = "accumulation" if net > 0 else "distribution" if net < 0 else "flat"
+    obv_trend = (
+        ("accumulation" if net > 0 else "distribution" if net < 0 else "flat")
+        if _finite(net)
+        else "flat"
+    )
 
+    avg = float(dollar_vol.mean())
     return {
         "dollar_volume_z": dv_z,
         "obv_trend": obv_trend,
-        "avg_dollar_volume": round(mean, 2),
+        "avg_dollar_volume": round(avg, 2) if _finite(avg) else None,
     }
 
 
@@ -59,7 +81,9 @@ def compute_etf_flows_proxy(price_window: pl.DataFrame, *, as_of: date) -> dict[
         enough data. ``note`` makes the proxy nature explicit for downstream prompts.
     """
     empty = {"as_of": as_of.isoformat(), "note": _PROXY_NOTE, "universe_size": 0, "flows": {}}
-    if price_window.is_empty():
+    # Total function: a non-empty frame missing a required column returns the empty shape rather
+    # than raising ColumnNotFoundError from the select/cast below.
+    if price_window.is_empty() or not set(_REQUIRED_COLUMNS).issubset(price_window.columns):
         return empty
 
     if price_window.schema.get("date") == pl.Utf8:

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -272,12 +272,15 @@ def get_etf_flows_proxy(
     True fund-flow data is paid; this derives a free turnover/accumulation proxy from
     ``price_history`` close+volume already stored, and delegates the math to
     :func:`compute_etf_flows_proxy`. Defaults to the configured sector ETFs; paginates the
-    window. Returns ``{}`` when the ETF universe is empty or ``price_history`` has no rows for
-    the window (the compute itself returns the empty-but-stamped proxy shape).
+    window. Always returns the stamped proxy shape (``as_of``/``note``/``universe_size``/
+    ``flows``) — empty-but-stamped when the universe is empty or ``price_history`` has no rows —
+    so callers see one consistent shape with the proxy caveat intact.
     """
     universe = list(etfs) if etfs else default_sector_etfs()
     if not universe:
-        return {}
+        # Stamped empty shape (with the proxy note), not a bare {} — keeps the JSON shape and
+        # the "NOT true flows" caveat consistent on the degraded path.
+        return compute_etf_flows_proxy(pl.DataFrame(), as_of=run_date)
     since = (run_date - timedelta(days=lookback_days)).isoformat()
     rows: list[dict[str, Any]] = []
     start = 0
@@ -297,8 +300,8 @@ def get_etf_flows_proxy(
         if len(batch) < page_size:
             break
         start += page_size
-    if not rows:
-        return {}
+    # compute_etf_flows_proxy returns the stamped empty shape for an empty frame, so both the
+    # no-rows and rows-exist paths share one consistent JSON shape (+ the proxy note).
     return compute_etf_flows_proxy(pl.DataFrame(rows), as_of=run_date)
 
 

--- a/digiquant/src/digiquant/olympus/atlas/diagnostics.py
+++ b/digiquant/src/digiquant/olympus/atlas/diagnostics.py
@@ -175,10 +175,12 @@ def _row(
     # prompt-cache-hit portion billed at the cheaper rate.
     if usage.get("by_kind"):
         breakdown["by_kind"] = usage["by_kind"]
-    if usage.get("cached_tokens"):
+    if usage.get("cached_tokens") is not None:  # include an explicit 0 (distinct from absent)
         breakdown["cached_tokens"] = usage["cached_tokens"]
-    # Fall back to the model(s) the usage observer actually saw when none was passed in.
-    resolved_model = model or (",".join(map(str, models)) if models else None)
+    # Keep the `model` column a single stable slug for GROUP BY (the full per-run set lives in
+    # breakdown["models"]). When the router serves several models we record the first; callers
+    # wanting the complete list read the breakdown.
+    resolved_model = model or (models[0] if models else None)
     return {
         "run_id": run_id,
         "run_type": run_type,

--- a/tests/dq/data/test_etf_flows.py
+++ b/tests/dq/data/test_etf_flows.py
@@ -57,3 +57,41 @@ class TestComputeEtfFlowsProxy:
         frame = pl.DataFrame(_rows()).with_columns(pl.col("date").str.to_date())
         out = compute_etf_flows_proxy(frame, as_of=date(2026, 6, 15))
         assert out["flows"]["XLK"]["obv_trend"] == "accumulation"
+
+    def test_zscore_uses_leave_one_out_baseline(self) -> None:
+        # The spike must NOT contaminate its own baseline: scored against the 3 prior steady
+        # days, the 6x last-day turnover is a large z (not damped toward a small in-sample cap).
+        z = compute_etf_flows_proxy(pl.DataFrame(_rows()), as_of=date(2026, 6, 15))["flows"]["XLK"][
+            "dollar_volume_z"
+        ]
+        assert z is not None and z > 5.0  # in-sample would have pinned it near ~1.3
+
+    def test_two_row_window_has_no_zscore(self) -> None:
+        # A 2-row window leaves only ONE baseline point → no sample std → z is None (not a
+        # spurious constant). OBV trend still computes.
+        rows = [
+            {"ticker": "AA", "date": "2026-06-12", "close": 10.0, "volume": 100},
+            {"ticker": "AA", "date": "2026-06-15", "close": 11.0, "volume": 5_000},
+        ]
+        sig = compute_etf_flows_proxy(pl.DataFrame(rows), as_of=date(2026, 6, 15))["flows"]["AA"]
+        assert sig["dollar_volume_z"] is None
+        assert sig["obv_trend"] == "accumulation"
+
+    def test_non_finite_values_yield_none_not_nan(self) -> None:
+        # An inf close*volume must not silently produce a NaN z / inf avg.
+        rows = [
+            {"ticker": "BB", "date": "2026-06-11", "close": 1.0, "volume": 100.0},
+            {"ticker": "BB", "date": "2026-06-12", "close": float("inf"), "volume": 100.0},
+            {"ticker": "BB", "date": "2026-06-15", "close": 3.0, "volume": 100.0},
+        ]
+        sig = compute_etf_flows_proxy(pl.DataFrame(rows), as_of=date(2026, 6, 15))["flows"]["BB"]
+        assert sig["dollar_volume_z"] is None
+        assert sig["avg_dollar_volume"] is None
+
+    def test_missing_required_column_returns_empty_not_crash(self) -> None:
+        # A non-empty frame missing `volume` returns the stamped empty shape, not a crash.
+        rows = [{"ticker": "CC", "date": "2026-06-15", "close": 10.0}]
+        out = compute_etf_flows_proxy(pl.DataFrame(rows), as_of=date(2026, 6, 15))
+        assert out["universe_size"] == 0
+        assert out["flows"] == {}
+        assert "proxy" in out["note"].lower()


### PR DESCRIPTION
Fixes from an extra-high-recall code review of the cost-routing (#775) + ETF-flows (#776) changes — 8 CONFIRMED bugs (the 7 PLAUSIBLE findings were either correct-as-is, matched existing patterns, or near-zero impact; the cache-key one is folded in here too).

### etf_flows.py (the new proxy)
- **Z-score self-contamination** → leave-one-out baseline. Including the scored day let a turnover spike inflate its own mean/std and self-damp; on short windows the in-sample z was pinned near a constant. Now scored against prior rows only; a 2-row window yields `z=None` (no sample std).
- **Non-finite guard** → an `inf`/`NaN` close×volume now yields `z=None` / `avg=None`, not a silent NaN slipping into the signal.
- **Missing-column crash** → a non-empty frame missing `date`/`close`/`volume` returns the stamped empty shape (total function), not `ColumnNotFoundError`.

### queries.get_etf_flows_proxy
- Empty-universe / no-rows paths now return the **stamped** proxy shape (with the "NOT true flows" caveat), not a bare `{}` — one consistent JSON shape exactly on the degraded path where the caveat matters.

### digillm/client.py (cost controls)
- **`OPENROUTER_SORT` validated** against the provider enum — an invalid value 400s (not a transient/410 error) and would crash the whole run; now dropped with a warning.
- **`max_price` must be finite & > 0** — `float()` silently accepts `-1`/`0`/`inf`/`nan`; now rejected.
- **Cache key folds in the cost-control env** — a response cached under one routing/price regime is no longer returned after those settings change.

### diagnostics.py
- The `model` column is a single representative slug (full per-run set stays in `breakdown.models`) so dashboards can still GROUP BY model; `cached_tokens` uses an is-not-None guard so a zero-cache run records `0` consistently.

### Tests
New: leave-one-out, 2-row no-z, non-finite, missing-column; sort-enum + price out-of-range validation. 48 digillm + 9 etf_flows + usage/diagnostics/tools pass; ruff clean; `make score` 10/10. No live run.

Part of #726.