### PR TITLE
fix(digillm): force require_parameters for OpenRouter structured-output requests

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -37,6 +37,16 @@
 # research    — multi-factor analysis, analytical prose, 32k+ context.
 # reasoning   — high-stakes synthesis reconciling 20+ signals; use best model.
 # The Auto Router covers all three; per-request selection scales cost to the task.
+#
+# ── STRUCTURED-OUTPUT CONTRACT (every phase) ──────────────────────────────────
+# Every call here is a structured-output (response_format json_schema) or tool
+# request. digigraph sends `strict:true` + a strict-legal schema, and digillm
+# FORCES `provider.require_parameters=true` for these requests so OpenRouter only
+# routes to a provider that honors the param (a provider that drops it returns an
+# EMPTY body, not an error). The Auto Router is best-effort for structured outputs
+# — if empties recur, pin a capable allowlist via OPENROUTER_FALLBACK_MODELS in
+# the workflow env (current slugs from the models page filtered by
+# supported_parameters=structured_outputs). See atlas docs/RUNBOOK.md triage.
 # ─────────────────────────────────────────────────────────────────────────────
 
 phase_models:

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -617,7 +617,13 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
 
     - ``provider.require_parameters`` (default ON) — only route to providers that support the
       request's params (response_format / tools), so the Auto Router never lands on a provider
-      that drops them and returns an empty body (the post-#717 failure mode).
+      that drops them and returns an empty body (the post-#717 failure mode). FORCED ON for any
+      request that actually carries ``response_format`` or ``tools``, regardless of the global
+      ``OPENROUTER_REQUIRE_PARAMETERS`` toggle: the toggle exists to allow plain-prose requests
+      onto cheaper providers that ignore harmless extra params, but a structured-output / tool
+      request that lands on a provider which drops the param comes back EMPTY — an operator must
+      not be able to footgun that off. (OpenRouter structured-outputs docs pair ``strict:true``
+      with ``require_parameters`` to keep routing on capable providers.)
     - a cheap-model allowlist with fallback routing (``OPENROUTER_FALLBACK_MODELS`` →
       ``models`` + ``route=fallback``), price-sorted endpoints, and an optional hard price
       ceiling (``provider.max_price``) — keeps automatic selection but bounds it to affordable
@@ -630,7 +636,10 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
         return kwargs
     fallbacks = _openrouter_fallback_models()
     prefs = _openrouter_provider_prefs()
-    require_params = _openrouter_require_parameters()
+    # Structured-output (json_schema) and tool requests empty-fail without require_parameters, so
+    # force it for them even when the global toggle is off; plain-prose requests honor the toggle.
+    structured = kwargs.get("response_format") is not None or bool(kwargs.get("tools"))
+    require_params = _openrouter_require_parameters() or structured
     if not fallbacks and not prefs and not require_params:
         return kwargs
     merged = dict(kwargs)

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -276,6 +276,25 @@ def test_cost_controls_default_adds_require_parameters(monkeypatch: pytest.Monke
     assert client_mod._with_openrouter_cost_controls(base, "xai") == base
 
 
+def test_require_parameters_forced_for_structured_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A response_format / tools request must keep require_parameters even when the operator
+    # disables the global toggle — those requests empty-fail on a provider that drops the param.
+    monkeypatch.setenv("OPENROUTER_REQUIRE_PARAMETERS", "0")
+    schema_req = {
+        "model": "openrouter/auto",
+        "messages": [],
+        "response_format": {"type": "json_schema", "json_schema": {"name": "X", "schema": {}}},
+    }
+    out = client_mod._with_openrouter_cost_controls(schema_req, "openrouter")
+    assert out["extra_body"] == {"provider": {"require_parameters": True}}
+    tool_req = {"model": "openrouter/auto", "messages": [], "tools": [{"type": "function"}]}
+    out = client_mod._with_openrouter_cost_controls(tool_req, "openrouter")
+    assert out["extra_body"] == {"provider": {"require_parameters": True}}
+    # A plain-prose request still honors the opt-out (no extra_body added).
+    prose_req = {"model": "openrouter/auto", "messages": []}
+    assert client_mod._with_openrouter_cost_controls(prose_req, "openrouter") == prose_req
+
+
 def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.MonkeyPatch) -> None:
     # The xAI search_parameters branch is openrouter-gated out, but a pre-existing extra_body
     # (and any pre-set provider keys) must be preserved/merged, not clobbered.

--- a/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/RUNBOOK.md
@@ -194,6 +194,15 @@ When the scheduled Atlas pipeline fails (`atlas baseline`, `atlas delta`, or `at
    - **Provider/model change** (e.g. Ollama Cloud capacity, Gemini quota): update [`config/litellm.yaml`](../../config/litellm.yaml) routing or the workflow `env:` block; document in commit message.
 4. **Closing:** leave the issue open until the next scheduled run is green. The dedupe-by-title logic re-opens a new issue automatically on the next failure, so closing prematurely does not lose state — a transient that recurs surfaces a fresh issue.
 
+### OpenRouter empty completions (degraded book, "empty completion from …" in logs)
+
+Every phase routes through the OpenRouter **Auto Router** (`openrouter/openrouter/auto`, [`config/model_modes.yaml`](../../config/model_modes.yaml)), and every research call is a **structured-output** (`response_format` json_schema) or **tool** request. The pipeline degrades to an empty/zero-weight book when those calls come back with empty bodies. Contract and levers, in order of cause:
+
+1. **Account state first.** An empty body can be the Auto Router silently degrading on a key with no credit/over a limit. Check OpenRouter `GET /api/v1/credits` (balance) and `GET /api/v1/key` (daily/weekly/monthly spend + limits) with the `OPENROUTER_API_KEY` as a Bearer token. This is the cheapest first check.
+2. **Strict structured outputs are sent correctly** (digigraph `research_agent`): `strict: true` + a strict-legal schema (`additionalProperties:false`, all-required, unsupported keywords stripped). A strict request carrying Pydantic's raw schema is rejected by the provider and surfaces as an empty body (not an error).
+3. **`provider.require_parameters` is forced on** for any request carrying `response_format`/`tools` (digillm, independent of the `OPENROUTER_REQUIRE_PARAMETERS` toggle) so the Auto Router only routes to a provider that honors the param. Do **not** disable it for the pipeline.
+4. **Capable-model fallback (operator lever).** The Auto Router is *best-effort* for structured outputs — OpenRouter's own docs do not recommend the bare auto router for json_schema. If empties persist after (1)–(3), pin a capable allowlist via **`OPENROUTER_FALLBACK_MODELS`** (comma-separated, cheap→capable) in the workflow `env:`; digillm routes among them with `route=fallback` and the empty-retry self-heal swaps off a flaky primary. Pick current slugs from the OpenRouter models page filtered by **`supported_parameters=structured_outputs`** (slugs churn — keep them in config, never hard-coded). Restoring this list also restores a cost ceiling if you re-add `OPENROUTER_MAX_*_PRICE`.
+
 ## Environment requirements
 1. Python 3.11+ recommended.
 2. Install dependencies:


### PR DESCRIPTION
Closes #796

## What

Harden OpenRouter **structured-output model selection** (Finding #2 of #796).

Every Atlas/Hermes phase routes through the OpenRouter Auto Router, and every research call is a structured-output (`response_format` json_schema) or tool request. Per [OpenRouter's structured-outputs docs](https://openrouter.ai/docs/guides/features/structured-outputs), such a request that lands on a provider which **drops** the param comes back **empty** (not an error), and the docs do **not** recommend the bare Auto Router for json_schema. `provider.require_parameters=true` is the documented mechanism that keeps these requests on a capable provider — but it was globally toggleable, so an operator could silently footgun the entire (100%-structured) pipeline into empties.

## Changes

- `digillm/client.py` — `_with_openrouter_cost_controls` now **forces** `require_parameters` ON for any OpenRouter request that actually carries `response_format` or `tools`, regardless of `OPENROUTER_REQUIRE_PARAMETERS`. Plain-prose requests still honor the opt-out (so they can ride cheaper providers that harmlessly ignore extra params).
- `digillm/tests/test_digillm.py` — structured/tool requests keep `require_parameters` with the toggle off; prose requests still no-op.
- `config/model_modes.yaml` — documents the structured-output routing contract (strict:true + strict-legal schema in digigraph, require_parameters forced in digillm, capable-model allowlist as the operator lever).
- atlas `RUNBOOK.md` — "OpenRouter empty completions" triage: account-state check first (`/credits`, `/key`), then strict schema, then require_parameters, then `OPENROUTER_FALLBACK_MODELS` capable allowlist (current slugs from the models page filtered by `supported_parameters=structured_outputs` — kept in config, never hard-coded, per the no-lock-in philosophy).

## Why slugs stay in config (not pinned in code)

digillm is the provider-agnostic core; hard-coding OpenRouter model slugs there is lock-in and churns. The capable-model allowlist is an operator lever (`OPENROUTER_FALLBACK_MODELS`, already wired into the empty-retry self-heal). This PR makes the **mechanism** robust; the **list** belongs in the workflow env where it can be kept current.

## Verification

- `pytest digillm/tests/test_digillm.py` → 49 passed; `ruff check` + `ruff format --check` clean.
- `make doc-check` → OK (167 files). `make score` → Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

## Scope

Second of three fixes from #796. Pairs with #797 (Finding #1: strict:true + strict-legal schema). Finding #3 (spend/usage observability + diagnostic script) follows next.

Refs #796, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)