### PR TITLE
feat(observability): OpenRouter per-run spend capture + diagnostic script

### DIFF
--- a/digigraph/src/digigraph/usage.py
+++ b/digigraph/src/digigraph/usage.py
@@ -46,6 +46,7 @@ def record(
     prompt_tokens: int = 0,
     completion_tokens: int = 0,
     cached_tokens: int = 0,
+    cost: float = 0.0,
     sources: int = 0,
     ok: bool = True,
     **_ignored: Any,
@@ -54,8 +55,10 @@ def record(
 
     ``cached_tokens`` is the prompt-cache-hit portion of ``prompt_tokens`` (OpenRouter
     ``prompt_tokens_details.cached_tokens``) — surfaced so a run can show how much of the
-    repeated shared-context prefix was billed at the cheaper cached rate. ``**_ignored`` keeps
-    the observer forward-compatible with future digillm fields."""
+    repeated shared-context prefix was billed at the cheaper cached rate. ``cost`` is the actual
+    USD charged for the call (OpenRouter ``usage.cost``, always present on its responses; 0.0 for
+    providers that don't report it) — summed into run-level spend for accurate cost telemetry.
+    ``**_ignored`` keeps the observer forward-compatible with future digillm fields."""
     if not _ACTIVE:
         return
     with _LOCK:
@@ -66,6 +69,7 @@ def record(
                 "prompt_tokens": int(prompt_tokens or 0),
                 "completion_tokens": int(completion_tokens or 0),
                 "cached_tokens": int(cached_tokens or 0),
+                "cost": float(cost or 0.0),
                 "sources": int(sources or 0),
                 "ok": bool(ok),
             }
@@ -81,7 +85,8 @@ def snapshot() -> dict[str, Any]:
     prompt = sum(c["prompt_tokens"] for c in chat)
     completion = sum(c["completion_tokens"] for c in chat)
     cached = sum(c.get("cached_tokens", 0) for c in chat)
-    by_kind: dict[str, dict[str, int]] = {}
+    cost = sum(c.get("cost", 0.0) for c in calls)
+    by_kind: dict[str, dict[str, float]] = {}
     for c in calls:
         b = by_kind.setdefault(
             c["kind"],
@@ -90,6 +95,7 @@ def snapshot() -> dict[str, Any]:
                 "prompt_tokens": 0,
                 "completion_tokens": 0,
                 "cached_tokens": 0,
+                "cost": 0.0,
                 "sources": 0,
             },
         )
@@ -97,6 +103,7 @@ def snapshot() -> dict[str, Any]:
         b["prompt_tokens"] += c["prompt_tokens"]
         b["completion_tokens"] += c["completion_tokens"]
         b["cached_tokens"] += c.get("cached_tokens", 0)
+        b["cost"] += c.get("cost", 0.0)
         b["sources"] += c["sources"]
     return {
         "llm_calls": len(chat),
@@ -104,6 +111,9 @@ def snapshot() -> dict[str, Any]:
         "completion_tokens": completion,
         "cached_tokens": cached,
         "total_tokens": prompt + completion,
+        # Actual USD charged across all calls (OpenRouter usage.cost); 0.0 when no provider
+        # reported a cost. Rounded to 6 dp — sub-cent per-call costs must not lose precision.
+        "cost_usd": round(cost, 6),
         "search_calls": len(search),
         "sources_used": sum(c["sources"] for c in search),
         "grounding_ok": sum(1 for c in search if c["ok"]),

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -557,10 +557,15 @@ def _openrouter_usage_cost(usage: Any) -> float:
         extra = getattr(usage, "model_extra", None)
         if isinstance(extra, dict):
             cost = extra.get("cost")
+    if cost is None:
+        return 0.0
     try:
-        return float(cost) if cost is not None else 0.0
+        value = float(cost)
     except (TypeError, ValueError):
         return 0.0
+    # float() also accepts 'nan'/'inf'/negatives; a bad cost must not poison run-level
+    # aggregation (one nan turns the whole run's cost_usd into nan). Clamp to a sane 0.0.
+    return value if math.isfinite(value) and value >= 0 else 0.0
 
 
 def _openrouter_fallback_models() -> list[str]:

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -545,6 +545,24 @@ def _is_empty_completion(resp: Any) -> bool:
     return not content and not tool_calls
 
 
+def _openrouter_usage_cost(usage: Any) -> float:
+    """Actual USD charged for a call, from OpenRouter's ``usage.cost`` (always present on its
+    responses). The OpenAI SDK is typed for OpenAI's schema, so an unknown ``cost`` field lands
+    in pydantic ``model_extra`` rather than a typed attribute — check both. Returns 0.0 for any
+    provider/SDK that doesn't surface it, so non-OpenRouter calls record no cost."""
+    if usage is None:
+        return 0.0
+    cost = getattr(usage, "cost", None)
+    if cost is None:
+        extra = getattr(usage, "model_extra", None)
+        if isinstance(extra, dict):
+            cost = extra.get("cost")
+    try:
+        return float(cost) if cost is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _openrouter_fallback_models() -> list[str]:
     """``OPENROUTER_FALLBACK_MODELS`` (comma-separated) — the cheap-model allowlist OpenRouter
     routes/falls-back across (keeps automatic selection, but only among affordable models)."""
@@ -787,6 +805,10 @@ def completion(
         prompt_tokens=getattr(_u, "prompt_tokens", 0) or 0,
         completion_tokens=getattr(_u, "completion_tokens", 0) or 0,
         cached_tokens=_cached_tokens,
+        # Actual USD charged. OpenRouter always includes ``usage.cost`` on its responses
+        # (usage accounting is on by default); the OpenAI SDK keeps unknown fields in
+        # ``model_extra``. Other providers don't report it → 0.0.
+        cost=_openrouter_usage_cost(_u),
     )
     # Cache the serialized response (tool-free, non-BYOK, non-empty content) so a
     # future hit rehydrates a ChatCompletion — keeping the return type consistent.

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -194,6 +194,29 @@ def test_openrouter_fallback_models_parsing(monkeypatch: pytest.MonkeyPatch) -> 
     assert client_mod._openrouter_fallback_models() == []
 
 
+def test_openrouter_usage_cost_reads_typed_extra_and_missing() -> None:
+    # OpenRouter usage.cost as a plain typed attribute.
+    typed = MagicMock(spec=["cost", "model_extra"])
+    typed.cost = 0.0042
+    typed.model_extra = None
+    assert client_mod._openrouter_usage_cost(typed) == pytest.approx(0.0042)
+    # Falls back to pydantic model_extra when the SDK drops the unknown field off the typed attr.
+    extra_only = MagicMock(spec=["cost", "model_extra"])
+    extra_only.cost = None
+    extra_only.model_extra = {"cost": 0.009}
+    assert client_mod._openrouter_usage_cost(extra_only) == pytest.approx(0.009)
+    # No usage / no cost / non-numeric → 0.0 (non-OpenRouter providers report no cost).
+    assert client_mod._openrouter_usage_cost(None) == 0.0
+    none_cost = MagicMock(spec=["cost", "model_extra"])
+    none_cost.cost = None
+    none_cost.model_extra = {}
+    assert client_mod._openrouter_usage_cost(none_cost) == 0.0
+    bad = MagicMock(spec=["cost", "model_extra"])
+    bad.cost = "free"
+    bad.model_extra = None
+    assert client_mod._openrouter_usage_cost(bad) == 0.0
+
+
 def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENROUTER_FALLBACK_MODELS", "a/x,b/y")
     base = {"model": "m", "messages": []}

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -215,6 +215,12 @@ def test_openrouter_usage_cost_reads_typed_extra_and_missing() -> None:
     bad.cost = "free"
     bad.model_extra = None
     assert client_mod._openrouter_usage_cost(bad) == 0.0
+    # Non-finite / negative cost must not poison run-level aggregation → clamped to 0.0.
+    for bad_value in (float("nan"), float("inf"), -0.5, "nan", "inf"):
+        nf = MagicMock(spec=["cost", "model_extra"])
+        nf.cost = bad_value
+        nf.model_extra = None
+        assert client_mod._openrouter_usage_cost(nf) == 0.0
 
 
 def test_with_openrouter_fallback_only_for_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/digiquant/scripts/atlas/openrouter_diagnose.py
+++ b/digiquant/scripts/atlas/openrouter_diagnose.py
@@ -23,6 +23,7 @@ Exit 1 = key unreachable, or the strict ping came back empty (the degraded-run s
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import sys
 import time
@@ -72,11 +73,15 @@ def _ensure_importable() -> None:
 
 
 def _money(value: Any) -> str:
-    """Render a credit/USD amount, or '—' when absent/non-numeric."""
+    """Render a credit/USD amount, or '—' when absent/non-numeric/non-finite.
+
+    float() accepts 'nan'/'inf', which would print a misleading ``$nan``/``$inf`` in operator
+    output — treat those (and any non-numeric) as missing."""
     try:
-        return f"${float(value):.4f}"
+        amount = float(value)
     except (TypeError, ValueError):
         return "—"
+    return f"${amount:.4f}" if math.isfinite(amount) else "—"
 
 
 def summarize_key(data: dict[str, Any]) -> str:

--- a/digiquant/scripts/atlas/openrouter_diagnose.py
+++ b/digiquant/scripts/atlas/openrouter_diagnose.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""OpenRouter diagnostic — root-cause an empty-completion / degraded Atlas run, and report spend.
+
+Runs three checks, cheapest first, and prints a verdict:
+
+  1. Key state  — GET /api/v1/key (works with a standard OPENROUTER_API_KEY): remaining credit,
+                  all-time + daily/weekly/monthly usage, free-tier flag, configured limit.
+  2. Credits    — GET /api/v1/credits (best-effort: needs a *management* key; 401 → skipped).
+  3. Strict ping — one real structured-output (json_schema, strict:true) completion through the
+                  SAME digillm path the pipeline uses (so it exercises require_parameters +
+                  schema strictification). Reports the model OpenRouter actually served, the
+                  per-call USD cost (from the response's ``usage.cost``), and whether the body
+                  came back empty (the failure mode we hunt).
+
+Usage:
+  python digiquant/scripts/atlas/openrouter_diagnose.py            # full run
+  python digiquant/scripts/atlas/openrouter_diagnose.py --no-ping  # account state only (free)
+
+Exit 0 = key reachable and (unless --no-ping) the strict ping produced a non-empty body.
+Exit 1 = key unreachable, or the strict ping came back empty (the degraded-run signature).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any  # noqa  # scored-lint: OpenRouter JSON ``data`` objects are heterogeneous
+
+import httpx
+
+_OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+
+_tty = sys.stdout.isatty()
+
+
+def _c(code: str, s: str) -> str:
+    return f"\033[{code}m{s}\033[0m" if _tty else s
+
+
+def _green(s: str) -> str:
+    return _c("32", s)
+
+
+def _red(s: str) -> str:
+    return _c("31", s)
+
+
+def _yellow(s: str) -> str:
+    return _c("33", s)
+
+
+def _bold(s: str) -> str:
+    return _c("1", s)
+
+
+PASS, FAIL, SKIP = _green("PASS"), _red("FAIL"), _yellow("SKIP")
+
+
+def _ensure_importable() -> None:
+    """Add monorepo src paths to sys.path so digillm/digigraph import when run from the repo."""
+    repo_root = Path(__file__).resolve().parents[3]
+    for rel in ("digigraph/src", "digillm/src", "digibase/src", "digismith/src"):
+        p = str(repo_root / rel)
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+
+# ── pure formatters (unit-tested without network) ─────────────────────────────
+
+
+def _money(value: Any) -> str:
+    """Render a credit/USD amount, or '—' when absent/non-numeric."""
+    try:
+        return f"${float(value):.4f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def summarize_key(data: dict[str, Any]) -> str:
+    """One-line summary of GET /api/v1/key's ``data`` object (field names per OpenRouter docs)."""
+    limit = data.get("limit")
+    remaining = data.get("limit_remaining")
+    parts = [
+        f"used(all-time)={_money(data.get('usage'))}",
+        f"today={_money(data.get('usage_daily'))}",
+        f"week={_money(data.get('usage_weekly'))}",
+        f"month={_money(data.get('usage_monthly'))}",
+        f"limit={'unlimited' if limit is None else _money(limit)}",
+        f"remaining={'n/a' if remaining is None else _money(remaining)}",
+        f"free_tier={bool(data.get('is_free_tier'))}",
+    ]
+    return ", ".join(parts)
+
+
+def key_is_exhausted(data: dict[str, Any]) -> bool:
+    """True when a finite credit limit is set and nothing is left — a hard cause of empty bodies."""
+    remaining = data.get("limit_remaining")
+    try:
+        return remaining is not None and float(remaining) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def summarize_credits(data: dict[str, Any]) -> str:
+    """One-line summary of GET /api/v1/credits's ``data`` object."""
+    total = data.get("total_credits")
+    used = data.get("total_usage")
+    balance = None
+    try:
+        balance = float(total) - float(used)
+    except (TypeError, ValueError):
+        balance = None
+    return (
+        f"purchased={_money(total)}, used={_money(used)}, "
+        f"balance={'—' if balance is None else _money(balance)}"
+    )
+
+
+# ── checks ────────────────────────────────────────────────────────────────────
+
+
+def _get_json(path: str, api_key: str) -> dict[str, Any]:
+    """GET an OpenRouter endpoint and return its ``data`` object; raise on non-2xx."""
+    resp = httpx.get(
+        f"{_OPENROUTER_BASE}{path}",
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    return payload.get("data", payload) if isinstance(payload, dict) else {}
+
+
+def check_key(api_key: str) -> bool:
+    print(_bold("\n1. Key state (GET /api/v1/key)"))
+    try:
+        data = _get_json("/key", api_key)
+    except (httpx.HTTPError, ValueError) as exc:
+        print(f"  {FAIL}  key unreachable — {exc}")
+        return False
+    print(f"  {PASS}  {summarize_key(data)}")
+    if key_is_exhausted(data):
+        print(f"  {FAIL}  credit limit reached — this alone degrades runs to empty bodies")
+        return False
+    return True
+
+
+def check_credits(api_key: str) -> None:
+    print(_bold("\n2. Credits (GET /api/v1/credits — needs a management key)"))
+    try:
+        data = _get_json("/credits", api_key)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            print(
+                f"  {SKIP}  not a management key (HTTP {exc.response.status_code}) — use /key above"
+            )
+        else:
+            print(f"  {SKIP}  {exc}")
+        return
+    except (httpx.HTTPError, ValueError) as exc:
+        print(f"  {SKIP}  {exc}")
+        return
+    print(f"  {PASS}  {summarize_credits(data)}")
+
+
+def check_strict_ping() -> bool:
+    """Run one strict json_schema completion through the real digillm path; True iff non-empty."""
+    print(_bold("\n3. Strict structured-output ping (real digillm path)"))
+    try:
+        _ensure_importable()
+        from pydantic import BaseModel, Field
+
+        from digigraph.graph.research_agent import run_research_agent
+        from digigraph import usage as usage_mod
+
+        class _Ping(BaseModel):
+            status: str = Field(description="the single word: ok")
+            confidence: float = Field(ge=0.0, le=1.0)
+
+        usage_mod.start()
+        t0 = time.monotonic()
+        out = run_research_agent(
+            skill_text="Reply that you are operational.",
+            phase_inputs={},
+            shared_context={},
+            output_model=_Ping,
+            model="openrouter/openrouter/auto",
+            max_retries=1,
+        )
+        elapsed = time.monotonic() - t0
+        snap = usage_mod.snapshot()
+        usage_mod.reset()
+        served = (snap.get("models") or ["?"])[0]
+        cost = snap.get("cost_usd", 0.0)
+        print(
+            f"  {PASS}  non-empty body in {elapsed:.1f}s — status={out.status!r}, "
+            f"model={served}, cost={_money(cost)}"
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — diagnostic: report any failure, never raise
+        # An empty body surfaces here as a ValidationError / "empty completion" RuntimeError.
+        print(f"  {FAIL}  strict ping failed — {type(exc).__name__}: {exc}")
+        print("        → this is the degraded-run signature. Triage: atlas docs/RUNBOOK.md")
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="OpenRouter diagnostic for Atlas runs.")
+    parser.add_argument(
+        "--no-ping",
+        action="store_true",
+        help="Account state only (free) — skip the live strict completion.",
+    )
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        print(f"  {FAIL}  OPENROUTER_API_KEY not set")
+        return 1
+
+    key_ok = check_key(api_key)
+    check_credits(api_key)
+    if args.no_ping:
+        print(_bold("\nVerdict:"), "key reachable" if key_ok else "key check FAILED")
+        return 0 if key_ok else 1
+
+    ping_ok = check_strict_ping()
+    ok = key_ok and ping_ok
+    print(_bold("\nVerdict:"), _green("healthy") if ok else _red("degraded — see checks above"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dg/test_usage.py
+++ b/tests/dg/test_usage.py
@@ -76,6 +76,20 @@ def test_aggregates_cached_tokens_and_tolerates_unknown_fields():
 
 
 @pytest.mark.unit
+def test_aggregates_cost_usd():
+    usage.start()
+    # Actual USD charged (OpenRouter usage.cost) sums into run-level cost_usd + by_kind.
+    usage.record(kind="chat", model="m", prompt_tokens=100, completion_tokens=40, cost=0.0123)
+    usage.record(kind="chat", model="m", prompt_tokens=50, completion_tokens=20, cost=0.0077)
+    # A call with no cost reported defaults to 0.0 (no KeyError, no skew).
+    usage.record(kind="web_search", model="m", sources=4, ok=True)
+    snap = usage.snapshot()
+    assert snap["cost_usd"] == pytest.approx(0.02)
+    assert snap["by_kind"]["chat"]["cost"] == pytest.approx(0.02)
+    assert snap["by_kind"]["web_search"]["cost"] == 0.0
+
+
+@pytest.mark.unit
 def test_reset_clears_and_deactivates():
     usage.start()
     usage.record(kind="chat", model="x", prompt_tokens=1, completion_tokens=1)

--- a/tests/dq/atlas/test_openrouter_diagnose.py
+++ b/tests/dq/atlas/test_openrouter_diagnose.py
@@ -38,6 +38,10 @@ def test_money_formats_and_tolerates_garbage() -> None:
     assert diag._money("0.0123") == "$0.0123"
     assert diag._money(None) == "—"
     assert diag._money("free") == "—"
+    # Non-finite values would print a misleading $nan/$inf → rendered as missing instead.
+    assert diag._money(float("nan")) == "—"
+    assert diag._money(float("inf")) == "—"
+    assert diag._money("nan") == "—"
 
 
 def test_summarize_key_includes_spend_windows() -> None:

--- a/tests/dq/atlas/test_openrouter_diagnose.py
+++ b/tests/dq/atlas/test_openrouter_diagnose.py
@@ -1,0 +1,79 @@
+"""OpenRouter diagnostic — pure formatters / verdict helpers (no network).
+
+The HTTP checks and the live strict ping are exercised in the field; here we cover the
+deterministic parsing that turns API ``data`` objects into operator-readable lines and the
+exhausted-credit verdict that flips a green run to FAIL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "scripts"
+    / "atlas"
+    / "openrouter_diagnose.py"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("openrouter_diagnose_script", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+diag = _load_script()
+
+
+def test_money_formats_and_tolerates_garbage() -> None:
+    assert diag._money(1.5) == "$1.5000"
+    assert diag._money("0.0123") == "$0.0123"
+    assert diag._money(None) == "—"
+    assert diag._money("free") == "—"
+
+
+def test_summarize_key_includes_spend_windows() -> None:
+    line = diag.summarize_key(
+        {
+            "usage": 12.34,
+            "usage_daily": 1.0,
+            "usage_weekly": 5.0,
+            "usage_monthly": 10.0,
+            "limit": None,
+            "limit_remaining": None,
+            "is_free_tier": False,
+        }
+    )
+    assert "used(all-time)=$12.3400" in line
+    assert "today=$1.0000" in line
+    assert "limit=unlimited" in line
+    assert "remaining=n/a" in line
+    assert "free_tier=False" in line
+
+
+def test_key_is_exhausted() -> None:
+    # Finite limit fully used → exhausted (a hard cause of empty bodies).
+    assert diag.key_is_exhausted({"limit_remaining": 0}) is True
+    assert diag.key_is_exhausted({"limit_remaining": -0.5}) is True
+    # Credit left, or no finite limit, or unparseable → not exhausted.
+    assert diag.key_is_exhausted({"limit_remaining": 4.2}) is False
+    assert diag.key_is_exhausted({"limit_remaining": None}) is False
+    assert diag.key_is_exhausted({}) is False
+    assert diag.key_is_exhausted({"limit_remaining": "n/a"}) is False
+
+
+def test_summarize_credits_computes_balance() -> None:
+    line = diag.summarize_credits({"total_credits": 100.0, "total_usage": 25.5})
+    assert "purchased=$100.0000" in line
+    assert "used=$25.5000" in line
+    assert "balance=$74.5000" in line
+    # Missing fields degrade to em-dashes, never raise.
+    assert "balance=—" in diag.summarize_credits({"total_credits": None, "total_usage": None})


### PR DESCRIPTION
Closes #796

## What

OpenRouter **spend/usage observability** + a one-shot **diagnostic** (Finding #3 of #796).

Goal (per the ask): accurate per-run spend so we can optimize token usage, and a cheap definitive tool to root-cause the empty-completion / degraded runs.

## Per-run cost capture

OpenRouter includes the actual USD `usage.cost` on **every** response (usage accounting is on by default; `usage:{include:true}` is deprecated — verified against the [usage-accounting docs](https://openrouter.ai/docs/cookbook/administration/usage-accounting)).

- `digillm/client.py` — `_openrouter_usage_cost()` reads it defensively (typed attr → pydantic `model_extra` fallback → `0.0` for providers that don't report it; the OpenAI SDK is typed for OpenAI's schema, so the unknown `cost` field lands in `model_extra`). Threaded into the usage observer alongside tokens.
- `digigraph/usage.py` — aggregates a run-level **`cost_usd`** + per-kind `cost`, so the diagnostics row carries real dollars, not just tokens.

## Diagnostic — `digiquant/scripts/atlas/openrouter_diagnose.py`

Three checks, cheapest first, with a verdict:
1. **GET /api/v1/key** (standard key works): remaining credit + all-time/daily/weekly/monthly spend + free-tier flag; flags an **exhausted limit** (a hard cause of empty bodies).
2. **GET /api/v1/credits** (best-effort; needs a *management* key → 401 skipped gracefully).
3. **Strict ping** — one real json_schema `strict:true` completion through the **same digillm path** the pipeline uses (so it exercises require_parameters + schema strictification from #797/#798), reporting the model OpenRouter actually served, the per-call USD cost, and empty-vs-not.

`python digiquant/scripts/atlas/openrouter_diagnose.py --no-ping` does account-state only (free). This is the cheap definitive check for the post-#717 empty-completion mystery — run it with the prod `OPENROUTER_API_KEY` to confirm whether the account is the cause.

## Verification

- `pytest digillm/tests/test_digillm.py tests/dg/test_usage.py tests/dq/atlas/test_openrouter_diagnose.py` → all pass (cost aggregation, `_openrouter_usage_cost` typed/extra/missing/non-numeric, and the diagnostic's pure formatters/verdict helpers).
- `ruff check` + `ruff format --check` clean. `make score` → 10/10/10/10.

## Scope

Third of three from #796 (pairs with #797 strict-schema and #798 require_parameters). The diagnostic also serves as the operator's account-state check referenced in the #798 RUNBOOK triage.

Refs #796, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)