### PR TITLE
fix(digigraph): request OpenRouter strict structured outputs correctly

### DIFF
--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -67,6 +67,66 @@ def _strip_json_fence(raw: str) -> str:
     return re.sub(r"\s*```$", "", s).strip()
 
 
+# JSON-Schema keywords OpenAI/OpenRouter STRICT structured-output mode does not allow. Pydantic
+# emits several of these (Field(ge=…) → minimum, date → format, max_length → maxLength, defaults),
+# and a strict request that carries any of them is REJECTED by the provider — which (via the
+# OpenRouter Auto Router) surfaces as an empty body, not an error. We strip them; the real bounds
+# are still enforced by the Pydantic ``model_validate`` after the call.
+_STRICT_UNSUPPORTED_KEYS = frozenset(
+    {
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "format",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "minProperties",
+        "maxProperties",
+        "default",
+    }
+)
+
+
+def _strictify_json_schema(node: Any) -> Any:
+    """Return a copy of a Pydantic-emitted JSON schema that satisfies OpenAI/OpenRouter STRICT
+    structured-output rules (purely functional — the input is not mutated):
+
+    - every object gets ``additionalProperties: false`` and ``required`` listing ALL its property
+      keys (strict has no notion of optional keys — Pydantic optionals are already nullable
+      ``anyOf`` unions, so requiring them just means "must be present, may be null");
+    - unsupported validation keywords (``_STRICT_UNSUPPORTED_KEYS``) are dropped.
+
+    Recurses through ``properties``, ``$defs``/``definitions``, ``items``, and the
+    ``anyOf``/``allOf``/``oneOf``/``prefixItems`` combinator arrays. ``description``/``enum``/
+    ``const``/``$ref`` are preserved (all strict-legal and useful to the model)."""
+    if isinstance(node, dict):
+        out: dict[str, Any] = {k: v for k, v in node.items() if k not in _STRICT_UNSUPPORTED_KEYS}
+        for mapping_key in ("properties", "$defs", "definitions", "patternProperties"):
+            sub = out.get(mapping_key)
+            if isinstance(sub, dict):
+                out[mapping_key] = {k: _strictify_json_schema(v) for k, v in sub.items()}
+        for child_key in ("items", "additionalItems", "not", "contains"):
+            if child_key in out:
+                out[child_key] = _strictify_json_schema(out[child_key])
+        for list_key in ("anyOf", "allOf", "oneOf", "prefixItems"):
+            seq = out.get(list_key)
+            if isinstance(seq, list):
+                out[list_key] = [_strictify_json_schema(v) for v in seq]
+        if out.get("type") == "object" and isinstance(out.get("properties"), dict):
+            out["additionalProperties"] = False
+            out["required"] = list(out["properties"].keys())
+        return out
+    if isinstance(node, list):
+        return [_strictify_json_schema(v) for v in node]
+    return node
+
+
 def _format_scope_block(
     *,
     skill_text: str,
@@ -178,9 +238,18 @@ def run_research_agent(
     )
     schema = output_model.model_json_schema()
     schema_name = output_model.__name__
+    # STRICT structured outputs (OpenRouter "Always set strict:true"): force the provider to
+    # honor the schema instead of returning a loose/empty body. The schema is strictified
+    # (additionalProperties:false, all-required, unsupported keywords dropped) so strict mode
+    # accepts it; the original ``schema`` (with bounds + descriptions) still goes in the prompt
+    # block below for providers that ignore response_format.
     response_format: dict[str, Any] = {
         "type": "json_schema",
-        "json_schema": {"name": schema_name, "schema": schema},
+        "json_schema": {
+            "name": schema_name,
+            "strict": True,
+            "schema": _strictify_json_schema(schema),
+        },
     }
     content_parts = _format_scope_block(
         skill_text=skill_text,

--- a/digigraph/src/digigraph/graph/research_agent.py
+++ b/digigraph/src/digigraph/graph/research_agent.py
@@ -97,13 +97,15 @@ def _strictify_json_schema(node: Any) -> Any:
     """Return a copy of a Pydantic-emitted JSON schema that satisfies OpenAI/OpenRouter STRICT
     structured-output rules (purely functional — the input is not mutated):
 
-    - every object gets ``additionalProperties: false`` and ``required`` listing ALL its property
-      keys (strict has no notion of optional keys — Pydantic optionals are already nullable
-      ``anyOf`` unions, so requiring them just means "must be present, may be null");
+    - every object with named ``properties`` gets ``additionalProperties: false`` and ``required``
+      listing ALL its property keys (strict has no notion of optional keys — Pydantic optionals are
+      already nullable ``anyOf`` unions, so requiring them just means "must be present, may be null");
     - unsupported validation keywords (``_STRICT_UNSUPPORTED_KEYS``) are dropped.
 
-    Recurses through ``properties``, ``$defs``/``definitions``, ``items``, and the
-    ``anyOf``/``allOf``/``oneOf``/``prefixItems`` combinator arrays. ``description``/``enum``/
+    Recurses through ``properties``, ``$defs``/``definitions``, ``items``, the
+    ``anyOf``/``allOf``/``oneOf``/``prefixItems`` combinator arrays, AND a schema-valued
+    ``additionalProperties`` (how Pydantic emits ``dict[str, X]`` map fields — those have no
+    ``properties`` key, so the value schema must still be strictified). ``description``/``enum``/
     ``const``/``$ref`` are preserved (all strict-legal and useful to the model)."""
     if isinstance(node, dict):
         out: dict[str, Any] = {k: v for k, v in node.items() if k not in _STRICT_UNSUPPORTED_KEYS}
@@ -111,7 +113,9 @@ def _strictify_json_schema(node: Any) -> Any:
             sub = out.get(mapping_key)
             if isinstance(sub, dict):
                 out[mapping_key] = {k: _strictify_json_schema(v) for k, v in sub.items()}
-        for child_key in ("items", "additionalItems", "not", "contains"):
+        # ``additionalProperties`` may be a bool (kept as-is by the leaf return) or a schema dict
+        # (dict[str, X] map fields) — recursing strictifies the value schema in the latter case.
+        for child_key in ("items", "additionalItems", "not", "contains", "additionalProperties"):
             if child_key in out:
                 out[child_key] = _strictify_json_schema(out[child_key])
         for list_key in ("anyOf", "allOf", "oneOf", "prefixItems"):

--- a/tests/dg/test_research_agent.py
+++ b/tests/dg/test_research_agent.py
@@ -131,6 +131,42 @@ class TestStrictifyJsonSchema:
         # anyOf members recursed (null branch left intact).
         assert {"type": "null"} in out["properties"]["maybe"]["anyOf"]
 
+    def test_recurses_into_additionalproperties_schema(self) -> None:
+        # Pydantic emits dict[str, X] map fields as an object with a schema-valued
+        # additionalProperties and NO properties — the value schema must still be strictified.
+        schema = {
+            "type": "object",
+            "properties": {
+                "weights": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {"pct": {"type": "number", "minimum": 0, "maximum": 1}},
+                    },
+                }
+            },
+        }
+        out = _strictify_json_schema(schema)
+        weights = out["properties"]["weights"]
+        # The map object has no named properties → not forced to additionalProperties:false,
+        # but its value schema is recursed: nested object strictified + bounds stripped.
+        value_schema = weights["additionalProperties"]
+        assert value_schema["additionalProperties"] is False
+        assert value_schema["required"] == ["pct"]
+        assert "minimum" not in value_schema["properties"]["pct"]
+        assert "maximum" not in value_schema["properties"]["pct"]
+
+    def test_boolean_additionalproperties_preserved(self) -> None:
+        # A bool additionalProperties (e.g. extra="forbid" → false) is passed through unchanged.
+        out = _strictify_json_schema(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "additionalProperties": False,
+            }
+        )
+        assert out["additionalProperties"] is False
+
     def test_input_not_mutated(self) -> None:
         schema = {
             "type": "object",

--- a/tests/dg/test_research_agent.py
+++ b/tests/dg/test_research_agent.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, ValidationError
 from digigraph.graph.research_agent import (
     ANALYST_SYSTEM,
     _format_scope_block,
+    _strictify_json_schema,
     run_research_agent,
 )
 
@@ -62,6 +63,90 @@ class TestFormatScopeBlock:
             schema_name="X",
         )
         assert a[0]["text"] == b[0]["text"]
+
+
+@pytest.mark.unit
+class TestStrictifyJsonSchema:
+    """The strictify transform must produce OpenRouter/OpenAI strict-mode-legal schemas."""
+
+    def test_object_gets_additional_properties_false_and_all_required(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+        }
+        out = _strictify_json_schema(schema)
+        assert out["additionalProperties"] is False
+        assert out["required"] == ["a", "b"]
+
+    def test_unsupported_keywords_stripped(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "score": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                    "default": 0.5,
+                },
+                "when": {"type": "string", "format": "date"},
+                "tag": {"type": "string", "pattern": "^[a-z]+$", "maxLength": 8},
+            },
+        }
+        out = _strictify_json_schema(schema)
+        score = out["properties"]["score"]
+        assert "minimum" not in score
+        assert "maximum" not in score
+        assert "default" not in score
+        assert "format" not in out["properties"]["when"]
+        assert "pattern" not in out["properties"]["tag"]
+        assert "maxLength" not in out["properties"]["tag"]
+        # type/description-class keywords survive.
+        assert score["type"] == "number"
+
+    def test_recurses_into_defs_and_anyof_and_items(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/Leg"},
+                    "maxItems": 5,
+                },
+                "maybe": {"anyOf": [{"$ref": "#/$defs/Leg"}, {"type": "null"}]},
+            },
+            "$defs": {
+                "Leg": {
+                    "type": "object",
+                    "properties": {"qty": {"type": "integer", "minimum": 1}},
+                }
+            },
+        }
+        out = _strictify_json_schema(schema)
+        # Array bound stripped, items recursed (no-op here), $defs object strictified.
+        assert "maxItems" not in out["properties"]["items"]
+        leg = out["$defs"]["Leg"]
+        assert leg["additionalProperties"] is False
+        assert leg["required"] == ["qty"]
+        assert "minimum" not in leg["properties"]["qty"]
+        # anyOf members recursed (null branch left intact).
+        assert {"type": "null"} in out["properties"]["maybe"]["anyOf"]
+
+    def test_input_not_mutated(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "number", "minimum": 0}},
+        }
+        before = json.dumps(schema, sort_keys=True)
+        _strictify_json_schema(schema)
+        assert json.dumps(schema, sort_keys=True) == before
+
+    def test_pydantic_model_schema_is_strictified(self) -> None:
+        """End-to-end on a real Pydantic schema: Field(ge/le) bounds → stripped, all required."""
+        out = _strictify_json_schema(_SampleOutput.model_json_schema())
+        assert out["additionalProperties"] is False
+        assert set(out["required"]) == {"regime", "confidence", "notes"}
+        conf = out["properties"]["confidence"]
+        assert "minimum" not in conf and "maximum" not in conf
 
 
 @pytest.mark.unit
@@ -156,4 +241,9 @@ class TestRunResearchAgent:
         assert rf is not None, "response_format must be passed to completion_text"
         assert rf["type"] == "json_schema"
         assert rf["json_schema"]["name"] == "_SampleOutput"
-        assert "properties" in rf["json_schema"]["schema"]
+        # Strict structured outputs: OpenRouter "Always set strict:true" + a strict-legal schema.
+        assert rf["json_schema"]["strict"] is True
+        strict_schema = rf["json_schema"]["schema"]
+        assert "properties" in strict_schema
+        assert strict_schema["additionalProperties"] is False
+        assert set(strict_schema["required"]) == {"regime", "confidence", "notes"}


### PR DESCRIPTION
Closes #796

## What

Request OpenRouter **strict structured outputs** correctly from the research-agent node.

OpenRouter's contract is "always set `strict: true`", and a strict request must carry a strict-legal schema: `additionalProperties: false`, every property in `required`, and **no** unsupported validation keywords (`minimum`/`maximum`/`format`/`maxLength`/`default`/…). Pydantic's `model_json_schema()` emits several of those and omits `additionalProperties`, so the strict request we built was rejected by the provider — which, via the Auto Router, surfaces as an **empty body** rather than an error. This is a root cause of the empty completions in #790.

## Changes

- `digigraph/graph/research_agent.py`
  - `_strictify_json_schema()` — pure-functional transform: recurses `properties`/`$defs`/`definitions`/`patternProperties`/`anyOf`/`allOf`/`oneOf`/`prefixItems`/`items`/…, sets `additionalProperties:false` + all-required on every object, strips `_STRICT_UNSUPPORTED_KEYS`.
  - `response_format.json_schema` now carries `strict: true` + the strictified schema. The original bounded schema still goes in the prompt block for providers that ignore `response_format`; real bounds stay enforced by `model_validate` after the call.
- `tests/dg/test_research_agent.py`
  - `TestStrictifyJsonSchema` — additionalProperties/required, keyword-strip, `$defs`/`anyOf`/`items` recursion, no-mutation, real Pydantic schema.
  - tightened the existing `response_format` test to assert `strict:true` + a strict-legal schema.

## Verification

- `pytest tests/dg/test_research_agent.py` → 12 passed; `pytest tests/dg/` → 332 passed (1 pre-existing failure: optional `langgraph-checkpoint-sqlite` not installed in this env — unrelated).
- `ruff check` + `ruff format --check` clean.
- `make score` → Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

## Scope

First of three fixes from #796 (OpenRouter structured-output correctness + spend observability). Findings #2 (model selection) and #3 (spend observability) follow in separate PRs.

Refs #796, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)