### PR TITLE
fix(digillm): require_parameters=true for OpenRouter — fixes empty completions

### DIFF
--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -594,35 +594,62 @@ def _openrouter_provider_prefs() -> dict[str, Any]:
     return prefs
 
 
+def _openrouter_require_parameters() -> bool:
+    """Default-ON: ask OpenRouter to route ONLY to providers that actually support the
+    parameters this request sends (``response_format`` json_schema, ``tools``).
+
+    Without ``provider.require_parameters``, the Auto Router can select a provider/model that
+    silently DROPS an unsupported param (e.g. a tiny model that ignores json_schema) and
+    returns an EMPTY body — which is exactly how the pipeline degraded after the #717
+    auto-router migration (every structured-output / tool call came back empty). Setting it
+    true makes OpenRouter skip those providers and pick a capable one (still the cheapest
+    capable one under any ``max_price`` ceiling). Disable with ``OPENROUTER_REQUIRE_PARAMETERS=0``."""
+    return os.environ.get("OPENROUTER_REQUIRE_PARAMETERS", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "",
+    )
+
+
 def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
-    """Merge OpenRouter cost controls into ``extra_body`` for an ``openrouter/`` request:
-    a cheap-model allowlist with fallback routing (``OPENROUTER_FALLBACK_MODELS`` →
-    ``models`` + ``route=fallback``), price-sorted endpoints, and an optional hard price
-    ceiling (``provider.max_price``). Keeps OpenRouter's automatic selection but bounds it to
-    affordable models — flagships are excluded by price, not by name. No-op for non-OpenRouter
-    providers and when nothing is configured. Merges with (never clobbers) an existing
-    ``extra_body`` (e.g. the xAI ``search_parameters`` branch)."""
+    """Merge OpenRouter routing controls into ``extra_body`` for an ``openrouter/`` request:
+
+    - ``provider.require_parameters`` (default ON) — only route to providers that support the
+      request's params (response_format / tools), so the Auto Router never lands on a provider
+      that drops them and returns an empty body (the post-#717 failure mode).
+    - a cheap-model allowlist with fallback routing (``OPENROUTER_FALLBACK_MODELS`` →
+      ``models`` + ``route=fallback``), price-sorted endpoints, and an optional hard price
+      ceiling (``provider.max_price``) — keeps automatic selection but bounds it to affordable
+      models (flagships excluded by price, not by name).
+
+    No-op for non-OpenRouter providers and when nothing (incl. require_parameters) is active.
+    Merges with (never clobbers) an existing ``extra_body`` (e.g. the xAI ``search_parameters``
+    branch)."""
     if provider != "openrouter":
         return kwargs
     fallbacks = _openrouter_fallback_models()
     prefs = _openrouter_provider_prefs()
-    if not fallbacks and not prefs:
+    require_params = _openrouter_require_parameters()
+    if not fallbacks and not prefs and not require_params:
         return kwargs
     merged = dict(kwargs)
     extra = dict(merged.get("extra_body") or {})
     if fallbacks:
         extra["models"] = fallbacks
         extra["route"] = "fallback"
-    if prefs:
-        provider_prefs = {**(extra.get("provider") or {})}
-        for key, value in prefs.items():
-            # Deep-merge the nested max_price dict so a caller-set ceiling key (e.g. only
-            # ``completion``) survives when env sets the other (``prompt``), rather than the
-            # whole sub-dict being overwritten.
-            if key == "max_price" and isinstance(provider_prefs.get("max_price"), dict):
-                provider_prefs["max_price"] = {**provider_prefs["max_price"], **value}
-            else:
-                provider_prefs[key] = value
+    provider_prefs = {**(extra.get("provider") or {})}
+    if require_params:
+        provider_prefs["require_parameters"] = True
+    for key, value in prefs.items():
+        # Deep-merge the nested max_price dict so a caller-set ceiling key (e.g. only
+        # ``completion``) survives when env sets the other (``prompt``), rather than the
+        # whole sub-dict being overwritten.
+        if key == "max_price" and isinstance(provider_prefs.get("max_price"), dict):
+            provider_prefs["max_price"] = {**provider_prefs["max_price"], **value}
+        else:
+            provider_prefs[key] = value
+    if provider_prefs:
         extra["provider"] = provider_prefs
     merged["extra_body"] = extra
     return merged

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -34,6 +34,7 @@ def _clean_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENROUTER_SORT",
         "OPENROUTER_MAX_PROMPT_PRICE",
         "OPENROUTER_MAX_COMPLETION_PRICE",
+        "OPENROUTER_REQUIRE_PARAMETERS",
         "DIGI_LLM_CACHE_TTL_SECONDS",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -197,7 +198,12 @@ def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.Monkey
     monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "a/x,b/y")
     base = {"model": "m", "messages": []}
     out = client_mod._with_openrouter_fallback(base, "openrouter")
-    assert out["extra_body"] == {"models": ["a/x", "b/y"], "route": "fallback"}
+    # require_parameters defaults ON, so it rides alongside the fallback allowlist.
+    assert out["extra_body"] == {
+        "models": ["a/x", "b/y"],
+        "route": "fallback",
+        "provider": {"require_parameters": True},
+    }
     # Non-openrouter providers (and the default client) are untouched.
     assert client_mod._with_openrouter_fallback(base, "xai") == base
     assert client_mod._with_openrouter_fallback(base, None) == base
@@ -248,12 +254,26 @@ def test_cost_controls_combine_allowlist_and_price_ceiling(monkeypatch: pytest.M
     )
     assert out["extra_body"]["models"] == ["a/x", "b/y"]
     assert out["extra_body"]["route"] == "fallback"
-    assert out["extra_body"]["provider"] == {"sort": "price", "max_price": {"prompt": 1.5}}
+    assert out["extra_body"]["provider"] == {
+        "require_parameters": True,
+        "sort": "price",
+        "max_price": {"prompt": 1.5},
+    }
 
 
-def test_cost_controls_noop_when_unconfigured() -> None:
+def test_cost_controls_default_adds_require_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With no cost knobs set, an OpenRouter request still gets provider.require_parameters
+    # (default ON) so the Auto Router only routes to a provider that honors the request's
+    # response_format / tools — preventing the empty-completion failure mode (#717 regression).
     base = {"model": "openrouter/auto", "messages": []}
+    out = client_mod._with_openrouter_cost_controls(base, "openrouter")
+    assert out["extra_body"] == {"provider": {"require_parameters": True}}
+    # Opt-out → a true no-op for OpenRouter.
+    monkeypatch.setenv("OPENROUTER_REQUIRE_PARAMETERS", "0")
     assert client_mod._with_openrouter_cost_controls(base, "openrouter") == base
+    # Never applies to non-OpenRouter providers regardless of the flag.
+    monkeypatch.delenv("OPENROUTER_REQUIRE_PARAMETERS", raising=False)
+    assert client_mod._with_openrouter_cost_controls(base, "xai") == base
 
 
 def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -267,7 +287,11 @@ def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.M
     }
     out = client_mod._with_openrouter_cost_controls(base, "openrouter")
     assert out["extra_body"]["foo"] == 1
-    assert out["extra_body"]["provider"] == {"order": ["x"], "sort": "price"}
+    assert out["extra_body"]["provider"] == {
+        "order": ["x"],
+        "require_parameters": True,
+        "sort": "price",
+    }
     assert base["extra_body"]["provider"] == {"order": ["x"]}  # input not mutated
 
 
@@ -327,7 +351,7 @@ def test_openrouter_cost_controls_applied_on_primary_and_retry(
     expected = {
         "models": ["openrouter/cheap-a", "openrouter/cheap-b"],
         "route": "fallback",
-        "provider": {"max_price": {"prompt": 1.5}},
+        "provider": {"require_parameters": True, "max_price": {"prompt": 1.5}},
     }
     assert calls[0].kwargs["extra_body"] == expected  # primary already bounded to cheap models
     assert calls[1].kwargs["extra_body"] == expected  # retry keeps the controls


### PR DESCRIPTION
## What
`openrouter/auto` has returned **empty completions** on every structured-output / tool call since the #717 auto-router migration → pipeline degrades → no book materializes.

## Root cause
OpenRouter's Auto Router can select a provider that **silently drops** an unsupported request param (our `response_format: json_schema`, or `tools`) and returns an **empty body**. The price-capped run landed on `gemini-2.5-flash-lite`, which doesn't honor json_schema → empty. (Confirmed: every run since 06-14 emptied; the only ever-successful run, 06-13, used the *direct xAI* API, not OpenRouter.)

## Fix
Default `provider.require_parameters=true` for OpenRouter requests (`OPENROUTER_REQUIRE_PARAMETERS=0` to opt out). OpenRouter then only routes to a provider that **supports** the request's params, and under the existing `max_price` ceiling it picks the cheapest *capable* one (e.g. full `gemini-2.5-flash`) — so it's both working **and** cheap. Applies on the primary call, the empty-retry path, and the tool loop (`run_tools` → `completion`).

## Tests
48 digillm tests pass (added `test_cost_controls_default_adds_require_parameters` + the opt-out/non-OpenRouter cases; updated the existing shape assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #792
