### PR TITLE
fix(ci): cost-routing returned empty completions — drop pinned fallback models + price-sort

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -84,12 +84,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Cost controls (#774): keep OpenRouter auto-selection, but bound it to a cheap-model
-          # allowlist (auto-fallback) + price-sorted endpoints + a hard price ceiling so
-          # flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY PRICE, not by name.
-          # Tune these to taste; verify slugs/prices on the OpenRouter dashboard.
-          OPENROUTER_FALLBACK_MODELS: "deepseek/deepseek-v4-flash,google/gemini-3.1-flash-lite,x-ai/grok-build-0.1"
-          OPENROUTER_SORT: "price"
+          # Cost controls (#774, fixed #790): keep OpenRouter's *auto* selection but bound it by a
+          # hard price CEILING so flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY
+          # PRICE, not by name — the requested "auto, minus expensive" control.
+          # Removed (caused empty completions → degraded every run since ~06-14):
+          #   * OPENROUTER_FALLBACK_MODELS — pinned `extra_body.models` to specific (unreliable)
+          #     slugs with route=fallback, which DEFEATS the auto router.
+          #   * OPENROUTER_SORT=price — forced the absolute-cheapest endpoint, whose tiny model
+          #     returned empty bodies on the structured-output calls.
           OPENROUTER_MAX_PROMPT_PRICE: "1.5"
           OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -81,12 +81,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Cost controls (#774): keep OpenRouter auto-selection, but bound it to a cheap-model
-          # allowlist (auto-fallback) + price-sorted endpoints + a hard price ceiling so
-          # flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY PRICE, not by name.
-          # Tune these to taste; verify slugs/prices on the OpenRouter dashboard.
-          OPENROUTER_FALLBACK_MODELS: "deepseek/deepseek-v4-flash,google/gemini-3.1-flash-lite,x-ai/grok-build-0.1"
-          OPENROUTER_SORT: "price"
+          # Cost controls (#774, fixed #790): keep OpenRouter's *auto* selection but bound it by a
+          # hard price CEILING so flagships (GPT-5.x / Claude / grok-4.3-class) are excluded BY
+          # PRICE, not by name — the requested "auto, minus expensive" control.
+          # Removed (caused empty completions → degraded every run since ~06-14):
+          #   * OPENROUTER_FALLBACK_MODELS — pinned `extra_body.models` to specific (unreliable)
+          #     slugs with route=fallback, which DEFEATS the auto router.
+          #   * OPENROUTER_SORT=price — forced the absolute-cheapest endpoint, whose tiny model
+          #     returned empty bodies on the structured-output calls.
           OPENROUTER_MAX_PROMPT_PRICE: "1.5"
           OPENROUTER_MAX_COMPLETION_PRICE: "4"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).


### PR DESCRIPTION
Discovered while running the post-audit proof baseline: `openrouter/auto` has returned **empty completions** on every run since ~06-14 (last green 06-13), degrading the pipeline so the book never materializes.

**Root cause** (the cheap cost-routing #775):
- `OPENROUTER_FALLBACK_MODELS` pinned `extra_body.models` to specific, unreliable slugs (`deepseek-v4-flash` / `gemini-3.1-flash-lite` / `grok-build-0.1`) with `route=fallback` — this defeats the auto router.
- `OPENROUTER_SORT=price` forced the absolute-cheapest endpoint, whose tiny model returns empty bodies on the structured-output (json_schema) calls.

**Fix:** drop both; keep only the hard price ceiling (`max_price` prompt 1.5 / completion 4) so `openrouter/auto` picks a capable cheap model while flagships stay excluded by price — the faithful "auto, minus expensive" control.

Validated by re-running the baseline after merge. Fixes #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
