### PR TITLE
fix(olympus): rebind dashboard to live pipeline data + null-honest metrics

### DIFF
--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -29,6 +29,7 @@ import { TodayActionsPanel } from '@/components/overview/today-actions-panel';
 import { DeliberationsStrip } from '@/components/overview/deliberations-strip';
 import { DecisionTrailPanel } from '@/components/overview/decision-trail-panel';
 import { AsOfBadge } from '@/components/overview/as-of-badge';
+import MacroSparklineRow from '@/components/overview/macro-sparkline-row';
 import { isRiskDebatePayload } from '@/lib/render-pipeline-payloads';
 import AtlasLoader from '@/components/AtlasLoader';
 import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
@@ -36,52 +37,73 @@ import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
 // ─── Regime config ────────────────────────────────────────────────────────────
 
 const REGIME_BORDER: Record<string, string> = {
+  strong_bullish: 'border-fin-green/70',
   bullish: 'border-fin-green/50',
   bearish: 'border-fin-red/50',
+  strong_bearish: 'border-fin-red/70',
   caution: 'border-fin-amber/50',
+  mixed: 'border-fin-amber/40',
   neutral: 'border-fin-blue/40',
 };
 
 const REGIME_GLOW: Record<string, string> = {
+  strong_bullish: 'shadow-[0_0_60px_-12px_rgba(16,185,129,0.40)]',
   bullish: 'shadow-[0_0_60px_-12px_rgba(16,185,129,0.25)]',
   bearish: 'shadow-[0_0_60px_-12px_rgba(239,68,68,0.25)]',
+  strong_bearish: 'shadow-[0_0_60px_-12px_rgba(239,68,68,0.40)]',
   caution: 'shadow-[0_0_60px_-12px_rgba(245,158,11,0.25)]',
+  mixed: 'shadow-[0_0_60px_-12px_rgba(245,158,11,0.18)]',
   neutral: 'shadow-[0_0_60px_-12px_rgba(59,130,246,0.20)]',
 };
 
 const REGIME_LABEL_COLOR: Record<string, string> = {
+  strong_bullish: 'text-fin-green',
   bullish: 'text-fin-green',
   bearish: 'text-fin-red',
+  strong_bearish: 'text-fin-red',
   caution: 'text-fin-amber',
+  mixed: 'text-fin-amber',
   neutral: 'text-fin-blue',
 };
 
 const REGIME_BG: Record<string, string> = {
+  strong_bullish: 'bg-gradient-to-br from-fin-green/[0.14] via-transparent to-transparent',
   bullish: 'bg-gradient-to-br from-fin-green/[0.08] via-transparent to-transparent',
   bearish: 'bg-gradient-to-br from-fin-red/[0.08] via-transparent to-transparent',
+  strong_bearish: 'bg-gradient-to-br from-fin-red/[0.14] via-transparent to-transparent',
   caution: 'bg-gradient-to-br from-fin-amber/[0.08] via-transparent to-transparent',
+  mixed: 'bg-gradient-to-br from-fin-amber/[0.06] via-transparent to-transparent',
   neutral: 'bg-gradient-to-br from-fin-blue/[0.07] via-transparent to-transparent',
 };
 
 const REGIME_PULSE: Record<string, string> = {
+  strong_bullish: 'bg-fin-green',
   bullish: 'bg-fin-green',
   bearish: 'bg-fin-red',
+  strong_bearish: 'bg-fin-red',
   caution: 'bg-fin-amber',
+  mixed: 'bg-fin-amber',
   neutral: 'bg-fin-blue',
 };
 
 const REGIME_BADGE: Record<string, 'green' | 'red' | 'amber' | 'blue'> = {
+  strong_bullish: 'green',
   bullish: 'green',
   bearish: 'red',
+  strong_bearish: 'red',
   caution: 'amber',
+  mixed: 'amber',
   neutral: 'blue',
 };
 
 /** Subtle inset wash so the overview feels regime-aware without drowning content. */
 const REGIME_PAGE_AMBIENT: Record<string, string> = {
+  strong_bullish: '[box-shadow:inset_0_0_140px_-36px_rgba(16,185,129,0.26)]',
   bullish: '[box-shadow:inset_0_0_140px_-36px_rgba(16,185,129,0.16)]',
   bearish: '[box-shadow:inset_0_0_140px_-36px_rgba(239,68,68,0.16)]',
+  strong_bearish: '[box-shadow:inset_0_0_140px_-36px_rgba(239,68,68,0.26)]',
   caution: '[box-shadow:inset_0_0_140px_-36px_rgba(245,158,11,0.14)]',
+  mixed: '[box-shadow:inset_0_0_140px_-36px_rgba(245,158,11,0.10)]',
   neutral: '[box-shadow:inset_0_0_140px_-36px_rgba(59,130,246,0.12)]',
 };
 
@@ -92,11 +114,16 @@ function pickBenchmarkTicker(benchmarks: BenchmarkHistoryMap): string | null {
   return null;
 }
 
-/** Inception-to-date portfolio vs first available dashboard benchmark (aligned window). */
+/**
+ * Portfolio vs benchmark over the aligned window (first NAV snap date →
+ * last NAV snap date, clipped to available benchmark history).
+ * Returns `startDate` so the blurb can say "Since {date}" rather than
+ * the dishonest "Since inception" (180-day window ≠ true inception).
+ */
 function inceptionVsBenchmark(
   snaps: NavChartPoint[],
   benchmarks: BenchmarkHistoryMap
-): { ticker: string; portPct: number; benchPct: number; excessPct: number } | null {
+): { ticker: string; portPct: number; benchPct: number; excessPct: number; startDate: string } | null {
   const ticker = pickBenchmarkTicker(benchmarks);
   if (!ticker || snaps.length < 2) return null;
   const hist = benchmarks[ticker]?.history;
@@ -110,7 +137,10 @@ function inceptionVsBenchmark(
   if (last.nav <= 0 || first.nav <= 0 || startBench.price <= 0 || endBench.price <= 0) return null;
   const portPct = (last.nav / first.nav - 1) * 100;
   const benchPct = (endBench.price / startBench.price - 1) * 100;
-  return { ticker, portPct, benchPct, excessPct: portPct - benchPct };
+  // Use the later of the two alignment starts so the label is honest about
+  // the actual window (NAV first date vs benchmark first available date).
+  const startDate = first.date > startBench.date ? first.date : startBench.date;
+  return { ticker, portPct, benchPct, excessPct: portPct - benchPct, startDate };
 }
 
 function thesisStatusColor(s: string): string {
@@ -402,7 +432,14 @@ export default function OverviewPage() {
           delta={dailyRet}
           subtitle={dailyRet != null ? 'today' : undefined}
           sparkData={navSparkData}
-          sparkColor={metrics.portfolio_pnl >= 0 ? '#10b981' : '#ef4444'}
+          // null pnl (no metrics row yet) → neutral blue sparkline; never fake-positive
+          sparkColor={
+            metrics.portfolio_pnl == null
+              ? '#60a5fa'
+              : metrics.portfolio_pnl >= 0
+                ? '#10b981'
+                : '#ef4444'
+          }
           enterStaggerIndex={0}
         />
         <StatCardEnhanced
@@ -446,10 +483,19 @@ export default function OverviewPage() {
       {/* ── Morning Brief — the digest, tabbed for a scannable read ────────── */}
       <MorningBriefPanel />
 
+      {/* ── Macro pulse — key macro series fetched on every load; shown here
+           as a compact strip so the data isn't wasted. Gated on non-empty
+           preview to avoid a blank card on the first run. */}
+      {Object.keys(data.macro_series_preview).length > 0 && (
+        <MacroSparklineRow series={data.macro_series_preview} />
+      )}
+
       {benchmarkBlurb && (
         <div className="glass-card px-5 py-3.5 border border-border-subtle/90">
           <p className="text-sm text-text-secondary leading-relaxed">
-            <span className="font-medium text-text-primary">Since inception</span>
+            {/* Reflects the actual aligned start date, not "inception" — the
+                window is bounded by available benchmark history, not day 0. */}
+            <span className="font-medium text-text-primary">Since {benchmarkBlurb.startDate}</span>
             {' — '}portfolio{' '}
             <span className={`font-mono font-semibold tabular-nums ${pnlColor(benchmarkBlurb.portPct)}`}>
               {formatPct(benchmarkBlurb.portPct)}

--- a/frontend/olympus/components/library/DeliberationDocumentView.tsx
+++ b/frontend/olympus/components/library/DeliberationDocumentView.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 
+// ── Legacy deliberation-transcript types ──────────────────────────────────
 type FinalRow = {
   ticker?: string;
   analyst_recommendation?: string;
@@ -13,7 +14,7 @@ type FinalRow = {
 };
 
 type Section = { heading?: string; markdown?: string };
-// Canonical schema shape: {label, sections[]}
+// Canonical legacy schema shape: {label, sections[]}
 type Round = { label?: string; sections?: Section[] };
 // Legacy chat shape (pre-schema): {round, pm, analyst}
 type LegacyChatRound = { round?: number; pm?: string; analyst?: string };
@@ -38,6 +39,28 @@ function normalizeRounds(raw: unknown[]): Round[] {
   });
 }
 
+// ── DebateSummary types (automated pipeline) ─────────────────────────────
+// { ticker, rounds: [{round_number, bull_argument, bear_argument}],
+//   bull_thesis, bear_thesis, net_stance: 'bullish'|'neutral'|'bearish',
+//   conviction_delta: int }
+type DebateRound = {
+  round_number?: number;
+  bull_argument?: string;
+  bear_argument?: string;
+};
+
+/** Colour class keyed on net_stance value */
+function stanceClass(stance: string | undefined): string {
+  switch (stance) {
+    case 'bullish':
+      return 'text-fin-green';
+    case 'bearish':
+      return 'text-fin-red/90';
+    default:
+      return 'text-text-secondary';
+  }
+}
+
 export default function DeliberationDocumentView({
   payload,
   fallbackMarkdown,
@@ -45,13 +68,39 @@ export default function DeliberationDocumentView({
   payload: Record<string, unknown> | null;
   fallbackMarkdown: string;
 }) {
+  // ── DebateSummary shape detection ─────────────────────────────────────
+  // The automated pipeline writes the DebateSummary fields directly onto the
+  // payload object (not nested under payload.body).
+  const debateRounds: DebateRound[] = Array.isArray(payload?.rounds)
+    ? (payload.rounds as DebateRound[]).filter(
+        (r) =>
+          r &&
+          typeof r === 'object' &&
+          // Bull/bear rounds have bull_argument or bear_argument; legacy rounds have label/sections
+          (r.bull_argument !== undefined || r.bear_argument !== undefined || r.round_number !== undefined),
+      )
+    : [];
+  const bullThesis =
+    payload?.bull_thesis != null && typeof payload.bull_thesis === 'string' ? payload.bull_thesis.trim() : '';
+  const bearThesis =
+    payload?.bear_thesis != null && typeof payload.bear_thesis === 'string' ? payload.bear_thesis.trim() : '';
+  const netStance =
+    payload?.net_stance != null && typeof payload.net_stance === 'string' ? payload.net_stance.trim() : '';
+  const convictionDelta =
+    payload?.conviction_delta != null ? Number(payload.conviction_delta) : null;
+  const debateTicker =
+    payload?.ticker != null && typeof payload.ticker === 'string' ? payload.ticker.trim() : '';
+
+  const isDebateShape = debateRounds.length > 0 || bullThesis !== '' || bearThesis !== '' || netStance !== '';
+
+  // ── Legacy deliberation-transcript shape ─────────────────────────────
   const body =
     payload && typeof payload.body === 'object' && payload.body !== null && !Array.isArray(payload.body)
       ? (payload.body as Record<string, unknown>)
       : null;
 
   const finalDecisions = Array.isArray(body?.final_decisions) ? (body.final_decisions as FinalRow[]) : [];
-  const rounds = Array.isArray(body?.rounds) ? normalizeRounds(body.rounds as unknown[]) : [];
+  const legacyRounds = Array.isArray(body?.rounds) ? normalizeRounds(body.rounds as unknown[]) : [];
   // trigger_summary may be a string (legacy) or array of strings (canonical)
   const triggerSummary = Array.isArray(body?.trigger_summary)
     ? (body.trigger_summary as string[]).filter(Boolean)
@@ -59,7 +108,8 @@ export default function DeliberationDocumentView({
       ? [(body.trigger_summary as string).trim()]
       : [];
 
-  if (!body || (!finalDecisions.length && !rounds.length)) {
+  // ── Fallback ────────────────────────────────────────────────────────────
+  if (!isDebateShape && (!body || (!finalDecisions.length && !legacyRounds.length))) {
     return (
       <div className="prose prose-invert max-w-none text-sm">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{fallbackMarkdown}</ReactMarkdown>
@@ -67,6 +117,70 @@ export default function DeliberationDocumentView({
     );
   }
 
+  // ── DebateSummary rendering ──────────────────────────────────────────────
+  if (isDebateShape) {
+    return (
+      <div className="space-y-8 text-sm">
+        {/* Header: ticker + net stance */}
+        {(debateTicker || netStance) && (
+          <div className="flex items-center gap-4 flex-wrap">
+            {debateTicker ? (
+              <span className="font-mono text-base text-fin-blue font-semibold">{debateTicker}</span>
+            ) : null}
+            {netStance ? (
+              <span className={`font-semibold capitalize ${stanceClass(netStance)}`}>
+                {netStance}
+                {convictionDelta != null && !Number.isNaN(convictionDelta) ? (
+                  <span className="ml-2 text-text-muted font-normal text-xs">
+                    Δ{convictionDelta > 0 ? '+' : ''}
+                    {convictionDelta}
+                  </span>
+                ) : null}
+              </span>
+            ) : null}
+          </div>
+        )}
+
+        {/* Bull / Bear thesis side-by-side */}
+        {(bullThesis || bearThesis) ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {bullThesis ? (
+              <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
+                <p className="text-[10px] uppercase tracking-wider text-fin-green mb-2">Bull thesis</p>
+                <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{bullThesis}</ReactMarkdown>
+                </div>
+              </div>
+            ) : null}
+            {bearThesis ? (
+              <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
+                <p className="text-[10px] uppercase tracking-wider text-fin-red/90 mb-2">Bear thesis</p>
+                <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{bearThesis}</ReactMarkdown>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* Per-round bull/bear exchange */}
+        {debateRounds.length > 0 ? (
+          <div>
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Debate rounds
+            </h3>
+            <div className="space-y-2">
+              {debateRounds.map((r, ri) => (
+                <DebateRoundBlock key={ri} round={r} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // ── Legacy deliberation-transcript rendering ─────────────────────────────
   return (
     <div className="space-y-8 text-sm">
       {triggerSummary.length > 0 ? (
@@ -120,13 +234,13 @@ export default function DeliberationDocumentView({
         </div>
       ) : null}
 
-      {rounds.length > 0 ? (
+      {legacyRounds.length > 0 ? (
         <div>
           <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
             Discussion rounds
           </h3>
           <div className="space-y-2">
-            {rounds.map((round, ri) => (
+            {legacyRounds.map((round, ri) => (
               <RoundBlock key={ri} round={round} />
             ))}
           </div>
@@ -136,6 +250,42 @@ export default function DeliberationDocumentView({
   );
 }
 
+// ── DebateRoundBlock — bull/bear per-round exchange ──────────────────────
+function DebateRoundBlock({ round }: { round: DebateRound }) {
+  const [open, setOpen] = useState(true);
+  const label = `Round ${round.round_number ?? '?'}`;
+
+  return (
+    <div className="rounded-lg border border-border-subtle overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 w-full text-left px-4 py-2 bg-bg-secondary/60 hover:bg-bg-secondary text-sm font-medium"
+      >
+        {open ? <ChevronDown size={16} className="shrink-0" /> : <ChevronRight size={16} className="shrink-0" />}
+        {label}
+      </button>
+      {open ? (
+        <div className="px-4 py-3 grid gap-3 md:grid-cols-2 border-t border-border-subtle">
+          <div>
+            <h4 className="text-xs font-semibold text-fin-green mb-2">Bull</h4>
+            <div className="prose prose-invert max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{round.bull_argument || '_—_'}</ReactMarkdown>
+            </div>
+          </div>
+          <div>
+            <h4 className="text-xs font-semibold text-fin-red/90 mb-2">Bear</h4>
+            <div className="prose prose-invert max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{round.bear_argument || '_—_'}</ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── RoundBlock — legacy {label, sections[]} rounds ───────────────────────
 function RoundBlock({ round }: { round: Round }) {
   const [open, setOpen] = useState(true);
   const label = round.label || 'Round';

--- a/frontend/olympus/components/library/RebalanceDocumentView.tsx
+++ b/frontend/olympus/components/library/RebalanceDocumentView.tsx
@@ -3,7 +3,8 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-type Row = {
+// Legacy shape: body.rebalance_table rows
+type LegacyRow = {
   ticker?: string;
   current_pct?: number | null;
   recommended_pct?: number | null;
@@ -13,9 +14,38 @@ type Row = {
   rationale?: string;
 };
 
+// Live automated shape: payload.actions rows
+type ActionRow = {
+  ticker?: string;
+  action?: string; // hold | add | trim | exit | new
+  current_pct?: number | null;
+  target_pct?: number | null;
+  rationale?: string;
+};
+
+// Live automated shape: payload.recommended_portfolio rows
+type WeightRow = {
+  ticker?: string;
+  target_pct?: number | null;
+};
+
 function pct(n: unknown): string {
   if (n == null || Number.isNaN(Number(n))) return '—';
   return `${Number(n).toFixed(2)}%`;
+}
+
+/** Badge colour keyed on action verb (live shape) */
+function actionClass(action: string | undefined): string {
+  switch (action) {
+    case 'add':
+    case 'new':
+      return 'text-fin-green';
+    case 'trim':
+    case 'exit':
+      return 'text-fin-red/90';
+    default:
+      return 'text-text-secondary';
+  }
 }
 
 export default function RebalanceDocumentView({
@@ -25,12 +55,30 @@ export default function RebalanceDocumentView({
   payload: Record<string, unknown> | null;
   fallbackMarkdown: string;
 }) {
+  // ── Live automated shape ─────────────────────────────────────────────────
+  // { recommended_portfolio: [{ticker, target_pct}], actions: [{ticker, action,
+  //   current_pct, target_pct, rationale}], notes: string }
+  const liveActions: ActionRow[] = Array.isArray(payload?.actions)
+    ? (payload.actions as ActionRow[])
+    : [];
+  const liveWeights: WeightRow[] = Array.isArray(payload?.recommended_portfolio)
+    ? (payload.recommended_portfolio as WeightRow[])
+    : [];
+  const liveNotes =
+    payload?.notes != null && typeof payload.notes === 'string' && payload.notes.trim()
+      ? payload.notes.trim()
+      : '';
+
+  const isLiveShape = liveActions.length > 0 || liveWeights.length > 0 || liveNotes !== '';
+
+  // ── Legacy shape ─────────────────────────────────────────────────────────
+  // { body: { rebalance_table: [...], pm_notes, delta_summary } }
   const body =
     payload && typeof payload.body === 'object' && payload.body !== null && !Array.isArray(payload.body)
       ? (payload.body as Record<string, unknown>)
       : null;
   const table = body?.rebalance_table;
-  const rows: Row[] = Array.isArray(table) ? (table as Row[]) : [];
+  const legacyRows: LegacyRow[] = Array.isArray(table) ? (table as LegacyRow[]) : [];
   const pmNotes = body?.pm_notes != null ? String(body.pm_notes) : '';
   const deltaSummary = body?.delta_summary;
   const ds =
@@ -38,7 +86,8 @@ export default function RebalanceDocumentView({
       ? (deltaSummary as Record<string, unknown>)
       : null;
 
-  if (!rows.length && !pmNotes) {
+  // ── Fallback ─────────────────────────────────────────────────────────────
+  if (!isLiveShape && !legacyRows.length && !pmNotes) {
     return (
       <div className="prose prose-invert max-w-none text-sm">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{fallbackMarkdown}</ReactMarkdown>
@@ -46,6 +95,75 @@ export default function RebalanceDocumentView({
     );
   }
 
+  // ── Live automated shape rendering ───────────────────────────────────────
+  if (isLiveShape) {
+    return (
+      <div className="space-y-6 text-sm">
+        {liveNotes ? (
+          <div>
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Notes</h3>
+            <div className="prose prose-invert max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{liveNotes}</ReactMarkdown>
+            </div>
+          </div>
+        ) : null}
+
+        {liveWeights.length > 0 ? (
+          <div className="overflow-x-auto">
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Recommended weights
+            </h3>
+            <table className="w-full text-left text-xs border-collapse">
+              <thead>
+                <tr className="border-b border-border-subtle text-text-muted">
+                  <th className="py-2 pr-3 font-medium">Ticker</th>
+                  <th className="py-2 font-medium text-right">Target %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {liveWeights.map((w, i) => (
+                  <tr key={i} className="border-b border-border-subtle/60">
+                    <td className="py-2 pr-3 font-mono text-fin-blue">{w.ticker ?? '—'}</td>
+                    <td className="py-2 text-right tabular-nums">{pct(w.target_pct)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        {liveActions.length > 0 ? (
+          <div className="overflow-x-auto">
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Actions</h3>
+            <table className="w-full text-left text-xs border-collapse">
+              <thead>
+                <tr className="border-b border-border-subtle text-text-muted">
+                  <th className="py-2 pr-3 font-medium">Ticker</th>
+                  <th className="py-2 pr-3 font-medium">Action</th>
+                  <th className="py-2 pr-3 font-medium text-right">Current</th>
+                  <th className="py-2 pr-3 font-medium text-right">Target</th>
+                  <th className="py-2 font-medium">Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                {liveActions.map((a, i) => (
+                  <tr key={i} className="border-b border-border-subtle/60 align-top">
+                    <td className="py-2 pr-3 font-mono text-fin-blue">{a.ticker ?? '—'}</td>
+                    <td className={`py-2 pr-3 font-medium ${actionClass(a.action)}`}>{a.action ?? '—'}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{pct(a.current_pct)}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{pct(a.target_pct)}</td>
+                    <td className="py-2 text-text-secondary whitespace-pre-wrap">{a.rationale ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  // ── Legacy shape rendering ────────────────────────────────────────────────
   return (
     <div className="space-y-6 text-sm">
       {ds && (
@@ -82,7 +200,7 @@ export default function RebalanceDocumentView({
         </div>
       ) : null}
 
-      {rows.length > 0 ? (
+      {legacyRows.length > 0 ? (
         <div className="overflow-x-auto">
           <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Rebalance table</h3>
           <table className="w-full text-left text-xs border-collapse">
@@ -98,7 +216,7 @@ export default function RebalanceDocumentView({
               </tr>
             </thead>
             <tbody>
-              {rows.map((r, i) => (
+              {legacyRows.map((r, i) => (
                 <tr key={i} className="border-b border-border-subtle/60 align-top">
                   <td className="py-2 pr-3 font-mono text-fin-blue">{r.ticker ?? '—'}</td>
                   <td className="py-2 pr-3 text-right tabular-nums">{pct(r.current_pct)}</td>

--- a/frontend/olympus/components/library/RebalanceDocumentView.tsx
+++ b/frontend/olympus/components/library/RebalanceDocumentView.tsx
@@ -15,18 +15,24 @@ type LegacyRow = {
 };
 
 // Live automated shape: payload.actions rows
+// `target_pct` is the canonical live-shape field; `recommended_pct` is used by
+// fixtures and test payloads — both are accepted so the UI renders either shape.
 type ActionRow = {
   ticker?: string;
   action?: string; // hold | add | trim | exit | new
   current_pct?: number | null;
   target_pct?: number | null;
+  recommended_pct?: number | null; // fixture / test alias for target_pct
   rationale?: string;
 };
 
 // Live automated shape: payload.recommended_portfolio rows
+// `target_pct` is the canonical live-shape field; `weight_pct` is used by
+// fixtures and test payloads — both are accepted so the UI renders either shape.
 type WeightRow = {
   ticker?: string;
   target_pct?: number | null;
+  weight_pct?: number | null; // fixture / test alias for target_pct
 };
 
 function pct(n: unknown): string {
@@ -124,7 +130,8 @@ export default function RebalanceDocumentView({
                 {liveWeights.map((w, i) => (
                   <tr key={i} className="border-b border-border-subtle/60">
                     <td className="py-2 pr-3 font-mono text-fin-blue">{w.ticker ?? '—'}</td>
-                    <td className="py-2 text-right tabular-nums">{pct(w.target_pct)}</td>
+                    {/* Live shape: `target_pct`; fixture / test payloads: `weight_pct`. */}
+                    <td className="py-2 text-right tabular-nums">{pct(w.target_pct ?? w.weight_pct)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -151,7 +158,8 @@ export default function RebalanceDocumentView({
                     <td className="py-2 pr-3 font-mono text-fin-blue">{a.ticker ?? '—'}</td>
                     <td className={`py-2 pr-3 font-medium ${actionClass(a.action)}`}>{a.action ?? '—'}</td>
                     <td className="py-2 pr-3 text-right tabular-nums">{pct(a.current_pct)}</td>
-                    <td className="py-2 pr-3 text-right tabular-nums">{pct(a.target_pct)}</td>
+                    {/* Live shape: `target_pct`; fixture / test payloads: `recommended_pct`. */}
+                    <td className="py-2 pr-3 text-right tabular-nums">{pct(a.target_pct ?? a.recommended_pct)}</td>
                     <td className="py-2 text-text-secondary whitespace-pre-wrap">{a.rationale ?? '—'}</td>
                   </tr>
                 ))}

--- a/frontend/olympus/components/observability/AttributionTab.tsx
+++ b/frontend/olympus/components/observability/AttributionTab.tsx
@@ -33,7 +33,11 @@ export default function AttributionTab({
   const summary = useMemo(() => {
     if (!attribution.length) return null;
     const activeReturn = sum(attribution.map((r) => r.total_attribution_pct));
-    const benchmarkReturn = attribution.find((r) => r.benchmark_return_pct != null)?.benchmark_return_pct ?? null;
+    // Sort descending by date so the most-recent row wins the benchmark lookup, regardless of the
+    // order rows arrived from the database.  An unsorted .find() is order-dependent and would
+    // silently pick a stale benchmark if rows happen to arrive oldest-first.
+    const sorted = [...attribution].sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
+    const benchmarkReturn = sorted.find((r) => r.benchmark_return_pct != null)?.benchmark_return_pct ?? null;
     const portfolioReturn = benchmarkReturn != null ? activeReturn + benchmarkReturn : null;
     const holdings = attribution.filter((r) => r.ticker !== 'CASH');
     // Unpriced holdings (no window return) carry null attribution; the sums then under-count and
@@ -47,6 +51,7 @@ export default function AttributionTab({
       <EmptyState
         title="No attribution rows yet"
         message="Per-position attribution is computed daily by refresh_attribution.py after EOD prices land, once the paper book holds positions. It will appear here after the next attribution run."
+        note="Populates after the daily attribution job runs (refresh_attribution)."
       />
     );
   }

--- a/frontend/olympus/components/observability/DecisionScorecardTab.tsx
+++ b/frontend/olympus/components/observability/DecisionScorecardTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Bar,
   BarChart,
@@ -18,7 +18,51 @@ import { EmptyState, SectionCard, StatTile, fmtPct, signColorClass } from './sha
 const FIN_GREEN = '#3fb984';
 const FIN_RED = '#e0654b';
 const AXIS = '#71717a';
-const BUCKET_LABEL: Record<string, string> = { low: 'Low (<2)', medium: 'Med (2–3)', high: 'High (≥4)' };
+// Buckets use |conviction| thresholds (magnitude), matching decision-scorecard.ts and backtest.py:
+//   low    |conv| < 2
+//   medium |conv| ≥ 2 and < 4
+//   high   |conv| ≥ 4
+// The conviction domain is [−5, +5], so "high" is ±4–5, not "just 5".
+const BUCKET_LABEL: Record<string, string> = {
+  low: 'Low (|conv|<2)',
+  medium: 'Med (|conv| 2–3)',
+  high: 'High (|conv|≥4)',
+};
+
+/** Per-decision drill-down row — expanded inline to keep the table scannable. */
+function ReasoningExpander({ thesis, reflection }: { thesis: string | null; reflection: string | null }) {
+  const [open, setOpen] = useState(false);
+  if (!thesis && !reflection) {
+    return <span className="text-text-muted/50 text-xs italic">none recorded</span>;
+  }
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="text-xs text-text-secondary underline underline-offset-2 decoration-dotted hover:text-text-primary text-left"
+        aria-expanded={open}
+      >
+        {open ? 'hide' : 'show reasoning'}
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2 text-xs mt-1 max-w-prose">
+          {thesis && (
+            <div>
+              <span className="text-text-muted font-medium">Thesis: </span>
+              <span className="text-text-secondary">{thesis}</span>
+            </div>
+          )}
+          {reflection && (
+            <div>
+              <span className="text-text-muted font-medium">Reflection: </span>
+              <span className="text-text-secondary">{reflection}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function DecisionScorecardTab({
   decisions,
@@ -26,6 +70,11 @@ export default function DecisionScorecardTab({
   decisions: TableRow<'decision_log'>[];
 }) {
   const scorecard = useMemo(() => computeDecisionScorecard(decisions), [decisions]);
+  // Resolved decisions only — the PM cares about calls that have a known outcome.
+  const resolved = useMemo(
+    () => decisions.filter((d) => d.status === 'resolved').sort((a, b) => (b.run_date ?? '').localeCompare(a.run_date ?? '')),
+    [decisions]
+  );
 
   if (!scorecard) {
     return (
@@ -148,6 +197,55 @@ export default function DecisionScorecardTab({
             </tbody>
           </table>
         </div>
+      </SectionCard>
+
+      {/* Per-decision drill-down — the PM's primary tool to evaluate the agent's reasoning.
+          Shows every resolved call with its thesis (why the agent made the call) and reflection
+          (what the agent learned at resolution time).  Sorted newest first. */}
+      <SectionCard
+        title="Resolved decisions"
+        subtitle="Each resolved call with the agent's original thesis and post-mortem reflection. Expand a row to read the full reasoning."
+      >
+        {resolved.length ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm tabular-nums">
+              <thead>
+                <tr className="text-left text-xs text-text-muted border-b border-border-subtle">
+                  <th className="py-2 pr-4 font-medium">Date</th>
+                  <th className="py-2 pr-4 font-medium">Ticker</th>
+                  <th className="py-2 pr-4 font-medium">Stance</th>
+                  <th className="py-2 pr-4 font-medium text-right">Conviction</th>
+                  <th className="py-2 pr-4 font-medium text-right">Return</th>
+                  <th className="py-2 pr-4 font-medium text-right">Alpha</th>
+                  <th className="py-2 font-medium">Reasoning</th>
+                </tr>
+              </thead>
+              <tbody>
+                {resolved.map((d) => (
+                  <tr key={d.id} className="border-b border-border-subtle/50 align-top">
+                    <td className="py-2 pr-4 text-text-muted text-xs">{d.run_date ?? '—'}</td>
+                    <td className="py-2 pr-4 text-text-primary font-medium">{d.ticker}</td>
+                    <td className="py-2 pr-4 text-text-secondary capitalize">{d.stance ?? '—'}</td>
+                    <td className="py-2 pr-4 text-right text-text-secondary">
+                      {d.conviction != null ? d.conviction.toFixed(1) : '—'}
+                    </td>
+                    <td className={`py-2 pr-4 text-right ${signColorClass(d.actual_return != null ? d.actual_return * 100 : null)}`}>
+                      {fmtPct(d.actual_return != null ? d.actual_return * 100 : null)}
+                    </td>
+                    <td className={`py-2 pr-4 text-right ${signColorClass(d.alpha != null ? d.alpha * 100 : null)}`}>
+                      {fmtPct(d.alpha != null ? d.alpha * 100 : null)}
+                    </td>
+                    <td className="py-2">
+                      <ReasoningExpander thesis={d.thesis} reflection={d.reflection} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-xs text-text-muted">No resolved decisions yet.</p>
+        )}
       </SectionCard>
     </div>
   );

--- a/frontend/olympus/components/observability/PositionRiskTab.tsx
+++ b/frontend/olympus/components/observability/PositionRiskTab.tsx
@@ -37,6 +37,7 @@ export default function PositionRiskTab({
       <EmptyState
         title="Advisory risk fields not populated"
         message="Per-position stops, targets, horizons, and conviction are written when the OLYMPUS_POSITION_RISK_FIELDS flag is enabled (migration 039). The book holds positions, but these advisory fields are not yet populated."
+        note="Advisory stop/target/conviction fields appear once per-position risk fields are enabled (OLYMPUS_POSITION_RISK_FIELDS)."
       />
     );
   }

--- a/frontend/olympus/components/observability/RunHealthTab.tsx
+++ b/frontend/olympus/components/observability/RunHealthTab.tsx
@@ -30,6 +30,7 @@ export default function RunHealthTab({
       <EmptyState
         title="Run-health view not yet enabled"
         message="The curated atlas_run_health view (migration 041) exposes run status, segment success/carry/fail counts, model, and timing — but never spend telemetry. It requires owner sign-off before it goes live, so this panel stays empty until the migration is applied."
+        note="Run-health view is enabled after migration 041 is applied."
       />
     );
   }

--- a/frontend/olympus/components/observability/shared.tsx
+++ b/frontend/olympus/components/observability/shared.tsx
@@ -64,11 +64,23 @@ export function SectionCard({
   );
 }
 
-export function EmptyState({ title, message }: { title: string; message: string }) {
+export function EmptyState({
+  title,
+  message,
+  note,
+}: {
+  title: string;
+  message: string;
+  /** Short secondary line for PMs — explains why the tab is empty without reading as "broken". */
+  note?: string;
+}) {
   return (
     <div className="glass-card p-8 flex flex-col items-center justify-center gap-2 text-center">
       <p className="text-sm font-medium text-text-secondary">{title}</p>
       <p className="text-xs text-text-muted max-w-md">{message}</p>
+      {note ? (
+        <p className="text-xs text-text-muted/60 max-w-md mt-1 italic">{note}</p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/olympus/components/portfolio/AllocationsPositionsTable.tsx
+++ b/frontend/olympus/components/portfolio/AllocationsPositionsTable.tsx
@@ -67,7 +67,16 @@ export default function AllocationsPositionsTable(props: {
 
   const maxWeight = sorted.length ? (sorted[0].weight_actual ?? 0) : 0;
 
-  const colCount = 9;
+  // Show the Target column only when at least one position has a target weight set.
+  // (WS1 populates weight_target from the pm-rebalance recommended book; it will be
+  //  null for every row in portfolios that haven't run through the PM rebalance node.)
+  const hasTargets = useMemo(
+    () => sorted.some((p) => p.weight_target != null),
+    [sorted]
+  );
+
+  // +1 for the Target column when visible, +1 for Δ (target vs actual) column.
+  const colCount = hasTargets ? 11 : 9;
 
   return (
     <div className="glass-card p-0 overflow-hidden">
@@ -89,7 +98,14 @@ export default function AllocationsPositionsTable(props: {
             <tr className="text-text-muted text-xs uppercase tracking-wider">
               <th className="pl-2 pr-2 py-3 text-left md:pl-4">Ticker</th>
               <th className="hidden max-w-[140px] px-2 py-3 text-left md:table-cell">Name</th>
-              <th className="px-2 py-3 text-right md:px-3">Weight</th>
+              <th className="px-2 py-3 text-right md:px-3">Actual</th>
+              {/* Target + Δ columns: only rendered when the data layer supplies targets */}
+              {hasTargets && (
+                <>
+                  <th className="hidden px-3 py-3 text-right md:table-cell">Target</th>
+                  <th className="hidden px-3 py-3 text-right md:table-cell">Δ vs target</th>
+                </>
+              )}
               <th className="hidden px-3 py-3 text-right md:table-cell">Δ weight</th>
               <th className="hidden px-3 py-3 text-left lg:table-cell">Category</th>
               <th className="hidden max-w-[200px] px-3 py-3 text-left xl:table-cell">Thesis</th>
@@ -105,6 +121,12 @@ export default function AllocationsPositionsTable(props: {
               const pctOfMax = maxWeight > 0 ? (w / maxWeight) * 100 : 0;
               const bar = `linear-gradient(90deg, rgba(59,130,246,0.16) 0%, rgba(59,130,246,0.16) ${pctOfMax}%, rgba(255,255,255,0) ${pctOfMax}%)`;
 
+              // Delta between actual and AI-recommended target (positive = overweight vs target).
+              const vsTarget =
+                hasTargets && p.weight_target != null && p.weight_actual != null
+                  ? p.weight_actual - p.weight_target
+                  : null;
+
               return (
                 <Fragment key={p.ticker}>
                   <tr
@@ -119,6 +141,25 @@ export default function AllocationsPositionsTable(props: {
                         <td className="px-2 py-3 text-right font-mono tabular-nums font-medium md:px-3">
                           {p.weight_actual?.toFixed(1)}%
                         </td>
+                        {/* Target and Δ-vs-target cells, matched to the header columns above */}
+                        {hasTargets && (
+                          <>
+                            <td className="hidden px-3 py-3 text-right font-mono tabular-nums text-xs text-text-secondary md:table-cell">
+                              {p.weight_target != null ? `${p.weight_target.toFixed(1)}%` : '—'}
+                            </td>
+                            <td
+                              className={`hidden px-3 py-3 text-right font-mono tabular-nums text-xs md:table-cell ${
+                                vsTarget != null && Math.abs(vsTarget) >= 0.05
+                                  ? pnlColor(-vsTarget) // negative vsTarget → needs to add (green); positive → overweight (red)
+                                  : 'text-text-muted'
+                              }`}
+                            >
+                              {vsTarget != null && Math.abs(vsTarget) >= 0.05
+                                ? `${vsTarget > 0 ? '+' : ''}${vsTarget.toFixed(1)}pp`
+                                : '—'}
+                            </td>
+                          </>
+                        )}
                         <td
                           className={`hidden px-3 py-3 text-right font-mono tabular-nums text-xs md:table-cell ${
                             typeof p.weight_delta === 'number' && p.weight_delta !== 0

--- a/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
@@ -1,12 +1,234 @@
 'use client';
 
 import { useCallback } from 'react';
-import { Calendar, FileText } from 'lucide-react';
+import { Calendar, FileText, GitBranch, Scale, TrendingUp } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import MiniCalendar, { type MiniCalendarRunKind } from '@/components/library/MiniCalendar';
 import DocumentExpandInline from '@/components/library/DocumentExpandInline';
-import type { Doc } from '@/lib/types';
+import type { Doc, PipelineObservabilityBundle, PipelineTickerDoc } from '@/lib/types';
 import type { LibraryDocumentResult } from '@/lib/queries';
 import { groupPmDocs, canonicalPmTitle } from '@/components/portfolio/tabs/palette-and-format';
+import { useDashboard } from '@/lib/dashboard-context';
+import {
+  isRebalancePayload,
+  renderRebalanceMarkdown,
+  isRiskDebatePayload,
+  isDebateSummaryPayload,
+} from '@/lib/render-pipeline-payloads';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline pipeline artifact panels (automated prod path — Hermes pipeline)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Renders the PM rebalance decision artifact if it has the live automated shape.
+ * We use the raw payload so we can render it inline without a library round-trip.
+ */
+function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
+  const md = renderRebalanceMarkdown(payload);
+  const actions: Array<Record<string, unknown>> = Array.isArray(payload.actions)
+    ? (payload.actions as Array<Record<string, unknown>>)
+    : [];
+  const notes =
+    typeof payload.notes === 'string' && payload.notes.trim() ? payload.notes.trim() : '';
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3 border-b border-border-subtle bg-bg-secondary flex items-center gap-2">
+        <GitBranch size={14} className="text-fin-blue shrink-0" aria-hidden />
+        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+          Rebalance Memo
+        </h3>
+        <span className="ml-auto text-[10px] text-text-muted font-mono">automated</span>
+      </div>
+      <div className="px-5 py-4 space-y-4 text-sm">
+        {notes ? (
+          <div className="prose prose-invert max-w-none text-sm">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{notes}</ReactMarkdown>
+          </div>
+        ) : null}
+        {actions.length > 0 ? (
+          <div className="overflow-x-auto">
+            <p className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Actions
+            </p>
+            <table className="w-full text-left text-xs border-collapse">
+              <thead>
+                <tr className="border-b border-border-subtle text-text-muted">
+                  <th className="py-2 pr-3 font-medium">Ticker</th>
+                  <th className="py-2 pr-3 font-medium">Action</th>
+                  <th className="py-2 pr-3 font-medium text-right">Current</th>
+                  <th className="py-2 pr-3 font-medium text-right">Target</th>
+                  <th className="py-2 font-medium">Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                {actions.map((a, i) => {
+                  const act = String(a.action ?? '').toLowerCase();
+                  const acColor =
+                    act === 'add' || act === 'new'
+                      ? 'text-fin-green'
+                      : act === 'trim' || act === 'exit'
+                        ? 'text-fin-red/90'
+                        : 'text-text-secondary';
+                  const fmtPct = (v: unknown) =>
+                    v == null || Number.isNaN(Number(v)) ? '—' : `${Number(v).toFixed(2)}%`;
+                  return (
+                    <tr key={i} className="border-b border-border-subtle/60 align-top">
+                      <td className="py-2 pr-3 font-mono text-fin-blue">{String(a.ticker ?? '—')}</td>
+                      <td className={`py-2 pr-3 font-medium ${acColor}`}>{String(a.action ?? '—')}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(a.current_pct)}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(a.target_pct)}</td>
+                      <td className="py-2 text-text-secondary whitespace-pre-wrap">
+                        {String(a.rationale ?? '—')}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : !notes ? (
+          // Fall back to raw markdown rendering if the structured view has nothing
+          <div className="prose prose-invert max-w-none text-sm">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{md}</ReactMarkdown>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** Renders the aggressive-vs-conservative risk debate (Hermes `risk-debate` doc). */
+function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
+  const s = (v: unknown) => (v == null ? '' : String(v));
+  const agg = s(payload.aggressive_case).trim();
+  const con = s(payload.conservative_case).trim();
+  const tension = s(payload.key_tension).trim();
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3 border-b border-border-subtle bg-bg-secondary flex items-center gap-2">
+        <Scale size={14} className="text-fin-amber shrink-0" aria-hidden />
+        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+          Risk Debate
+        </h3>
+        <span className="ml-auto text-[10px] text-text-muted font-mono">automated</span>
+      </div>
+      <div className="px-5 py-4 grid md:grid-cols-2 gap-4 text-sm">
+        {agg ? (
+          <div>
+            <p className="text-[11px] font-semibold text-fin-green uppercase tracking-wider mb-1">
+              Aggressive
+            </p>
+            <p className="text-text-secondary text-xs leading-relaxed">{agg}</p>
+          </div>
+        ) : null}
+        {con ? (
+          <div>
+            <p className="text-[11px] font-semibold text-fin-amber uppercase tracking-wider mb-1">
+              Conservative
+            </p>
+            <p className="text-text-secondary text-xs leading-relaxed">{con}</p>
+          </div>
+        ) : null}
+        {tension ? (
+          <div className="md:col-span-2 border-t border-border-subtle pt-3">
+            <p className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-1">
+              Key tension
+            </p>
+            <p className="text-text-secondary text-xs leading-relaxed">{tension}</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders all per-ticker bull/bear debate summaries (Hermes `deliberation/{ticker}` docs).
+ * Only the DebateSummary-shaped entries are shown (those with `net_stance`).
+ */
+function DeliberationsPanel({ docs }: { docs: PipelineTickerDoc[] }) {
+  // Filter to the automated Hermes DebateSummary shape — drop any legacy operator docs
+  const bulletins = docs.filter((d) => isDebateSummaryPayload(d.payload));
+  if (!bulletins.length) return null;
+
+  const s = (v: unknown) => (v == null ? '' : String(v));
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3 border-b border-border-subtle bg-bg-secondary flex items-center gap-2">
+        <TrendingUp size={14} className="text-fin-purple shrink-0" aria-hidden />
+        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+          Deliberations
+        </h3>
+        <span className="ml-auto text-[10px] text-text-muted font-mono">automated · {bulletins.length} ticker{bulletins.length !== 1 ? 's' : ''}</span>
+      </div>
+      <div className="divide-y divide-border-subtle">
+        {bulletins.map((d) => {
+          const p = d.payload;
+          const stance = s(p.net_stance).trim().toLowerCase();
+          const stanceColor =
+            stance === 'bullish'
+              ? 'text-fin-green'
+              : stance === 'bearish'
+                ? 'text-fin-red'
+                : 'text-fin-amber';
+          const bull = s(p.bull_thesis).trim();
+          const bear = s(p.bear_thesis).trim();
+          const delta = s(p.conviction_delta).trim();
+          const sign = delta && !delta.startsWith('-') && delta !== '0' ? `+${delta}` : delta;
+
+          return (
+            <div key={d.ticker} className="px-5 py-4 space-y-3">
+              <div className="flex items-baseline gap-3">
+                <span className="font-mono text-sm font-semibold text-fin-blue">{d.ticker}</span>
+                {stance ? (
+                  <span className={`text-xs font-medium capitalize ${stanceColor}`}>{stance}</span>
+                ) : null}
+                {delta ? (
+                  <span className="text-[11px] text-text-muted">conviction Δ {sign}</span>
+                ) : null}
+              </div>
+              <div className="grid md:grid-cols-2 gap-3 text-xs text-text-secondary leading-relaxed">
+                {bull ? (
+                  <div>
+                    <p className="text-[10px] font-semibold text-fin-green/80 uppercase tracking-wider mb-1">
+                      Bull
+                    </p>
+                    <p>{bull}</p>
+                  </div>
+                ) : null}
+                {bear ? (
+                  <div>
+                    <p className="text-[10px] font-semibold text-fin-red/80 uppercase tracking-wider mb-1">
+                      Bear
+                    </p>
+                    <p>{bear}</p>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** True when the pipeline_observability bundle has at least one renderable automated artifact. */
+function hasPipelineArtifacts(pipe: PipelineObservabilityBundle | null): boolean {
+  if (!pipe) return false;
+  return (
+    isRebalancePayload(pipe.pm_rebalance) ||
+    isRiskDebatePayload(pipe.risk_debate) ||
+    pipe.deliberation_transcripts.some((d) => isDebateSummaryPayload(d.payload))
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function AnalysisTab(props: {
   historyTimelineDates: string[];
@@ -40,6 +262,16 @@ export default function AnalysisTab(props: {
     onOpenPmDocument,
     onClosePmDocument,
   } = props;
+
+  // Pull pipeline_observability from the dashboard context so we can render
+  // the automated Hermes pipeline artifacts (pm_rebalance, risk_debate,
+  // deliberation_transcripts) directly — these are never written as library
+  // docs in the automated prod path, so the Track-B doc section below is
+  // always empty in automated prod. We render them first; the Track-B section
+  // remains as a graceful fallback for analyst-authored sessions.
+  const { data } = useDashboard();
+  const pipe = data?.pipeline_observability ?? null;
+  const showPipelineArtifacts = hasPipelineArtifacts(pipe);
 
   const selectHistoryDate = useCallback(
     (iso: string) => {
@@ -76,6 +308,36 @@ export default function AnalysisTab(props: {
       </div>
 
       <div className="flex-1 min-w-0 space-y-10">
+        {/* ── Automated pipeline artifacts (Hermes prod path) ──────────────────
+            pm_rebalance, risk_debate, deliberation_transcripts are written by
+            the automated pipeline but never appear as library docs, so the
+            Track-B section below is blank in prod. We surface them here first.
+        ──────────────────────────────────────────────────────────────────── */}
+        {showPipelineArtifacts && pipe ? (
+          <section className="space-y-3">
+            <p className="text-[11px] font-semibold text-text-muted tracking-wide">
+              Pipeline artifacts
+            </p>
+
+            {isRebalancePayload(pipe.pm_rebalance) && pipe.pm_rebalance ? (
+              <PmRebalancePanel payload={pipe.pm_rebalance} />
+            ) : null}
+
+            {isRiskDebatePayload(pipe.risk_debate) && pipe.risk_debate ? (
+              <RiskDebatePanel payload={pipe.risk_debate} />
+            ) : null}
+
+            {pipe.deliberation_transcripts.length > 0 ? (
+              <DeliberationsPanel docs={pipe.deliberation_transcripts} />
+            ) : null}
+          </section>
+        ) : null}
+
+        {/* ── Track-B analyst session docs (date-scoped library files) ─────────
+            In automated prod these are always empty. They appear after an
+            analyst has run Track-B phases (market-thesis-exploration, etc.)
+            and published docs via the operator interface.
+        ──────────────────────────────────────────────────────────────────── */}
         <section className="space-y-3">
           <div className="flex items-center gap-2 px-0.5">
             <Calendar size={15} className="text-fin-amber shrink-0" aria-hidden />
@@ -91,9 +353,13 @@ export default function AnalysisTab(props: {
           </div>
 
           {pmDocsForHistory.length === 0 ? (
-            <div className="glass-card px-5 py-10 text-center text-text-muted text-sm">
-              No PM files for this date.
-            </div>
+            // Only show the fallback "no files" card when there are also no
+            // pipeline artifacts above — otherwise the tab would look empty.
+            !showPipelineArtifacts ? (
+              <div className="glass-card px-5 py-10 text-center text-text-muted text-sm">
+                No PM files for this date.
+              </div>
+            ) : null
           ) : (
             (() => {
               const groups = groupPmDocs(pmDocsForHistory);

--- a/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
@@ -74,12 +74,16 @@ function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
                         : 'text-text-secondary';
                   const fmtPct = (v: unknown) =>
                     v == null || Number.isNaN(Number(v)) ? '—' : `${Number(v).toFixed(2)}%`;
+                  // Live shape: `target_pct`; fixture / test payloads: `recommended_pct`.
+                  const targetPct =
+                    (a as Record<string, unknown>).target_pct ??
+                    (a as Record<string, unknown>).recommended_pct;
                   return (
                     <tr key={i} className="border-b border-border-subtle/60 align-top">
                       <td className="py-2 pr-3 font-mono text-fin-blue">{String(a.ticker ?? '—')}</td>
                       <td className={`py-2 pr-3 font-medium ${acColor}`}>{String(a.action ?? '—')}</td>
                       <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(a.current_pct)}</td>
-                      <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(a.target_pct)}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(targetPct)}</td>
                       <td className="py-2 text-text-secondary whitespace-pre-wrap">
                         {String(a.rationale ?? '—')}
                       </td>

--- a/frontend/olympus/lib/decision-scorecard.test.ts
+++ b/frontend/olympus/lib/decision-scorecard.test.ts
@@ -11,13 +11,22 @@ function rec(conviction: number | null, alpha: number | null, status = 'resolved
 }
 
 describe('bucketFor', () => {
-  it('thresholds match the Python backtest (high≥4, medium≥2, low otherwise)', () => {
+  it('thresholds match the Python backtest (high≥4, medium≥2, low otherwise) on positive values', () => {
     expect(bucketFor(5)).toBe('high');
     expect(bucketFor(4)).toBe('high');
     expect(bucketFor(3)).toBe('medium');
     expect(bucketFor(2)).toBe('medium');
     expect(bucketFor(1)).toBe('low');
     expect(bucketFor(0)).toBe('low');
+  });
+
+  it('conviction domain is [-5,+5] — negative values bucket by magnitude, not clamped to low', () => {
+    // Sell-side calls (negative conviction) should mirror the buy-side buckets.
+    expect(bucketFor(-5)).toBe('high');
+    expect(bucketFor(-4)).toBe('high');
+    expect(bucketFor(-3)).toBe('medium');
+    expect(bucketFor(-2)).toBe('medium');
+    expect(bucketFor(-1)).toBe('low');
   });
 });
 

--- a/frontend/olympus/lib/decision-scorecard.ts
+++ b/frontend/olympus/lib/decision-scorecard.ts
@@ -4,13 +4,23 @@
  * Pure functions over resolved `decision_log` rows. The central question: do **higher-
  * conviction** calls earn **higher alpha**? `alpha` is the realized excess return over the
  * benchmark (SPY) computed at resolution time, stored as a FRACTION (0.05 = +5%); we surface
- * percent points. Conviction is the 0..5 effective conviction recorded with each decision.
+ * percent points.
  *
- * Buckets mirror the Python backtest core (digiquant/src/digiquant/olympus/atlas/backtest.py):
- * high ≥ 4, medium ≥ 2, low otherwise — so the in-graph backtest and this dashboard agree.
+ * Conviction domain: `decision_log.conviction` maps to `AnalystPayload.conviction_score`
+ * which is `ge=-5 le=5` — the full range is `[-5, +5]`, NOT `[0..5]`.  A sell-side call
+ * recorded as −4 is high-conviction (short/exit) and must not be bucketed as "low".
+ * Buckets are therefore applied to |conviction| (the magnitude):
+ *
+ *   high   |conv| ≥ 4
+ *   medium |conv| ≥ 2
+ *   low    |conv| < 2
+ *
+ * This matches the Python backtest core (digiquant/…/atlas/backtest.py
+ * `_HIGH_CONVICTION` / `_MED_CONVICTION`) — both sides of the sign axis use the same
+ * thresholds so the in-graph backtest and this dashboard agree.
  */
 
-/** Conviction thresholds — kept in sync with backtest.py `_HIGH_CONVICTION` / `_MED_CONVICTION`. */
+/** Conviction magnitude thresholds — kept in sync with backtest.py. */
 const HIGH_CONVICTION = 4;
 const MED_CONVICTION = 2;
 
@@ -58,9 +68,15 @@ function round4(x: number): number {
   return Math.round(x * 1e4) / 1e4;
 }
 
+/**
+ * Map a conviction value to a calibration bucket.
+ * Uses |conviction| (magnitude) so that sell-side calls (negative values) are
+ * bucketed symmetrically with buy-side calls of equal strength.
+ */
 export function bucketFor(conviction: number): ConvictionBucket {
-  if (conviction >= HIGH_CONVICTION) return 'high';
-  if (conviction >= MED_CONVICTION) return 'medium';
+  const mag = Math.abs(conviction);
+  if (mag >= HIGH_CONVICTION) return 'high';
+  if (mag >= MED_CONVICTION) return 'medium';
   return 'low';
 }
 

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -127,18 +127,30 @@ function resolveLibraryDocumentView(document_key: string, payload: unknown): Lib
       : null;
   const dt = String(p?.doc_type || '');
 
-  if (key === 'rebalance-decision.json' || dt === 'rebalance_decision') return 'rebalance';
+  // Both the legacy `rebalance-decision.json` key and the Hermes flat
+  // `pm-rebalance` key (no date segment) route to the rebalance structured view.
+  // `dt === 'rebalance_decision'` covers any future payload-typed variant.
+  if (key === 'rebalance-decision.json' || key === 'pm-rebalance' || dt === 'rebalance_decision') {
+    return 'rebalance';
+  }
   if (key === 'delta-request.json' || dt === 'delta_request') return 'delta_request';
   if (key === 'opportunity-screener.json' || dt === 'opportunity_screen') return 'opportunity_screener';
   const isDeliberationTranscriptPath =
     dt === 'deliberation_transcript' ||
     (key.includes('deliberation-transcript/') && !key.includes('deliberation-transcript-index'));
+  // Pipeline bull/bear summaries use a flat `deliberation/{ticker}` key (single
+  // slash, no date segment).  Match: starts with "deliberation/" but is NOT
+  // the transcript path or the transcript index.
+  const isPipelineDeliberation =
+    key.startsWith('deliberation/') &&
+    !key.startsWith('deliberation-transcript/') &&
+    !key.startsWith('deliberation-transcript-index/');
   const isLegacyDeliberationArtifact =
     key === 'deliberation.json' ||
     key.endsWith('/deliberation.json') ||
     key === 'deliberation.md' ||
     key.endsWith('/deliberation.md');
-  if (isDeliberationTranscriptPath || isLegacyDeliberationArtifact) {
+  if (isDeliberationTranscriptPath || isPipelineDeliberation || isLegacyDeliberationArtifact) {
     return 'deliberation';
   }
   if (dt === 'evolution_sources') return 'evolution_sources';
@@ -376,6 +388,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
   const [
     snapshotRes, positionsRes, thesesRes, navRes,
     benchRes, metricsRes, docsRes, deltaDocsRes, changelogDocsRes, tickerViewRes, snapshotRunTypesRes,
+    pmRebalanceRes,
   ] = await Promise.all([
     supabase.from('daily_snapshots').select('id,date,run_type,baseline_date,snapshot,digest_markdown,created_at').order('date', { ascending: false }).limit(1).single(),
     supabase.from('positions').select('*').order('date', { ascending: false }).limit(1000),
@@ -388,10 +401,14 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       .gte('date', benchCutoff)
       .order('date', { ascending: true }),
     supabase.from('portfolio_metrics').select('*').order('date', { ascending: false }).limit(1).maybeSingle(),
+    // Documents index (metadata only — no payload) used for the Research Library.
+    // Raised from 500 → 2000 to avoid truncating history on dense runs; a full
+    // pagination loop is unnecessary here because the caller only needs metadata
+    // (id/date/title/…) not the heavy `payload` JSONB.
     supabase.from('documents')
       .select('id, date, title, doc_type, phase, category, segment, sector, run_type, document_key')
       .order('date', { ascending: false })
-      .limit(500),
+      .limit(2000),
     supabase
       .from('documents')
       .select('date, payload')
@@ -406,10 +423,25 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       .limit(400),
     supabase.from('price_history_tickers').select('ticker'),
     supabase.from('daily_snapshots').select('date, run_type').order('date', { ascending: false }).limit(500),
+    // Fetch the latest pm-rebalance doc upfront so it is available before
+    // proposedPositions is computed (the late fetchPipelineObservabilityForDate
+    // call happens after that block and cannot be used as the primary source).
+    // Guard: we compare its `.date` against the dashboard date below — stale
+    // rows (date mismatch) are silently ignored and the UI falls back to [].
+    supabase
+      .from('documents')
+      .select('date, payload')
+      .eq('document_key', 'pm-rebalance')
+      .order('date', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ]);
 
   const eventsRaw = await fetchPositionEventsForDashboard();
 
+  if (pmRebalanceRes.error) {
+    console.warn('Supabase pm-rebalance prefetch:', pmRebalanceRes.error);
+  }
   if (docsRes.error) {
     console.error('Supabase documents query:', docsRes.error);
   }
@@ -589,8 +621,63 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     filename: d.document_key?.split('/').pop() || d.document_key,
   }));
 
-  // Proposed positions from the published digest snapshot (DB-first).
+  // ── Resolve proposed positions — pm-rebalance is the primary source ─────────
+  //
+  // The live Hermes pipeline writes the recommended book into the `documents`
+  // table as `document_key='pm-rebalance'`.  Its payload shape:
+  //   { recommended_portfolio: [{ticker, target_pct}], actions: [{ticker,
+  //     action, current_pct, target_pct, rationale}], notes: string }
+  // (`action` ∈ hold|add|trim|exit|new).
+  //
+  // We fetched the latest row in the top Promise.all above (`pmRebalanceRes`).
+  // Guard: only use it when its `date` matches the dashboard snapshot date —
+  // surfacing a stale rebalance would mislead the UI.
+  //
+  // Back-compat: if a future digest DOES carry `portfolio.proposed_positions`
+  // AND pm-rebalance is absent/stale, we still honor that legacy field.
+
+  // Parse the prefetched pm-rebalance row.
+  type PmRebalRow = { date: string; payload: unknown } | null;
+  const pmRebRow = pmRebalanceRes.data as PmRebalRow;
+  const pmRebPayload: Record<string, unknown> | null =
+    pmRebRow?.payload != null && typeof pmRebRow.payload === 'object' && !Array.isArray(pmRebRow.payload)
+      ? (pmRebRow.payload as Record<string, unknown>)
+      : null;
+
+  // `snapshot` is already declared above (line ~489) from `snapshotRes.data`.
+  // Use it directly — `snapshot.date` is typed as `string | null` by the DB types.
+  const _snapDate: string | null = snapshot.date ?? null;
+  const pmRebDateMatches = !!pmRebRow?.date && !!_snapDate && pmRebRow.date === _snapDate;
+
+  /** Proposed positions from pm-rebalance (primary) or legacy snapshot field (fallback). */
   const proposedPositions: { ticker: string; weight_pct: number; action?: string }[] = (() => {
+    // Primary: use pm-rebalance when it matches the dashboard date.
+    if (pmRebDateMatches && pmRebPayload) {
+      const rp = pmRebPayload.recommended_portfolio;
+      if (Array.isArray(rp) && rp.length > 0) {
+        return rp
+          .map((x) => {
+            if (!x || typeof x !== 'object') return null;
+            const o = x as Record<string, unknown>;
+            const ticker = String(o.ticker || '').trim().toUpperCase();
+            const weight = Number(o.target_pct ?? NaN);
+            if (!ticker || Number.isNaN(weight)) return null;
+            // Carry the action from pm_rebalance.actions when present — lets
+            // downstream consumers skip a second lookup.
+            const actions = pmRebPayload.actions;
+            let action: string | undefined;
+            if (Array.isArray(actions)) {
+              const match = actions.find(
+                (a) => a && typeof a === 'object' && String((a as Record<string, unknown>).ticker || '').toUpperCase() === ticker
+              ) as Record<string, unknown> | undefined;
+              if (match?.action) action = String(match.action);
+            }
+            return { ticker, weight_pct: weight, action };
+          })
+          .filter(Boolean) as { ticker: string; weight_pct: number; action?: string }[];
+      }
+    }
+    // Back-compat: legacy `snapshot.portfolio.proposed_positions` field.
     const p = snapshotJson?.portfolio as Record<string, unknown> | undefined;
     const pp = p?.proposed_positions;
     if (!Array.isArray(pp)) return [];
@@ -779,16 +866,44 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     metrics_as_of: p.metrics_as_of ?? null,
   }));
 
-  const rebalanceActions = proposedPositions.map((p) => {
-    const curr = Number(currentPositions.find((cp) => cp.ticker === p.ticker)?.weight_pct ?? 0);
-    const rec = Number(p.weight_pct ?? 0);
-    const action =
-      rec === 0 && curr > 0 ? 'EXIT' :
-      rec > 0 && curr === 0 ? 'OPEN' :
-      Math.abs(rec - curr) >= 0.01 ? (rec < curr ? 'TRIM' : 'ADD') :
-      'HOLD';
-    return { ticker: p.ticker, current_pct: curr, recommended_pct: rec, action };
-  });
+  // Rebalance actions — prefer pm-rebalance.actions (carry per-ticker rationale
+  // from the PM LLM) over the locally derived action labels when pm-rebalance is
+  // the source of truth.  Fall back to deriving action from weight deltas when
+  // pm-rebalance is absent/stale or its actions array is empty.
+  const rebalanceActions = (() => {
+    // When pm-rebalance matched the dashboard date, use its `actions` array
+    // directly — it carries the PM's rationale for each ticker.
+    if (pmRebDateMatches && pmRebPayload) {
+      const acts = pmRebPayload.actions;
+      if (Array.isArray(acts) && acts.length > 0) {
+        return acts
+          .map((a) => {
+            if (!a || typeof a !== 'object') return null;
+            const o = a as Record<string, unknown>;
+            const ticker = String(o.ticker || '').trim().toUpperCase();
+            if (!ticker) return null;
+            const current_pct = Number(o.current_pct ?? 0);
+            const recommended_pct = Number(o.target_pct ?? 0);
+            const action = String(o.action || 'HOLD').toUpperCase();
+            // Carry rationale so downstream UI can render it without another fetch.
+            const rationale = o.rationale != null ? String(o.rationale) : undefined;
+            return { ticker, current_pct, recommended_pct, action, rationale };
+          })
+          .filter(Boolean) as { ticker: string; current_pct: number; recommended_pct: number; action: string; rationale?: string }[];
+      }
+    }
+    // Fallback: derive action from proposed vs current weight delta.
+    return proposedPositions.map((p) => {
+      const curr = Number(currentPositions.find((cp) => cp.ticker === p.ticker)?.weight_pct ?? 0);
+      const rec = Number(p.weight_pct ?? 0);
+      const action =
+        rec === 0 && curr > 0 ? 'EXIT' :
+        rec > 0 && curr === 0 ? 'OPEN' :
+        Math.abs(rec - curr) >= 0.01 ? (rec < curr ? 'TRIM' : 'ADD') :
+        'HOLD';
+      return { ticker: p.ticker, current_pct: curr, recommended_pct: rec, action };
+    });
+  })();
 
   // segment_biases / market_data flat columns dropped (#714) — bullets come
   // from the snapshot JSONB digest.
@@ -857,8 +972,16 @@ export async function getFullDashboardData(): Promise<DashboardData> {
         invested_pct: h.invested_pct != null ? Number(h.invested_pct) : null,
       })),
       strategy: {
+        // Prefer the short `regime_label` string (e.g. "Risk-Off Consolidation")
+        // over the full `market_regime_snapshot` paragraph — that is a multi-
+        // sentence blob unsuited to a panel header.  Fall-back chain:
+        //   digest.regime_label (new optional field, backend adds later)
+        //   → regime.label (v1 schema nested object)
+        //   → regime.regime (raw enum string)
+        //   → digest.headline (always-present one-liner)
+        //   → 'Unknown' (safe final fallback; never the paragraph)
         regime: String(
-          regime.label ?? regime.regime ?? digest.market_regime_snapshot ?? 'Unknown'
+          digest.regime_label ?? regime.label ?? regime.regime ?? digest.headline ?? 'Unknown'
         ),
         regime_label: String(regime.bias ?? regime.regime_label ?? digest.bias ?? 'neutral'),
         summary: String(regime.summary ?? digest.headline ?? ''),
@@ -906,7 +1029,10 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     price_history_tickers,
     server_portfolio_metrics,
     calculated: {
-      portfolio_pnl: metrics.pnl_pct != null ? Number(metrics.pnl_pct) : 0,
+      // Return null (not 0) when the portfolio_metrics row is absent so the UI
+      // can render "—" instead of a misleading zero.  Only total_invested and
+      // cash_pct have real live fallbacks (derived from position weights).
+      portfolio_pnl: metrics.pnl_pct != null ? Number(metrics.pnl_pct) : null,
       total_invested:
         proposedPositions.length > 0
           ? totalInvested
@@ -915,10 +1041,10 @@ export async function getFullDashboardData(): Promise<DashboardData> {
         proposedPositions.length > 0
           ? 100 - totalInvested
           : (metrics.invested_pct != null ? 100 - Number(metrics.invested_pct) : 100 - totalInvested),
-      sharpe: metrics.sharpe != null ? Number(metrics.sharpe) : 0,
-      volatility: metrics.volatility != null ? Number(metrics.volatility) : 0,
-      max_drawdown: metrics.max_drawdown != null ? Number(metrics.max_drawdown) : 0,
-      alpha: metrics.alpha != null ? Number(metrics.alpha) : 0,
+      sharpe: metrics.sharpe != null ? Number(metrics.sharpe) : null,
+      volatility: metrics.volatility != null ? Number(metrics.volatility) : null,
+      max_drawdown: metrics.max_drawdown != null ? Number(metrics.max_drawdown) : null,
+      alpha: metrics.alpha != null ? Number(metrics.alpha) : null,
     },
     snapshot_context_bullets,
     macro_series_preview,
@@ -1029,6 +1155,8 @@ export function collectThesisRelatedDocLinks(
       if (
         low.includes(`asset-recommendations/${d.date}/${t.toLowerCase()}`) ||
         low.includes(`deliberation-transcript/${d.date}/${t.toLowerCase()}`) ||
+        // Pipeline flat key: `deliberation/{ticker}` (single slash, no date segment)
+        low === `deliberation/${t.toLowerCase()}` ||
         low.includes(`/${t.toLowerCase()}.json`)
       ) {
         seen.add(key);

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -660,7 +660,8 @@ export async function getFullDashboardData(): Promise<DashboardData> {
             if (!x || typeof x !== 'object') return null;
             const o = x as Record<string, unknown>;
             const ticker = String(o.ticker || '').trim().toUpperCase();
-            const weight = Number(o.target_pct ?? NaN);
+            // Live shape uses `target_pct`; fixture / test payloads use `weight_pct`.
+            const weight = Number(o.target_pct ?? o.weight_pct ?? NaN);
             if (!ticker || Number.isNaN(weight)) return null;
             // Carry the action from pm_rebalance.actions when present — lets
             // downstream consumers skip a second lookup.
@@ -883,7 +884,8 @@ export async function getFullDashboardData(): Promise<DashboardData> {
             const ticker = String(o.ticker || '').trim().toUpperCase();
             if (!ticker) return null;
             const current_pct = Number(o.current_pct ?? 0);
-            const recommended_pct = Number(o.target_pct ?? 0);
+            // Live shape: `target_pct`; fixture / test payloads: `recommended_pct`.
+            const recommended_pct = Number(o.target_pct ?? o.recommended_pct ?? 0);
             const action = String(o.action || 'HOLD').toUpperCase();
             // Carry rationale so downstream UI can render it without another fetch.
             const rationale = o.rationale != null ? String(o.rationale) : undefined;

--- a/frontend/olympus/lib/render-digest-from-snapshot.ts
+++ b/frontend/olympus/lib/render-digest-from-snapshot.ts
@@ -12,6 +12,12 @@ export type DigestSnapshot = {
   risks?: string[];
   sector_scorecard?: Array<Record<string, unknown>>;
   narrative?: Record<string, unknown>;
+  /**
+   * Short regime label from the Atlas pipeline — when present, preferred over
+   * the full `market_regime_snapshot` paragraph for display headers.
+   * Optional: absent on rows written before this field was added.
+   */
+  regime_label?: string;
 };
 
 function str(v: unknown): string {

--- a/frontend/olympus/lib/snapshot-types.ts
+++ b/frontend/olympus/lib/snapshot-types.ts
@@ -86,6 +86,13 @@ export interface DigestPayload {
   actionable_summary: ActionableItem[];
   risk_radar: RiskItem[];
   segment_freshness: Record<string, SegmentFreshness>;
+  /**
+   * Short regime label (e.g. "Risk-Off Consolidation") added by the backend
+   * pipeline when it populates the digest.  Optional because rows written before
+   * this field was introduced will not have it; the frontend falls back to the
+   * full `market_regime_snapshot` paragraph.
+   */
+  regime_label?: string;
 }
 
 /**

--- a/frontend/olympus/lib/thesis-static-params.ts
+++ b/frontend/olympus/lib/thesis-static-params.ts
@@ -36,7 +36,9 @@ export async function fetchThesisStaticParams(): Promise<{ thesisId: string }[]>
 
   while (offset < THESIS_PARAMS_MAX) {
     const end = offset + THESIS_PARAMS_PAGE - 1;
-    const res = await fetch(`${url}/rest/v1/theses?select=thesis_id`, {
+    // `order=thesis_id` makes Range-based pagination deterministic — without it
+    // PostgREST result order (and thus page boundaries) is undefined.
+    const res = await fetch(`${url}/rest/v1/theses?select=thesis_id&order=thesis_id`, {
       headers: {
         apikey: key,
         Authorization: `Bearer ${key}`,

--- a/frontend/olympus/lib/thesis-static-params.ts
+++ b/frontend/olympus/lib/thesis-static-params.ts
@@ -7,27 +7,56 @@
 export const THESIS_BUILD_STATIC_PARAMS: { thesisId: string }[] = [{ thesisId: '_unlinked' }];
 
 /**
+ * PostgREST page size and cap for the thesis id enumeration fetch.
+ * The default PostgREST limit of 1000 rows can truncate a large thesis table and
+ * cause 404s for tickers not included in the static export.  We paginate using
+ * the `Range` header (`offset-end` notation) and dedupe `thesis_id` so each id
+ * appears at most once regardless of how many historical rows the table has.
+ */
+const THESIS_PARAMS_PAGE = 1000;
+const THESIS_PARAMS_MAX = 50000; // safety cap — well beyond any realistic thesis count
+
+/**
  * Resolve the thesis ids to pre-render. With Supabase env present (production /
  * Cloudflare Pages builds) the ids come from the `theses` table; without it
  * (CI, local builds) only `_unlinked` is exported. A fetch failure when env IS
  * configured throws: silently falling back would ship 404s for every live
  * thesis link, which is the regression this exists to prevent (#674).
+ *
+ * Paginates through the full table (PostgREST `Range` header) and dedupes
+ * `thesis_id` so a thesis with many historical rows doesn't inflate the export.
  */
 export async function fetchThesisStaticParams(): Promise<{ thesisId: string }[]> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) return THESIS_BUILD_STATIC_PARAMS;
 
-  const res = await fetch(`${url}/rest/v1/theses?select=thesis_id`, {
-    headers: { apikey: key, Authorization: `Bearer ${key}` },
-  });
-  if (!res.ok) {
-    throw new Error(`thesis-static-params: theses fetch failed with ${res.status}`);
-  }
-  const rows: { thesis_id: string | null }[] = await res.json();
   const ids = new Set<string>(THESIS_BUILD_STATIC_PARAMS.map((p) => p.thesisId));
-  for (const row of rows) {
-    if (row.thesis_id) ids.add(row.thesis_id);
+  let offset = 0;
+
+  while (offset < THESIS_PARAMS_MAX) {
+    const end = offset + THESIS_PARAMS_PAGE - 1;
+    const res = await fetch(`${url}/rest/v1/theses?select=thesis_id`, {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        // PostgREST range-based pagination; `Prefer: count=none` skips the
+        // expensive COUNT(*) query that the Range header would otherwise trigger.
+        Range: `${offset}-${end}`,
+        'Prefer': 'count=none',
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`thesis-static-params: theses fetch failed with ${res.status}`);
+    }
+    const rows: { thesis_id: string | null }[] = await res.json();
+    for (const row of rows) {
+      if (row.thesis_id) ids.add(row.thesis_id);
+    }
+    // If we got fewer rows than requested, we've reached the end of the table.
+    if (rows.length < THESIS_PARAMS_PAGE) break;
+    offset += THESIS_PARAMS_PAGE;
   }
+
   return [...ids].map((thesisId) => ({ thesisId }));
 }

--- a/frontend/olympus/lib/types.ts
+++ b/frontend/olympus/lib/types.ts
@@ -80,6 +80,8 @@ export interface RebalanceAction {
   current_pct: number;
   recommended_pct: number;
   action: string;
+  /** PM LLM rationale from pm-rebalance.actions, when available. */
+  rationale?: string;
 }
 
 /** Current position as stored in portfolio_management. */
@@ -215,13 +217,17 @@ export interface PortfolioManagement {
 
 /** Computed summary metrics for the performance page. */
 export interface CalculatedMetrics {
-  portfolio_pnl: number;
+  /** Derived from portfolio_metrics.pnl_pct; null when the metrics row is absent. */
+  portfolio_pnl: number | null;
+  /** Sum of effective position weights (always has a real fallback — never null). */
   total_invested: number;
+  /** 100 − total_invested (always has a real fallback — never null). */
   cash_pct: number;
-  sharpe: number;
-  volatility: number;
-  max_drawdown: number;
-  alpha: number;
+  /** null when portfolio_metrics row is absent (prefer "—" over fake zero in UI). */
+  sharpe: number | null;
+  volatility: number | null;
+  max_drawdown: number | null;
+  alpha: number | null;
 }
 
 /** Parsed delta-request.json envelope for library badges and diff scoping. */


### PR DESCRIPTION
## What

Frontend half of the post-audit Olympus fix pass (`docs/olympus/OLYMPUS_FRONTEND_AUDIT.md`). The dashboard's decision-critical surfaces were bound to a stale digest shape the pipeline no longer writes (`snapshot.portfolio.proposed_positions`, a `regime` object) and showed fake `0.00` metrics when `portfolio_metrics` is empty. This rebinds them to the data that **is** published.

## Changes

**Data layer (`lib/`)**
- Recommended book + rebalance actions now come from the published `pm-rebalance` document (`recommended_portfolio` + `actions`, carrying PM rationale), date-guarded; legacy field kept as fallback.
- `sharpe/volatility/max_drawdown/alpha/pnl` return `null` (not `0`) when `portfolio_metrics` is empty → UI renders "—" instead of a misleading `0.00`.
- `resolveLibraryDocumentView` + `collectThesisRelatedDocLinks` match the automated keys `pm-rebalance` and `deliberation/{ticker}`.
- `decision-scorecard` buckets on `|conviction|` over the real `[-5,+5]` domain (was `[0..5]`).
- `documents` query limit raised; thesis static params paginated + deduped (404 fix).

**Components**
- **Overview:** complete 6-value regime color map; P&L "—" guard; `MacroSparklineRow` mounted (was fetched, never rendered); honest "Since {date}" benchmark label.
- **Portfolio:** Allocations **Target** column + Δ-vs-target; Analysis tab now surfaces the automated `pm-rebalance` / `risk-debate` / per-ticker `deliberation` artifacts (was filtering only Track-B keys → blank).
- **Observability:** per-decision drill-down rendering `thesis` + `reflection` (fetched but never shown); "enabled after…" notes on the gated Attribution/RunHealth/PositionRisk empty states; deterministic attribution benchmark lookup.
- **Library:** `RebalanceDocumentView` + `DeliberationDocumentView` render the automated payload shapes (legacy shapes preserved).

## Verification
- `tsc --noEmit`: 0 new errors (2 pre-existing `security-headers.test.ts`)
- `eslint`: clean · `vitest`: 96/96 · `next build`: 14/14 routes export
- `make score`: 10/10 all dimensions

## Notes
- The short `regime_label` digest field is read here with a graceful fallback; the **backend PR** populates it.
- Backend gaps that leave some surfaces empty until activated (unscheduled `portfolio_metrics`/`position_attribution` crons, held migration 041, `OLYMPUS_POSITION_RISK_FIELDS` flag) are addressed in the backend + activation PRs of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #783