### PR TITLE
feat(atlas): Fed rate-decision probabilities data tool (PR1, Part of #778)

### DIFF
--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -288,8 +288,9 @@ def compute_technicals_cmd(
     type=str,
     default="fred,yahoo",
     help=(
-        "Comma-separated subset of {fred,yahoo,frankfurter,fng}. "
-        "Default = fred,yahoo. frankfurter and fng are legacy opt-ins."
+        "Comma-separated subset of {fred,yahoo,frankfurter,fng,fedprob}. "
+        "Default = fred,yahoo. frankfurter and fng are legacy opt-ins; fedprob ingests free "
+        "prediction-market Fed rate-decision odds (Kalshi + Polymarket)."
     ),
 )
 @click.option(
@@ -354,6 +355,15 @@ def fetch_macro_cmd(
         tasks["frankfurter"] = lambda: fetch_frankfurter(mani, start=fr_start)
     if "fng" in sources_set:
         tasks["fng"] = lambda: fetch_crypto_fng(mani, backfill=backfill)
+    if "fedprob" in sources_set:
+        # Free prediction-market Fed rate-decision odds (Kalshi + Polymarket); daily snapshot,
+        # fail-soft per source. No backfill (point-in-time odds). See fed_probabilities.py.
+        from digiquant.data.prices.fed_probabilities import (
+            fetch_fed_prob_kalshi,
+            fetch_fed_prob_polymarket,
+        )
+
+        tasks["fedprob"] = lambda: [*fetch_fed_prob_kalshi(), *fetch_fed_prob_polymarket()]
 
     all_rows: list[dict] = []
     if tasks:

--- a/digiquant/src/digiquant/data/prices/fed_probabilities.py
+++ b/digiquant/src/digiquant/data/prices/fed_probabilities.py
@@ -22,12 +22,13 @@ HTTP-free for unit testing; the ``fetch_*`` wrappers add the network + fail-soft
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from datetime import date, datetime, timezone
 from typing import Any  # noqa  # scored-lint: heterogeneous prediction-market JSON
 
-from digiquant.data.prices.macro_ingest import MacroObservation, _retrying_session
+from digiquant.data.prices.macro_ingest import MacroObservation, retrying_session
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,7 @@ def kalshi_markets_to_rows(markets: list[dict[str, Any]], *, as_of: date) -> lis
                 "obs_date": as_of.isoformat(),
                 "value": prob,
                 "unit": _UNIT,
-                "meta": {  # type: ignore[typeddict-item]
+                "meta": {
                     "classification": "fed_rate_probability",
                     "event_ticker": str(m.get("event_ticker") or ""),
                     "strike": strike_f,
@@ -114,7 +115,7 @@ def fetch_fed_prob_kalshi(
 ) -> list[MacroObservation]:
     """Fetch open ``KXFED`` markets (paginated, no auth) → survival-ladder rows. Fail-soft to []."""
     as_of = as_of or datetime.now(timezone.utc).date()
-    s = session if session is not None else _retrying_session()
+    s = session if session is not None else retrying_session()
     markets: list[dict[str, Any]] = []
     cursor = ""
     try:
@@ -143,6 +144,17 @@ def fetch_fed_prob_kalshi(
 
 
 # ── Polymarket (best-effort cross-check) ────────────────────────────────────
+
+
+def _pm_series_id(anchor: str, slug: str) -> str:
+    """Collision-safe Polymarket series_id. ``series_id`` is part of the (source, series_id,
+    obs_date) PK, so we never blind-truncate (two long slugs could collide and overwrite); when
+    over the cap we keep a readable prefix + a short hash of the FULL slug for uniqueness."""
+    full = f"FEDPROB/{anchor}/pm/{slug}"
+    if len(full) <= 200:
+        return full
+    digest = hashlib.sha1(slug.encode("utf-8")).hexdigest()[:12]
+    return f"FEDPROB/{anchor}/pm/{slug[:160]}-{digest}"
 
 
 def _json_list(value: Any) -> list[Any]:
@@ -188,11 +200,11 @@ def polymarket_events_to_rows(
             rows.append(
                 {
                     "source": "polymarket",
-                    "series_id": f"FEDPROB/{anchor}/pm/{slug}"[:240],
+                    "series_id": _pm_series_id(anchor, slug),
                     "obs_date": as_of.isoformat(),
                     "value": round(yes_prob, 4),
                     "unit": _UNIT,
-                    "meta": {  # type: ignore[typeddict-item]
+                    "meta": {
                         "classification": "fed_rate_probability",
                         "question": str(m.get("question") or ""),
                         "group_item_threshold": str(m.get("groupItemThreshold") or ""),
@@ -207,7 +219,7 @@ def fetch_fed_prob_polymarket(
 ) -> list[MacroObservation]:
     """Fetch open Polymarket ``fed-rates`` events → outcome rows. Best-effort, fail-soft to []."""
     as_of = as_of or datetime.now(timezone.utc).date()
-    s = session if session is not None else _retrying_session()
+    s = session if session is not None else retrying_session()
     try:
         r = s.get(
             _POLYMARKET_EVENTS_URL,

--- a/digiquant/src/digiquant/data/prices/fed_probabilities.py
+++ b/digiquant/src/digiquant/data/prices/fed_probabilities.py
@@ -1,0 +1,263 @@
+"""Fed rate-decision probabilities from FREE prediction markets (Atlas research, #778).
+
+Markets pivot around FOMC decisions, so the analysts + PM need forward-looking hike/cut/hold
+odds. CME FedWatch has no free API (licensed/paid), so we DON'T call it — we read the same
+market-implied signal from prediction markets that publish free, no-auth JSON:
+
+- **Kalshi** (``KXFED`` series, CFTC-regulated) — a per-meeting ladder of "upper bound of the
+  fed funds rate > X%" threshold contracts. Differencing adjacent strikes gives a per-meeting
+  probability distribution over 25bp target-rate levels. This is the structured source of truth.
+- **Polymarket** (Gamma API, no key) — best-effort cross-check; its Fed events are coarser and
+  their structure varies, so we parse defensively and fail soft.
+
+Each fetcher returns ``macro_series_observations`` rows (the existing macro-ingest contract) so
+the data flows through the same upsert + look-ahead-safe read path as every other macro series:
+
+    series_id = "FEDPROB/{meeting_date}/upper_gt_{strike}"   # Kalshi survival ladder, value=P(>strike)
+    series_id = "FEDPROB/{meeting_date}/pm/{outcome}"         # Polymarket outcome, value=probability
+
+``obs_date`` is the run date (a point-in-time odds snapshot). The pure ``*_to_rows`` helpers are
+HTTP-free for unit testing; the ``fetch_*`` wrappers add the network + fail-soft to ``[]``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timezone
+from typing import Any  # noqa  # scored-lint: heterogeneous prediction-market JSON
+
+from digiquant.data.prices.macro_ingest import MacroObservation, _retrying_session
+
+logger = logging.getLogger(__name__)
+
+_KALSHI_MARKETS_URL = "https://api.elections.kalshi.com/trade-api/v2/markets"
+_KALSHI_SERIES = "KXFED"
+_POLYMARKET_EVENTS_URL = "https://gamma-api.polymarket.com/events"
+_POLYMARKET_TAG = "fed-rates"
+_USER_AGENT = "digiquant-research/1.0 (+https://digiquant.io)"
+_UNIT = "probability"
+
+
+def _opt_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if 0.0 <= out <= 1.0 else None  # prediction-market prices are in [0, 1]
+
+
+def _meeting_date_from_iso(value: Any) -> str | None:
+    """Date part of an ISO timestamp (Kalshi ``close_time`` ~= the meeting day)."""
+    if not isinstance(value, str) or len(value) < 10:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        return value[:10] if value[:10].count("-") == 2 else None
+
+
+# ── Kalshi (structured per-meeting ladder) ──────────────────────────────────
+
+
+def kalshi_markets_to_rows(markets: list[dict[str, Any]], *, as_of: date) -> list[MacroObservation]:
+    """Turn Kalshi ``KXFED`` threshold markets into survival-ladder observation rows.
+
+    Each market is a "upper bound > ``floor_strike``%" contract; the mid of yes_bid/yes_ask
+    (falling back to last) is ``P(upper bound > strike)``. We store the raw survival ladder per
+    meeting; the derived tool differences it into a distribution at read time.
+    """
+    rows: list[MacroObservation] = []
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        strike = m.get("floor_strike")
+        meeting = _meeting_date_from_iso(m.get("close_time"))
+        if strike is None or meeting is None:
+            continue
+        bid = _opt_float(m.get("yes_bid_dollars"))
+        ask = _opt_float(m.get("yes_ask_dollars"))
+        if bid is not None and ask is not None:
+            prob = round((bid + ask) / 2.0, 4)
+        else:
+            prob = _opt_float(m.get("last_price_dollars"))
+        if prob is None:
+            continue
+        try:
+            strike_f = float(strike)
+        except (TypeError, ValueError):
+            continue
+        rows.append(
+            {
+                "source": "kalshi",
+                "series_id": f"FEDPROB/{meeting}/upper_gt_{strike_f:g}",
+                "obs_date": as_of.isoformat(),
+                "value": prob,
+                "unit": _UNIT,
+                "meta": {  # type: ignore[typeddict-item]
+                    "classification": "fed_rate_probability",
+                    "event_ticker": str(m.get("event_ticker") or ""),
+                    "strike": strike_f,
+                    "strike_type": str(m.get("strike_type") or "greater"),
+                    "yes_bid": bid,
+                    "yes_ask": ask,
+                },
+            }
+        )
+    return rows
+
+
+def fetch_fed_prob_kalshi(
+    *, as_of: date | None = None, session: Any | None = None
+) -> list[MacroObservation]:
+    """Fetch open ``KXFED`` markets (paginated, no auth) → survival-ladder rows. Fail-soft to []."""
+    as_of = as_of or datetime.now(timezone.utc).date()
+    s = session if session is not None else _retrying_session()
+    markets: list[dict[str, Any]] = []
+    cursor = ""
+    try:
+        for _ in range(12):  # hard page cap (12 * 200 = 2400 markets) — never loop forever
+            params: dict[str, Any] = {
+                "series_ticker": _KALSHI_SERIES,
+                "status": "open",
+                "limit": 200,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            r = s.get(
+                _KALSHI_MARKETS_URL, params=params, headers={"User-Agent": _USER_AGENT}, timeout=30
+            )
+            r.raise_for_status()
+            body = r.json()
+            batch = body.get("markets") or []
+            markets.extend(b for b in batch if isinstance(b, dict))
+            cursor = body.get("cursor") or ""
+            if not cursor or not batch:
+                break
+    except Exception as exc:  # noqa: BLE001 — a data-source flake must never break the macro job
+        logger.warning("Kalshi KXFED fetch failed: %s", exc)
+        return []
+    return kalshi_markets_to_rows(markets, as_of=as_of)
+
+
+# ── Polymarket (best-effort cross-check) ────────────────────────────────────
+
+
+def _json_list(value: Any) -> list[Any]:
+    """Polymarket ``outcomes``/``outcomePrices`` arrive as JSON-encoded strings."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, list) else []
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def polymarket_events_to_rows(
+    events: list[dict[str, Any]], *, as_of: date
+) -> list[MacroObservation]:
+    """Best-effort: map Polymarket Fed events' Yes prices to outcome-probability rows.
+
+    Polymarket Fed markets are coarser and their slugs/structure vary per event, so this is a
+    cross-check, not the source of truth. We key rows by the event end-date (a meeting/period
+    anchor) and the market slug, storing the ``Yes`` probability.
+    """
+    rows: list[MacroObservation] = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        anchor = _meeting_date_from_iso(ev.get("endDate")) or as_of.isoformat()
+        for m in ev.get("markets") or []:
+            if not isinstance(m, dict) or m.get("closed"):
+                continue
+            outcomes = [str(o).lower() for o in _json_list(m.get("outcomes"))]
+            prices = _json_list(m.get("outcomePrices"))
+            yes_prob: float | None = None
+            if "yes" in outcomes and len(prices) == len(outcomes):
+                yes_prob = _opt_float(prices[outcomes.index("yes")])
+            if yes_prob is None:
+                yes_prob = _opt_float(m.get("lastTradePrice"))
+            slug = str(m.get("slug") or m.get("question") or "").strip()
+            if yes_prob is None or not slug:
+                continue
+            rows.append(
+                {
+                    "source": "polymarket",
+                    "series_id": f"FEDPROB/{anchor}/pm/{slug}"[:240],
+                    "obs_date": as_of.isoformat(),
+                    "value": round(yes_prob, 4),
+                    "unit": _UNIT,
+                    "meta": {  # type: ignore[typeddict-item]
+                        "classification": "fed_rate_probability",
+                        "question": str(m.get("question") or ""),
+                        "group_item_threshold": str(m.get("groupItemThreshold") or ""),
+                    },
+                }
+            )
+    return rows
+
+
+def fetch_fed_prob_polymarket(
+    *, as_of: date | None = None, session: Any | None = None
+) -> list[MacroObservation]:
+    """Fetch open Polymarket ``fed-rates`` events → outcome rows. Best-effort, fail-soft to []."""
+    as_of = as_of or datetime.now(timezone.utc).date()
+    s = session if session is not None else _retrying_session()
+    try:
+        r = s.get(
+            _POLYMARKET_EVENTS_URL,
+            params={"closed": "false", "tag_slug": _POLYMARKET_TAG, "limit": 30},
+            headers={"User-Agent": _USER_AGENT},
+            timeout=30,
+        )
+        r.raise_for_status()
+        events = r.json()
+        if not isinstance(events, list):
+            return []
+    except Exception as exc:  # noqa: BLE001 — cross-check source; degrade silently
+        logger.warning("Polymarket fed-rates fetch failed: %s", exc)
+        return []
+    return polymarket_events_to_rows(events, as_of=as_of)
+
+
+# ── Derivation: survival ladder → per-meeting 25bp distribution (read side) ──
+
+
+def fed_distribution_from_ladder(ladder: dict[float, float]) -> dict[str, Any]:
+    """Convert a Kalshi survival ladder ``{strike: P(upper bound > strike)}`` into a normalized
+    probability distribution over 25bp fed-funds upper-bound outcomes.
+
+    On a 25bp grid, ``P(upper == s) = surv(prev) - surv(s)`` for interior strikes, with tail
+    buckets ``"<=min"`` and ``">max"``. Negatives (from noisy bid/ask) are clamped to 0 and the
+    result is normalized to sum 1. Returns ``{}`` for fewer than 2 strikes.
+    """
+    strikes = sorted(ladder)
+    if len(strikes) < 2:
+        return {}
+    dist: dict[str, float] = {}
+    lo = strikes[0]
+    dist[f"<={lo:g}"] = max(0.0, 1.0 - ladder[lo])
+    for prev, cur in zip(strikes, strikes[1:], strict=False):
+        dist[f"{cur:g}"] = max(0.0, ladder[prev] - ladder[cur])
+    hi = strikes[-1]
+    dist[f">{hi:g}"] = max(0.0, ladder[hi])
+    total = sum(dist.values())
+    if total <= 0:
+        return {}
+    dist = {k: round(v / total, 4) for k, v in dist.items()}
+    most_likely = max(dist, key=lambda k: dist[k])
+    return {"distribution": dist, "most_likely": most_likely, "n_strikes": len(strikes)}
+
+
+__all__ = [
+    "fed_distribution_from_ladder",
+    "fetch_fed_prob_kalshi",
+    "fetch_fed_prob_polymarket",
+    "kalshi_markets_to_rows",
+    "polymarket_events_to_rows",
+]

--- a/digiquant/src/digiquant/data/prices/macro_ingest.py
+++ b/digiquant/src/digiquant/data/prices/macro_ingest.py
@@ -63,6 +63,14 @@ class MacroObservationMeta(TypedDict, total=False):
     yahoo_symbol: str
     quote_convention: str
     classification: str
+    # Fed rate-probability provenance (#778, fed_probabilities.py).
+    event_ticker: str
+    strike: float
+    strike_type: str
+    yes_bid: float | None
+    yes_ask: float | None
+    question: str
+    group_item_threshold: str
 
 
 class MacroObservation(TypedDict, total=False):
@@ -163,6 +171,11 @@ def _retrying_session(
     s.mount("https://", adapter)
     s.mount("http://", adapter)
     return s
+
+
+# Public, stable alias so other ingest modules (e.g. fed_probabilities) don't depend on the
+# underscored private name.
+retrying_session = _retrying_session
 
 
 # ─── FRED ───────────────────────────────────────────────────────────────────

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -15,6 +15,7 @@ import polars as pl
 
 from digiquant.data.prices.breadth import compute_breadth
 from digiquant.data.prices.etf_flows import compute_etf_flows_proxy
+from digiquant.data.prices.fed_probabilities import fed_distribution_from_ladder
 from digiquant.data.prices.relative_strength import compute_relative_strength
 
 logger = logging.getLogger(__name__)
@@ -303,6 +304,86 @@ def get_etf_flows_proxy(
     # compute_etf_flows_proxy returns the stamped empty shape for an empty frame, so both the
     # no-rows and rows-exist paths share one consistent JSON shape (+ the proxy note).
     return compute_etf_flows_proxy(pl.DataFrame(rows), as_of=run_date)
+
+
+def get_fed_rate_probabilities(
+    *, client: Any, run_date: date, lookback_days: int = 7
+) -> dict[str, Any]:
+    """Forward FOMC rate-decision odds for the NEAREST upcoming meeting, from prediction markets.
+
+    Reads the ``FEDPROB/*`` rows ingested into ``macro_series_observations`` (Kalshi survival
+    ladder + Polymarket cross-check), takes the freshest snapshot ``<= run_date`` (look-ahead
+    safe), picks the nearest meeting on/after ``run_date``, and derives the full 25bp upper-bound
+    distribution from the Kalshi ladder. Returns ``{}`` when no Fed-probability data is present.
+    """
+    since = (run_date - timedelta(days=lookback_days)).isoformat()
+    resp = (
+        client.table("macro_series_observations")
+        .select("source,series_id,obs_date,value,meta")
+        .in_("source", ["kalshi", "polymarket"])
+        .gte("obs_date", since)
+        .lte("obs_date", run_date.isoformat())
+        .order("obs_date", desc=True)
+        .limit(3000)
+        .execute()
+    )
+    rows = [
+        r
+        for r in (getattr(resp, "data", None) or [])
+        if str(r.get("series_id", "")).startswith("FEDPROB/")
+    ]
+    if not rows:
+        return {}
+    latest_obs = max(str(r.get("obs_date") or "") for r in rows)
+    rows = [r for r in rows if str(r.get("obs_date") or "") == latest_obs]
+
+    meetings: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        parts = str(r.get("series_id", "")).split("/")
+        if len(parts) < 3:
+            continue
+        bucket = meetings.setdefault(parts[1], {"ladder": {}, "polymarket": []})
+        value = r.get("value")
+        if value is None:
+            continue
+        if r.get("source") == "kalshi" and parts[2].startswith("upper_gt_"):
+            try:
+                bucket["ladder"][float(parts[2].removeprefix("upper_gt_"))] = float(value)
+            except ValueError:
+                continue
+        elif r.get("source") == "polymarket":
+            bucket["polymarket"].append(
+                {
+                    "outcome": "/".join(parts[2:]),
+                    "prob": float(value),
+                    "question": (r.get("meta") or {}).get("question"),
+                }
+            )
+    if not meetings:
+        return {}
+    # Nearest meeting on/after the run date (else the latest available).
+    future = sorted(mk for mk in meetings if mk >= run_date.isoformat())
+    meeting = future[0] if future else max(meetings)
+    data = meetings[meeting]
+    ladder = data["ladder"]
+    kalshi: dict[str, Any] = {}
+    if ladder:
+        kalshi = {"ladder": {f"{k:g}": v for k, v in sorted(ladder.items())}}
+        kalshi.update(fed_distribution_from_ladder(ladder))
+    sources = [
+        s
+        for s, present in (("kalshi", bool(ladder)), ("polymarket", bool(data["polymarket"])))
+        if present
+    ]
+    if not sources:
+        return {}
+    return {
+        "as_of": run_date.isoformat(),
+        "meeting_date": meeting,
+        "kalshi": kalshi,
+        "polymarket": sorted(data["polymarket"], key=lambda d: -(d["prob"] or 0))[:12],
+        "sources": sources,
+    }
 
 
 # ── Generic scoped data reader (Pillar 1D) ───────────────────────────────────

--- a/digiquant/src/digiquant/olympus/atlas/data/tools.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/tools.py
@@ -14,6 +14,7 @@ from typing import Any, Callable  # noqa  # scored-lint suppression: duck-typed 
 from digiquant.olympus.atlas.data.queries import (
     get_macro_series,
     get_etf_flows_proxy,
+    get_fed_rate_probabilities,
     get_market_breadth,
     get_sector_relative_strength,
     get_vix_term_structure,
@@ -133,6 +134,20 @@ DATA_TOOLS: list[dict[str, Any]] = [
             "parameters": {"type": "object", "properties": {}},
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_fed_rate_probabilities",
+            "description": (
+                "Market-implied FOMC rate-decision odds for the nearest upcoming meeting, from "
+                "prediction markets (Kalshi target-rate ladder as a 25bp probability distribution "
+                "over the fed-funds upper bound, plus a Polymarket cross-check). Use to ground "
+                "monetary-policy / rate-pivot claims; the market actively reprices these and the "
+                "broad market pivots around FOMC decisions. Returns {} when no odds are available."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
 ]
 
 
@@ -193,6 +208,8 @@ def build_data_tool_dispatcher(
                 result = get_vix_term_structure(client=client, run_date=as_of)
             elif name == "get_etf_flows_proxy":
                 result = get_etf_flows_proxy(client=client, run_date=as_of)
+            elif name == "get_fed_rate_probabilities":
+                result = get_fed_rate_probabilities(client=client, run_date=as_of)
             else:
                 return f"Error: unknown tool {name!r}"
             return json.dumps(result, default=str)

--- a/tests/dq/atlas/data/test_tools.py
+++ b/tests/dq/atlas/data/test_tools.py
@@ -21,6 +21,7 @@ def test_tool_definitions_shape():
         "get_sector_relative_strength",
         "get_vix_term_structure",
         "get_etf_flows_proxy",
+        "get_fed_rate_probabilities",
     }
     for t in DATA_TOOLS:
         assert t["type"] == "function"

--- a/tests/dq/data/test_fed_probabilities.py
+++ b/tests/dq/data/test_fed_probabilities.py
@@ -145,6 +145,31 @@ class TestPolymarket:
             polymarket_events_to_rows([{"markets": [{"outcomes": "not-json"}]}], as_of=AS_OF) == []
         )
 
+    def test_long_slugs_get_distinct_series_ids(self) -> None:
+        # Two long, near-identical slugs must NOT collide on the (source, series_id, obs_date) PK.
+        base = "will-the-fed-do-something-very-specific-" + "x" * 250
+        ev = {
+            "endDate": "2026-12-31T00:00:00Z",
+            "markets": [
+                {
+                    "slug": base + "-A",
+                    "outcomes": '["Yes","No"]',
+                    "outcomePrices": '["0.5","0.5"]',
+                    "closed": False,
+                },
+                {
+                    "slug": base + "-B",
+                    "outcomes": '["Yes","No"]',
+                    "outcomePrices": '["0.4","0.6"]',
+                    "closed": False,
+                },
+            ],
+        }
+        rows = polymarket_events_to_rows([ev], as_of=AS_OF)
+        ids = {r["series_id"] for r in rows}
+        assert len(ids) == 2  # distinct despite the shared 290-char prefix
+        assert all(len(i) <= 200 for i in ids)
+
 
 class TestDistribution:
     def test_ladder_differences_into_normalized_pmf(self) -> None:

--- a/tests/dq/data/test_fed_probabilities.py
+++ b/tests/dq/data/test_fed_probabilities.py
@@ -1,0 +1,215 @@
+"""Tests for Fed rate-probability parsers (Pillar / #778).
+
+Fixtures mirror the REAL Kalshi (KXFED) + Polymarket (gamma) JSON shapes captured live, so the
+pure ``*_to_rows`` parsers are validated against production field names without any network.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.data.prices.fed_probabilities import (
+    fed_distribution_from_ladder,
+    kalshi_markets_to_rows,
+    polymarket_events_to_rows,
+)
+
+pytestmark = pytest.mark.unit
+
+AS_OF = date(2026, 6, 16)
+
+
+def _kalshi_markets() -> list[dict]:
+    # Real KXFED shape: "upper bound > strike" threshold contracts, prices as 0-1 strings.
+    base = {
+        "status": "active",
+        "close_time": "2027-04-28T17:55:00Z",
+        "strike_type": "greater",
+        "event_ticker": "KXFED-27APR",
+    }
+    return [
+        {
+            **base,
+            "ticker": "KXFED-27APR-T4.25",
+            "floor_strike": 4.25,
+            "yes_bid_dollars": "0.1100",
+            "yes_ask_dollars": "0.2900",
+            "last_price_dollars": "0.2900",
+        },
+        {
+            **base,
+            "ticker": "KXFED-27APR-T4.00",
+            "floor_strike": 4.0,
+            "yes_bid_dollars": "0.2700",
+            "yes_ask_dollars": "0.5300",
+            "last_price_dollars": "0.2600",
+        },
+        # Bad rows that must be skipped (no strike / no close_time / no prices).
+        {
+            **base,
+            "ticker": "X",
+            "floor_strike": None,
+            "yes_bid_dollars": "0.5",
+            "yes_ask_dollars": "0.5",
+        },
+        {"ticker": "Y", "floor_strike": 3.5, "strike_type": "greater"},  # no close_time, no price
+    ]
+
+
+class TestKalshi:
+    def test_parses_survival_ladder(self) -> None:
+        rows = kalshi_markets_to_rows(_kalshi_markets(), as_of=AS_OF)
+        assert len(rows) == 2  # the two well-formed strikes; bad rows dropped
+        by_id = {r["series_id"]: r for r in rows}
+        top = by_id["FEDPROB/2027-04-28/upper_gt_4.25"]
+        assert top["source"] == "kalshi"
+        assert top["value"] == pytest.approx(0.20)  # mid(0.11, 0.29)
+        assert top["obs_date"] == "2026-06-16"
+        assert top["unit"] == "probability"
+        assert top["meta"]["strike"] == 4.25
+        assert by_id["FEDPROB/2027-04-28/upper_gt_4"]["value"] == pytest.approx(
+            0.40
+        )  # mid(0.27,0.53)
+
+    def test_falls_back_to_last_price_when_no_bid_ask(self) -> None:
+        rows = kalshi_markets_to_rows(
+            [
+                {
+                    "floor_strike": 3.5,
+                    "close_time": "2026-06-17T18:00:00Z",
+                    "last_price_dollars": "0.7",
+                }
+            ],
+            as_of=AS_OF,
+        )
+        assert rows[0]["value"] == pytest.approx(0.7)
+
+    def test_out_of_range_price_dropped(self) -> None:
+        rows = kalshi_markets_to_rows(
+            [
+                {
+                    "floor_strike": 3.5,
+                    "close_time": "2026-06-17T18:00:00Z",
+                    "last_price_dollars": "1.4",
+                }
+            ],
+            as_of=AS_OF,
+        )
+        assert rows == []  # a price > 1 is not a valid probability
+
+
+def _polymarket_events() -> list[dict]:
+    # Real gamma shape: outcomes / outcomePrices are JSON-ENCODED STRINGS.
+    return [
+        {
+            "id": "51456",
+            "slug": "how-many-fed-rate-cuts-in-2026",
+            "endDate": "2026-12-31T00:00:00Z",
+            "markets": [
+                {
+                    "question": "Will no Fed rate cuts happen in 2026?",
+                    "slug": "will-no-fed-rate-cuts-happen-in-2026",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.6915", "0.3085"]',
+                    "lastTradePrice": 0.691,
+                    "closed": False,
+                    "groupItemThreshold": "0",
+                },
+                {  # closed → skipped
+                    "question": "old",
+                    "slug": "old",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["1", "0"]',
+                    "closed": True,
+                },
+            ],
+        }
+    ]
+
+
+class TestPolymarket:
+    def test_parses_yes_probability_from_json_strings(self) -> None:
+        rows = polymarket_events_to_rows(_polymarket_events(), as_of=AS_OF)
+        assert len(rows) == 1  # the open market; closed one dropped
+        row = rows[0]
+        assert row["source"] == "polymarket"
+        assert row["value"] == pytest.approx(0.6915)  # Yes price, JSON-decoded
+        assert row["series_id"].startswith("FEDPROB/2026-12-31/pm/")
+        assert row["obs_date"] == "2026-06-16"
+
+    def test_empty_or_malformed_is_safe(self) -> None:
+        assert polymarket_events_to_rows([], as_of=AS_OF) == []
+        assert (
+            polymarket_events_to_rows([{"markets": [{"outcomes": "not-json"}]}], as_of=AS_OF) == []
+        )
+
+
+class TestDistribution:
+    def test_ladder_differences_into_normalized_pmf(self) -> None:
+        ladder = {3.25: 0.97, 3.50: 0.80, 3.75: 0.60, 4.00: 0.40, 4.25: 0.20}
+        out = fed_distribution_from_ladder(ladder)
+        dist = out["distribution"]
+        assert dist["<=3.25"] == pytest.approx(0.03)
+        assert dist["3.5"] == pytest.approx(0.17)
+        assert dist[">4.25"] == pytest.approx(0.20)
+        assert sum(dist.values()) == pytest.approx(1.0, abs=1e-6)
+        assert out["n_strikes"] == 5
+        assert out["most_likely"] in dist  # a real bucket
+
+    def test_negative_diffs_clamped_and_renormalized(self) -> None:
+        # A non-monotone (noisy) ladder: surv should fall with strike, but here it rises — the
+        # negative band masses clamp to 0 and the result still normalizes (no negative probs).
+        out = fed_distribution_from_ladder({3.5: 0.4, 3.75: 0.6})
+        assert all(v >= 0 for v in out["distribution"].values())
+        assert sum(out["distribution"].values()) == pytest.approx(1.0, abs=1e-6)
+
+    def test_too_few_strikes_returns_empty(self) -> None:
+        assert fed_distribution_from_ladder({3.5: 0.5}) == {}
+
+
+class TestReader:
+    def test_get_fed_rate_probabilities_nearest_meeting(self) -> None:
+        from digiquant.olympus.atlas.data.queries import get_fed_rate_probabilities
+        from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+        client = FakeSupabaseClient(
+            canned_reads={
+                "macro_series_observations": [
+                    {
+                        "source": "kalshi",
+                        "series_id": "FEDPROB/2026-06-17/upper_gt_3.75",
+                        "obs_date": "2026-06-16",
+                        "value": 0.6,
+                        "meta": {},
+                    },
+                    {
+                        "source": "kalshi",
+                        "series_id": "FEDPROB/2026-06-17/upper_gt_4",
+                        "obs_date": "2026-06-16",
+                        "value": 0.4,
+                        "meta": {},
+                    },
+                    {
+                        "source": "polymarket",
+                        "series_id": "FEDPROB/2026-06-17/pm/will-the-fed-hold",
+                        "obs_date": "2026-06-16",
+                        "value": 0.7,
+                        "meta": {"question": "Will the Fed hold?"},
+                    },
+                ]
+            }
+        )
+        out = get_fed_rate_probabilities(client=client, run_date=AS_OF)
+        assert out["meeting_date"] == "2026-06-17"
+        assert set(out["sources"]) == {"kalshi", "polymarket"}
+        assert out["kalshi"]["distribution"]["4"] == pytest.approx(0.2)  # 0.6 - 0.4
+        assert out["polymarket"][0]["prob"] == pytest.approx(0.7)
+
+    def test_get_fed_rate_probabilities_empty_when_no_rows(self) -> None:
+        from digiquant.olympus.atlas.data.queries import get_fed_rate_probabilities
+        from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+        client = FakeSupabaseClient(canned_reads={"macro_series_observations": []})
+        assert get_fed_rate_probabilities(client=client, run_date=AS_OF) == {}


### PR DESCRIPTION
First PR of the Fed monetary-policy research integration — the **rate hike/cut/hold probabilities** pipeline. (PR2 = FOMC/CPI calendar + persisted documents + lighting the `fed_odds` slot.)

## Source of truth (all FREE)
CME FedWatch has **no free API** (licensed/paid) → we **reproduce** the market-implied signal from prediction markets:
- **Kalshi** `KXFED` (no auth, CFTC-regulated) — a per-meeting "upper bound > X%" threshold ladder; differencing adjacent strikes → a 25bp probability distribution. **Structured source of truth.**
- **Polymarket** gamma `fed-rates` (no key) — best-effort cross-check (events are coarser; `outcomes`/`outcomePrices` are JSON-encoded strings, handled).

Both API shapes were **captured live** and the pure parsers are tested against them.

## What it does
- `data/prices/fed_probabilities.py` — `fetch_fed_prob_kalshi` + `fetch_fed_prob_polymarket` → `macro_series_observations` rows (`series_id=FEDPROB/{meeting}/...`), fail-soft per source; `fed_distribution_from_ladder` (survival ladder → normalized 25bp PMF, negatives clamped).
- `cli/prices.py` — `fedprob` source for `fetch-macro --sources` (daily snapshot via the existing ThreadPool + dedupe + upsert path; no backfill).
- `queries.get_fed_rate_probabilities` — reads `FEDPROB` rows by `source` (no `.like` needed → FakeSupabase-testable), nearest upcoming meeting, full distribution + Polymarket cross-check + `sources`; `{}` when absent. Registered in `DATA_TOOLS` + dispatcher, so the **macro analyst** (`use_data_tools`) grounds on it.

## Ops note
New external egress (free, no-auth reads): `api.elections.kalshi.com`, `gamma-api.polymarket.com`. (The repo's bash network-host-guard is a dev-time hook on the agent, not the runtime; flagging for awareness.)

## Tests
13 pass — Kalshi/Polymarket parsers (real-shape fixtures, bad-row drops, JSON-string decode, out-of-range price), the ladder→distribution math (differencing, clamp+renormalize, <2-strike empty), and the reader (nearest-meeting + empty). ruff clean; `make score` 10/10. No live run.

Part of #778.