### PR TITLE
fix(digillm): constrain OpenRouter Auto Router to a capable-model pool (#802)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -84,12 +84,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Cost controls REMOVED for now (#794): the $1.5/$4 price ceiling forced the Auto Router
-          # onto google/gemini-2.5-flash-lite, which returns EMPTY bodies on the pipeline's
-          # json_schema/tool calls → every run degraded (#790). Running UNCAPPED so auto picks a
-          # capable model; provider.require_parameters=true (digillm default, #793) keeps it on a
-          # provider that honors the params. Re-introduce a tuned ceiling once OpenRouter is proven
-          # to produce completions for this pipeline (the cheap-routing-that-works follow-up).
+          # Auto Router candidate pool CONSTRAINED to capable models (#802). The bare Auto Router
+          # kept landing on google/gemini-2.5-flash-lite, which doesn't honor strict structured
+          # outputs → loose/empty JSON → degraded runs (#790). OPENROUTER_ALLOWED_MODELS fences the
+          # Auto Router (plugins[auto-router].allowed_models) to reasoning + structured-output
+          # capable models across providers (incl. DeepSeek for cheap reasoning), excluding
+          # flash-lite — auto still picks best-per-prompt within the set; require_parameters stays
+          # on (digillm). Tune the pool here; bias cost/quality via OPENROUTER_COST_QUALITY_TRADEOFF.
+          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -81,12 +81,14 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # All phases route through OpenRouter Auto Router (config/model_modes.yaml).
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Cost controls REMOVED for now (#794): the $1.5/$4 price ceiling forced the Auto Router
-          # onto google/gemini-2.5-flash-lite, which returns EMPTY bodies on the pipeline's
-          # json_schema/tool calls → every run degraded (#790). Running UNCAPPED so auto picks a
-          # capable model; provider.require_parameters=true (digillm default, #793) keeps it on a
-          # provider that honors the params. Re-introduce a tuned ceiling once OpenRouter is proven
-          # to produce completions for this pipeline (the cheap-routing-that-works follow-up).
+          # Auto Router candidate pool CONSTRAINED to capable models (#802). The bare Auto Router
+          # kept landing on google/gemini-2.5-flash-lite, which doesn't honor strict structured
+          # outputs → loose/empty JSON → degraded runs (#790). OPENROUTER_ALLOWED_MODELS fences the
+          # Auto Router (plugins[auto-router].allowed_models) to reasoning + structured-output
+          # capable models across providers (incl. DeepSeek for cheap reasoning), excluding
+          # flash-lite — auto still picks best-per-prompt within the set; require_parameters stays
+          # on (digillm). Tune the pool here; bias cost/quality via OPENROUTER_COST_QUALITY_TRADEOFF.
+          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -43,10 +43,13 @@
 # request. digigraph sends `strict:true` + a strict-legal schema, and digillm
 # FORCES `provider.require_parameters=true` for these requests so OpenRouter only
 # routes to a provider that honors the param (a provider that drops it returns an
-# EMPTY body, not an error). The Auto Router is best-effort for structured outputs
-# — if empties recur, pin a capable allowlist via OPENROUTER_FALLBACK_MODELS in
-# the workflow env (current slugs from the models page filtered by
-# supported_parameters=structured_outputs). See atlas docs/RUNBOOK.md triage.
+# EMPTY body, not an error). The bare Auto Router is NOT enough — it kept selecting
+# google/gemini-2.5-flash-lite, which accepts json_schema but ignores strict mode →
+# loose/empty JSON (#790/#802). So the Auto Router's candidate pool is CONSTRAINED to
+# a curated set of reasoning + structured-output capable models via the workflow env
+# OPENROUTER_ALLOWED_MODELS (digillm → plugins[auto-router].allowed_models); auto still
+# picks best-per-prompt within that set. Tune the pool / cost bias in the workflow env.
+# See atlas docs/RUNBOOK.md triage.
 # ─────────────────────────────────────────────────────────────────────────────
 
 phase_models:

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -635,6 +635,36 @@ def _openrouter_require_parameters() -> bool:
     )
 
 
+def _openrouter_allowed_models() -> list[str]:
+    """``OPENROUTER_ALLOWED_MODELS`` (comma-separated) — the Auto Router's candidate pool.
+
+    Constrains ``openrouter/auto`` to select ONLY from this curated set of reasoning +
+    structured-output-capable models (exact slugs and/or ``provider/*`` wildcards), via the
+    OpenRouter ``auto-router`` plugin. This keeps per-prompt auto-selection but fences out
+    models that don't honor strict structured outputs (e.g. ``google/gemini-2.5-flash-lite``,
+    which the bare Auto Router kept picking → loose/empty JSON, #802). Empty = unconstrained."""
+    raw = os.environ.get("OPENROUTER_ALLOWED_MODELS", "").strip()
+    return [m.strip() for m in raw.split(",") if m.strip()]
+
+
+def _openrouter_cost_quality_tradeoff() -> int | None:
+    """``OPENROUTER_COST_QUALITY_TRADEOFF`` — the Auto Router plugin's 0-10 dial (0 = always the
+    most capable model, 10 = cheapest; OpenRouter default 7). Returns None (use the default) when
+    unset or out of range."""
+    raw = os.environ.get("OPENROUTER_COST_QUALITY_TRADEOFF", "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("ignoring non-integer OPENROUTER_COST_QUALITY_TRADEOFF=%r", raw)
+        return None
+    if not 0 <= value <= 10:
+        logger.warning("ignoring out-of-range OPENROUTER_COST_QUALITY_TRADEOFF=%r (need 0-10)", raw)
+        return None
+    return value
+
+
 def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
     """Merge OpenRouter routing controls into ``extra_body`` for an ``openrouter/`` request:
 
@@ -647,6 +677,11 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
       request that lands on a provider which drops the param comes back EMPTY — an operator must
       not be able to footgun that off. (OpenRouter structured-outputs docs pair ``strict:true``
       with ``require_parameters`` to keep routing on capable providers.)
+    - the Auto Router candidate pool (``OPENROUTER_ALLOWED_MODELS`` → ``plugins[auto-router]
+      .allowed_models``, with optional ``cost_quality_tradeoff``) — keeps ``openrouter/auto``'s
+      per-prompt selection but constrains it to a curated set of reasoning + structured-output
+      capable models, so it stops landing on incapable models like gemini-2.5-flash-lite (#802).
+      Only applied to ``openrouter/auto`` requests (the plugin is meaningless on a pinned model).
     - a cheap-model allowlist with fallback routing (``OPENROUTER_FALLBACK_MODELS`` →
       ``models`` + ``route=fallback``), price-sorted endpoints, and an optional hard price
       ceiling (``provider.max_price``) — keeps automatic selection but bounds it to affordable
@@ -659,17 +694,27 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
         return kwargs
     fallbacks = _openrouter_fallback_models()
     prefs = _openrouter_provider_prefs()
+    allowed_models = _openrouter_allowed_models()
     # Structured-output (json_schema) and tool requests empty-fail without require_parameters, so
     # force it for them even when the global toggle is off; plain-prose requests honor the toggle.
     structured = kwargs.get("response_format") is not None or bool(kwargs.get("tools"))
     require_params = _openrouter_require_parameters() or structured
-    if not fallbacks and not prefs and not require_params:
+    if not fallbacks and not prefs and not require_params and not allowed_models:
         return kwargs
     merged = dict(kwargs)
     extra = dict(merged.get("extra_body") or {})
     if fallbacks:
         extra["models"] = fallbacks
         extra["route"] = "fallback"
+    # Auto Router candidate-pool constraint — only meaningful for the auto router itself.
+    if allowed_models and (merged.get("model") or "").endswith("/auto"):
+        plugin: dict[str, Any] = {"id": "auto-router", "allowed_models": allowed_models}
+        tradeoff = _openrouter_cost_quality_tradeoff()
+        if tradeoff is not None:
+            plugin["cost_quality_tradeoff"] = tradeoff
+        # Replace any prior auto-router plugin, preserve other plugins (e.g. web search).
+        others = [p for p in (extra.get("plugins") or []) if p.get("id") != "auto-router"]
+        extra["plugins"] = [*others, plugin]
     provider_prefs = {**(extra.get("provider") or {})}
     if require_params:
         provider_prefs["require_parameters"] = True

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -35,6 +35,8 @@ def _clean_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENROUTER_MAX_PROMPT_PRICE",
         "OPENROUTER_MAX_COMPLETION_PRICE",
         "OPENROUTER_REQUIRE_PARAMETERS",
+        "OPENROUTER_ALLOWED_MODELS",
+        "OPENROUTER_COST_QUALITY_TRADEOFF",
         "DIGI_LLM_CACHE_TTL_SECONDS",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -322,6 +324,43 @@ def test_require_parameters_forced_for_structured_requests(monkeypatch: pytest.M
     # A plain-prose request still honors the opt-out (no extra_body added).
     prose_req = {"model": "openrouter/auto", "messages": []}
     assert client_mod._with_openrouter_cost_controls(prose_req, "openrouter") == prose_req
+
+
+def test_allowed_models_constrains_auto_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    # OPENROUTER_ALLOWED_MODELS fences the Auto Router's candidate pool via the auto-router
+    # plugin (keeps per-prompt auto-selection, excludes incapable models like flash-lite, #802).
+    monkeypatch.setenv(
+        "OPENROUTER_ALLOWED_MODELS", " openai/gpt-4o-mini , deepseek/deepseek-chat ,"
+    )
+    monkeypatch.setenv("OPENROUTER_COST_QUALITY_TRADEOFF", "6")
+    req = {"model": "openrouter/auto", "messages": []}
+    out = client_mod._with_openrouter_cost_controls(req, "openrouter")
+    assert out["extra_body"]["plugins"] == [
+        {
+            "id": "auto-router",
+            "allowed_models": ["openai/gpt-4o-mini", "deepseek/deepseek-chat"],
+            "cost_quality_tradeoff": 6,
+        }
+    ]
+    # require_parameters still rides alongside the plugin.
+    assert out["extra_body"]["provider"] == {"require_parameters": True}
+
+
+def test_allowed_models_only_for_auto_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The plugin is meaningless on a pinned model → not injected there.
+    monkeypatch.setenv("OPENROUTER_ALLOWED_MODELS", "openai/gpt-4o-mini")
+    pinned = {"model": "deepseek/deepseek-chat", "messages": []}
+    out = client_mod._with_openrouter_cost_controls(pinned, "openrouter")
+    assert "plugins" not in out.get("extra_body", {})
+    # Out-of-range / non-int tradeoff is ignored (plugin omits the key, uses OpenRouter default).
+    monkeypatch.setenv("OPENROUTER_COST_QUALITY_TRADEOFF", "99")
+    out = client_mod._with_openrouter_cost_controls(
+        {"model": "openrouter/auto", "messages": []}, "openrouter"
+    )
+    assert out["extra_body"]["plugins"][0] == {
+        "id": "auto-router",
+        "allowed_models": ["openai/gpt-4o-mini"],
+    }
 
 
 def test_cost_controls_merge_preserves_existing_extra_body(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Keep the OpenRouter **Auto Router** but **constrain its candidate pool** to reasoning + structured-output-capable models — the fix for the failed inception baseline.

## Why

`atlas_run_diagnostics` from the failed run (the #799 telemetry) showed **100% of LLM calls routed to `google/gemini-2.5-flash-lite`**, even uncapped and with `require_parameters=true`. flash-lite *accepts* `response_format` but ignores strict mode → loose/empty JSON (`Extra data: column 543`, single-quoted keys) → Hermes `phase7c_analyst` `JSONDecodeError` → no sized book. `require_parameters` only checks param *support*, not strict-mode *quality*, so the Auto Router kept choosing it.

Per [OpenRouter's Auto Router docs](https://openrouter.ai/docs/guides/routing/routers/auto-router), the `plugins[auto-router].allowed_models` constraint keeps per-prompt auto-selection but fences the candidate set.

## Changes

- **digillm** `_with_openrouter_cost_controls`: `OPENROUTER_ALLOWED_MODELS` → `plugins:[{id:"auto-router", allowed_models:[…], cost_quality_tradeoff?}]`, injected **only** for `openrouter/auto` requests; `OPENROUTER_COST_QUALITY_TRADEOFF` (0–10) validated. `require_parameters` rides alongside.
- **workflows** (atlas-baseline + atlas-delta): `OPENROUTER_ALLOWED_MODELS="openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"` — cross-provider, **excludes flash-lite**, **includes DeepSeek** for cheap reasoning.
- **model_modes.yaml**: stays `openrouter/openrouter/auto` (auto preserved); contract comment updated.
- tests: plugin injected for auto-router only; tradeoff range-validated; merges with `require_parameters`/existing plugins.

## Verification

- `pytest digillm/tests/test_digillm.py` → 52 passed; `ruff` clean; `make doc-check` OK; `make score` 10/10/10/10.
- End-to-end proof = the re-dispatched inception baseline (after merge): `atlas_run_diagnostics.breakdown.models` should show capable models (not flash-lite) + a non-empty sized book.

Closes #802. Refs #790, #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
