### PR TITLE
ci(olympus): schedule metrics/attribution refresh crons + flip risk-fields flag

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -94,6 +94,9 @@ jobs:
           OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
+          # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the
+          # materialize writer populates stop/target/horizon/conviction/sector_bucket.
+          OLYMPUS_POSITION_RISK_FIELDS: "1"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).
           # Degrades to no-checkpointing if the secret/package is absent.

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -91,6 +91,9 @@ jobs:
           OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
+          # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the
+          # materialize writer populates stop/target/horizon/conviction/sector_bucket.
+          OLYMPUS_POSITION_RISK_FIELDS: "1"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).
           DIGI_CHECKPOINTER: postgres

--- a/.github/workflows/atlas-refresh-metrics.yml
+++ b/.github/workflows/atlas-refresh-metrics.yml
@@ -1,0 +1,76 @@
+name: atlas refresh metrics
+
+# Daily refresh of the derived performance + attribution surfaces the Olympus
+# dashboard reads (portfolio_metrics, position_attribution). Both are deterministic
+# Polars/SQL recomputes — zero LLM cost. Runs after the EOD price ingest (21:00,
+# digiquant-prices.yml) so the latest closes are in price_history, and after the
+# weekday delta book (12:00) / Saturday baseline book have materialized.
+#
+# Before this cron, these scripts ran nowhere, so portfolio_metrics +
+# position_attribution stayed empty in prod and the Performance / Attribution
+# dashboard tabs showed no data (post-audit fix, #786).
+
+on:
+  schedule:
+    - cron: "0 22 * * MON-SAT"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Metrics/attribution date (YYYY-MM-DD). Empty = latest book / today UTC."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: atlas-refresh-metrics
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            digibase/pyproject.toml
+            digigraph/pyproject.toml
+            digiquant/pyproject.toml
+
+      - name: Install digiquant (olympus.atlas imports + polars/supabase)
+        run: |
+          bash scripts/install-workspace.sh digiquant
+          pip install -e "./digiquant[atlas]"
+
+      - name: Refresh portfolio_metrics (Sharpe / vol / drawdown / NAV continuity)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # Bind the dispatch input via env (never interpolate ${{ inputs.* }} into run:).
+          RUN_DATE: ${{ inputs.date }}
+        run: |
+          if [ -n "$RUN_DATE" ]; then
+            python digiquant/scripts/atlas/refresh_performance_metrics.py --supabase --date "$RUN_DATE"
+          else
+            python digiquant/scripts/atlas/refresh_performance_metrics.py --supabase
+          fi
+
+      - name: Refresh position_attribution (single-benchmark Brinson-lite)
+        # Run even if metrics refresh failed — the two surfaces are independent.
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          RUN_DATE: ${{ inputs.date }}
+        run: |
+          if [ -n "$RUN_DATE" ]; then
+            python digiquant/scripts/atlas/refresh_attribution.py --date "$RUN_DATE"
+          else
+            python digiquant/scripts/atlas/refresh_attribution.py
+          fi


### PR DESCRIPTION
## What (WS6 activation)

Lights up the dashboard surfaces the audit found unscheduled, and enables the per-position risk fields. Pairs with the merged fix PRs (#780/#781/#782).

## Changes
- **New `atlas-refresh-metrics.yml`** — daily (MON–SAT 22:00 UTC, after the EOD price ingest) deterministic recompute of `portfolio_metrics` (`refresh_performance_metrics.py`) + `position_attribution` (`refresh_attribution.py`). These scripts ran **nowhere** before, so both tables were empty in prod and the Performance / Attribution dashboard tabs showed no data. Zero LLM cost. The `workflow_dispatch` date input is bound via `env:` (no `${{ inputs }}` interpolation into `run:`).
- **`atlas-baseline.yml` + `atlas-delta.yml`** — set `OLYMPUS_POSITION_RISK_FIELDS=1` so `portfolio_materialize` writes per-position advisory `stop_loss_pct`/`target_pct_gain`/`horizon_days`/`conviction`/`sector_bucket`.

## Prod migrations (already applied via MCP)
- `039_position_risk_fields` — advisory columns on `positions` (inert until the flag above).
- `040_position_attribution` — attribution table + anon SELECT RLS.
- `041_atlas_run_health_view` — curated security-definer view (run health only; excludes spend/tokens/errors), anon SELECT. (The #707 human-gate item — owner-authorized this round.)

Verified in prod: `positions` has the 5 risk columns, `position_attribution` exists with its anon policy, `atlas_run_health` view exists.

## Next
After merge: one baseline run is the end-to-end proof (non-empty sized book + populated metrics/attribution + lit fed_odds + dashboard render).

Fixes #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)