### PR TITLE
feat(atlas): on-chain cohort-positioning signal (smart-money vs rekt divergence, Hyperdash) (#801)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -108,6 +108,10 @@ jobs:
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the
           # materialize writer populates stop/target/horizon/conviction/sector_bucket.
           OLYMPUS_POSITION_RISK_FIELDS: "1"
+          # On-chain cohort-positioning signal (#801): preflight scrapes Hyperdash's public cohort
+          # GraphQL, computes the smart-money-vs-rekt divergence, and writes onchain_cohort_positioning.
+          # Default-off kill-switch; fail-soft (a Hyperdash outage never blocks the run).
+          ATLAS_ONCHAIN_POSITIONING: "1"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).
           # Degrades to no-checkpointing if the secret/package is absent.

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -105,6 +105,10 @@ jobs:
           # Per-position advisory risk fields (Pillar 2E, migration 039 now applied): the
           # materialize writer populates stop/target/horizon/conviction/sector_bucket.
           OLYMPUS_POSITION_RISK_FIELDS: "1"
+          # On-chain cohort-positioning signal (#801): preflight scrapes Hyperdash's public cohort
+          # GraphQL, computes the smart-money-vs-rekt divergence, and writes onchain_cohort_positioning.
+          # Default-off kill-switch; fail-soft (a Hyperdash outage never blocks the run).
+          ATLAS_ONCHAIN_POSITIONING: "1"
           DRY_RUN: ${{ inputs.dry_run }}
           # Durable per-node checkpointing → resume on retry / re-dispatch (#665).
           DIGI_CHECKPOINTER: postgres

--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -55,12 +55,13 @@
 phase_models:
 
   # ── Phase 1 — Alt-data extraction ──────────────────────────────────────────
-  # [tier: extraction] ~500 tokens each, 5 parallel segments.
+  # [tier: extraction] ~500 tokens each, 6 parallel segments.
   alt-sentiment-news:      "openrouter/openrouter/auto"
   alt-cta-positioning:     "openrouter/openrouter/auto"
   alt-options-derivatives: "openrouter/openrouter/auto"
   alt-politician-signals:  "openrouter/openrouter/auto"
   alt-ai-portfolios:       "openrouter/openrouter/auto"
+  alt-onchain-positioning: "openrouter/openrouter/auto"
 
   # ── Phase 2 — Institutional flow extraction ────────────────────────────────
   # [tier: extraction] ~800 tokens each, 2 segments.

--- a/digiquant/src/digiquant/data/onchain/__init__.py
+++ b/digiquant/src/digiquant/data/onchain/__init__.py
@@ -1,0 +1,7 @@
+"""On-chain data providers — Polars-only, fail-soft.
+
+Public surface:
+    - hyperdash.HyperdashScraper / CohortPositioningProvider
+    - hyperdash.get_onchain_cohort_positioning
+    - hyperdash.cohort_summary_to_positioning (HTTP-free parser/divergence)
+"""

--- a/digiquant/src/digiquant/data/onchain/hyperdash.py
+++ b/digiquant/src/digiquant/data/onchain/hyperdash.py
@@ -1,0 +1,387 @@
+"""Hyperdash on-chain cohort-positioning provider — Polars-only, fail-soft (#801).
+
+Scrapes Hyperliquid trader positioning segmented by *profitability cohort* from Hyperdash's
+public GraphQL endpoint (no auth), and computes a **smart-money vs. rekt divergence** per market.
+
+Why this is a signal: Hyperdash buckets every tracked trader into six profitability cohorts
+(extremely-profitable 👑 … rekt 💀). When the consistently-profitable cohorts lean one way while
+the consistently-unprofitable ones lean the other, that divergence is an early read on
+distribution / investor-class divergence — validated on live data (the extremely-profitable
+cohort net-short ETH while the rekt cohort piled long). It rides on Hyperliquid perps, which now
+include **equity perps** (``xyz:SP500``, ``xyz:XYZ100``) alongside crypto, so the read spans both.
+
+Boundaries (deliberate):
+- The endpoint is undocumented/internal and may drift, so EVERY failure mode (network, HTTP
+  error, GraphQL error, shape change) fails soft to an empty result — a Hyperdash outage must
+  never block an Atlas run. The signal is an overlay that adjusts conviction/sizing; it never
+  originates a trade.
+- HTTP is split from computation: ``cohort_summary_to_positioning`` is a pure, HTTP-free parser +
+  divergence calculator (unit-tested against a captured-shape fixture); ``HyperdashScraper.fetch``
+  adds only the network + fail-soft. This mirrors ``data/prices/fed_probabilities.py``.
+- Polars-only: the JSON boundary is converted to a Polars frame immediately; the divergence math
+  is Polars expressions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol  # noqa  # scored-lint: heterogeneous GraphQL/JSON payload shapes
+
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+_HYPERDASH_GRAPHQL_URL = "https://api.hyperdash.com/graphql"
+# Polite, identifiable UA for a low-volume (~1 call/day) read of a public endpoint.
+_USER_AGENT = "digiquant-research/1.0 (+https://digiquant.io)"
+
+# pnlCohort ``id``s grouped by profitability. "smart" = consistently profitable (the signal we
+# trust); "crowd" = consistently unprofitable (the fade side). Mid cohorts are intentionally
+# excluded — the divergence is sharpest at the tails. Matching is on the lower-cased id with an
+# emoji/whitespace-tolerant fallback so a cosmetic label tweak upstream doesn't silently drop a
+# cohort.
+_SMART_COHORTS = ("extremely_profitable", "very_profitable", "profitable")
+_CROWD_COHORTS = ("unprofitable", "very_unprofitable", "rekt")
+
+# GraphQL query the cohorts page fires (no auth). topMarkets(limit:3) is the per-market breakdown
+# used for the divergence; the cohort-level long/short give the aggregate net read.
+_COHORT_SUMMARY_QUERY = """
+query CohortSummary {
+  analytics {
+    cohortSummary {
+      timestamp
+      totalTraders
+      pnlCohorts {
+        id
+        label
+        emoji
+        range
+        totalTraders
+        longNotional
+        shortNotional
+        topMarkets(limit: 3) {
+          ticker
+          longNotional
+          shortNotional
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+_DIVERGENCE_COLUMNS = (
+    "market",
+    "smart_long",
+    "smart_short",
+    "crowd_long",
+    "crowd_short",
+    "smart_bias",
+    "crowd_bias",
+    "divergence",
+)
+
+
+def _f(value: Any) -> float:
+    """Coerce a notional to float; non-numeric / missing → 0.0 (notionals are additive)."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _classify_cohort(cohort_id: Any) -> str | None:
+    """Map a pnlCohort id to ``"smart"`` / ``"crowd"`` / ``None`` (mid or unknown cohort)."""
+    if not isinstance(cohort_id, str):
+        return None
+    key = cohort_id.strip().lower().replace(" ", "_").replace("-", "_")
+    if key in _SMART_COHORTS:
+        return "smart"
+    if key in _CROWD_COHORTS:
+        return "crowd"
+    return None
+
+
+def _bias_expr(long_col: str, short_col: str) -> pl.Expr:
+    """long / (long+short) in [0,1]; null when the cohort has no notional on that market."""
+    denom = pl.col(long_col) + pl.col(short_col)
+    return pl.when(denom > 0).then(pl.col(long_col) / denom).otherwise(None)
+
+
+def _empty_divergence_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            c: pl.Series(c, [], dtype=pl.Utf8 if c == "market" else pl.Float64)
+            for c in _DIVERGENCE_COLUMNS
+        }
+    )
+
+
+def _round(value: Any, ndigits: int = 4) -> float | None:
+    if value is None:
+        return None
+    try:
+        return round(float(value), ndigits)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class CohortPositioning:
+    """Parsed Hyperdash cohort snapshot + the derived smart-vs-crowd divergence.
+
+    ``market_divergence`` is one row per market (BTC/ETH/HYPE + equity perps) with the smart and
+    crowd long/short notionals, each cohort group's directional bias, and ``divergence =
+    smart_bias - crowd_bias`` (+1 = smart maximally long while crowd maximally short → smart-money
+    confirm; -1 = smart short while crowd long → distribution/fade). ``overall`` carries the same
+    read at the aggregate cohort level. ``error`` is set only on a transport/parse failure.
+    """
+
+    snapshot_ts: str | None
+    total_traders: int | None
+    market_divergence: pl.DataFrame
+    overall: dict[str, float | None]
+    error: str | None = None
+
+    @classmethod
+    def empty(cls, *, error: str | None = None) -> CohortPositioning:
+        return cls(
+            snapshot_ts=None,
+            total_traders=None,
+            market_divergence=_empty_divergence_frame(),
+            overall={"smart_net_bias": None, "crowd_net_bias": None, "overall_divergence": None},
+            error=error,
+        )
+
+    @property
+    def has_data(self) -> bool:
+        """True when at least one market produced a (smart, crowd) divergence pair."""
+        if self.market_divergence.height == 0:
+            return False
+        return self.market_divergence.get_column("divergence").drop_nulls().len() > 0
+
+    def top_divergent_markets(self, limit: int = 5) -> list[dict[str, Any]]:
+        """Markets with the largest |divergence|, most extreme first."""
+        if self.market_divergence.height == 0:
+            return []
+        ranked = (
+            self.market_divergence.filter(pl.col("divergence").is_not_null())
+            .with_columns(_absd=pl.col("divergence").abs())
+            .sort("_absd", descending=True)
+            .head(limit)
+        )
+        out: list[dict[str, Any]] = []
+        for row in ranked.iter_rows(named=True):
+            out.append(
+                {
+                    "market": row["market"],
+                    "divergence": _round(row["divergence"]),
+                    "smart_bias": _round(row["smart_bias"]),
+                    "crowd_bias": _round(row["crowd_bias"]),
+                }
+            )
+        return out
+
+    def compact_summary(self) -> dict[str, Any]:
+        """Small dict for ``market_context`` + the Phase 6 bias row (mirrors fed_odds compact)."""
+        return {
+            "snapshot_ts": self.snapshot_ts,
+            "total_traders": self.total_traders,
+            "smart_net_bias": _round(self.overall.get("smart_net_bias")),
+            "crowd_net_bias": _round(self.overall.get("crowd_net_bias")),
+            "overall_divergence": _round(self.overall.get("overall_divergence")),
+            "top_divergent_markets": self.top_divergent_markets(),
+            "source": "hyperdash",
+        }
+
+    def to_rows(self, date_str: str) -> list[dict[str, Any]]:
+        """Per-market rows for the ``onchain_cohort_positioning`` table (history → backtest)."""
+        rows: list[dict[str, Any]] = []
+        for row in self.market_divergence.iter_rows(named=True):
+            rows.append(
+                {
+                    "date": date_str,
+                    "market": row["market"],
+                    "smart_long_notional": _round(row["smart_long"], 2),
+                    "smart_short_notional": _round(row["smart_short"], 2),
+                    "crowd_long_notional": _round(row["crowd_long"], 2),
+                    "crowd_short_notional": _round(row["crowd_short"], 2),
+                    "smart_bias": _round(row["smart_bias"]),
+                    "crowd_bias": _round(row["crowd_bias"]),
+                    "divergence": _round(row["divergence"]),
+                    "total_traders": self.total_traders,
+                    "snapshot_ts": self.snapshot_ts,
+                }
+            )
+        return rows
+
+
+def cohort_summary_to_positioning(summary: dict[str, Any]) -> CohortPositioning:
+    """Pure parser + divergence calculator over a ``cohortSummary`` payload (HTTP-free, tested).
+
+    Accepts the ``data.analytics.cohortSummary`` object. An empty / unrecognized payload returns
+    an empty (but error-free) result — "fetched, nothing to read" is distinct from a transport
+    failure, which the caller flags via ``error``.
+    """
+    if not isinstance(summary, dict):
+        return CohortPositioning.empty()
+    cohorts = summary.get("pnlCohorts") or []
+    if not isinstance(cohorts, list):
+        return CohortPositioning.empty()
+
+    # Per-market accumulator and aggregate cohort-level totals, both grouped smart/crowd.
+    per_market: dict[str, dict[str, float]] = {}
+    agg = {"smart_long": 0.0, "smart_short": 0.0, "crowd_long": 0.0, "crowd_short": 0.0}
+    for cohort in cohorts:
+        if not isinstance(cohort, dict):
+            continue
+        group = _classify_cohort(cohort.get("id"))
+        if group is None:
+            continue
+        agg[f"{group}_long"] += _f(cohort.get("longNotional"))
+        agg[f"{group}_short"] += _f(cohort.get("shortNotional"))
+        for market in cohort.get("topMarkets") or []:
+            if not isinstance(market, dict):
+                continue
+            ticker = market.get("ticker")
+            if not isinstance(ticker, str) or not ticker:
+                continue
+            rec = per_market.setdefault(
+                ticker,
+                {"smart_long": 0.0, "smart_short": 0.0, "crowd_long": 0.0, "crowd_short": 0.0},
+            )
+            rec[f"{group}_long"] += _f(market.get("longNotional"))
+            rec[f"{group}_short"] += _f(market.get("shortNotional"))
+
+    if per_market:
+        frame = (
+            pl.DataFrame(
+                [{"market": m, **rec} for m, rec in sorted(per_market.items())],
+                schema={
+                    "market": pl.Utf8,
+                    "smart_long": pl.Float64,
+                    "smart_short": pl.Float64,
+                    "crowd_long": pl.Float64,
+                    "crowd_short": pl.Float64,
+                },
+            )
+            .with_columns(
+                smart_bias=_bias_expr("smart_long", "smart_short"),
+                crowd_bias=_bias_expr("crowd_long", "crowd_short"),
+            )
+            .with_columns(divergence=pl.col("smart_bias") - pl.col("crowd_bias"))
+            .select(_DIVERGENCE_COLUMNS)
+        )
+    else:
+        frame = _empty_divergence_frame()
+
+    overall = {
+        "smart_net_bias": _net_bias(agg["smart_long"], agg["smart_short"]),
+        "crowd_net_bias": _net_bias(agg["crowd_long"], agg["crowd_short"]),
+    }
+    overall["overall_divergence"] = (
+        overall["smart_net_bias"] - overall["crowd_net_bias"]
+        if overall["smart_net_bias"] is not None and overall["crowd_net_bias"] is not None
+        else None
+    )
+
+    ts = summary.get("timestamp")
+    traders = summary.get("totalTraders")
+    return CohortPositioning(
+        snapshot_ts=str(ts) if ts is not None else None,
+        total_traders=int(traders) if isinstance(traders, (int, float)) else None,
+        market_divergence=frame,
+        overall=overall,
+    )
+
+
+def _net_bias(long_notional: float, short_notional: float) -> float | None:
+    denom = long_notional + short_notional
+    return long_notional / denom if denom > 0 else None
+
+
+def _post_graphql(
+    endpoint: str, query: str, *, timeout: float, session: Any | None
+) -> dict[str, Any]:
+    """POST a GraphQL query and return the decoded body. Raises on transport/HTTP error."""
+    import requests  # lazy — requests is the data-layer HTTP dep (see macro_ingest)
+
+    caller = session if session is not None else requests
+    resp = caller.post(
+        endpoint,
+        json={"query": query, "operationName": "CohortSummary"},
+        headers={"User-Agent": _USER_AGENT, "Content-Type": "application/json"},
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    return body if isinstance(body, dict) else {}
+
+
+class CohortPositioningProvider(Protocol):
+    """Swap-able source of cohort positioning (Hyperdash today; HyperTracker etc. tomorrow)."""
+
+    def fetch(self) -> CohortPositioning: ...
+
+
+@dataclass(frozen=True)
+class HyperdashScraper:
+    """Scrape Hyperdash's public cohort-summary GraphQL endpoint. Fail-soft."""
+
+    endpoint: str = _HYPERDASH_GRAPHQL_URL
+    timeout: float = 30.0
+    session: Any | None = None  # inject a requests-like session in tests
+
+    def fetch(self) -> CohortPositioning:
+        try:
+            body = _post_graphql(
+                self.endpoint, _COHORT_SUMMARY_QUERY, timeout=self.timeout, session=self.session
+            )
+        except Exception as exc:  # noqa: BLE001 — any transport/HTTP flake → empty, never crash
+            logger.warning("Hyperdash cohort fetch failed: %s", exc)
+            return CohortPositioning.empty(error=str(exc))
+        if body.get("errors"):
+            logger.warning("Hyperdash GraphQL returned errors: %s", body.get("errors"))
+            return CohortPositioning.empty(error="graphql_errors")
+        summary = (((body.get("data") or {}).get("analytics") or {}).get("cohortSummary")) or {}
+        return cohort_summary_to_positioning(summary)
+
+
+def _onchain_enabled() -> bool:
+    """Opt-in kill-switch for the LIVE Hyperdash scrape (env ATLAS_ONCHAIN_POSITIONING).
+
+    Defaults OFF so unit tests never hit the network just by invoking preflight (the scrape is an
+    external HTTP call, unlike the DB-backed fed_odds path). The Atlas workflows set it to "1" to
+    enable the signal in CI/prod; the owner can flip it off instantly if the third-party endpoint
+    becomes unavailable or its ToS changes — no code change. An injected ``provider`` bypasses the
+    switch entirely (tests + alternative providers)."""
+    import os
+
+    return os.environ.get("ATLAS_ONCHAIN_POSITIONING", "0").strip().lower() in ("1", "true", "yes")
+
+
+def get_onchain_cohort_positioning(
+    *, provider: CohortPositioningProvider | None = None
+) -> CohortPositioning:
+    """Fetch + compute the on-chain cohort divergence. Always returns a value (empty on failure).
+
+    With no ``provider`` the default Hyperdash scrape runs only when ``ATLAS_ONCHAIN_POSITIONING``
+    is enabled (see :func:`_onchain_enabled`); otherwise it short-circuits to an empty result with
+    no network call. An injected ``provider`` always runs (tests / alternative sources). Callers
+    gate on ``result.error is None and result.has_data``.
+    """
+    if provider is not None:
+        return provider.fetch()
+    if not _onchain_enabled():
+        return CohortPositioning.empty()
+    return HyperdashScraper().fetch()
+
+
+__all__ = [
+    "CohortPositioning",
+    "CohortPositioningProvider",
+    "HyperdashScraper",
+    "cohort_summary_to_positioning",
+    "get_onchain_cohort_positioning",
+]

--- a/digiquant/src/digiquant/olympus/atlas/docs/agentic/SKILLS-CATALOG.md
+++ b/digiquant/src/digiquant/olympus/atlas/docs/agentic/SKILLS-CATALOG.md
@@ -35,9 +35,9 @@
 
 ---
 
-## Alternative data (4)
+## Alternative data (5)
 
-`alt-sentiment-news`, `alt-cta-positioning`, `alt-options-derivatives`, `alt-politician-signals`
+`alt-sentiment-news`, `alt-cta-positioning`, `alt-options-derivatives`, `alt-politician-signals`, `alt-onchain-positioning`
 
 ---
 

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase1_altdata.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase1_altdata.py
@@ -1,4 +1,4 @@
-"""Phase 1 — alternative data & positioning (4 parallel segment nodes).
+"""Phase 1 — alternative data & positioning (6 parallel segment nodes).
 
 Per-skill Pydantic models extend :class:`digiquant.olympus.atlas.segments.SegmentReport`.
 """
@@ -38,6 +38,21 @@ class CtaPositioningReport(SegmentReport):
     systematic_stance: Literal["long", "short", "neutral", "mixed"] | None = None
     futures_oi_trend: Literal["expanding", "contracting", "flat"] | None = None
     cta_flow_bias: Literal["adding", "reducing", "neutral", "mixed"] | None = None
+
+
+class OnchainCohortPositioningReport(SegmentReport):
+    """Phase 1F — on-chain cohort positioning (smart-money vs rekt divergence, Hyperdash, #801)."""
+
+    smart_money_stance: Literal["long", "short", "neutral", "mixed"] | None = None
+    crowd_stance: Literal["long", "short", "neutral", "mixed"] | None = None
+    divergence_signal: (
+        Literal["smart_long_crowd_short", "smart_short_crowd_long", "aligned", "none"] | None
+    ) = None
+    top_divergent_markets: list[str] = Field(
+        default_factory=list,
+        description="≤5 markets (BTC/ETH/HYPE or equity perps) with the largest smart-vs-crowd "
+        "divergence, most extreme first.",
+    )
 
 
 class OptionsDerivativesReport(SegmentReport):
@@ -132,6 +147,15 @@ _SPECS = (
         live_search=True,
     ),
     SegmentNodeSpec(
+        segment_slug="alt-onchain-positioning",
+        skill_slug="alt-onchain-positioning",
+        output_model=OnchainCohortPositioningReport,
+        phase_outputs_field=_PHASE_FIELD,
+        # No live_search / data_tools: the deterministic Hyperdash divergence is injected into
+        # shared_context.data_layer.market_context.onchain_positioning by preflight (#801). The
+        # segment interprets that — zero per-run search cost.
+    ),
+    SegmentNodeSpec(
         segment_slug="alt-ai-portfolios",
         skill_slug="alt-ai-portfolios",
         output_model=AiPortfoliosReport,
@@ -142,7 +166,7 @@ _SPECS = (
 
 
 def build_phase1() -> PipelinePhase:
-    """Return the Phase-1 fan-out (4 parallel nodes)."""
+    """Return the Phase-1 fan-out (6 parallel nodes)."""
     return PipelinePhase(
         name="phase1_altdata",
         nodes=[NodeSpec(name=spec.segment_slug, run=build_segment_node(spec)) for spec in _SPECS],
@@ -152,6 +176,7 @@ def build_phase1() -> PipelinePhase:
 __all__ = [
     "AiPortfoliosReport",
     "CtaPositioningReport",
+    "OnchainCohortPositioningReport",
     "OptionsDerivativesReport",
     "PoliticianSignalsReport",
     "SentimentNewsReport",

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase6_consolidate.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase6_consolidate.py
@@ -64,6 +64,16 @@ def _fed_odds_compact(state: AtlasResearchState) -> dict[str, Any] | None:
     return out
 
 
+def _onchain_positioning_compact(state: AtlasResearchState) -> dict[str, Any] | None:
+    """Surface the on-chain cohort-positioning summary preflight injected into market_context.
+
+    The provider already stores a compact dict (overall divergence + the top divergent markets),
+    so this is a guarded pass-through. Returns None when preflight did not populate it (Hyperdash
+    outage or no cohort data) — fail-soft, mirroring fed_odds (#801)."""
+    compact = state.data_layer.market_context.get("onchain_positioning")
+    return compact if isinstance(compact, dict) and compact else None
+
+
 def _phase6_node(state: AtlasResearchState) -> dict[str, Any]:
     """Assemble the daily_snapshots bias row from phases 1–5."""
     bias_row: Phase6BiasRow = {
@@ -83,6 +93,8 @@ def _phase6_node(state: AtlasResearchState) -> dict[str, Any]:
         # Populated by preflight from prediction-market data (Kalshi + Polymarket).
         # Fail-soft: None when no ingested rows or preflight encountered an outage.
         "fed_odds": _fed_odds_compact(state),
+        # On-chain smart-money vs rekt cohort divergence (Hyperdash). Fail-soft to None (#801).
+        "onchain_positioning": _onchain_positioning_compact(state),
         "notes": "",  # filled by Phase 7 master synthesis
     }
     return {"phase6_bias_row": bias_row}

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -189,12 +189,15 @@ def _data_layer_snapshot(
         logger.warning("onchain positioning unavailable (%s); slot will be None this run", exc)
         onchain = None
     if onchain is not None and onchain.error is None and onchain.has_data:
+        # Inject the signal even if persistence fails: the segment + bias row only need the compact
+        # summary, so the overlay is fully usable before migration 042 lands.
         market_context["onchain_positioning"] = onchain.compact_summary()
         try:
             upsert_onchain_cohort_positioning(
                 client=deps.client, rows=onchain.to_rows(run_date.isoformat())
             )
-        except _SUPABASE_READ_ERRORS as exc:
+        except Exception as exc:  # noqa: BLE001 — persistence is best-effort; a missing table
+            # (pre-migration window) or any postgrest/network error must never block the run.
             logger.warning("onchain positioning persist failed (%s); continuing", exc)
 
     return DataLayerSnapshot(

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -14,6 +14,7 @@ from typing import Any, Callable  # noqa: F401 — used for heterogeneous node-u
 
 import yaml
 
+from digiquant.data.onchain.hyperdash import get_onchain_cohort_positioning
 from digiquant.olympus.atlas.data.queries import get_fed_rate_probabilities, get_market_context
 from digiquant.olympus.atlas.decision_log import (
     ReflectorOutput,
@@ -32,6 +33,7 @@ from digiquant.olympus.atlas.supabase_io import (
     load_prior_context,
     query_macro_series_freshness,
     query_price_technicals_freshness,
+    upsert_onchain_cohort_positioning,
 )
 
 # decision_log may be empty or not yet migrated — do not fail the rest of preflight.
@@ -176,6 +178,24 @@ def _data_layer_snapshot(
         fed_odds = None
     if fed_odds is not None:
         market_context["fed_odds"] = fed_odds
+
+    # On-chain cohort positioning (smart-money vs rekt divergence) from Hyperdash (#801). The
+    # compact summary is injected into market_context so the alt-onchain-positioning segment + the
+    # phase6 bias row can read it (mirrors fed_odds); the per-market frame is persisted for
+    # backtest. Best-effort end to end — a Hyperdash outage/shape-drift must never block a run.
+    try:
+        onchain = get_onchain_cohort_positioning()
+    except Exception as exc:  # noqa: BLE001 — provider is fail-soft, but never let it crash preflight
+        logger.warning("onchain positioning unavailable (%s); slot will be None this run", exc)
+        onchain = None
+    if onchain is not None and onchain.error is None and onchain.has_data:
+        market_context["onchain_positioning"] = onchain.compact_summary()
+        try:
+            upsert_onchain_cohort_positioning(
+                client=deps.client, rows=onchain.to_rows(run_date.isoformat())
+            )
+        except _SUPABASE_READ_ERRORS as exc:
+            logger.warning("onchain positioning persist failed (%s); continuing", exc)
 
     return DataLayerSnapshot(
         price_technicals_latest=latest_tech,

--- a/digiquant/src/digiquant/olympus/atlas/skills/alt-onchain-positioning/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/alt-onchain-positioning/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: alt-data-onchain-positioning
+description: Interprets on-chain Hyperliquid positioning segmented by trader profitability cohort (Hyperdash), reading a pre-computed smart-money-vs-rekt divergence per market (crypto + equity perps). Surfaces distribution / investor-class-divergence as an early conviction/risk overlay. Runs in Phase 1 with zero per-run search cost.
+---
+
+# On-Chain Cohort Positioning Sub-Agent
+
+## Grounding Data (use first)
+
+This segment is **deterministically grounded** — do NOT web-search. A `onchain_positioning` object
+is injected into PHASE_INPUTS / shared context at `data_layer.market_context.onchain_positioning`,
+pre-computed by the pipeline from Hyperdash's public cohort-summary endpoint. Read it as the
+factual backbone:
+
+- `overall_divergence` — aggregate `smart_net_bias − crowd_net_bias` in [−1, +1].
+- `smart_net_bias` / `crowd_net_bias` — directional bias (long ÷ (long+short), 0..1) of the
+  consistently-**profitable** ("smart") and consistently-**unprofitable** ("crowd"/rekt) cohorts.
+- `top_divergent_markets` — per-market `{market, divergence, smart_bias, crowd_bias}`, most
+  extreme first. Markets span crypto (BTC/ETH/HYPE) **and equity perps** (`xyz:SP500`, etc.).
+- `snapshot_ts`, `total_traders` — provenance.
+
+If `onchain_positioning` is **absent or empty** (a Hyperdash outage or no cohort data this run),
+do not invent numbers: set `bias: neutral`, `data_quality: absent`, and say so in `notes`.
+
+## Purpose
+
+Hyperdash buckets every tracked Hyperliquid trader by realized profitability. When the
+consistently-profitable cohorts lean one way while the consistently-unprofitable ("rekt") cohorts
+lean the other, that divergence is an early read on distribution / investor-class divergence —
+smart money quietly positioning against the crowd before a move. Now that Hyperliquid lists equity
+perps, this read spans crypto **and** equity-index exposure. This is a conviction/risk **overlay**;
+it never originates a trade.
+
+## How to read the divergence
+
+- **Large positive `divergence`** (smart long, crowd short) → smart-money-confirm **bullish** for
+  that market; supports adding conviction.
+- **Large negative `divergence`** (smart short, crowd long) → **distribution / bearish**; the crowd
+  is offside. This is the strongest fade signal.
+- **Near zero** → cohorts aligned; no edge.
+- **Extreme crowd crowding** (very high or very low `crowd_bias` with thin smart presence) → fade
+  the crowd, but lower conviction (one-sided data).
+
+---
+
+## Output Format
+
+```
+### 🔗 ON-CHAIN COHORT POSITIONING
+**Net Signal**: [smart-money-confirm bullish / distribution bearish / aligned / mixed]
+
+**Aggregate (as of [snapshot_ts], [total_traders] traders):**
+- Smart-money net bias: [smart_net_bias]   Crowd net bias: [crowd_net_bias]
+- Overall divergence: [overall_divergence]
+
+**Most divergent markets:**
+| Market | Divergence | Smart bias | Crowd bias | Read |
+|--------|-----------|-----------|-----------|------|
+| [ticker] | [±] | [0..1] | [0..1] | [smart-confirm / distribution / aligned] |
+
+**Implication for Portfolio**:
+[Which holdings or asset-class tilts does this confirm or contradict? Equity perps → equity tilt;
+BTC/ETH → crypto tilt. Adjust conviction, not direction-of-record.]
+```
+
+Populate the structured fields: `bias` (overall), `smart_money_stance`, `crowd_stance`,
+`divergence_signal` (`smart_long_crowd_short` / `smart_short_crowd_long` / `aligned` / `none`),
+`top_divergent_markets` (≤5 tickers), and `material_findings` for each notable divergence.

--- a/digiquant/src/digiquant/olympus/atlas/skills/digest/SKILL.md
+++ b/digiquant/src/digiquant/olympus/atlas/skills/digest/SKILL.md
@@ -23,7 +23,9 @@ The `phase_inputs` block contains:
 
 - `bias_row` — the Phase 6 deterministic bias row (macro_regime, equity_bias, crypto_bias,
   bond_bias, commodity_bias, forex_bias, vix_level, inst_flow, options_sentiment, cta_direction,
-  hf_consensus, fed_odds). Use these as the factual backbone; do not override them with guesses.
+  hf_consensus, fed_odds, onchain_positioning). Use these as the factual backbone; do not override
+  them with guesses. `onchain_positioning` is the Hyperdash smart-money-vs-rekt cohort divergence
+  (overall_divergence + top divergent markets); null on a data outage.
 - `phase1` — alternative data outputs (sentiment, CTA positioning, options/derivatives, politician
   and Fed signals). Key signals: risk-appetite proxies, systematic positioning, options skew.
 - `phase2` — institutional intelligence (ETF flows, hedge-fund intel). Key signals: net
@@ -126,4 +128,6 @@ Fields: `horizon_hours` (int 1–168), `label` (≤ 60 chars), `trigger` (1 sent
 3. Every `ActionableItem` and `RiskItem` has a clear evidential basis traceable to a phase body.
 4. `bias` is consistent with `market_regime_snapshot` and `equity_bias` from bias_row.
 5. `fed_odds` from bias_row is referenced in `market_regime_snapshot` if non-null.
-6. When `custom_prompt` is present, it is addressed in `notes`.
+6. `onchain_positioning` from bias_row is referenced in `alt_data_dashboard` if non-null (smart-money
+   vs rekt divergence; flag any extreme `overall_divergence` or top divergent market).
+7. When `custom_prompt` is present, it is addressed in `notes`.

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -205,7 +205,7 @@ class DataLayerSnapshot(BaseModel):
 
 
 class Phase6BiasRow(TypedDict, total=False):
-    """14-column daily_snapshots bias row assembled in phase6_consolidate."""
+    """Deterministic daily_snapshots bias row assembled in phase6_consolidate."""
 
     date: str
     run_type: str
@@ -221,6 +221,9 @@ class Phase6BiasRow(TypedDict, total=False):
     cta_direction: str
     hf_consensus: str
     fed_odds: Any | None
+    # On-chain smart-money vs rekt cohort divergence from Hyperdash (#801). Compact dict
+    # (overall_divergence + top divergent markets) populated by preflight; None on outage.
+    onchain_positioning: Any | None
     notes: str
 
 

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -282,6 +282,29 @@ def publish_daily_snapshot(
     )
 
 
+def upsert_onchain_cohort_positioning(
+    *,
+    client: SupabaseClient,
+    rows: list[dict[str, Any]],
+) -> int:
+    """Idempotently upsert per-(date,market) on-chain cohort positioning rows (#801).
+
+    Returns the number of rows written. A no-op (returns 0) when ``rows`` is empty, so the
+    preflight caller can skip cleanly on a Hyperdash outage without a special case. Upserts one
+    row at a time on ``(date, market)`` — the per-run market set is small (a handful) and this
+    matches the single-dict upsert convention used by every other writer here.
+    """
+    if not rows:
+        return 0
+    for row in rows:
+        client.table("onchain_cohort_positioning").upsert(row, on_conflict="date,market").execute()
+    _audit(
+        "upsert_onchain_cohort_positioning",
+        {"date": rows[0].get("date"), "row_count": len(rows)},
+    )
+    return len(rows)
+
+
 def load_prior_context(
     *,
     client: SupabaseClient,

--- a/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
+++ b/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
@@ -290,6 +290,7 @@ DEFAULT_RESPONSES: dict[str, FixtureResponse] = {
     "OptionsDerivativesReport": _segment("alt-options-derivatives"),
     "PoliticianSignalsReport": _segment("alt-politician-signals"),
     "AiPortfoliosReport": _segment("alt-ai-portfolios"),
+    "OnchainCohortPositioningReport": _segment("alt-onchain-positioning"),
     # Phase 2
     "InstitutionalFlowsReport": _segment("inst-institutional-flows"),
     "HedgeFundIntelReport": _segment("inst-hedge-fund-intel"),

--- a/digiquant/supabase/migrations/042_onchain_cohort_positioning.sql
+++ b/digiquant/supabase/migrations/042_onchain_cohort_positioning.sql
@@ -1,0 +1,54 @@
+-- 042_onchain_cohort_positioning.sql — On-chain cohort positioning signal (Atlas research, #801).
+--
+-- One row per (date, market) from Hyperdash's public cohort-summary GraphQL: the long/short
+-- notional of the consistently-PROFITABLE ("smart") cohorts vs the consistently-UNPROFITABLE
+-- ("crowd") cohorts on each Hyperliquid market (crypto + equity perps), each side's directional
+-- bias [0,1], and divergence = smart_bias - crowd_bias in [-1,1] (+1 = smart long / crowd short →
+-- smart-money confirm; -1 = smart short / crowd long → distribution / fade). Written best-effort
+-- by the Atlas preflight; idempotent upsert on (date, market). Persisted as a time series so the
+-- divergence can be backtested as a conviction/risk overlay.
+
+CREATE TABLE IF NOT EXISTS public.onchain_cohort_positioning (
+    id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    date                   date NOT NULL,
+    market                 text NOT NULL,
+    smart_long_notional    numeric,
+    smart_short_notional   numeric,
+    crowd_long_notional    numeric,
+    crowd_short_notional   numeric,
+    smart_bias             numeric,
+    crowd_bias             numeric,
+    divergence             numeric,
+    total_traders          integer,
+    snapshot_ts            text,
+    created_at             timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (date, market)
+);
+
+COMMENT ON TABLE public.onchain_cohort_positioning IS
+  'Per-(date,market) Hyperliquid positioning by profitability cohort (Hyperdash scrape): smart '
+  '(profitable) vs crowd (rekt) long/short notional + directional bias, and divergence = '
+  'smart_bias - crowd_bias. A conviction/risk overlay, never a trade originator (#801).';
+COMMENT ON COLUMN public.onchain_cohort_positioning.smart_bias IS
+  'smart long / (smart long + smart short), 0..1; null when smart cohorts hold no notional here.';
+COMMENT ON COLUMN public.onchain_cohort_positioning.crowd_bias IS
+  'crowd long / (crowd long + crowd short), 0..1; null when crowd cohorts hold no notional here.';
+COMMENT ON COLUMN public.onchain_cohort_positioning.divergence IS
+  'smart_bias - crowd_bias in [-1,1]; +1 smart-money-confirm bullish, -1 distribution/fade.';
+COMMENT ON COLUMN public.onchain_cohort_positioning.snapshot_ts IS
+  'Hyperdash cohort-summary timestamp for this snapshot (provenance; date is the Atlas run date).';
+
+CREATE INDEX IF NOT EXISTS onchain_cohort_positioning_date_idx
+    ON public.onchain_cohort_positioning (date DESC);
+CREATE INDEX IF NOT EXISTS onchain_cohort_positioning_market_idx
+    ON public.onchain_cohort_positioning (market, date DESC);
+
+-- Anon SELECT only (read-only dashboard surface), mirroring positions / nav_history /
+-- position_attribution. Writes go through the service-role key in the Atlas preflight.
+ALTER TABLE public.onchain_cohort_positioning ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS onchain_cohort_positioning_anon_select ON public.onchain_cohort_positioning;
+CREATE POLICY onchain_cohort_positioning_anon_select
+    ON public.onchain_cohort_positioning
+    FOR SELECT TO anon
+    USING (true);

--- a/tests/dq/atlas/test_onchain_positioning_wiring.py
+++ b/tests/dq/atlas/test_onchain_positioning_wiring.py
@@ -1,0 +1,203 @@
+"""Wiring tests for the on-chain cohort-positioning signal (#801).
+
+Covers the full fed_odds-style path:
+- preflight: provider result → market_context['onchain_positioning'] + persisted rows.
+- preflight fail-soft: empty/errored result or a provider exception leaves it absent, no crash.
+- phase6: market_context → bias_row['onchain_positioning'].
+- phase7: bias_row['onchain_positioning'] reaches the digest LLM's phase_inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import Any  # noqa  # scored-lint: heterogeneous fixture / kwargs dicts
+from unittest.mock import patch
+
+import pytest
+
+from digigraph.graph.pipeline_builder import build_pipeline
+
+from digiquant.data.onchain.hyperdash import CohortPositioning, cohort_summary_to_positioning
+from digiquant.olympus.atlas.phases.phase6_consolidate import build_phase6
+from digiquant.olympus.atlas.phases.phase7_synthesis import build_phase7
+from digiquant.olympus.atlas.state import (
+    AtlasConfigBundle,
+    AtlasResearchState,
+    DataLayerSnapshot,
+    SegmentPayload,
+    SegmentSlot,
+)
+
+from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+
+def _slot(slug: str, bias: str = "bullish", **extra: Any) -> SegmentSlot:
+    body = {"segment": slug, "bias": bias, **extra}
+    return SegmentSlot(payload=SegmentPayload(segment=slug, body=body, as_of=date(2026, 4, 26)))
+
+
+def _base_state() -> AtlasResearchState:
+    state = AtlasResearchState(
+        run_type="baseline",
+        run_date=date(2026, 4, 26),
+        config=AtlasConfigBundle(watchlist=["AAPL"]),
+    )
+    state.phase1_outputs = {
+        "alt-options-derivatives": _slot("alt-options-derivatives", vix_level=14.5)
+    }
+    state.phase3_output = _slot("macro", regime_label="Risk-on / Policy easing")
+    state.phase4_outputs = {"crypto": _slot("crypto")}
+    state.phase5_outputs = {"equity": _slot("equity")}
+    return state
+
+
+def _canned_positioning() -> CohortPositioning:
+    """Smart cohort net-short ETH, crowd net-long ETH → divergence -0.8 (the live-validated read)."""
+    summary = {
+        "timestamp": "2026-04-26T00:00:00Z",
+        "totalTraders": 999,
+        "pnlCohorts": [
+            {
+                "id": "extremely_profitable",
+                "longNotional": 1_000_000,
+                "shortNotional": 4_000_000,
+                "topMarkets": [
+                    {"ticker": "ETH", "longNotional": 100_000, "shortNotional": 900_000}
+                ],
+            },
+            {
+                "id": "rekt",
+                "longNotional": 5_000_000,
+                "shortNotional": 1_000_000,
+                "topMarkets": [
+                    {"ticker": "ETH", "longNotional": 900_000, "shortNotional": 100_000}
+                ],
+            },
+        ],
+    }
+    return cohort_summary_to_positioning(summary)
+
+
+@pytest.mark.unit
+class TestPreflightOnchain:
+    def _deps(self) -> Any:
+        from digiquant.olympus.atlas.phases.preflight import PreflightDeps
+
+        client = FakeSupabaseClient(
+            canned_reads={
+                "daily_snapshots": [],
+                "documents": [],
+                "price_technicals": [{"date": "2026-04-26", "ticker": "SPY"}],
+                "macro_series_observations": [],
+            }
+        )
+        return PreflightDeps(client=client, config_loader=AtlasConfigBundle)
+
+    def test_populates_market_context_and_persists_rows(self) -> None:
+        import digiquant.olympus.atlas.phases.preflight as pf_mod
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+
+        deps = self._deps()
+        node = build_preflight_node(deps)
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch.object(pf_mod, "get_onchain_cohort_positioning", lambda: _canned_positioning()):
+            out = node(state)
+
+        mc = out["data_layer"].market_context
+        assert "onchain_positioning" in mc
+        assert mc["onchain_positioning"]["overall_divergence"] == pytest.approx(
+            0.2 - 5 / 6, abs=1e-4
+        )
+        # Per-market rows were persisted for backtest history.
+        rows = deps.client.store.get("onchain_cohort_positioning", [])
+        assert any(r["market"] == "ETH" for r in rows)
+        assert all(r["_on_conflict"] == "date,market" for r in rows)
+
+    def test_absent_when_provider_returns_empty(self) -> None:
+        import digiquant.olympus.atlas.phases.preflight as pf_mod
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+
+        node = build_preflight_node(self._deps())
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch.object(pf_mod, "get_onchain_cohort_positioning", CohortPositioning.empty):
+            out = node(state)
+        assert "onchain_positioning" not in out["data_layer"].market_context
+
+    def test_fail_soft_on_provider_exception(self) -> None:
+        import digiquant.olympus.atlas.phases.preflight as pf_mod
+        from digiquant.olympus.atlas.phases.preflight import build_preflight_node
+
+        def _boom() -> CohortPositioning:
+            raise OSError("hyperdash unreachable")
+
+        node = build_preflight_node(self._deps())
+        state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
+        with patch.object(pf_mod, "get_onchain_cohort_positioning", _boom):
+            out = node(state)  # must not raise
+        assert "onchain_positioning" not in out["data_layer"].market_context
+
+
+@pytest.mark.unit
+class TestOnchainBiasRow:
+    def test_reaches_phase6_bias_row(self) -> None:
+        state = _base_state()
+        compact = _canned_positioning().compact_summary()
+        state.data_layer = DataLayerSnapshot(market_context={"onchain_positioning": compact})
+
+        compiled = build_pipeline(AtlasResearchState, [build_phase6()])
+        result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        row = final.phase6_bias_row
+        assert row is not None
+        assert row["onchain_positioning"] is not None
+        assert row["onchain_positioning"]["top_divergent_markets"][0]["market"] == "ETH"
+
+    def test_none_when_market_context_empty(self) -> None:
+        state = _base_state()
+        state.data_layer = DataLayerSnapshot(market_context={})
+        compiled = build_pipeline(AtlasResearchState, [build_phase6()])
+        result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+        assert final.phase6_bias_row is not None
+        assert final.phase6_bias_row["onchain_positioning"] is None
+
+    def test_reaches_phase7_digest_phase_inputs(self) -> None:
+        state = _base_state()
+        compact = _canned_positioning().compact_summary()
+        state.data_layer = DataLayerSnapshot(market_context={"onchain_positioning": compact})
+
+        compiled = build_pipeline(AtlasResearchState, [build_phase6(), build_phase7()])
+        captured: list[dict[str, Any]] = []
+
+        def fake_completion(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            for part in msgs[1]["content"]:
+                if isinstance(part, dict) and part.get("text", "").startswith("PHASE_INPUTS"):
+                    captured.append(json.loads(part["text"].split(":", 1)[1].strip()))
+                    break
+            return json.dumps(
+                {
+                    "segment": "master-digest",
+                    "date": "2026-04-26",
+                    "bias": "neutral",
+                    "headline": "x",
+                    "material_findings": [],
+                    "sources": [],
+                    "notes": "",
+                    "market_regime_snapshot": "x",
+                    "alt_data_dashboard": "y",
+                    "institutional_summary": "z",
+                    "asset_classes_summary": "a",
+                    "us_equities_summary": "b",
+                    "regime_label": "",
+                }
+            )
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake_completion):
+            compiled.invoke(state)
+
+        assert captured, "LLM must have been called"
+        bias_row = captured[0].get("bias_row", {})
+        assert bias_row.get("onchain_positioning") is not None
+        assert bias_row["onchain_positioning"]["top_divergent_markets"][0]["market"] == "ETH"

--- a/tests/dq/atlas/test_phase12.py
+++ b/tests/dq/atlas/test_phase12.py
@@ -22,6 +22,7 @@ from digigraph.graph.pipeline_builder import build_pipeline
 from digiquant.olympus.atlas.phases.phase1_altdata import (
     AiPortfoliosReport,
     CtaPositioningReport,
+    OnchainCohortPositioningReport,
     OptionsDerivativesReport,
     PoliticianSignalsReport,
     SentimentNewsReport,
@@ -71,6 +72,7 @@ def _dispatch_fake_completion(_model: str, messages: list[dict[str, Any]], **_: 
         OptionsDerivativesReport,
         PoliticianSignalsReport,
         AiPortfoliosReport,
+        OnchainCohortPositioningReport,
         InstitutionalFlowsReport,
         HedgeFundIntelReport,
     ):
@@ -136,7 +138,7 @@ class TestBiasNormalization:
 
 @pytest.mark.unit
 class TestPhase1AltData:
-    def test_fan_out_produces_five_segments(self) -> None:
+    def test_fan_out_produces_all_segments(self) -> None:
         compiled = build_pipeline(AtlasResearchState, [build_phase1()])
         state = AtlasResearchState(run_type="baseline", run_date=date(2026, 4, 26))
         with patch(
@@ -146,13 +148,14 @@ class TestPhase1AltData:
             result = compiled.invoke(state)
         final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
 
-        # All five segment slugs present.
+        # All segment slugs present.
         assert set(final.phase1_outputs.keys()) == {
             "alt-sentiment-news",
             "alt-cta-positioning",
             "alt-options-derivatives",
             "alt-politician-signals",
             "alt-ai-portfolios",
+            "alt-onchain-positioning",
         }
         # Each slot carries a fresh payload (not Carried).
         for slot in final.phase1_outputs.values():
@@ -196,5 +199,5 @@ class TestChainedPhases:
             result = compiled.invoke(state)
         final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
 
-        assert len(final.phase1_outputs) == 5
+        assert len(final.phase1_outputs) == 6
         assert len(final.phase2_outputs) == 2

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -21,16 +21,20 @@ def test_macro_uses_data_tools_and_fallback_search():
 
 @pytest.mark.unit
 def test_alt_phases_grounding_modes():
-    # alt-options-derivatives reads data tools (#708); every other alt-data
-    # segment still grounds on soft signals (web/x search).
+    # Two alt-data segments are deterministically grounded (no soft search): options reads the
+    # Supabase data tools (#708); onchain reads the Hyperdash divergence preflight injects into
+    # market_context (#801). Every other alt-data segment grounds on web/x search.
     by_slug = {s.segment_slug: s for s in ALT_SPECS}
     opts = by_slug["alt-options-derivatives"]
     assert opts.use_data_tools is True
     assert opts.live_search is False and opts.ai_portfolios is False
-    # Every other alt-data segment still grounds on soft signals (web/x search),
-    # never data tools.
+    onchain = by_slug["alt-onchain-positioning"]
+    assert onchain.use_data_tools is False  # reads injected market_context, not data tools
+    assert onchain.live_search is False and onchain.ai_portfolios is False
+    # Every remaining alt-data segment grounds on soft signals (web/x search), never data tools.
+    _deterministic = {"alt-options-derivatives", "alt-onchain-positioning"}
     for spec in ALT_SPECS:
-        if spec.segment_slug == "alt-options-derivatives":
+        if spec.segment_slug in _deterministic:
             continue
         assert spec.use_data_tools is False, spec.segment_slug
         assert spec.live_search or spec.ai_portfolios, spec.segment_slug

--- a/tests/dq/data/test_onchain_hyperdash.py
+++ b/tests/dq/data/test_onchain_hyperdash.py
@@ -1,0 +1,278 @@
+"""Tests for the Hyperdash on-chain cohort-positioning provider (#801).
+
+The fixture mirrors the REAL ``data.analytics.cohortSummary`` GraphQL shape (pnlCohorts with
+top-level long/short + topMarkets), so the pure ``cohort_summary_to_positioning`` parser +
+divergence calculator is validated against production field names with NO network. The scraper
+itself is exercised with an injected fake session (still no network).
+"""
+
+from __future__ import annotations
+
+from typing import Any  # noqa  # scored-lint: heterogeneous GraphQL fixture / JSON dicts
+
+import polars as pl
+import pytest
+
+from digiquant.data.onchain.hyperdash import (
+    CohortPositioning,
+    HyperdashScraper,
+    cohort_summary_to_positioning,
+    get_onchain_cohort_positioning,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _cohort_summary() -> dict[str, Any]:
+    """Captured-shape cohortSummary: extremely-profitable net SHORT ETH while rekt piles LONG
+    ETH (the live-validated divergence), and the mirror image on BTC. Mid cohorts carry no
+    notional so the math is driven by the tails."""
+    zero_mid = lambda cid: {  # noqa: E731 — terse fixture helper
+        "id": cid,
+        "longNotional": 0,
+        "shortNotional": 0,
+        "topMarkets": [],
+    }
+    return {
+        "timestamp": "2026-06-17T00:00:00Z",
+        "totalTraders": 12_345,
+        "pnlCohorts": [
+            {
+                "id": "extremely_profitable",
+                "label": "Extremely Profitable",
+                "emoji": "👑",
+                "range": "+$1M",
+                "totalTraders": 100,
+                "longNotional": 1_000_000,
+                "shortNotional": 4_000_000,
+                "topMarkets": [
+                    {"ticker": "ETH", "longNotional": 100_000, "shortNotional": 900_000},
+                    {"ticker": "BTC", "longNotional": 800_000, "shortNotional": 200_000},
+                ],
+            },
+            zero_mid("very_profitable"),
+            zero_mid("profitable"),
+            zero_mid("unprofitable"),
+            zero_mid("very_unprofitable"),
+            {
+                "id": "rekt",
+                "label": "Rekt",
+                "emoji": "💀",
+                "range": "-$1M",
+                "totalTraders": 200,
+                "longNotional": 5_000_000,
+                "shortNotional": 1_000_000,
+                "topMarkets": [
+                    {"ticker": "ETH", "longNotional": 900_000, "shortNotional": 100_000},
+                    {"ticker": "BTC", "longNotional": 300_000, "shortNotional": 700_000},
+                ],
+            },
+        ],
+    }
+
+
+class _FakeResp:
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    def raise_for_status(self) -> None:  # noqa: D401
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _FakeSession:
+    """Minimal requests-like session for the scraper (no network)."""
+
+    def __init__(self, *, body: dict[str, Any] | None = None, exc: Exception | None = None) -> None:
+        self._body = body
+        self._exc = exc
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResp:
+        self.calls.append((url, kwargs))
+        if self._exc is not None:
+            raise self._exc
+        return _FakeResp(self._body or {})
+
+
+def _eth(pos: CohortPositioning) -> dict[str, Any]:
+    return pos.market_divergence.filter(pl.col("market") == "ETH").to_dicts()[0]
+
+
+class TestDivergenceParser:
+    def test_parses_real_shape_and_computes_divergence(self) -> None:
+        pos = cohort_summary_to_positioning(_cohort_summary())
+        assert pos.error is None
+        assert pos.has_data
+        assert pos.snapshot_ts == "2026-06-17T00:00:00Z"
+        assert pos.total_traders == 12_345
+
+        eth = _eth(pos)
+        # smart 100k/900k → bias 0.1; crowd 900k/100k → bias 0.9; divergence -0.8 (distribution).
+        assert eth["smart_bias"] == pytest.approx(0.1)
+        assert eth["crowd_bias"] == pytest.approx(0.9)
+        assert eth["divergence"] == pytest.approx(-0.8)
+
+        by_market = {r["market"]: r for r in pos.market_divergence.to_dicts()}
+        # BTC: smart 800k/200k → 0.8; crowd 300k/700k → 0.3; divergence +0.5 (smart-money confirm).
+        assert by_market["BTC"]["divergence"] == pytest.approx(0.5)
+
+    def test_overall_aggregate_bias(self) -> None:
+        pos = cohort_summary_to_positioning(_cohort_summary())
+        # smart agg 1M/4M → 0.2; crowd agg 5M/1M → 0.8333; overall divergence ≈ -0.6333.
+        assert pos.overall["smart_net_bias"] == pytest.approx(0.2)
+        assert pos.overall["crowd_net_bias"] == pytest.approx(5 / 6)
+        assert pos.overall["overall_divergence"] == pytest.approx(0.2 - 5 / 6)
+
+    def test_top_divergent_markets_sorted_by_magnitude(self) -> None:
+        top = cohort_summary_to_positioning(_cohort_summary()).top_divergent_markets()
+        assert [m["market"] for m in top] == ["ETH", "BTC"]  # |−0.8| > |+0.5|
+        assert top[0]["divergence"] == pytest.approx(-0.8)
+
+    def test_compact_summary_shape(self) -> None:
+        compact = cohort_summary_to_positioning(_cohort_summary()).compact_summary()
+        assert compact["source"] == "hyperdash"
+        assert compact["total_traders"] == 12_345
+        assert compact["overall_divergence"] == pytest.approx(0.2 - 5 / 6, abs=1e-4)
+        assert compact["top_divergent_markets"][0]["market"] == "ETH"
+
+    def test_to_rows_for_persistence(self) -> None:
+        rows = cohort_summary_to_positioning(_cohort_summary()).to_rows("2026-06-17")
+        by_market = {r["market"]: r for r in rows}
+        assert set(by_market) == {"ETH", "BTC"}
+        assert by_market["ETH"]["date"] == "2026-06-17"
+        assert by_market["ETH"]["divergence"] == pytest.approx(-0.8)
+        assert by_market["ETH"]["total_traders"] == 12_345
+        assert by_market["ETH"]["snapshot_ts"] == "2026-06-17T00:00:00Z"
+
+    def test_unknown_cohorts_ignored(self) -> None:
+        summary = {
+            "timestamp": "t",
+            "totalTraders": 1,
+            "pnlCohorts": [
+                {"id": "mystery_cohort", "topMarkets": [{"ticker": "X", "longNotional": 9}]},
+            ],
+        }
+        pos = cohort_summary_to_positioning(summary)
+        assert not pos.has_data  # the only cohort was unclassifiable → no signal
+
+    def test_empty_and_malformed_are_safe(self) -> None:
+        assert cohort_summary_to_positioning({}).has_data is False
+        assert cohort_summary_to_positioning({"pnlCohorts": "nope"}).error is None
+        assert cohort_summary_to_positioning({"pnlCohorts": []}).has_data is False
+
+
+class TestDivergenceMonotonicity:
+    @staticmethod
+    def _eth_only(
+        smart_long: float, smart_short: float, crowd_long: float, crowd_short: float
+    ) -> dict:
+        return {
+            "timestamp": "t",
+            "totalTraders": 1,
+            "pnlCohorts": [
+                {
+                    "id": "extremely_profitable",
+                    "longNotional": 0,
+                    "shortNotional": 0,
+                    "topMarkets": [
+                        {"ticker": "ETH", "longNotional": smart_long, "shortNotional": smart_short}
+                    ],
+                },
+                {
+                    "id": "rekt",
+                    "longNotional": 0,
+                    "shortNotional": 0,
+                    "topMarkets": [
+                        {"ticker": "ETH", "longNotional": crowd_long, "shortNotional": crowd_short}
+                    ],
+                },
+            ],
+        }
+
+    def test_bounds_and_zero(self) -> None:
+        # Smart fully long, crowd fully short → +1 (max). Reversed → -1. Identical → 0.
+        hi = _eth(cohort_summary_to_positioning(self._eth_only(100, 0, 0, 100)))["divergence"]
+        lo = _eth(cohort_summary_to_positioning(self._eth_only(0, 100, 100, 0)))["divergence"]
+        flat = _eth(cohort_summary_to_positioning(self._eth_only(50, 50, 50, 50)))["divergence"]
+        assert hi == pytest.approx(1.0)
+        assert lo == pytest.approx(-1.0)
+        assert flat == pytest.approx(0.0)
+
+    def test_strictly_increasing_in_smart_long(self) -> None:
+        # Crowd fixed (fully short → crowd_bias 0). As smart leans more long, divergence rises.
+        divs = [
+            _eth(cohort_summary_to_positioning(self._eth_only(sl, 100 - sl, 0, 100)))["divergence"]
+            for sl in (10, 50, 90)
+        ]
+        assert divs[0] < divs[1] < divs[2]
+
+    def test_divergence_null_when_one_side_absent(self) -> None:
+        # A market only the smart cohort touches → crowd_bias null → divergence null (no pair).
+        pos = cohort_summary_to_positioning(self._eth_only(80, 20, 0, 0))
+        eth = _eth(pos)
+        assert eth["smart_bias"] == pytest.approx(0.8)
+        assert eth["crowd_bias"] is None
+        assert eth["divergence"] is None
+        assert pos.has_data is False  # no complete (smart, crowd) pair
+
+
+class TestHyperdashScraper:
+    def test_fetch_parses_full_graphql_body(self) -> None:
+        body = {"data": {"analytics": {"cohortSummary": _cohort_summary()}}}
+        session = _FakeSession(body=body)
+        pos = HyperdashScraper(session=session).fetch()
+        assert pos.error is None and pos.has_data
+        assert _eth(pos)["divergence"] == pytest.approx(-0.8)
+        # The query went to the GraphQL endpoint with a polite UA.
+        url, kwargs = session.calls[0]
+        assert url.endswith("/graphql")
+        assert "User-Agent" in kwargs["headers"]
+
+    def test_fetch_fail_soft_on_network_error(self) -> None:
+        session = _FakeSession(exc=ConnectionError("boom"))
+        pos = HyperdashScraper(session=session).fetch()
+        assert pos.error is not None
+        assert pos.has_data is False
+        assert pos.compact_summary()["overall_divergence"] is None
+
+    def test_fetch_fail_soft_on_graphql_errors(self) -> None:
+        session = _FakeSession(body={"errors": [{"message": "bad query"}], "data": None})
+        pos = HyperdashScraper(session=session).fetch()
+        assert pos.error == "graphql_errors"
+        assert pos.has_data is False
+
+    def test_get_onchain_uses_injected_provider(self) -> None:
+        class _FakeProvider:
+            def fetch(self) -> CohortPositioning:
+                return cohort_summary_to_positioning(_cohort_summary())
+
+        pos = get_onchain_cohort_positioning(provider=_FakeProvider())
+        assert pos.has_data
+        assert pos.total_traders == 12_345
+
+    def test_default_path_disabled_makes_no_network_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Kill-switch off (the default) → no provider construction, no network: empty result.
+        monkeypatch.delenv("ATLAS_ONCHAIN_POSITIONING", raising=False)
+
+        def _boom(*_a: Any, **_k: Any) -> Any:
+            raise AssertionError("must not construct a live scraper when the switch is off")
+
+        monkeypatch.setattr("digiquant.data.onchain.hyperdash.HyperdashScraper", _boom)
+        pos = get_onchain_cohort_positioning()
+        assert pos.has_data is False and pos.error is None
+
+    def test_default_path_enabled_runs_scraper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Switch on → the default HyperdashScraper runs (here with an injected fake session).
+        monkeypatch.setenv("ATLAS_ONCHAIN_POSITIONING", "1")
+        body = {"data": {"analytics": {"cohortSummary": _cohort_summary()}}}
+        monkeypatch.setattr(
+            "digiquant.data.onchain.hyperdash.HyperdashScraper",
+            lambda: HyperdashScraper(session=_FakeSession(body=body)),
+        )
+        pos = get_onchain_cohort_positioning()
+        assert pos.has_data and pos.total_traders == 12_345


### PR DESCRIPTION
## What

Adds an **on-chain cohort-positioning** signal to Atlas research. Preflight scrapes Hyperdash's public cohort-summary GraphQL (no auth), computes a **smart-money-vs-rekt divergence** per Hyperliquid market (crypto + equity perps), and threads it through the pipeline as a **conviction/risk overlay** — it never originates a trade.

Divergence between consistently-profitable ("smart") and consistently-unprofitable ("rekt") cohorts is an early read on distribution / investor-class divergence — validated on live data (the extremely-profitable cohort net-short ETH while the rekt cohort piled long).

## How

**Data layer** — `digiquant/src/digiquant/data/onchain/hyperdash.py`
- `CohortPositioningProvider` protocol + `HyperdashScraper` (`requests` POST, fail-soft), mirroring `data/prices/fed_probabilities.py`: a **pure, HTTP-free parser** (`cohort_summary_to_positioning`) split from the network wrapper so the divergence math is unit-tested against a captured-shape fixture.
- **Polars divergence**: per-market `smart_bias`/`crowd_bias` and `divergence = smart_bias − crowd_bias ∈ [−1,1]`; aggregate overall divergence; compact summary + DB rows.
- **Default-off kill-switch** `ATLAS_ONCHAIN_POSITIONING` — the live scrape is opt-in (keeps unit tests hermetic; owner can disable instantly if the third-party endpoint/ToS changes). An injected provider always runs.

**Wiring (fed_odds pattern)**
- **preflight**: fetch → `market_context['onchain_positioning']` + persist per-market rows to `onchain_cohort_positioning` (best-effort; a Hyperdash outage never blocks a run).
- **phase6**: new bias-row `onchain_positioning` field (`state.Phase6BiasRow` + `_onchain_positioning_compact`).
- **phase1**: new `alt-onchain-positioning` segment (SKILL + spec + `model_modes` entry) interprets the injected divergence — **no per-run search cost**.
- **digest SKILL** references `onchain_positioning` in `alt_data_dashboard`.
- **migration `042_onchain_cohort_positioning`** (+ anon-SELECT RLS, idempotent upsert on `(date, market)`).
- Workflows enable `ATLAS_ONCHAIN_POSITIONING=1` in the baseline/delta run steps.

## Verification

- `make test-unit`: atlas + data **577 pass**, full `tests/dq` **976 pass** (skips are pre-existing optional-deps).
- New tests: pure parser/divergence + **monotonicity/bounds** + fail-soft scraper (fixture, **no network**); preflight populate+persist, fail-soft, bias-row + digest threading; kill-switch gate.
- `make score`: **Security 10 / Quality 10 / Optimization 10 / Accuracy 10**.
- `make doc-check`: clean (167 files). `ruff check` + `ruff format`: clean.
- The live GraphQL query + parser were incidentally exercised against the real Hyperdash endpoint (returned current cohort data) before the hermeticity gate was added — confirming the production contract.

## Not in this PR (deferred to activation, like WS6)

Applying migration 042 to prod and the first proof run are **human-gated activation** — not done here. The kill-switch is wired and on in the workflows, but the table must be created before a run persists rows (fail-soft until then).

Fixes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
