### PR TITLE
feat(olympus): always link the FX Research suite in the sidebar

### DIFF
--- a/frontend/olympus/app/twelve-x/page.tsx
+++ b/frontend/olympus/app/twelve-x/page.tsx
@@ -4,8 +4,8 @@ import TwelveXClient from '@/components/twelve-x/TwelveXClient';
 
 /**
  * OLYMPUS FX Research suite (twelve-x). Thin server wrapper → Suspense →
- * client, mirroring `app/research/page.tsx`. The route is intentionally
- * UNLINKED from the sidebar nav (gated behind NEXT_PUBLIC_TWELVEX_ENABLED).
+ * client, mirroring `app/research/page.tsx`. Linked in the sidebar nav; the
+ * client renders based on Supabase configuration (see `isTwelveXConfigured`).
  */
 export default function TwelveXPage() {
   return (

--- a/frontend/olympus/components/sidebar.tsx
+++ b/frontend/olympus/components/sidebar.tsx
@@ -20,17 +20,8 @@ const NAV: NavItem[] = [
   { href: '/portfolio', label: 'Portfolio', icon: PieChart },
   { href: '/research', label: 'Research', icon: BookOpen },
   { href: '/observability', label: 'Observability', icon: Activity },
+  { href: '/twelve-x', label: 'FX Research', icon: LineChart },
 ];
-
-/**
- * Gated nav entries — only rendered when their feature flag is on. The twelve-x
- * FX Research suite ships UNLINKED by default; set NEXT_PUBLIC_TWELVEX_ENABLED=1
- * to surface it in the sidebar.
- */
-const GATED_NAV: NavItem[] =
-  process.env.NEXT_PUBLIC_TWELVEX_ENABLED === '1'
-    ? [{ href: '/twelve-x', label: 'FX Research', icon: LineChart }]
-    : [];
 
 function routeActive(pathname: string, base: string, href: string): boolean {
   const norm = pathname.replace(/\/+$/, '') || '/';
@@ -123,7 +114,7 @@ export default function Sidebar() {
         </div>
 
         <nav className="flex-1 py-4 flex flex-col">
-          {[...NAV, ...GATED_NAV].map(({ href, label, icon: Icon }) => {
+          {NAV.map(({ href, label, icon: Icon }) => {
             const isActive = routeActive(pathname, base, href);
             return (
               <Link


### PR DESCRIPTION
Drops the `NEXT_PUBLIC_TWELVEX_ENABLED` flag so the FX Research suite is linked in the Olympus sidebar unconditionally — one fewer build-time env var for the digiquant.io deploy. The page still renders based on Supabase config (`isTwelveXConfigured`), so an unconfigured env degrades gracefully.

- `sidebar.tsx`: FX Research folded into `NAV`; `GATED_NAV` + flag removed.
- `app/twelve-x/page.tsx`: stale docstring updated.

Suite already merged + data backfilled; this just unlinks the gate. `next build`/vitest green (106/106).

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)