### PR TITLE
fix(olympus): MotionLayer reveals client-navigated/tab-switched cards (#814)

### DIFF
--- a/frontend/olympus/components/motion-layer.tsx
+++ b/frontend/olympus/components/motion-layer.tsx
@@ -2,10 +2,22 @@
 /**
  * MotionLayer — non-invasive "comes to life" scroll reveals for the dashboard.
  * Adds `html.motion-on` only when motion is allowed (JS active + not reduced),
- * then reveals `.glass-card` and `[data-reveal]` elements as they scroll into
- * view. With JS off or reduced-motion, nothing is hidden (content always shown).
- * Pure CSS + IntersectionObserver — no animation library, no edits to the
- * data components, CSP-safe.
+ * then reveals `.glass-card` and `[data-reveal]` elements. With JS off or
+ * reduced-motion, nothing is hidden (content always shown). Pure CSS +
+ * IntersectionObserver — no animation library, no edits to data components,
+ * CSP-safe.
+ *
+ * `motion-on` hides un-revealed cards (opacity:0), so the reveal MUST be
+ * bullet-proof or content silently disappears. This effect runs once and the
+ * layout never remounts, so client-side navigation and tab switches mount fresh
+ * cards into a live DOM. Two rules keep those visible:
+ *   1. Cards already in the viewport at scan time are revealed immediately
+ *      instead of waiting on the observer — an above-the-fold card mounted by a
+ *      tab switch would otherwise never receive an intersection callback and
+ *      stay invisible until a hard refresh.
+ *   2. The MutationObserver lives for the page's lifetime (rAF-debounced) so
+ *      panels that mount after navigation are always re-scanned. It previously
+ *      self-disconnected after 8s, which left anything mounted later hidden.
  */
 import { useEffect } from "react";
 
@@ -28,21 +40,46 @@ export default function MotionLayer() {
       { rootMargin: "0px 0px -8% 0px", threshold: 0.08 }
     );
 
+    const inViewport = (el: HTMLElement) => {
+      const r = el.getBoundingClientRect();
+      return r.bottom > 0 && r.top < (window.innerHeight || document.documentElement.clientHeight);
+    };
+
     const observe = () => {
       document.querySelectorAll<HTMLElement>(".glass-card, [data-reveal]").forEach((el) => {
         if (seen.has(el)) return;
         seen.add(el);
-        // already-visible-on-load elements reveal immediately (no flash of empty)
-        io.observe(el);
+        // Reveal anything already on-screen now (initial load, or a card mounted
+        // above the fold by client-side nav / a tab switch); only defer to the
+        // observer for cards genuinely below the fold.
+        if (inViewport(el)) {
+          el.classList.add("reveal-in");
+        } else {
+          io.observe(el);
+        }
       });
     };
     observe();
-    // re-scan as client-rendered data panels mount
-    const mo = new MutationObserver(observe);
-    mo.observe(document.body, { childList: true, subtree: true });
-    const stop = setTimeout(() => mo.disconnect(), 8000);
 
-    return () => { io.disconnect(); mo.disconnect(); clearTimeout(stop); root.classList.remove("motion-on"); };
+    // Re-scan as client-rendered data panels mount — for the page's lifetime,
+    // debounced to one scan per frame so a busy dashboard stays cheap.
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        observe();
+      });
+    };
+    const mo = new MutationObserver(schedule);
+    mo.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      io.disconnect();
+      mo.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+      root.classList.remove("motion-on");
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## What
Fixes the dashboard's "elements don't load until I refresh" bug — the most-hit UX issue from the 2026-06-17 end-to-end review. Part of #814 (WS-UI).

## Root cause
`MotionLayer` adds `html.motion-on`, which CSS-hides every `.glass-card` / `[data-reveal]` at `opacity:0` until an IntersectionObserver adds `.reveal-in`. Two flaws left content permanently hidden after first paint:
- the effect runs once (`[]` deps) and the layout never remounts, so client-side navigation and tab switches mount fresh cards into a live DOM;
- the MutationObserver that re-scans for newly-mounted panels self-disconnected after 8s.

So any card mounted by an in-app navigation or tab switch (e.g. Observability → Run Health / Attribution, which were 100% invisible) never got an intersection callback and stayed at `opacity:0` until a hard refresh.

## Fix (one file — `components/motion-layer.tsx`)
- Reveal any card already in the viewport at scan time immediately, instead of waiting on the observer (deterministic for above-the-fold content mounted by a tab switch / nav).
- Keep the MutationObserver alive for the page's lifetime (rAF-debounced to one scan/frame) so later-mounted panels are always re-scanned.
- Reduced-motion / no-IntersectionObserver behaviour unchanged (content always shown).

## Verification
- `npm run lint` — 0 errors
- `npm run build` — all 14 routes prerender
- `npm run test` — 106/106 pass
- `make score` — Security 10 / Quality 10 / Optimization 10 / Accuracy 10
- Reproduced against the live site: Observability Run Health / Attribution cards were present in the DOM but `opacity:0` on tab-switch; this reveals in-viewport cards on mount.

Draft — for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
