### PR TITLE
fix(digillm): allowed_models supersedes require_parameters + preflight routing check (#802)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -74,6 +74,9 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Same curated pool as the run step (below) so the preflight validates the REAL routing
+          # path and fails FAST on a misconfig instead of burning the full pipeline (#802).
+          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
 

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -72,6 +72,9 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Same curated pool as the run step (below) so the preflight validates the REAL routing
+          # path and fails FAST on a misconfig instead of burning the full pipeline (#802).
+          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
 

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -676,7 +676,9 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
       onto cheaper providers that ignore harmless extra params, but a structured-output / tool
       request that lands on a provider which drops the param comes back EMPTY — an operator must
       not be able to footgun that off. (OpenRouter structured-outputs docs pair ``strict:true``
-      with ``require_parameters`` to keep routing on capable providers.)
+      with ``require_parameters`` to keep routing on capable providers.) SKIPPED when the Auto
+      Router pool is constrained (below): the curated pool is the capability guarantee, and
+      applying both filters compounds to an empty set → 404 (#802).
     - the Auto Router candidate pool (``OPENROUTER_ALLOWED_MODELS`` → ``plugins[auto-router]
       .allowed_models``, with optional ``cost_quality_tradeoff``) — keeps ``openrouter/auto``'s
       per-prompt selection but constrains it to a curated set of reasoning + structured-output
@@ -695,11 +697,17 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
     fallbacks = _openrouter_fallback_models()
     prefs = _openrouter_provider_prefs()
     allowed_models = _openrouter_allowed_models()
+    # Constrain the Auto Router to a curated capable pool only for the auto router itself.
+    constrain_auto = bool(allowed_models) and (kwargs.get("model") or "").endswith("/auto")
     # Structured-output (json_schema) and tool requests empty-fail without require_parameters, so
     # force it for them even when the global toggle is off; plain-prose requests honor the toggle.
     structured = kwargs.get("response_format") is not None or bool(kwargs.get("tools"))
-    require_params = _openrouter_require_parameters() or structured
-    if not fallbacks and not prefs and not require_params and not allowed_models:
+    # allowed_models SUPERSEDES require_parameters: the curated pool is already the capability
+    # guarantee, and applying BOTH filters compounds to an empty set → OpenRouter 404
+    # "No models match your request and model restrictions" (#802). So when we constrain the auto
+    # router, drop require_parameters; otherwise keep the #798 behavior (forced for structured/tool).
+    require_params = (not constrain_auto) and (_openrouter_require_parameters() or structured)
+    if not fallbacks and not prefs and not require_params and not constrain_auto:
         return kwargs
     merged = dict(kwargs)
     extra = dict(merged.get("extra_body") or {})
@@ -707,7 +715,7 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
         extra["models"] = fallbacks
         extra["route"] = "fallback"
     # Auto Router candidate-pool constraint — only meaningful for the auto router itself.
-    if allowed_models and (merged.get("model") or "").endswith("/auto"):
+    if constrain_auto:
         plugin: dict[str, Any] = {"id": "auto-router", "allowed_models": allowed_models}
         tradeoff = _openrouter_cost_quality_tradeoff()
         if tradeoff is not None:

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -342,8 +342,9 @@ def test_allowed_models_constrains_auto_router(monkeypatch: pytest.MonkeyPatch) 
             "cost_quality_tradeoff": 6,
         }
     ]
-    # require_parameters still rides alongside the plugin.
-    assert out["extra_body"]["provider"] == {"require_parameters": True}
+    # allowed_models supersedes require_parameters — applying both compounds to an empty set
+    # → OpenRouter 404 (#802). The curated pool is the capability guarantee, so no provider block.
+    assert "provider" not in out["extra_body"]
 
 
 def test_allowed_models_only_for_auto_router(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -145,6 +145,62 @@ def check_openrouter(model: str = "openrouter/auto") -> bool:
         return check("OpenRouter ping", False, str(exc))
 
 
+def check_openrouter_structured() -> bool:
+    """Validate the REAL structured-output routing path (digillm + env), not just a plain ping.
+
+    A plain ping (check_openrouter) succeeds even when the model can't honor strict json_schema —
+    that's how the pipeline silently degraded (#790/#802). This runs one strict json_schema call
+    through the same digillm path the phases use, so any OPENROUTER_ALLOWED_MODELS / require_parameters
+    routing misconfig (e.g. the 404 "No models match your request and model restrictions" compound)
+    fails the preflight FAST — before the 30-minute pipeline burns a run."""
+    print(_bold("\n3. OpenRouter structured-output routing (digillm path)"))
+    if not os.environ.get("OPENROUTER_API_KEY", "").strip():
+        return check("Structured-output ping", False, "OPENROUTER_API_KEY not set")
+    try:
+        _ensure_importable()
+        from pydantic import BaseModel, Field
+
+        from digigraph import usage as usage_mod
+        from digigraph.graph.research_agent import run_research_agent
+
+        class _Ping(BaseModel):
+            status: str = Field(description="the single word: ok")
+
+        usage_mod.start()
+        t0 = time.monotonic()
+        out = run_research_agent(
+            skill_text="Reply that you are operational.",
+            phase_inputs={},
+            shared_context={},
+            output_model=_Ping,
+            model="openrouter/openrouter/auto",
+            max_retries=1,
+        )
+        elapsed = time.monotonic() - t0
+        snap = usage_mod.snapshot()
+        usage_mod.reset()
+        served = (snap.get("models") or ["?"])[0]
+        return check(
+            "Structured-output ping (openrouter/auto)",
+            bool(out.status),
+            f"{elapsed:.1f}s — model={served}, cost=${snap.get('cost_usd', 0.0):.4f}",
+        )
+    except (
+        OSError,
+        RuntimeError,
+        KeyError,
+        AttributeError,
+        ImportError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        return check(
+            "Structured-output ping (openrouter/auto)",
+            False,
+            f"{type(exc).__name__}: {exc}  (routing misconfig — fix before a full run)",
+        )
+
+
 def check_supabase() -> bool:
     print(_bold("\n4. Supabase connectivity + baseline row"))
     url = os.environ.get("SUPABASE_URL", "").strip()
@@ -256,6 +312,7 @@ def main() -> int:
 
     if not args.skip_llm:
         check_openrouter("openrouter/auto")
+        check_openrouter_structured()
 
     if not args.skip_db:
         check_supabase()


### PR DESCRIPTION
## What

Fix the over-constraint from #803 and add a cheap preflight routing validation.

## Why

The constrained-auto attempt (#803) hit OpenRouter **404 "No models match your request and model restrictions"** (0 LLM calls): `plugins.allowed_models` + the forced `provider.require_parameters=true` compounded to an empty candidate set.

## Changes

- **digillm**: `allowed_models` **supersedes** `require_parameters`. When the Auto Router pool is constrained (allowed_models set + `…/auto` model), the curated pool is already the capability guarantee — applying `require_parameters` too yields the empty-set 404. So we drop it in that case; non-constrained setups keep #798 behavior.
- **validate-providers preflight**: new **structured-output routing check** — one strict `json_schema` call through the **real digillm path** (so `OPENROUTER_ALLOWED_MODELS` applies). A routing misconfig now fails the preflight in ~minutes instead of burning the 30-min pipeline. Reports served model + per-call cost.
- **workflows**: `OPENROUTER_ALLOWED_MODELS` added to the preflight step env (baseline+delta) so the preflight validates the real pool.
- tests updated (no `provider` block when the pool is constrained).

## Verify

`pytest digillm/tests/test_digillm.py` → 52 passed; ruff clean; `make score` 10/10. Then dispatch `atlas-baseline` with `dry_run=true` → the new preflight check confirms routing cheaply before any full run.

Refs #802, #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)