### PR TITLE
fix(olympus): real digest prompt, lit fed_odds, wired correlation, regime_label

### DIFF
--- a/digiquant/docs/schemas/atlas_snapshot.v1.json
+++ b/digiquant/docs/schemas/atlas_snapshot.v1.json
@@ -4,15 +4,15 @@
       "additionalProperties": false,
       "description": "One actionable summary entry. Mirrors phase7_synthesis.ActionableItem.",
       "properties": {
-        "label": {
-          "title": "Label",
-          "type": "string"
-        },
         "priority": {
           "maximum": 5,
           "minimum": 1,
           "title": "Priority",
           "type": "integer"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
         },
         "rationale": {
           "title": "Rationale",
@@ -31,19 +31,13 @@
       "additionalProperties": false,
       "description": "Frontend-facing copy of the Phase 7 master synthesis payload.\n\n**This duplicates** ``digiquant.olympus.atlas.phases.phase7_synthesis.DigestSnapshot``\non purpose \u2014 see module docstring for the import-direction rationale. The\nparity test enforces drift detection.\n\nLayout: a :class:`SegmentReport`-shaped core (segment, date, bias,\nheadline, findings, sources, notes) plus the digest-specific narrative\nsections defined in ARCHITECTURE.md \u00a7Phase 7.",
       "properties": {
-        "actionable_summary": {
-          "items": {
-            "$ref": "#/$defs/ActionableItem"
-          },
-          "title": "Actionable Summary",
-          "type": "array"
-        },
-        "alt_data_dashboard": {
-          "title": "Alt Data Dashboard",
+        "segment": {
+          "title": "Segment",
           "type": "string"
         },
-        "asset_classes_summary": {
-          "title": "Asset Classes Summary",
+        "date": {
+          "format": "date",
+          "title": "Date",
           "type": "string"
         },
         "bias": {
@@ -58,17 +52,28 @@
           "title": "Bias",
           "type": "string"
         },
-        "confidence": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Confidence"
+        "headline": {
+          "title": "Headline",
+          "type": "string"
+        },
+        "material_findings": {
+          "items": {
+            "$ref": "#/$defs/Finding"
+          },
+          "title": "Material Findings",
+          "type": "array"
+        },
+        "sources": {
+          "items": {
+            "$ref": "#/$defs/Source"
+          },
+          "title": "Sources",
+          "type": "array"
+        },
+        "notes": {
+          "default": "",
+          "title": "Notes",
+          "type": "string"
         },
         "data_quality": {
           "anyOf": [
@@ -88,39 +93,54 @@
           "default": null,
           "title": "Data Quality"
         },
-        "date": {
-          "format": "date",
-          "title": "Date",
+        "confidence": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Confidence"
+        },
+        "market_regime_snapshot": {
+          "title": "Market Regime Snapshot",
           "type": "string"
         },
-        "headline": {
-          "title": "Headline",
+        "alt_data_dashboard": {
+          "title": "Alt Data Dashboard",
           "type": "string"
         },
         "institutional_summary": {
           "title": "Institutional Summary",
           "type": "string"
         },
-        "market_regime_snapshot": {
-          "title": "Market Regime Snapshot",
+        "asset_classes_summary": {
+          "title": "Asset Classes Summary",
           "type": "string"
         },
-        "material_findings": {
-          "items": {
-            "$ref": "#/$defs/Finding"
-          },
-          "title": "Material Findings",
-          "type": "array"
+        "us_equities_summary": {
+          "title": "Us Equities Summary",
+          "type": "string"
         },
-        "notes": {
+        "thesis_tracker": {
           "default": "",
-          "title": "Notes",
+          "title": "Thesis Tracker",
           "type": "string"
         },
         "portfolio_recommendations": {
           "default": "",
           "title": "Portfolio Recommendations",
           "type": "string"
+        },
+        "actionable_summary": {
+          "items": {
+            "$ref": "#/$defs/ActionableItem"
+          },
+          "title": "Actionable Summary",
+          "type": "array"
         },
         "risk_radar": {
           "items": {
@@ -129,10 +149,6 @@
           "title": "Risk Radar",
           "type": "array"
         },
-        "segment": {
-          "title": "Segment",
-          "type": "string"
-        },
         "segment_freshness": {
           "additionalProperties": {
             "$ref": "#/$defs/SegmentFreshness"
@@ -140,20 +156,10 @@
           "title": "Segment Freshness",
           "type": "object"
         },
-        "sources": {
-          "items": {
-            "$ref": "#/$defs/Source"
-          },
-          "title": "Sources",
-          "type": "array"
-        },
-        "thesis_tracker": {
+        "regime_label": {
           "default": "",
-          "title": "Thesis Tracker",
-          "type": "string"
-        },
-        "us_equities_summary": {
-          "title": "Us Equities Summary",
+          "description": "Short regime token, e.g. 'Risk-on / Policy easing' \u2014 NOT the full market_regime_snapshot paragraph.",
+          "title": "Regime Label",
           "type": "string"
         }
       },
@@ -179,16 +185,16 @@
           "title": "Label",
           "type": "string"
         },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
         "source_ids": {
           "items": {
             "type": "string"
           },
           "title": "Source Ids",
           "type": "array"
-        },
-        "summary": {
-          "title": "Summary",
-          "type": "string"
         }
       },
       "required": [
@@ -229,17 +235,17 @@
       "additionalProperties": false,
       "description": "Per-segment provenance marker used by the dashboard.\n\nMirrors :class:`digiquant.olympus.atlas.phases.phase7_synthesis.SegmentFreshness`.",
       "properties": {
-        "as_of": {
-          "description": "ISO date string ('' if unknown)",
-          "title": "As Of",
-          "type": "string"
-        },
         "source": {
           "enum": [
             "today",
             "baseline"
           ],
           "title": "Source",
+          "type": "string"
+        },
+        "as_of": {
+          "description": "ISO date string ('' if unknown)",
+          "title": "As Of",
           "type": "string"
         }
       },
@@ -293,27 +299,11 @@
   "additionalProperties": false,
   "description": "Frontend-consumable wrapper around a ``daily_snapshots`` row.\n\nLayout (top-level keys ordered for human-readability when serialized):\n\n- ``schema_version`` \u2014 int; bump on breaking changes (see module docstring).\n- ``run_date`` \u2014 the trading date the digest was synthesized for.\n- ``run_type`` \u2014 ``\"baseline\"`` (Sunday weekly) or ``\"delta\"`` (weekday).\n- ``baseline_date`` \u2014 for delta runs, the most recent baseline this delta\n  builds on; ``None`` on a baseline run.\n- ``published_at`` \u2014 UTC timestamp the envelope was assembled.\n- ``digest`` \u2014 the validated :class:`DigestPayload`.",
   "properties": {
-    "baseline_date": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Baseline Date"
-    },
-    "digest": {
-      "$ref": "#/$defs/DigestPayload"
-    },
-    "published_at": {
-      "description": "UTC timestamp the envelope was assembled",
-      "format": "date-time",
-      "title": "Published At",
-      "type": "string"
+    "schema_version": {
+      "default": 1,
+      "description": "Envelope schema version",
+      "title": "Schema Version",
+      "type": "integer"
     },
     "run_date": {
       "format": "date",
@@ -328,11 +318,27 @@
       "title": "Run Type",
       "type": "string"
     },
-    "schema_version": {
-      "default": 1,
-      "description": "Envelope schema version",
-      "title": "Schema Version",
-      "type": "integer"
+    "baseline_date": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Baseline Date"
+    },
+    "published_at": {
+      "description": "UTC timestamp the envelope was assembled",
+      "format": "date-time",
+      "title": "Published At",
+      "type": "string"
+    },
+    "digest": {
+      "$ref": "#/$defs/DigestPayload"
     }
   },
   "required": [

--- a/digiquant/src/digiquant/data/prices/correlation.py
+++ b/digiquant/src/digiquant/data/prices/correlation.py
@@ -1,0 +1,99 @@
+"""Pairwise return correlations from close-price history (pure, no I/O).
+
+Consumed by the risk sizer (Phase 7E) to correct the conservative ρ=1.0
+full-correlation default in ``_portfolio_vol`` and to allow ``_corr_dedup``
+to drop the lower-conviction leg of a highly correlated pair.
+
+The output is a long frame ``{a, b, corr}`` — one unordered pair per row —
+that ``sizing.size_portfolio(corr=...)`` consumes directly. Both ``(a,b)``
+and ``(b,a)`` orders are looked up by the sizer, so returning one order per
+pair is fine and avoids row-count confusion.
+
+Polars only (no pandas, no numpy). HTTP-free; the Supabase read lives in
+``queries.get_return_correlations``.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def pairwise_return_correlations(
+    closes: pl.DataFrame,
+    *,
+    min_overlap: int = 30,
+) -> pl.DataFrame:
+    """Compute pairwise Pearson return correlations from long close-price history.
+
+    Args:
+        closes: long frame with columns ``ticker``, ``date``, ``close``.
+            ``date`` may be ISO string or ``pl.Date``; ``close`` must be numeric.
+        min_overlap: minimum number of shared trading days with *both* tickers
+            having a return to include the pair. Pairs with fewer common return
+            dates are omitted so a newly-listed ticker doesn't produce spurious
+            near-1.0 correlations from a handful of coincidental days.
+
+    Returns:
+        Long frame ``{a: Utf8, b: Utf8, corr: Float64}``.  One row per
+        unordered pair (a < b lexicographically).  Empty when fewer than two
+        tickers survive the overlap threshold.
+    """
+    if closes.is_empty():
+        return pl.DataFrame({"a": [], "b": [], "corr": []}).cast(
+            {"a": pl.Utf8, "b": pl.Utf8, "corr": pl.Float64}
+        )
+
+    # Normalise date column to pl.Date so sorting and joining are unambiguous.
+    schema = closes.schema
+    df = closes.select(
+        pl.col("ticker").cast(pl.Utf8),
+        pl.col("date").cast(pl.Date) if schema.get("date") != pl.Date else pl.col("date"),
+        pl.col("close").cast(pl.Float64),
+    )
+
+    # Compute daily simple returns (r_t = close_t / close_{t-1} - 1) per ticker,
+    # sorted ascending so shift(1) is the previous trading day for that ticker.
+    df = df.sort(["ticker", "date"])
+    df = df.with_columns(
+        (pl.col("close") / pl.col("close").shift(1).over("ticker") - 1.0).alias("ret")
+    ).filter(pl.col("ret").is_not_null() & pl.col("ret").is_finite())
+
+    tickers: list[str] = df["ticker"].unique().sort().to_list()
+    if len(tickers) < 2:
+        return pl.DataFrame({"a": [], "b": [], "corr": []}).cast(
+            {"a": pl.Utf8, "b": pl.Utf8, "corr": pl.Float64}
+        )
+
+    # Pivot to wide form: date × ticker.  Missing dates for a ticker → null.
+    wide = df.pivot(values="ret", index="date", on="ticker", aggregate_function="first")
+
+    rows_a: list[str] = []
+    rows_b: list[str] = []
+    rows_corr: list[float] = []
+
+    for i, ta in enumerate(tickers):
+        for tb in tickers[i + 1 :]:
+            # Both columns must exist in the wide frame (they do — every ticker that
+            # survived the filter above is a column).  Select the pair, drop rows
+            # where either is null (non-overlapping trading days, e.g. ETF closed).
+            if ta not in wide.columns or tb not in wide.columns:
+                continue  # defensive: should never happen, but skip rather than crash
+            pair = wide.select([ta, tb]).drop_nulls()
+            if len(pair) < min_overlap:
+                # Not enough overlapping history to estimate a reliable correlation.
+                continue
+            # Pearson r via the pl.corr expression — .item() extracts the scalar float.
+            # pl.corr requires Polars ≥ 0.15 (present in any supported install).
+            rho = pair.select(pl.corr(ta, tb)).item()
+            if rho is None or not isinstance(rho, float):
+                continue
+            rows_a.append(ta)
+            rows_b.append(tb)
+            rows_corr.append(rho)
+
+    return pl.DataFrame({"a": rows_a, "b": rows_b, "corr": rows_corr}).cast(
+        {"a": pl.Utf8, "b": pl.Utf8, "corr": pl.Float64}
+    )
+
+
+__all__ = ["pairwise_return_correlations"]

--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -14,6 +14,7 @@ from typing import Any  # noqa  # scored-lint suppression: duck-typed Supabase c
 import polars as pl
 
 from digiquant.data.prices.breadth import compute_breadth
+from digiquant.data.prices.correlation import pairwise_return_correlations
 from digiquant.data.prices.etf_flows import compute_etf_flows_proxy
 from digiquant.data.prices.fed_probabilities import fed_distribution_from_ladder
 from digiquant.data.prices.relative_strength import compute_relative_strength
@@ -384,6 +385,53 @@ def get_fed_rate_probabilities(
         "polymarket": sorted(data["polymarket"], key=lambda d: -(d["prob"] or 0))[:12],
         "sources": sources,
     }
+
+
+def get_return_correlations(
+    *,
+    client: Any,
+    tickers: list[str],
+    run_date: date,
+    lookback_days: int = 63,
+    page_size: int = 1000,
+) -> pl.DataFrame | None:
+    """Pairwise Pearson return correlations for ``tickers`` over a trailing window.
+
+    Loads ``price_history`` closes for the requested tickers over the
+    ``lookback_days`` trailing window with ``.lte("date", run_date)`` as a
+    look-ahead guard (no future closes leak into the correlation estimate).
+    Uses a single capped query (``tickers × lookback_days`` rows is small for a
+    typical PM book; the ``page_size`` argument is kept for API symmetry with the
+    other readers but is applied as a hard limit, not a paginated loop, since the
+    correlation window is bounded by the PM's position count).
+
+    Returns a long Polars frame ``{a, b, corr}`` ready for
+    ``sizing.size_portfolio(corr=...)``, or ``None`` on any error or when there
+    are fewer than two tickers with enough history (the caller keeps the
+    conservative ρ=1.0 default). Fail-soft: no exception propagates to the caller.
+    """
+    if len(tickers) < 2:
+        return None
+    since = (run_date - timedelta(days=lookback_days)).isoformat()
+    try:
+        resp = (
+            client.table("price_history")
+            .select("date,ticker,close")
+            .in_("ticker", list(tickers))
+            .gte("date", since)
+            .lte("date", run_date.isoformat())  # look-ahead guard (no future closes)
+            .order("date", desc=False)
+            .limit(len(tickers) * page_size)
+            .execute()
+        )
+        rows: list[dict[str, Any]] = getattr(resp, "data", None) or []
+        if not rows:
+            return None
+        frame = pairwise_return_correlations(pl.DataFrame(rows))
+        return frame if not frame.is_empty() else None
+    except Exception as exc:  # noqa: BLE001 — correlation is best-effort; caller uses None
+        logger.warning("get_return_correlations: failed (%s); skipping correlation", exc)
+        return None
 
 
 # ── Generic scoped data reader (Pillar 1D) ───────────────────────────────────

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase6_consolidate.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase6_consolidate.py
@@ -37,6 +37,33 @@ def _vix_level(state: AtlasResearchState) -> float | None:
         return None
 
 
+def _fed_odds_compact(state: AtlasResearchState) -> dict[str, Any] | None:
+    """Extract a compact fed_odds summary from the preflight market_context.
+
+    The full ``get_fed_rate_probabilities`` payload (meeting_date, kalshi distribution,
+    polymarket list) is richer than the bias row needs. We surface the most actionable
+    slice: meeting date, most-likely bucket, and p(cut)/p(hold)/p(hike) when available.
+    Returns None when preflight did not populate fed_odds (outage or no ingested rows).
+    """
+    full = state.data_layer.market_context.get("fed_odds")
+    if not isinstance(full, dict) or not full:
+        return None
+    out: dict[str, Any] = {"meeting_date": full.get("meeting_date")}
+    kalshi = full.get("kalshi") or {}
+    dist = kalshi.get("distribution") or {}
+    if dist:
+        out["most_likely"] = kalshi.get("most_likely")
+        # Aggregate into the three coarse buckets the bias row uses.
+        # bucket keys look like "<=3.25", "3.5", ">4.25"; a cut = key < current fed funds.
+        # We surface the raw distribution so downstream consumers can re-aggregate.
+        out["distribution"] = dist
+    polymarket = full.get("polymarket")
+    if polymarket:
+        out["polymarket_top"] = polymarket[0] if polymarket else None
+    out["sources"] = full.get("sources", [])
+    return out
+
+
 def _phase6_node(state: AtlasResearchState) -> dict[str, Any]:
     """Assemble the daily_snapshots bias row from phases 1–5."""
     bias_row: Phase6BiasRow = {
@@ -53,7 +80,9 @@ def _phase6_node(state: AtlasResearchState) -> dict[str, Any]:
         "options_sentiment": _bias_of(state, "phase1_outputs", "alt-options-derivatives"),
         "cta_direction": _bias_of(state, "phase1_outputs", "alt-cta-positioning"),
         "hf_consensus": _bias_of(state, "phase2_outputs", "inst-hedge-fund-intel"),
-        "fed_odds": None,  # populated by Phase 7 synthesis via rate-futures lookup
+        # Populated by preflight from prediction-market data (Kalshi + Polymarket).
+        # Fail-soft: None when no ingested rows or preflight encountered an outage.
+        "fed_odds": _fed_odds_compact(state),
         "notes": "",  # filled by Phase 7 master synthesis
     }
     return {"phase6_bias_row": bias_row}

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
@@ -47,6 +47,17 @@ class DigestSnapshot(SegmentReport):
         default_factory=dict,
         description="Per-segment provenance (today vs. carried) — populated from state",
     )
+    # Short machine-readable regime token for the dashboard chip.
+    # The LLM is asked to populate this from phase3; when it omits it we
+    # deterministically backfill from state.phase3_output.payload.body.get("regime_label")
+    # — same fail-soft pattern used for segment_freshness above.
+    regime_label: str = Field(
+        default="",
+        description=(
+            "Short regime token, e.g. 'Risk-on / Policy easing' — "
+            "NOT the full market_regime_snapshot paragraph."
+        ),
+    )
 
 
 def _segment_freshness(state: AtlasResearchState) -> dict[str, SegmentFreshness]:
@@ -107,8 +118,21 @@ def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
     # Overwrite the LLM-proposed freshness map with the deterministic one.
     # The LLM is prone to inferring freshness incorrectly on delta runs;
     # state is authoritative.
-    digest = result.model_copy(update={"segment_freshness": _segment_freshness(state)})
+    overrides: dict[str, Any] = {"segment_freshness": _segment_freshness(state)}
+    # Deterministically backfill regime_label when the LLM omitted it.
+    # Phase 3's macro body carries the authoritative short regime token; the
+    # digest skill is asked to copy it but may leave the field empty.
+    if not result.regime_label:
+        overrides["regime_label"] = _regime_label_from_phase3(state)
+    digest = result.model_copy(update=overrides)
     return {"phase7_digest": digest.model_dump(mode="json")}
+
+
+def _regime_label_from_phase3(state: AtlasResearchState) -> str:
+    """Return the short regime token from phase3's macro body (fail-soft to empty string)."""
+    if state.phase3_output is None or state.phase3_output.payload.source != "today":
+        return ""
+    return str(state.phase3_output.payload.body.get("regime_label") or "")  # type: ignore[union-attr]
 
 
 def _body(slot: Any) -> dict[str, Any]:

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -14,7 +14,7 @@ from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-u
 
 import yaml
 
-from digiquant.olympus.atlas.data.queries import get_market_context
+from digiquant.olympus.atlas.data.queries import get_fed_rate_probabilities, get_market_context
 from digiquant.olympus.atlas.decision_log import (
     ReflectorOutput,
     fetch_recent_lessons,
@@ -165,6 +165,17 @@ def _data_layer_snapshot(
         )
     except _SUPABASE_READ_ERRORS as exc:
         logger.warning("market_context unavailable (%s); phases run without injected values", exc)
+
+    # Fed rate-decision odds from prediction markets. Injected into market_context so
+    # phase6_consolidate can read it for the bias-row fed_odds slot. Fail-soft to None —
+    # a Kalshi/Polymarket outage must never block a run.
+    try:
+        fed_odds = get_fed_rate_probabilities(client=deps.client, run_date=run_date) or None
+    except _SUPABASE_READ_ERRORS as exc:
+        logger.warning("fed_odds unavailable (%s); fed_odds slot will be None this run", exc)
+        fed_odds = None
+    if fed_odds is not None:
+        market_context["fed_odds"] = fed_odds
 
     return DataLayerSnapshot(
         price_technicals_latest=latest_tech,

--- a/digiquant/src/digiquant/olympus/atlas/skills/digest/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/digest/SKILL.md
@@ -1,48 +1,129 @@
 ---
-name: digiquant-atlas
+name: master-digest
 description: >
-  Run this skill to produce the full daily market digest. Triggers when the user says "run today's digest",
-  "daily analysis", "market update", "morning brief", or pastes the new-day prompt. UPGRADED: This skill
-  now delegates to the orchestrator skill which runs a full 7-phase pipeline with dedicated sub-agents for
-  each sector, asset class, and alternative data source. Always use this skill for any full market analysis session.
+  Synthesize all upstream phase outputs into the daily DigestSnapshot. Run as Phase 7 after
+  phases 1–5 have completed. Produces market_regime_snapshot, alt_data_dashboard,
+  institutional_summary, asset_classes_summary, us_equities_summary, thesis_tracker,
+  portfolio_recommendations, actionable_summary[], risk_radar[], and a short regime_label.
+  Triggered internally by the pipeline orchestrator — not a user-facing session skill.
 ---
 
-# digiquant-atlas — Pointer to Orchestrator (v2)
+# Master Digest Synthesis — Phase 7
 
-> **This skill has been superseded by the full orchestrator pipeline.**
-> Follow the instructions below to run the upgraded system.
+## Role
 
----
+You are a disciplined sell-side macro strategist writing the daily synthesis brief. Your only
+job is to integrate the upstream phase outputs — do not fabricate facts, quote prices, or assert
+probabilities you were not given. When evidence is absent for a section, say so in one sentence
+rather than inventing content.
 
-## Action Required
+## Inputs
 
-When this skill is triggered by any of these phrases:
-- "run today's digest"
-- "daily analysis"
-- "market update"
-- "morning brief"
-- Pasting the `scripts/cowork-daily-prompt.txt` content
+The `phase_inputs` block contains:
 
-**Immediately load and follow: `skills/orchestrator/SKILL.md`**
+- `bias_row` — the Phase 6 deterministic bias row (macro_regime, equity_bias, crypto_bias,
+  bond_bias, commodity_bias, forex_bias, vix_level, inst_flow, options_sentiment, cta_direction,
+  hf_consensus, fed_odds). Use these as the factual backbone; do not override them with guesses.
+- `phase1` — alternative data outputs (sentiment, CTA positioning, options/derivatives, politician
+  and Fed signals). Key signals: risk-appetite proxies, systematic positioning, options skew.
+- `phase2` — institutional intelligence (ETF flows, hedge-fund intel). Key signals: net
+  flow direction, HF crowding or rotation.
+- `phase3` — macro analysis (regime classification, yield curve, central bank, inflation, geopolitics).
+  The `regime_label` field from phase3 is the authoritative short regime token.
+- `phase4` — asset classes (bonds, commodities, forex, crypto, international equities).
+- `phase5` — US equities plus sector sub-agent outputs (11 GICS sectors).
+- `custom_prompt` (optional) — a targeted question or override injected by the operator for this
+  run. When present, treat it as the top priority and address it explicitly in `notes`.
 
-The orchestrator runs the complete pipeline:
-1. **Phase 1**: Alternative Data (sentiment, CTA positioning, options, politician signals)
-2. **Phase 2**: Institutional Intelligence (ETF flows, hedge fund intel)
-3. **Phase 3**: Macro Analysis
-4. **Phase 4**: Asset Classes (bonds, commodities, forex, crypto, international)
-5. **Phase 5**: US Equities + 11 GICS Sector Sub-Agents
-6. **Phase 7**: Master digest synthesis (JSON-first, DB-first publish)
+## Evidence standards
 
-Output is stored DB-first (Supabase). Markdown is a derived view.
+- Every assertion in the narrative sections must trace to at least one upstream body field.
+- If phase bodies are empty (carry run or missing segment), write "No fresh data this run."
+  rather than inferring or repeating yesterday's view.
+- `material_findings` must each cite `source_ids` referencing a real entry in `sources`.
+- Do not repeat the same point across sections. Each section adds distinct value.
+- State the bias directly. "Cautiously" and "somewhat" are noise — cut them.
+- Where evidence conflicts (e.g., macro bearish but equities printing new highs), flag the
+  tension explicitly rather than resolving it prematurely.
 
----
+## Output fields
 
-## Quality Standards (Preserved)
+Produce a valid `DigestSnapshot` JSON object. All string fields are plain prose (no markdown
+headers, no bullet lists inside a single string). The `actionable_summary` and `risk_radar`
+arrays are structured per their schemas.
 
-- Be direct. State the bias. Don't hedge everything into meaningless mush.
-- Use the user's preferences to filter for what matters to THEM, not general market commentary.
-- When evidence is conflicted, say so clearly and explain both sides.
-- Flag anything that contradicts the user's active theses.
-- Do not repeat the same sentence twice in different sections.
-- Every section should end with an implication or action, not just a description.
+### `market_regime_snapshot` (paragraph, ~150 words)
+Integrate phase3's regime assessment with the phase1/phase2 flow confirmation or denial.
+Cover: growth/inflation/policy 4-factor classification, recession probability signal, yield
+curve status, key central-bank stance, and whether the systemic risk environment supports
+or contradicts the headline regime. End with one sentence on what this regime implies for
+positioning over the next 5–10 trading days.
 
+### `regime_label` (token string, ≤ 40 chars)
+A short machine-readable regime token derived from phase3 — e.g. "Risk-on / Policy easing",
+"Risk-off / Stagflation watch", "Neutral / Rate plateau". Use the `regime_label` field from
+`phase3` if present; otherwise derive it from the 4-factor classification in `phase3`'s body.
+This is NOT a restatement of `market_regime_snapshot` — it is a short label for the dashboard
+chip. Keep it factual, not aspirational.
+
+### `alt_data_dashboard` (paragraph, ~100 words)
+Summarize phase1 outputs: consumer/transaction-data sentiment trend, CTA net positioning
+(long/short/covering), options skew and put/call ratio reading, and any politician or Fed
+signal worth flagging. State the aggregate alt-data stance (supportive / cautionary / neutral).
+
+### `institutional_summary` (paragraph, ~80 words)
+Summarize phase2 outputs: net ETF flow direction and magnitude class (large/moderate/small
+inflow or outflow), dominant destination sectors, and hedge-fund consensus stance. Note any
+crowding risks or notable rotation signals.
+
+### `asset_classes_summary` (paragraph, ~120 words)
+Synthesize phase4 outputs across bonds (duration bias), commodities (energy/metals direction),
+forex (DXY trend and key pair moves), crypto (risk-on/risk-off signal), and international
+equities (EM vs DM divergence). Focus on cross-asset confirmation or divergence from the
+macro regime.
+
+### `us_equities_summary` (paragraph, ~120 words)
+Synthesize phase5 outputs: market-cap-weighted index bias, sector leadership and laggards
+(by GICS tier), breadth reading, and any single-stock or earnings catalyst dominating the
+session. Confirm or contradict the macro regime signal from equities' perspective.
+
+### `thesis_tracker` (paragraph, default "")
+For each active thesis from `prior_context` that intersects with today's evidence, state:
+thesis label → current status (intact / under pressure / invalidated) → key evidence.
+Omit if no active theses are present.
+
+### `portfolio_recommendations` (paragraph, default "")
+High-level positioning implications: asset class tilts, sector over/underweights, duration
+and credit guidance, and any hedging considerations warranted by the risk_radar. Do not
+size individual positions here — that is Phase 7E's job.
+
+### `actionable_summary` (list[ActionableItem])
+3–5 items, priority 1 (highest urgency) to 5 (low). Each item must be directly executable
+— a monitoring level, a tilt trigger, or a hedging action. No padding items.
+
+Fields: `priority` (int 1–5), `label` (≤ 60 chars), `rationale` (1–2 sentences citing evidence).
+
+### `risk_radar` (list[RiskItem])
+2–4 items covering the most time-sensitive tail risks. Do not list macro background risks
+that are always present — only risks with a specific trigger level or event that could
+materialize within the `horizon_hours` window.
+
+Fields: `horizon_hours` (int 1–168), `label` (≤ 60 chars), `trigger` (1 sentence: "X if Y").
+
+### SegmentReport core fields
+
+- `segment` — always `"master-digest"`
+- `bias` — overall market bias: `strong_bullish | bullish | neutral | bearish | strong_bearish | mixed`
+- `headline` — one sentence (≤ 120 chars) capturing the dominant macro-market theme of the day
+- `material_findings` — 3–6 high-signal findings with `label`, `summary`, and `source_ids`
+- `sources` — cite every source referenced in material_findings (id, title, url)
+- `notes` — operator notes or custom_prompt response (empty string if neither applies)
+
+## Quality checklist (verify before emitting)
+
+1. `regime_label` is ≤ 40 characters and matches phase3 evidence.
+2. No section repeats the same substantive point found in another section.
+3. Every `ActionableItem` and `RiskItem` has a clear evidential basis traceable to a phase body.
+4. `bias` is consistent with `market_regime_snapshot` and `equity_bias` from bias_row.
+5. `fed_odds` from bias_row is referenced in `market_regime_snapshot` if non-null.
+6. When `custom_prompt` is present, it is addressed in `notes`.

--- a/digiquant/src/digiquant/olympus/atlas/snapshot.py
+++ b/digiquant/src/digiquant/olympus/atlas/snapshot.py
@@ -164,6 +164,15 @@ class DigestPayload(BaseModel):
     actionable_summary: list[ActionableItem] = Field(default_factory=list)
     risk_radar: list[RiskItem] = Field(default_factory=list)
     segment_freshness: dict[str, SegmentFreshness] = Field(default_factory=dict)
+    # Short regime token for the dashboard chip — mirrors DigestSnapshot.regime_label.
+    # Default "" so existing rows without this field validate without error.
+    regime_label: str = Field(
+        default="",
+        description=(
+            "Short regime token, e.g. 'Risk-on / Policy easing' — "
+            "NOT the full market_regime_snapshot paragraph."
+        ),
+    )
 
 
 # ─── SnapshotEnvelope — the wire-level contract ─────────────────────────────

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -289,6 +289,7 @@ class Phase7DigestPayload(TypedDict, total=False):
     actionable_summary: list[dict[str, Any]]
     risk_radar: list[dict[str, Any]]
     segment_freshness: dict[str, dict[str, Any]]
+    regime_label: str
     # MonthlyDigest-only.
     month_over_month_regime_delta: str
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7c_analyst.py
@@ -81,7 +81,6 @@ class AnalystPayload(BaseModel):
     conviction_score: int = Field(ge=-5, le=5, description="-5 strong sell … +5 strong buy")
     stance: Literal["buy", "hold", "sell", "watch"]
     thesis: str = Field()
-    risks: str = Field(default="")
     sources: list[str] = Field(default_factory=list)
 
 
@@ -213,8 +212,7 @@ def _join_analyst_node_factory(ticker: str):
     ``conviction_score`` is the [-5,+5] int from the weighted-average axis
     score; ``stance`` is the highest-weighted axis stance (with tie-break
     to "hold"); ``thesis`` concatenates the per-axis rationales and notes
-    any missing axes; ``risks`` stays empty (a follow-up issue wires it);
-    ``sources`` unions across axes preserving insertion order.
+    any missing axes; ``sources`` unions across axes preserving insertion order.
     """
 
     def _node(state: HermesState) -> dict[str, Any]:
@@ -230,7 +228,6 @@ def _join_analyst_node_factory(ticker: str):
                 conviction_score=0,
                 stance="hold",
                 thesis="(no specialist outputs available for this ticker)",
-                risks="",
                 sources=[],
             )
             return {"phase7c_analysts": {ticker: payload.model_dump(mode="json")}}
@@ -281,7 +278,6 @@ def _join_analyst_node_factory(ticker: str):
             conviction_score=conviction_score,
             stance=chosen_stance,  # type: ignore[arg-type]
             thesis=thesis,
-            risks="",
             sources=list(sources_seen),
         )
         return {"phase7c_analysts": {ticker: payload.model_dump(mode="json")}}

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
@@ -207,6 +207,9 @@ def _pm_node(state: HermesState) -> dict[str, Any]:
         # rationale field — see ``skills/decision-reflector/SKILL.md`` for
         # the lesson shape.
         "past_context": list(state.prior_context.decision_lessons),
+        # Fed rate-decision odds forwarded from the bias_row for the PM's
+        # macro-policy awareness. Already fail-soft (None when unavailable).
+        "fed_odds": (state.phase6_bias_row or {}).get("fed_odds"),
     }
     tools, execute_tool, _ = _pm_tools(state)
     result = run_research_agent(

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -264,7 +264,9 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
                 run_date=state.run_date,
             )
         except Exception as exc:  # noqa: BLE001 — correlation is best-effort
-            logger.warning("phase7e: correlation read failed (%s); using full-correlation default", exc)
+            logger.warning(
+                "phase7e: correlation read failed (%s); using full-correlation default", exc
+            )
             corr_frame = None
 
         try:

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -28,9 +28,12 @@ rebalance (``None``) — distinct from a deliberate 100%-cash stance (empty
 
 The drawdown circuit breaker is wired (``risk_controls.breaker_scale_from_nav_history``):
 a deepening drawdown from the NAV peak scales gross exposure down (raises cash); a shallow
-or freshly launched book leaves it at 1.0. Correlation is still stubbed (``corr=None`` →
-the sizer's conservative full-correlation default), arriving in a follow-up PR without
-changing this node's contract.
+or freshly launched book leaves it at 1.0. Real pairwise return correlations are loaded
+from ``price_history`` via ``queries.get_return_correlations`` (look-ahead-guarded, same
+discipline as the vol read) and passed to the sizer so ``_corr_dedup`` and
+``_portfolio_vol`` use real ρ instead of the conservative ρ=1.0 default. Fail-soft:
+correlation errors fall back to ``corr=None`` (conservative full-correlation) without
+affecting the rest of sizing.
 """
 
 from __future__ import annotations
@@ -42,6 +45,7 @@ from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
 
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 
+from digiquant.olympus.atlas.data.queries import get_return_correlations
 from digiquant.olympus.atlas.state import AtlasResearchState, RebalancePayload
 from digiquant.olympus.atlas.supabase_io import SupabaseClient
 from digiquant.olympus.hermes.risk_controls import BreakerConfig, breaker_scale_from_nav_history
@@ -250,6 +254,19 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
             logger.warning("phase7e: drawdown breaker failed (%s); neutral scale", exc)
             breaker_scale, breaker_note = 1.0, ""
 
+        # Real pairwise correlations — OWN fail-soft scope so a DB error or a thin-history
+        # book (< min_overlap days) falls back to corr=None (ρ=1.0 conservative default) and
+        # never aborts sizing. Uses the same look-ahead discipline as the vol read above.
+        try:
+            corr_frame = get_return_correlations(
+                client=deps.client,
+                tickers=pm_tickers,
+                run_date=state.run_date,
+            )
+        except Exception as exc:  # noqa: BLE001 — correlation is best-effort
+            logger.warning("phase7e: correlation read failed (%s); using full-correlation default", exc)
+            corr_frame = None
+
         try:
             convictions, stances = _effective_inputs(
                 pm_tickers,
@@ -262,7 +279,7 @@ def build_risk_sizing_node(deps: RiskSizingDeps):
                 convictions=convictions,
                 stances=stances,
                 risk=risk,
-                corr=None,
+                corr=corr_frame,
                 caps=caps,
                 breaker_scale=breaker_scale,
             )

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -125,9 +125,7 @@ def _upsert_theses(
         analyst = analysts.get(ticker) or {}
         debate = debates.get(ticker) or {}
         short = _clip(analyst.get("thesis"), 60)
-        invalidation = _clip(
-            debate.get("bear_case") or debate.get("key_tension"), 400
-        )
+        invalidation = _clip(debate.get("bear_case") or debate.get("key_tension"), 400)
         thesis_rows.append(
             {
                 "date": date_str,

--- a/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
+++ b/digiquant/src/digiquant/olympus/hermes/portfolio_materialize.py
@@ -110,7 +110,7 @@ def _upsert_theses(
     frozen legacy scripts did), so the dashboard's Theses surface stayed empty.
     This derives one thesis per held ticker — keyed ``(date, thesis_id=ticker.lower())``
     to match the ``theses`` unique key — from the per-ticker ``AnalystPayload``
-    (thesis text → notes/name, stance → status, debate bear-case / analyst risks
+    (thesis text → notes/name, stance → status, debate bear-case / key tension
     → invalidation). The vehicle is the holding's own ticker.
 
     ``thesis_vehicles`` FK-references ``(date, thesis_id)`` on ``theses``, so the
@@ -126,7 +126,7 @@ def _upsert_theses(
         debate = debates.get(ticker) or {}
         short = _clip(analyst.get("thesis"), 60)
         invalidation = _clip(
-            debate.get("bear_case") or debate.get("key_tension") or analyst.get("risks"), 400
+            debate.get("bear_case") or debate.get("key_tension"), 400
         )
         thesis_rows.append(
             {

--- a/tests/dq/atlas/test_phase7_synthesis_regime_fed.py
+++ b/tests/dq/atlas/test_phase7_synthesis_regime_fed.py
@@ -251,7 +251,7 @@ class TestFedOddsWiring:
         )
         return PreflightDeps(
             client=client,
-            config_loader=lambda: AtlasConfigBundle(),
+            config_loader=AtlasConfigBundle,
         )
 
     def test_fed_odds_populated_in_market_context(self) -> None:

--- a/tests/dq/atlas/test_phase7_synthesis_regime_fed.py
+++ b/tests/dq/atlas/test_phase7_synthesis_regime_fed.py
@@ -1,0 +1,367 @@
+"""Tests for WS3a additions to Phase 7 synthesis and Phase 6 consolidate.
+
+Covers:
+- DigestSnapshot.regime_label field presence and defaults.
+- Deterministic regime_label backfill from phase3 when LLM omits it.
+- LLM-emitted regime_label is preserved when non-empty.
+- fed_odds wiring: preflight market_context → phase6 bias row → phase7 phase_inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa  # scored-lint: heterogeneous FakeSupabase fixture / kwargs dicts
+from unittest.mock import patch
+
+import pytest
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant.olympus.atlas.phases.phase6_consolidate import build_phase6
+from digiquant.olympus.atlas.phases.phase7_synthesis import (
+    DigestSnapshot,
+    _regime_label_from_phase3,
+    build_phase7,
+)
+from digiquant.olympus.atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    Carried,
+    DataLayerSnapshot,
+    SegmentPayload,
+    SegmentSlot,
+)
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _slot(slug: str, bias: str = "bullish", **extra: Any) -> SegmentSlot:
+    body = {"segment": slug, "bias": bias, **extra}
+    return SegmentSlot(payload=SegmentPayload(segment=slug, body=body, as_of=date(2026, 4, 26)))
+
+
+def _base_state(regime_label: str = "Risk-on / Policy easing") -> AtlasResearchState:
+    """Minimal state seeded through phase 5 with an optional regime_label in phase3."""
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=AtlasConfigBundle(watchlist=["AAPL"]),
+    )
+    state.phase1_outputs = {
+        "alt-cta-positioning": _slot("alt-cta-positioning", bias="neutral"),
+        "alt-options-derivatives": _slot("alt-options-derivatives", vix_level=14.5),
+    }
+    state.phase2_outputs = {
+        "inst-institutional-flows": _slot("inst-institutional-flows"),
+        "inst-hedge-fund-intel": _slot("inst-hedge-fund-intel"),
+    }
+    state.phase3_output = _slot("macro", regime_label=regime_label)
+    state.phase4_outputs = {
+        "bonds": _slot("bonds"),
+        "commodities": _slot("commodities"),
+        "forex": _slot("forex"),
+        "crypto": _slot("crypto"),
+    }
+    state.phase5_outputs = {"equity": _slot("equity")}
+    return state
+
+
+def _digest_json(regime_label: str = "") -> str:
+    """Build a minimal DigestSnapshot-shaped JSON the fake LLM returns."""
+    return json.dumps(
+        {
+            "segment": "master-digest",
+            "date": "2026-04-26",
+            "bias": "neutral",
+            "headline": "Late-cycle consolidation; policy easing priced.",
+            "material_findings": [],
+            "sources": [],
+            "notes": "",
+            "market_regime_snapshot": "Growth slowing, policy easing.",
+            "alt_data_dashboard": "CTAs neutral.",
+            "institutional_summary": "Modest inflows.",
+            "asset_classes_summary": "Bonds rallying.",
+            "us_equities_summary": "Narrow breadth.",
+            "thesis_tracker": "",
+            "portfolio_recommendations": "",
+            "actionable_summary": [],
+            "risk_radar": [],
+            "segment_freshness": {},
+            # regime_label intentionally absent (or supplied below) per test scenario.
+            "regime_label": regime_label,
+        }
+    )
+
+
+# ─── DigestSnapshot model-level tests ────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDigestSnapshotField:
+    def test_regime_label_has_default_empty(self) -> None:
+        """regime_label must be optional with a default of ''."""
+        snapshot = DigestSnapshot(
+            segment="master-digest",
+            date=date(2026, 4, 26),
+            bias="neutral",
+            headline="Test",
+            market_regime_snapshot="x",
+            alt_data_dashboard="y",
+            institutional_summary="z",
+            asset_classes_summary="a",
+            us_equities_summary="b",
+        )
+        assert snapshot.regime_label == ""
+
+    def test_regime_label_round_trips(self) -> None:
+        snapshot = DigestSnapshot(
+            segment="master-digest",
+            date=date(2026, 4, 26),
+            bias="neutral",
+            headline="Test",
+            market_regime_snapshot="x",
+            alt_data_dashboard="y",
+            institutional_summary="z",
+            asset_classes_summary="a",
+            us_equities_summary="b",
+            regime_label="Risk-off / Stagflation watch",
+        )
+        dumped = snapshot.model_dump(mode="json")
+        assert dumped["regime_label"] == "Risk-off / Stagflation watch"
+
+
+# ─── Deterministic backfill tests ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestRegimeLabelBackfill:
+    def test_backfill_from_phase3_when_llm_emits_empty(self) -> None:
+        """When LLM returns regime_label='', we backfill from phase3 body."""
+        compiled = build_pipeline(AtlasResearchState, [build_phase6(), build_phase7()])
+        state = _base_state(regime_label="Neutral / Rate plateau")
+
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            return_value=_digest_json(regime_label=""),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert final.phase7_digest is not None
+        # LLM gave empty string → deterministic backfill from phase3.
+        assert final.phase7_digest["regime_label"] == "Neutral / Rate plateau"
+
+    def test_llm_emitted_regime_label_preserved(self) -> None:
+        """When LLM emits a non-empty regime_label, it is preserved as-is."""
+        compiled = build_pipeline(AtlasResearchState, [build_phase6(), build_phase7()])
+        state = _base_state(regime_label="Risk-on / Policy easing")
+
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            return_value=_digest_json(regime_label="Risk-on / Early recovery"),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert final.phase7_digest is not None
+        # LLM supplied a non-empty value → keep it.
+        assert final.phase7_digest["regime_label"] == "Risk-on / Early recovery"
+
+    def test_backfill_falls_back_to_empty_when_phase3_absent(self) -> None:
+        """No phase3 output → regime_label stays empty string (no crash)."""
+        compiled = build_pipeline(AtlasResearchState, [build_phase6(), build_phase7()])
+        state = _base_state()
+        state.phase3_output = None  # no macro phase this run
+
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            return_value=_digest_json(regime_label=""),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        assert final.phase7_digest is not None
+        assert final.phase7_digest["regime_label"] == ""
+
+    def test_regime_label_from_phase3_helper_returns_empty_on_none(self) -> None:
+        """Unit-test the private helper directly."""
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        assert _regime_label_from_phase3(state) == ""
+
+    def test_regime_label_from_phase3_helper_skips_carry_slots(self) -> None:
+        """Carry slots (source='carried') must not feed the backfill."""
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        # Simulate a carry slot: SegmentSlot with a Carried payload (delta run carry-forward).
+        state.phase3_output = SegmentSlot(
+            payload=Carried(
+                baseline_date=date(2026, 4, 25),
+                reason="below_triage_threshold",
+            )
+        )
+        assert _regime_label_from_phase3(state) == ""
+
+
+# ─── fed_odds wiring tests ────────────────────────────────────────────────────
+
+
+def _fed_odds_rows() -> list[dict[str, Any]]:
+    """Canned macro_series_observations rows for the FakeSupabaseClient."""
+    return [
+        {
+            "source": "kalshi",
+            "series_id": "FEDPROB/2026-06-17/upper_gt_3.75",
+            "obs_date": "2026-06-16",
+            "value": 0.6,
+            "meta": {},
+        },
+        {
+            "source": "kalshi",
+            "series_id": "FEDPROB/2026-06-17/upper_gt_4",
+            "obs_date": "2026-06-16",
+            "value": 0.4,
+            "meta": {},
+        },
+        {
+            "source": "polymarket",
+            "series_id": "FEDPROB/2026-06-17/pm/will-the-fed-hold",
+            "obs_date": "2026-06-16",
+            "value": 0.7,
+            "meta": {"question": "Will the Fed hold?"},
+        },
+    ]
+
+
+@pytest.mark.unit
+class TestFedOddsWiring:
+    def _preflight_deps(self, fed_rows: list[dict[str, Any]]) -> Any:
+        """Build PreflightDeps backed by a FakeSupabaseClient with canned fed rows."""
+        from digiquant.olympus.atlas.phases.preflight import PreflightDeps
+
+        client = FakeSupabaseClient(
+            canned_reads={
+                "daily_snapshots": [],
+                "documents": [],
+                "price_technicals": [{"date": "2026-06-16", "ticker": "SPY"}],
+                "macro_series_observations": fed_rows,
+            }
+        )
+        return PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(),
+        )
+
+    def test_fed_odds_populated_in_market_context(self) -> None:
+        """When macro_series_observations has FEDPROB rows, market_context['fed_odds'] is set."""
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+
+        deps = self._preflight_deps(_fed_odds_rows())
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 16))
+        out = node(state)
+        mc = out["data_layer"].market_context
+        assert "fed_odds" in mc, "fed_odds must appear in market_context when rows exist"
+        assert mc["fed_odds"]["meeting_date"] == "2026-06-17"
+
+    def test_fed_odds_absent_when_no_rows(self) -> None:
+        """No FEDPROB rows → fed_odds must NOT appear in market_context (not even None)."""
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+
+        deps = self._preflight_deps([])
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 16))
+        out = node(state)
+        # Empty result from get_fed_rate_probabilities → fed_odds not added to market_context.
+        assert "fed_odds" not in out["data_layer"].market_context
+
+    def test_fed_odds_fail_soft_on_db_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A database error in get_fed_rate_probabilities must not crash preflight."""
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+        import digiquant.olympus.atlas.phases.preflight as pf_mod
+
+        deps = self._preflight_deps([])
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 16))
+
+        with patch.object(
+            pf_mod,
+            "get_fed_rate_probabilities",
+            side_effect=OSError("connection reset"),
+        ):
+            out = node(state)
+        # Preflight completed normally; fed_odds is absent (not None, not raised).
+        assert "fed_odds" not in out["data_layer"].market_context
+
+    def test_fed_odds_reaches_phase6_bias_row(self) -> None:
+        """fed_odds flows from market_context through phase6 into the bias row."""
+        # Build state as if preflight ran and injected fed_odds into data_layer.
+        state = _base_state()
+        fed_odds_payload = {
+            "meeting_date": "2026-06-17",
+            "most_likely": "3.5",
+            "distribution": {"<=3.25": 0.03, "3.5": 0.17, ">4.25": 0.20},
+            "sources": ["kalshi"],
+        }
+        state.data_layer = DataLayerSnapshot(
+            market_context={"fed_odds": fed_odds_payload},
+        )
+
+        compiled = build_pipeline(AtlasResearchState, [build_phase6()])
+        result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        row = final.phase6_bias_row
+        assert row is not None
+        # fed_odds must be propagated into the bias row (not None).
+        assert row["fed_odds"] is not None
+        assert row["fed_odds"]["meeting_date"] == "2026-06-17"
+
+    def test_fed_odds_none_when_market_context_empty(self) -> None:
+        """No fed_odds in market_context → bias row fed_odds is None (fail-soft)."""
+        state = _base_state()
+        # data_layer with empty market_context (default).
+        state.data_layer = DataLayerSnapshot(market_context={})
+
+        compiled = build_pipeline(AtlasResearchState, [build_phase6()])
+        result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        row = final.phase6_bias_row
+        assert row is not None
+        assert row["fed_odds"] is None
+
+    def test_fed_odds_in_phase7_digest_phase_inputs(self) -> None:
+        """fed_odds from bias_row must be visible to the LLM via phase_inputs.bias_row."""
+        state = _base_state()
+        fed_odds_payload = {
+            "meeting_date": "2026-06-17",
+            "most_likely": "3.5",
+            "distribution": {"<=3.25": 0.03},
+            "sources": ["kalshi"],
+        }
+        state.data_layer = DataLayerSnapshot(market_context={"fed_odds": fed_odds_payload})
+
+        compiled = build_pipeline(AtlasResearchState, [build_phase6(), build_phase7()])
+        captured_inputs: list[dict[str, Any]] = []
+
+        def fake_completion(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            # Extract the PHASE_INPUTS block that was passed to the LLM.
+            for part in msgs[1]["content"]:
+                if isinstance(part, dict) and part.get("text", "").startswith("PHASE_INPUTS"):
+                    body = json.loads(part["text"].split(":", 1)[1].strip())
+                    captured_inputs.append(body)
+                    break
+            return _digest_json(regime_label="")
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake_completion):
+            compiled.invoke(state)
+
+        assert captured_inputs, "LLM must have been called"
+        bias_row = captured_inputs[0].get("bias_row", {})
+        assert bias_row.get("fed_odds") is not None, (
+            "fed_odds must appear in bias_row passed to Phase 7 LLM"
+        )
+        assert bias_row["fed_odds"]["meeting_date"] == "2026-06-17"

--- a/tests/dq/data/test_correlation.py
+++ b/tests/dq/data/test_correlation.py
@@ -1,0 +1,283 @@
+"""Tests for pairwise_return_correlations (pure function) and get_return_correlations reader.
+
+Covers:
+  - perfectly-correlated pair → ρ ≈ 1.0
+  - anti-correlated pair → ρ ≈ -1.0
+  - insufficient overlap → pair omitted
+  - look-ahead guard: a decision dated D sees no close > D
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any  # noqa  # scored-lint: heterogeneous FakeSupabase fixture dicts
+
+import polars as pl
+import pytest
+
+from digiquant.data.prices.correlation import pairwise_return_correlations
+from digiquant.olympus.atlas.data.queries import get_return_correlations
+
+pytestmark = pytest.mark.unit
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _close_rows(series: dict[str, list[float]], start: date) -> list[dict]:
+    """Build long close-price rows for {ticker: [close, ...]}, consecutive trading days."""
+    rows = []
+    for ticker, closes in series.items():
+        for i, c in enumerate(closes):
+            rows.append({"ticker": ticker, "date": (start + timedelta(days=i)).isoformat(), "close": c})
+    return rows
+
+
+def _corr_map(frame: pl.DataFrame) -> dict[tuple[str, str], float]:
+    """Convert the output frame to a {(a,b): corr} dict for easy assertion."""
+    return {(r["a"], r["b"]): r["corr"] for r in frame.to_dicts()}
+
+
+# ── FakeSupabaseClient (mirrors the atlas/test_supabase_io version, minimal) ─
+
+
+@dataclass
+class _FakeResponse:
+    data: list[dict[str, Any]]
+
+
+@dataclass
+class _FakeQuery:
+    table_name: str
+    canned: list[dict[str, Any]] = field(default_factory=list)
+    _filters: list[tuple[str, str, Any]] = field(default_factory=list)
+    _order: tuple[str, bool] | None = None
+    _limit: int | None = None
+
+    def select(self, _cols: str) -> "_FakeQuery":
+        return self
+
+    def lte(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("lte", col, val))
+        return self
+
+    def gte(self, col: str, val: Any) -> "_FakeQuery":
+        self._filters.append(("gte", col, val))
+        return self
+
+    def in_(self, col: str, vals: list[Any]) -> "_FakeQuery":
+        self._filters.append(("in_", col, list(vals)))
+        return self
+
+    def order(self, col: str, desc: bool = False) -> "_FakeQuery":
+        self._order = (col, desc)
+        return self
+
+    def limit(self, n: int) -> "_FakeQuery":
+        self._limit = n
+        return self
+
+    def execute(self) -> _FakeResponse:
+        rows = list(self.canned)
+        for op, col, val in self._filters:
+            if op == "lte":
+                rows = [r for r in rows if str(r.get(col, "")) <= str(val)]
+            elif op == "gte":
+                rows = [r for r in rows if str(r.get(col, "")) >= str(val)]
+            elif op == "in_":
+                rows = [r for r in rows if r.get(col) in val]
+        if self._order is not None:
+            col, desc = self._order
+            rows.sort(key=lambda r: r.get(col, ""), reverse=desc)
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return _FakeResponse(data=rows)
+
+
+@dataclass
+class FakeSupabaseClient:
+    canned_reads: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+    def table(self, name: str) -> _FakeQuery:
+        return _FakeQuery(table_name=name, canned=list(self.canned_reads.get(name, [])))
+
+
+# ── pairwise_return_correlations — pure function ───────────────────────────────
+
+
+class TestPairwiseReturnCorrelations:
+    """Pure-function contract tests — no I/O, no Supabase fake needed."""
+
+    def test_perfectly_correlated_pair_approx_one(self) -> None:
+        # A and B move identically → Pearson r = 1.0.
+        start = date(2026, 1, 2)
+        closes = {
+            "A": [100.0 + i for i in range(40)],
+            "B": [200.0 + i * 2 for i in range(40)],  # same direction, different scale
+        }
+        frame = pairwise_return_correlations(pl.DataFrame(_close_rows(closes, start)))
+        m = _corr_map(frame)
+        assert ("A", "B") in m
+        assert m[("A", "B")] == pytest.approx(1.0, abs=1e-6)
+
+    def test_anti_correlated_pair_approx_minus_one(self) -> None:
+        # Alternating pattern: A zig-zags up (+1, +1, +1, ...) while B zig-zags down
+        # (-1, -1, -1, ...) with the same absolute return → Pearson r = -1.0.
+        start = date(2026, 1, 2)
+        # A alternates between two levels → constant return.
+        # B is the mirror: same magnitude, opposite sign.
+        a_closes = [100.0 if i % 2 == 0 else 101.0 for i in range(40)]
+        b_closes = [100.0 if i % 2 == 0 else 99.0 for i in range(40)]
+        closes = {"A": a_closes, "B": b_closes}
+        frame = pairwise_return_correlations(pl.DataFrame(_close_rows(closes, start)))
+        m = _corr_map(frame)
+        assert ("A", "B") in m
+        assert m[("A", "B")] == pytest.approx(-1.0, abs=1e-6)
+
+    def test_insufficient_overlap_pair_omitted(self) -> None:
+        # Only 5 common dates with returns — below the default min_overlap=30.
+        start = date(2026, 1, 2)
+        closes = {
+            "A": [100.0 + i for i in range(10)],
+            "B": [50.0 + i for i in range(10)],
+        }
+        frame = pairwise_return_correlations(
+            pl.DataFrame(_close_rows(closes, start)), min_overlap=30
+        )
+        # Pair should be absent because only 9 return periods exist (10 closes → 9 returns).
+        assert frame.is_empty()
+
+    def test_sufficient_overlap_pair_present(self) -> None:
+        # Exactly min_overlap=5 overlapping returns (6 closes → 5 returns) → pair included.
+        start = date(2026, 1, 2)
+        closes = {
+            "A": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0],
+            "B": [200.0, 201.0, 202.0, 203.0, 204.0, 205.0],
+        }
+        frame = pairwise_return_correlations(
+            pl.DataFrame(_close_rows(closes, start)), min_overlap=5
+        )
+        assert not frame.is_empty()
+        assert ("A", "B") in _corr_map(frame)
+
+    def test_single_ticker_returns_empty(self) -> None:
+        start = date(2026, 1, 2)
+        closes = {"A": [100.0 + i for i in range(40)]}
+        frame = pairwise_return_correlations(pl.DataFrame(_close_rows(closes, start)))
+        assert frame.is_empty()
+
+    def test_empty_frame_returns_empty(self) -> None:
+        frame = pairwise_return_correlations(pl.DataFrame())
+        assert frame.is_empty()
+
+    def test_output_schema(self) -> None:
+        # Output always has exactly columns a, b, corr with correct dtype.
+        start = date(2026, 1, 2)
+        closes = {
+            "A": [100.0 + i for i in range(40)],
+            "B": [200.0 + i for i in range(40)],
+        }
+        frame = pairwise_return_correlations(pl.DataFrame(_close_rows(closes, start)))
+        assert set(frame.columns) == {"a", "b", "corr"}
+        assert frame.schema["a"] == pl.Utf8
+        assert frame.schema["b"] == pl.Utf8
+        assert frame.schema["corr"] == pl.Float64
+
+    def test_each_pair_appears_once(self) -> None:
+        # Three tickers → 3 unordered pairs; verify no duplicate (a,b)/(b,a) rows.
+        start = date(2026, 1, 2)
+        closes = {
+            "A": [100.0 + i for i in range(40)],
+            "B": [200.0 + i for i in range(40)],
+            "C": [300.0 + i for i in range(40)],
+        }
+        frame = pairwise_return_correlations(pl.DataFrame(_close_rows(closes, start)))
+        pairs = [(r["a"], r["b"]) for r in frame.to_dicts()]
+        assert len(pairs) == len(set(pairs))  # no duplicates
+        assert len(pairs) == 3  # C(3,2) = 3
+
+
+# ── get_return_correlations — look-ahead guard + fail-soft ───────────────────
+
+
+class TestGetReturnCorrelations:
+    """Reader tests — use FakeSupabaseClient; verify look-ahead guard and fail-soft."""
+
+    _RUN_DATE = date(2026, 3, 15)
+
+    def _price_rows(self, n: int = 40) -> list[dict]:
+        """Generate n close rows for two tickers ending at _RUN_DATE.
+
+        Anchored to _RUN_DATE so rows fall inside the default 63-day lookback window.
+        """
+        rows = []
+        for i in range(n):
+            d = (self._RUN_DATE - timedelta(days=n - 1 - i)).isoformat()
+            rows.append({"date": d, "ticker": "A", "close": 100.0 + i})
+            rows.append({"date": d, "ticker": "B", "close": 200.0 + i})
+        return rows
+
+    def test_returns_correlation_frame(self) -> None:
+        client = FakeSupabaseClient(canned_reads={"price_history": self._price_rows()})
+        frame = get_return_correlations(
+            client=client,
+            tickers=["A", "B"],
+            run_date=self._RUN_DATE,
+        )
+        assert frame is not None
+        assert not frame.is_empty()
+        m = _corr_map(frame)
+        assert ("A", "B") in m
+        # Consecutive-integer closes produce very-high but not exact-1.0 correlation
+        # (returns shrink as price rises), so 1e-3 absolute tolerance is appropriate.
+        assert m[("A", "B")] == pytest.approx(1.0, abs=1e-3)
+
+    def test_look_ahead_guard_excludes_future_closes(self) -> None:
+        # We have 40 on-time rows (ending at _RUN_DATE) plus 2 future-dated rows.
+        # The future rows have a huge jump for A and a crash for B, which would produce
+        # extreme outlier returns and push ρ strongly negative if included.
+        # The .lte(run_date) guard must exclude them so the result stays strongly positive.
+        future_date = (self._RUN_DATE + timedelta(days=5)).isoformat()
+        rows = self._price_rows(40)
+        # Future rows: extreme outliers that would crush the positive correlation.
+        rows.append({"date": future_date, "ticker": "A", "close": 99999.0})
+        rows.append({"date": future_date, "ticker": "B", "close": 0.01})
+        client = FakeSupabaseClient(canned_reads={"price_history": rows})
+        frame = get_return_correlations(
+            client=client,
+            tickers=["A", "B"],
+            run_date=self._RUN_DATE,
+            lookback_days=63,
+        )
+        # The FakeQuery's lte filter strips future rows; result must still be strongly +.
+        assert frame is not None
+        m = _corr_map(frame)
+        assert ("A", "B") in m
+        assert m[("A", "B")] > 0.5  # strongly positive, not distorted by future data
+
+    def test_fewer_than_two_tickers_returns_none(self) -> None:
+        # The fast-path guard: a single-ticker portfolio has no pairs to compute.
+        client = FakeSupabaseClient(canned_reads={"price_history": self._price_rows()})
+        result = get_return_correlations(
+            client=client, tickers=["A"], run_date=self._RUN_DATE
+        )
+        assert result is None
+
+    def test_empty_price_history_returns_none(self) -> None:
+        client = FakeSupabaseClient(canned_reads={"price_history": []})
+        result = get_return_correlations(
+            client=client, tickers=["A", "B"], run_date=self._RUN_DATE
+        )
+        assert result is None
+
+    def test_db_error_returns_none(self) -> None:
+        # The reader must not propagate exceptions — it returns None on failure.
+        class _BrokenClient:
+            def table(self, _name: str):
+                raise RuntimeError("db down")
+
+        result = get_return_correlations(
+            client=_BrokenClient(), tickers=["A", "B"], run_date=self._RUN_DATE
+        )
+        assert result is None

--- a/tests/dq/data/test_correlation.py
+++ b/tests/dq/data/test_correlation.py
@@ -30,7 +30,9 @@ def _close_rows(series: dict[str, list[float]], start: date) -> list[dict]:
     rows = []
     for ticker, closes in series.items():
         for i, c in enumerate(closes):
-            rows.append({"ticker": ticker, "date": (start + timedelta(days=i)).isoformat(), "close": c})
+            rows.append(
+                {"ticker": ticker, "date": (start + timedelta(days=i)).isoformat(), "close": c}
+            )
     return rows
 
 
@@ -259,16 +261,12 @@ class TestGetReturnCorrelations:
     def test_fewer_than_two_tickers_returns_none(self) -> None:
         # The fast-path guard: a single-ticker portfolio has no pairs to compute.
         client = FakeSupabaseClient(canned_reads={"price_history": self._price_rows()})
-        result = get_return_correlations(
-            client=client, tickers=["A"], run_date=self._RUN_DATE
-        )
+        result = get_return_correlations(client=client, tickers=["A"], run_date=self._RUN_DATE)
         assert result is None
 
     def test_empty_price_history_returns_none(self) -> None:
         client = FakeSupabaseClient(canned_reads={"price_history": []})
-        result = get_return_correlations(
-            client=client, tickers=["A", "B"], run_date=self._RUN_DATE
-        )
+        result = get_return_correlations(client=client, tickers=["A", "B"], run_date=self._RUN_DATE)
         assert result is None
 
     def test_db_error_returns_none(self) -> None:

--- a/tests/dq/hermes/test_phase7c_specialists.py
+++ b/tests/dq/hermes/test_phase7c_specialists.py
@@ -332,7 +332,7 @@ class TestFullPhase7c:
 
         payload = final.phase7c_analysts["AAPL"]
         # All AnalystPayload fields present on the dict the PM reads.
-        for field in ("ticker", "conviction_score", "stance", "thesis", "risks", "sources"):
+        for field in ("ticker", "conviction_score", "stance", "thesis", "sources"):
             assert field in payload
 
 

--- a/tests/dq/hermes/test_phase7e_risk_sizing.py
+++ b/tests/dq/hermes/test_phase7e_risk_sizing.py
@@ -8,8 +8,9 @@ fail-soft (errors keep the PM book) and a no-op when the PM never ran.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
+import polars as pl
 import pytest
 
 from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
@@ -326,3 +327,111 @@ def test_missing_technicals_uses_default_vol() -> None:
         FakeSupabaseClient(canned_reads={"price_technicals": []}),
     )
     assert _weights(rebal) == {"SPY": pytest.approx(30.0)}
+
+
+# --------------------------------------------------------------------------- correlation pass-through
+
+
+def _price_history_rows(tickers: list[str], n: int = 40) -> list[dict]:
+    """Generate n price_history rows per ticker anchored just before RUN_DATE.
+
+    Rows end at RUN_DATE so they fall inside the default 63-day lookback window
+    used by ``get_return_correlations``. All tickers move together → ρ ≈ 1.0.
+    """
+    rows = []
+    for i in range(n):
+        d = (RUN_DATE - timedelta(days=n - 1 - i)).isoformat()
+        for j, t in enumerate(tickers):
+            rows.append({"date": d, "ticker": t, "close": 100.0 + i + j * 10})
+    return rows
+
+
+def test_corr_frame_passed_to_sizer_triggers_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real corr frame wired from price_history through phase7e into size_portfolio.
+
+    Two tickers with a >0.8 correlation and different convictions: the lower-conviction
+    leg must be dropped by ``_corr_dedup`` (the ρ≈1.0 pair exceeds the default 0.80
+    threshold). This verifies end-to-end that the corr frame is actually passed — if
+    ``corr=None`` were still hardcoded, the identical-vol pair would NOT be de-duped.
+    """
+    # AAA conviction 5, BBB conviction 3 → BBB should be dropped (lower conviction).
+    # Both are the same sector (UNKNOWN by default) so sector cap doesn't interfere.
+    # All caps relaxed except the dedup threshold (default 0.80).
+    tickers = ["AAA", "BBB"]
+    # price_history: 40 rows each, perfectly correlated → ρ=1.0 > 0.80 threshold.
+    ph_rows = _price_history_rows(tickers, n=40)
+    tech_rows = [
+        {"ticker": "AAA", "date": "2026-06-12", "hist_vol_21": 20, "atr_pct": None},
+        {"ticker": "BBB", "date": "2026-06-12", "hist_vol_21": 20, "atr_pct": None},
+    ]
+    client = FakeSupabaseClient(
+        canned_reads={"price_technicals": tech_rows, "price_history": ph_rows}
+    )
+
+    captured: dict = {}
+    original_size = phase7e_risk_sizing.size_portfolio
+
+    def _spy_size_portfolio(**kwargs):
+        captured["corr"] = kwargs.get("corr")
+        return original_size(**kwargs)
+
+    monkeypatch.setattr(phase7e_risk_sizing, "size_portfolio", _spy_size_portfolio)
+
+    rebal = _run(
+        _state(
+            [{"ticker": "AAA", "target_pct": 50}, {"ticker": "BBB", "target_pct": 50}],
+            analysts={
+                "AAA": {"conviction_score": 5, "stance": "buy"},
+                "BBB": {"conviction_score": 3, "stance": "buy"},
+            },
+            preferences={
+                "max_single_etf_pct": 100,
+                "max_sector_pct": 100,
+                "target_portfolio_vol": 1.0e6,
+                "weight_increment_pct": 0,
+                "corr_dedup_threshold": 0.80,
+                "min_conviction": 2.0,
+            },
+        ),
+        client,
+    )
+    # The corr frame was passed (not None) — confirms the plumbing is wired.
+    assert captured.get("corr") is not None, "corr=None was passed; reader was not wired"
+    assert isinstance(captured["corr"], pl.DataFrame)
+
+    # BBB (conviction 3) must be dropped in favour of AAA (conviction 5).
+    w = _weights(rebal)
+    assert "AAA" in w, "AAA (higher conviction) should be retained"
+    assert "BBB" not in w, "BBB (lower conviction, |corr|>0.80 with AAA) should be de-duped"
+
+
+def test_correlation_reader_error_falls_back_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Correlation read failure must not crash phase7e; corr=None is the safe fallback."""
+    from digiquant.olympus.atlas.data import queries as _queries_mod
+
+    def _boom(**_kwargs):
+        raise RuntimeError("price_history table gone")
+
+    monkeypatch.setattr(_queries_mod, "get_return_correlations", _boom)
+
+    captured: dict = {}
+    original_size = phase7e_risk_sizing.size_portfolio
+
+    def _spy(**kwargs):
+        captured["corr"] = kwargs.get("corr")
+        return original_size(**kwargs)
+
+    monkeypatch.setattr(phase7e_risk_sizing, "size_portfolio", _spy)
+
+    rebal = _run(
+        _state(
+            [{"ticker": "SPY", "target_pct": 100}],
+            analysts={"SPY": {"conviction_score": 5, "stance": "buy"}},
+        ),
+        FakeSupabaseClient(canned_reads={"price_technicals": _tech_rows({"SPY": 15})}),
+    )
+    # The node must still produce a valid sized book.
+    assert rebal is not None
+    assert "SPY" in _weights(rebal)
+    # And corr=None must have been passed (conservative fallback).
+    assert captured.get("corr") is None, "expected corr=None fallback on reader error"

--- a/tests/dq/hermes/test_portfolio_materialize.py
+++ b/tests/dq/hermes/test_portfolio_materialize.py
@@ -215,13 +215,11 @@ class TestThesesWrite:
                     "ticker": "SPY",
                     "stance": "buy",
                     "thesis": "AI capex tailwind",
-                    "risks": "valuation",
                 },
                 "TLT": {
                     "ticker": "TLT",
                     "stance": "hold",
                     "thesis": "duration hedge",
-                    "risks": "fiscal supply",
                 },
             },
         )
@@ -274,7 +272,7 @@ class TestThesesWrite:
         _run_full(
             client,
             [{"ticker": "SPY", "target_pct": 100}],
-            {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t", "risks": "fallback risk"}},
+            {"SPY": {"ticker": "SPY", "stance": "buy", "thesis": "t"}},
             {"SPY": {"bear_case": "breaks below 200dma"}},
         )
         spy = next(r for r in client.store["theses"] if r["thesis_id"] == "spy")


### PR DESCRIPTION
## What

Backend pipeline-fix half of the post-audit Olympus pass (`docs/olympus/OLYMPUS_ARCHITECTURE_AUDIT.md`). Fixes the substantive backend gaps the audit found.

## Changes
- **digest synthesis prompt** — the master-digest `SKILL.md` was a dead pointer ("superseded… load the orchestrator skill"); the most important synthesis LLM call had no real instruction (only the JSON schema saved it). Rewritten into a real disciplined-analyst synthesis brief matching `DigestSnapshot`.
- **`regime_label`** — new short `DigestSnapshot` field (the frontend reads it for the regime hero). LLM-emitted with a deterministic phase-3 macro backfill; mirrored into `DigestPayload` + the exported `atlas_snapshot.v1.json` schema (parity test).
- **`fed_odds` lit** — the long-reserved slot is now populated: `preflight` computes market-implied FOMC odds via the existing `get_fed_rate_probabilities` reader into `data_layer.market_context`; `phase6` fills the bias-row `fed_odds`; threaded into the phase7 digest inputs + the PM's context. Fail-soft to `None`.
- **phase7e correlation** — was hard-stubbed `corr=None`, so vol-targeting assumed ρ=1.0 (full correlation) and systematically over-raised cash. New Polars 63-day return-correlation reader (`data/prices/correlation.py` + `queries.get_return_correlations`), look-ahead-guarded, wired into `size_portfolio`, fail-soft to the old behavior on error.
- **deslop** — dropped the always-empty `AnalystPayload.risks` field and its dead `materialize` fallback (invalidation already uses the debate bear-case).

## Verification
- 999 digiquant unit tests pass (pre-existing `fredapi`/`statsmodels`/`nautilus_trader` skips unchanged)
- ruff clean · `make score` 10/10 all dimensions
- New tests: `regime_label` (emit + backfill), `fed_odds` wiring (FakeSupabase), `pairwise_return_correlations` (ρ≈±1, overlap, look-ahead), phase7e corr-dedup pass-through

## Pairs with
- The frontend PR (#780) reads `regime_label` + the rebound decision surfaces.
- Activation (crons / migrations / risk-fields flag / proof baseline) lands in the activation PR of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #784