### PR TITLE
fix(atlas): wildcard model pool for the Auto Router + clean preflight FAIL (#802)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -76,7 +76,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Same curated pool as the run step (below) so the preflight validates the REAL routing
           # path and fails FAST on a misconfig instead of burning the full pipeline (#802).
-          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
+          OPENROUTER_ALLOWED_MODELS: "openai/*,anthropic/*,deepseek/*"
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
 
@@ -94,7 +94,7 @@ jobs:
           # capable models across providers (incl. DeepSeek for cheap reasoning), excluding
           # flash-lite — auto still picks best-per-prompt within the set; require_parameters stays
           # on (digillm). Tune the pool here; bias cost/quality via OPENROUTER_COST_QUALITY_TRADEOFF.
-          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
+          OPENROUTER_ALLOWED_MODELS: "openai/*,anthropic/*,deepseek/*"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -74,7 +74,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Same curated pool as the run step (below) so the preflight validates the REAL routing
           # path and fails FAST on a misconfig instead of burning the full pipeline (#802).
-          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
+          OPENROUTER_ALLOWED_MODELS: "openai/*,anthropic/*,deepseek/*"
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
 
@@ -91,7 +91,7 @@ jobs:
           # capable models across providers (incl. DeepSeek for cheap reasoning), excluding
           # flash-lite — auto still picks best-per-prompt within the set; require_parameters stays
           # on (digillm). Tune the pool here; bias cost/quality via OPENROUTER_COST_QUALITY_TRADEOFF.
-          OPENROUTER_ALLOWED_MODELS: "openai/gpt-4o-mini,openai/gpt-4o,anthropic/claude-3.5-sonnet,google/gemini-2.5-flash,deepseek/deepseek-chat"
+          OPENROUTER_ALLOWED_MODELS: "openai/*,anthropic/*,deepseek/*"
           # Cap Phase 7C fan-out to 25 tickers in CI (bounds run time/cost).
           ATLAS_MAX_ANALYSTS: "25"
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -185,15 +185,9 @@ def check_openrouter_structured() -> bool:
             bool(out.status),
             f"{elapsed:.1f}s — model={served}, cost=${snap.get('cost_usd', 0.0):.4f}",
         )
-    except (
-        OSError,
-        RuntimeError,
-        KeyError,
-        AttributeError,
-        ImportError,
-        TypeError,
-        ValueError,
-    ) as exc:
+    except Exception as exc:  # noqa: BLE001 — diagnostic: any failure (incl. OpenRouter HTTP
+        # 4xx like the 404 "No models match … model restrictions") must report a clean FAIL,
+        # not crash the preflight with a traceback. Catching broadly is correct for a probe.
         return check(
             "Structured-output ping (openrouter/auto)",
             False,


### PR DESCRIPTION
Exact-slug `allowed_models` still 404'd — the Auto Router matches against NotDiamond's curated (flagship) pool ∩ structured-output support, and our exact slugs weren't in it. Switch to wildcards `openai/*,anthropic/*,deepseek/*` (overlap the flagship pool; Google dropped to exclude flash-lite; DeepSeek kept). Also: the preflight structured-ping now catches any Exception → clean FAIL, not a crash. Verified next via dry-run preflight. Refs #802, #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)