### PR TITLE
fix(olympus): standalone FX Research surface + fix digest load

### DIFF
--- a/frontend/olympus/app/layout.tsx
+++ b/frontend/olympus/app/layout.tsx
@@ -1,12 +1,10 @@
 import './globals.css';
-import { ReactNode, Suspense } from 'react';
+import { ReactNode } from 'react';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { DashboardProvider } from '@/lib/dashboard-context';
 import { AppShellProvider } from '@/components/app-shell-context';
 import { ThemeProvider } from '@/components/theme-provider';
-import Sidebar from '@/components/sidebar';
-import MobileAppBar from '@/components/mobile-app-bar';
-import CommandPalette from '@/components/command-palette';
+import AppFrame from '@/components/app-frame';
 import MotionLayer from '@/components/motion-layer';
 
 /** Default + invalid keys → follow prefers-color-scheme; light/dark fixed; auto → OS */
@@ -46,31 +44,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <MotionLayer />
           <DashboardProvider>
             <AppShellProvider>
-              <div className="flex min-h-screen">
-                <Suspense fallback={<aside className="w-[260px] shrink-0 border-r border-border-subtle bg-bg-glass" />}>
-                  <Sidebar />
-                </Suspense>
-                <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto max-h-screen">
-                  <div className="qn-page-chrome">
-                    <div className="qn-crumbs">
-                      <strong>Olympus</strong>
-                      <span aria-hidden="true"> / </span>
-                      <span>investment intelligence</span>
-                    </div>
-                    <div className="flex items-center gap-4">
-                      <a href="https://digiquant.io" target="_blank" rel="noopener noreferrer">
-                        Open digiquant.io -&gt;
-                      </a>
-                      <span className="qn-env">
-                        {process.env.NEXT_PUBLIC_OLYMPUS_VERSION ?? 'v0.1 · dev'}
-                      </span>
-                    </div>
-                  </div>
-                  <MobileAppBar />
-                  <CommandPalette />
-                  <div className="flex min-h-0 flex-1 flex-col">{children}</div>
-                </main>
-              </div>
+              <AppFrame>{children}</AppFrame>
             </AppShellProvider>
           </DashboardProvider>
         </ThemeProvider>

--- a/frontend/olympus/components/app-frame.tsx
+++ b/frontend/olympus/components/app-frame.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ReactNode, Suspense } from 'react';
+import { usePathname } from 'next/navigation';
+import Sidebar from '@/components/sidebar';
+import MobileAppBar from '@/components/mobile-app-bar';
+import CommandPalette from '@/components/command-palette';
+
+/**
+ * App frame: the Olympus shell (sidebar + page chrome) for normal routes.
+ *
+ * The twelve-x FX Research suite is a STANDALONE surface — reachable only by direct
+ * URL, with no sidebar, breadcrumbs, or cross-navigation. For any path under
+ * `/twelve-x` we render the page bare (just a scroll container) so it reads as its
+ * own self-contained app rather than an Olympus tab.
+ */
+export default function AppFrame({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const standalone = pathname?.startsWith('/twelve-x') ?? false;
+
+  if (standalone) {
+    return (
+      <main className="flex min-h-screen min-w-0 flex-1 flex-col overflow-y-auto max-h-screen">
+        {children}
+      </main>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <Suspense fallback={<aside className="w-[260px] shrink-0 border-r border-border-subtle bg-bg-glass" />}>
+        <Sidebar />
+      </Suspense>
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto max-h-screen">
+        <div className="qn-page-chrome">
+          <div className="qn-crumbs">
+            <strong>Olympus</strong>
+            <span aria-hidden="true"> / </span>
+            <span>investment intelligence</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <a href="https://digiquant.io" target="_blank" rel="noopener noreferrer">
+              Open digiquant.io -&gt;
+            </a>
+            <span className="qn-env">
+              {process.env.NEXT_PUBLIC_OLYMPUS_VERSION ?? 'v0.1 · dev'}
+            </span>
+          </div>
+        </div>
+        <MobileAppBar />
+        <CommandPalette />
+        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/olympus/components/sidebar.tsx
+++ b/frontend/olympus/components/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 import { ElementType } from 'react';
-import { LayoutDashboard, PieChart, BookOpen, Activity, LineChart, ChevronLeft, ChevronRight } from 'lucide-react';
+import { LayoutDashboard, PieChart, BookOpen, Activity, ChevronLeft, ChevronRight } from 'lucide-react';
 import { AtlasMark } from '@/components/atlas-mark';
 import { useAppShell } from '@/components/app-shell-context';
 import SidebarSettings from '@/components/sidebar-settings';
@@ -20,7 +20,6 @@ const NAV: NavItem[] = [
   { href: '/portfolio', label: 'Portfolio', icon: PieChart },
   { href: '/research', label: 'Research', icon: BookOpen },
   { href: '/observability', label: 'Observability', icon: Activity },
-  { href: '/twelve-x', label: 'FX Research', icon: LineChart },
 ];
 
 function routeActive(pathname: string, base: string, href: string): boolean {

--- a/frontend/olympus/components/twelve-x/TodayTab.tsx
+++ b/frontend/olympus/components/twelve-x/TodayTab.tsx
@@ -6,7 +6,6 @@ import type { FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
 
 interface DigestData {
   run_date: string;
-  headline: string;
   summary: string;
   key_themes: string[];
   doc_count: number;
@@ -73,7 +72,7 @@ export default function TodayTab({
       <div className="glass-card p-5 md:p-6 space-y-4">
         <div className="flex flex-wrap items-center gap-3">
           <Sparkles size={18} className="text-fin-blue shrink-0" />
-          <h2 className="text-lg md:text-xl font-semibold text-text-primary">{digest.headline}</h2>
+          <h2 className="text-lg md:text-xl font-semibold text-text-primary">Daily FX brief</h2>
           <span className="text-[10px] font-mono text-text-muted ml-auto">{digest.run_date}</span>
         </div>
 

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -156,7 +156,7 @@ export async function getLatestDigest(): Promise<
   const rows = await querySupabase<FxDailyDigestRow[]>((sb) =>
     sb
       .from('fx_daily_digest')
-      .select('run_date, headline, summary, key_themes, doc_count, broker_count')
+      .select('run_date, summary, key_themes, doc_count, broker_count')
       .order('run_date', { ascending: false })
       .limit(1)
   );
@@ -165,7 +165,6 @@ export async function getLatestDigest(): Promise<
   if (!row) return null;
   return {
     run_date: row.run_date,
-    headline: row.headline,
     summary: row.summary,
     key_themes: normalizeKeyThemes(row.key_themes),
     doc_count: Number(row.doc_count ?? 0),

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -67,7 +67,6 @@ export interface FxConfluenceSnapshotRow {
  */
 export interface FxDailyDigestRow {
   run_date: string; // date (ISO YYYY-MM-DD)
-  headline: string;
   summary: string;
   key_themes: string[] | string | null; // jsonb / text[]
   doc_count: number;


### PR DESCRIPTION
Two fixes for the now-live FX Research suite.

**1. Digest load was failing** ("Failed to load FX research data"): `getLatestDigest` selected a `headline` column that doesn't exist on `fx_daily_digest` (real columns: `run_date, summary, key_themes, doc_count, broker_count`). The 400 threw and — with the error-swallow removed in #804 — broke the entire initial `Promise.all` load. Dropped `headline` from the select, the `FxDailyDigestRow` type, and `TodayTab` (static "Daily FX brief" heading; the dated summary still renders).

**2. Standalone surface**: `/twelve-x` is now reachable only by direct URL — no Olympus sidebar, breadcrumbs, or cross-nav. New `AppFrame` client component renders the full shell for normal routes and bare children under `/twelve-x`; the FX Research entry is removed from the sidebar nav.

`next build` green (15 routes incl. `/twelve-x` static); vitest 106/106; tsc + eslint clean.

Part of #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)