### PR TITLE
fix(olympus): reliable FX tab nav + per-currency Matrix + review fixes

### DIFF
--- a/frontend/olympus/components/twelve-x/BriefPanel.tsx
+++ b/frontend/olympus/components/twelve-x/BriefPanel.tsx
@@ -1,40 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ExternalLink, FileText, Users, X } from 'lucide-react';
 
 import { SafeMarkdown } from '@/components/SafeMarkdown';
 import { getBrief } from '@/lib/twelve-x/fetch';
 import type { FxBriefRow } from '@/lib/twelve-x/types';
-
-/**
- * Build an href that sets `?brief=<source_file>` (and, when known,
- * `?briefDate=<run_date>`) on the current path while preserving every other
- * query param (e.g. ?tab=). Use this to wire a "drill to brief" affordance into
- * any tab.
- *
- * Passing `runDate` is important for uniqueness: two run_dates can share a
- * `source_file`, so the date pins the right brief — `getBrief` filters on both.
- * When `runDate` is omitted, `getBrief` falls back to the latest run carrying
- * that file. Any stale `briefDate` is cleared so a date-less drill opens latest.
- */
-export function briefHref(
-  pathname: string,
-  searchParams: URLSearchParams,
-  sourceFile: string,
-  runDate?: string | null
-): string {
-  const p = new URLSearchParams(searchParams.toString());
-  p.set('brief', sourceFile);
-  if (runDate) {
-    p.set('briefDate', runDate);
-  } else {
-    p.delete('briefDate');
-  }
-  const s = p.toString();
-  return s ? `${pathname}?${s}` : pathname;
-}
 
 function asStringList(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw.map((x) => String(x)).filter((s) => s.trim().length > 0);
@@ -42,44 +13,43 @@ function asStringList(raw: unknown): string[] {
 }
 
 /**
- * Slide-over panel that opens whenever `?brief=<source_file>` is present in the
- * URL. Lazily fetches the brief (run_date, source_file) and renders broker,
- * dates, central thesis, the SafeMarkdown body, and a source link. Closing
- * clears the `brief` param while preserving the rest of the query.
+ * Slide-over panel for a single broker brief. Prop-driven (NOT URL-driven): the
+ * parent owns the open/close state locally and passes the brief key down, so
+ * opening a brief never touches the Next router — which is unreliable under this
+ * suite's static export (see TwelveXClient). Lazily fetches by (source_file,
+ * run_date) and renders broker, dates, central thesis, the markdown body, and a
+ * source link.
+ *
+ * `runDate` pins the right brief when two runs share a `source_file`; `getBrief`
+ * falls back to the latest run carrying that file when it's null.
  */
-export default function BriefPanel() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const sourceFile = searchParams.get('brief');
-  const runDate = searchParams.get('briefDate');
-
+export default function BriefPanel({
+  open,
+  sourceFile,
+  runDate,
+  onClose,
+}: {
+  open: boolean;
+  sourceFile: string | null;
+  runDate: string | null;
+  onClose: () => void;
+}) {
   const [brief, setBrief] = useState<FxBriefRow | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const close = useCallback(() => {
-    const p = new URLSearchParams(searchParams.toString());
-    p.delete('brief');
-    p.delete('briefDate');
-    const s = p.toString();
-    router.replace(s ? `${pathname}?${s}` : pathname, { scroll: false });
-  }, [pathname, router, searchParams]);
-
-  // Reset the resolved brief whenever the key clears. Adjusting state during
-  // render (rather than synchronously inside an effect) avoids the cascading-
-  // render lint — see https://react.dev/learn/you-might-not-need-an-effect.
-  if (!sourceFile && (brief !== null || error !== null)) {
+  // Reset the resolved brief whenever the panel closes / key clears. Adjusting
+  // state during render (rather than in an effect) avoids the cascading-render
+  // lint — see https://react.dev/learn/you-might-not-need-an-effect.
+  if (!open && (brief !== null || error !== null)) {
     setBrief(null);
     setError(null);
   }
 
-  // Lazily resolve the brief whenever the key changes. All state writes live
-  // inside the async closure (off the synchronous effect body) so we don't
-  // trigger a cascading render on mount — see the React effects guidance:
-  // https://react.dev/learn/you-might-not-need-an-effect.
+  // Lazily resolve the brief whenever the key changes. All state writes live in
+  // the async closure so we don't trigger a cascading render on mount.
   useEffect(() => {
-    if (!sourceFile) return;
+    if (!open || !sourceFile) return;
     let cancelled = false;
     (async () => {
       setLoading(true);
@@ -99,21 +69,22 @@ export default function BriefPanel() {
     return () => {
       cancelled = true;
     };
-  }, [sourceFile, runDate]);
+  }, [open, sourceFile, runDate]);
 
   // Close on Escape while open.
+  const handleClose = useCallback(() => onClose(), [onClose]);
   useEffect(() => {
-    if (!sourceFile) return;
+    if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
+      if (e.key === 'Escape') handleClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [sourceFile, close]);
+  }, [open, handleClose]);
 
   const analysts = useMemo(() => asStringList(brief?.analyst_names), [brief?.analyst_names]);
 
-  if (!sourceFile) return null;
+  if (!open || !sourceFile) return null;
 
   return (
     <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label="Research brief">
@@ -121,7 +92,7 @@ export default function BriefPanel() {
       <button
         type="button"
         aria-label="Close brief"
-        onClick={close}
+        onClick={handleClose}
         className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
       />
 
@@ -137,7 +108,7 @@ export default function BriefPanel() {
           </div>
           <button
             type="button"
-            onClick={close}
+            onClick={handleClose}
             aria-label="Close"
             className="shrink-0 rounded-lg p-1.5 text-text-muted transition-colors hover:bg-white/[0.06] hover:text-text-primary"
           >

--- a/frontend/olympus/components/twelve-x/EventsTab.tsx
+++ b/frontend/olympus/components/twelve-x/EventsTab.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
 import { CalendarClock, ChevronRight, FileText, Globe, Users } from 'lucide-react';
-import { briefHref } from './BriefPanel';
 import type {
   FxEconomicCalendarRow,
   FxEventCitation,
@@ -73,6 +70,24 @@ function normalizeName(name: string | null | undefined): string {
     .trim();
 }
 
+// Snapshot event_names often carry a leading country/region code that the
+// calendar event_name lacks ("US FOMC Statement" / "[CN] Retail Sales YoY" vs
+// "FOMC Statement"). Split that prefix off so the name-fallback can align the
+// two, qualified by country to avoid cross-country false matches.
+const COUNTRY_CODES = new Set([
+  'us', 'eu', 'ez', 'gb', 'uk', 'jp', 'cn', 'au', 'nz', 'ca', 'ch', 'de', 'fr',
+  'it', 'es', 'se', 'no', 'dk', 'tr', 'sg', 'in', 'kr', 'mx', 'za', 'br', 'hk',
+  'tw', 'id', 'th', 'pl', 'cz', 'hu', 'il',
+]);
+
+function splitCountry(normalized: string): { country: string; rest: string } {
+  const sp = normalized.indexOf(' ');
+  if (sp <= 0) return { country: '', rest: normalized };
+  const head = normalized.slice(0, sp);
+  if (COUNTRY_CODES.has(head)) return { country: head, rest: normalized.slice(sp + 1) };
+  return { country: '', rest: normalized };
+}
+
 interface MatchedOpinions {
   mentions: number;
   brokers: string[];
@@ -83,12 +98,12 @@ interface MatchedOpinions {
 function ExpandedOpinions({
   opinions,
   runDate,
+  onOpenBrief,
 }: {
   opinions: MatchedOpinions;
   runDate: string | null;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
 }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   return (
     <div className="space-y-2 border-t border-border-subtle/60 px-4 py-3">
       {opinions.citations.length > 0 ? (
@@ -99,20 +114,15 @@ function ExpandedOpinions({
                 {c.broker || 'Unknown desk'}
               </span>
               {c.source_file ? (
-                <Link
-                  href={briefHref(
-                    pathname,
-                    new URLSearchParams(searchParams.toString()),
-                    c.source_file,
-                    runDate
-                  )}
-                  scroll={false}
+                <button
+                  type="button"
+                  onClick={() => onOpenBrief(c.source_file, runDate)}
                   className="flex shrink-0 items-center gap-1 text-[11px] font-medium text-fin-blue hover:underline"
                   title={`Open brief ${c.source_file}`}
                 >
                   <FileText size={11} aria-hidden />
                   Brief
-                </Link>
+                </button>
               ) : null}
             </div>
             {c.expected_outcome ? (
@@ -144,10 +154,12 @@ function EventRow({
   event,
   opinions,
   runDate,
+  onOpenBrief,
 }: {
   event: FxEconomicCalendarRow;
   opinions: MatchedOpinions | null;
   runDate: string | null;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const { text: impactText, dot: impactDot } = impactClass(event.impact);
@@ -225,7 +237,7 @@ function EventRow({
       </button>
 
       {hasOpinions && open ? (
-        <ExpandedOpinions opinions={opinions!} runDate={runDate} />
+        <ExpandedOpinions opinions={opinions!} runDate={runDate} onOpenBrief={onOpenBrief} />
       ) : null}
     </div>
   );
@@ -235,25 +247,29 @@ export default function EventsTab({
   events,
   opinions,
   runDate,
+  onOpenBrief,
 }: {
   events: FxEconomicCalendarRow[];
   opinions: FxEventSnapshotRow[];
   runDate: string | null;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
 }) {
   // Index broker opinions so each upcoming calendar row can pick up the aggregated
   // desk views. Two lookups, mirroring how twelve-x groups risk events:
   //   1. byExternalId — keyed on the snapshot's `calendar_external_id` (== the calendar
   //      row's `external_id`) for calendar-linked snapshots. This is the precise join
   //      and is preferred whenever available.
-  //   2. byNameAndDate — keyed on (normalizedName + '\u001f' + event_date) for unlinked
-  //      snapshots. Including the date is what stops same-named events ("CPI",
-  //      "Rate Decision") on different dates/countries from colliding. Name alone is
+  //   2. byNameAndDate — keyed on (normalizedName + date), with a country-stripped,
+  //      country-qualified fallback so a snapshot name like "US FOMC Statement" still
+  //      aligns to the calendar's "FOMC Statement". The date + country qualifier stop
+  //      same-named events on different dates/countries from colliding. Name alone is
   //      never used as a key.
   const { byExternalId, byNameAndDate } = useMemo(() => {
-    const nameDateKey = (name: string, date: string | null): string =>
-      `${normalizeName(name)}\u001f${date ?? ''}`;
     const externalIdMap = new Map<string, MatchedOpinions>();
     const nameDateMap = new Map<string, MatchedOpinions>();
+    const put = (key: string, m: MatchedOpinions) => {
+      if (!nameDateMap.has(key)) nameDateMap.set(key, m); // first write wins -> deterministic
+    };
     for (const o of opinions) {
       const matched: MatchedOpinions = {
         mentions: Number(o.mentions ?? 0),
@@ -267,25 +283,40 @@ export default function EventsTab({
         if (!externalIdMap.has(externalId)) externalIdMap.set(externalId, matched);
         continue;
       }
-      // Unlinked snapshot: fall back to (name + date). A normalized name is required
-      // for a usable key, and first write wins to keep matching deterministic.
-      const n = normalizeName(o.event_name);
-      if (!n) continue;
-      const key = nameDateKey(o.event_name, o.event_date);
-      if (!nameDateMap.has(key)) nameDateMap.set(key, matched);
+      // Unlinked snapshot: register under name+date keys. The snapshot name often
+      // carries a leading country code ("US FOMC Statement") the calendar name lacks,
+      // so register BOTH the exact normalized name AND the country-stripped form, the
+      // latter qualified by country to avoid cross-country false matches.
+      const full = normalizeName(o.event_name);
+      if (!full) continue;
+      const date = o.event_date ?? '';
+      put(`${full}|${date}`, matched);
+      const { country, rest } = splitCountry(full);
+      if (country && rest) put(`${rest}|${date}|${country}`, matched);
     }
     return { byExternalId: externalIdMap, byNameAndDate: nameDateMap };
   }, [opinions]);
 
   const matchOpinions = (event: FxEconomicCalendarRow): MatchedOpinions | null => {
-    // Prefer the exact calendar_external_id ↔ external_id key match.
+    // 1) Prefer the exact calendar_external_id -> external_id key match.
     const externalId = (event.external_id ?? '').trim();
     if (externalId) {
       const linked = byExternalId.get(externalId);
       if (linked) return linked;
     }
-    // Fall back to (normalized event_name AND event_date) — never name alone.
-    return byNameAndDate.get(`${normalizeName(event.event_name)}\u001f${event.event_date}`) ?? null;
+    const name = normalizeName(event.event_name);
+    const date = event.event_date ?? '';
+    // 2) Exact (normalized name + date) - matches snapshots without a country prefix.
+    const exact = byNameAndDate.get(`${name}|${date}`);
+    if (exact) return exact;
+    // 3) Country-qualified (name + date + calendar country) - matches snapshots whose
+    //    name carried a country prefix that is now stripped. Never name alone.
+    const country = normalizeName(event.country);
+    if (country) {
+      const qualified = byNameAndDate.get(`${name}|${date}|${country}`);
+      if (qualified) return qualified;
+    }
+    return null;
   };
 
   // Group the upcoming window by day for a timeline layout.
@@ -334,6 +365,7 @@ export default function EventsTab({
                     event={event}
                     opinions={matchOpinions(event)}
                     runDate={runDate}
+                    onOpenBrief={onOpenBrief}
                   />
                 ))}
               </div>

--- a/frontend/olympus/components/twelve-x/IntelligenceTab.tsx
+++ b/frontend/olympus/components/twelve-x/IntelligenceTab.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { Layers, Users, CalendarClock, FileText } from 'lucide-react';
-import { briefHref } from './BriefPanel';
+import { Layers, Users, CalendarClock } from 'lucide-react';
 import type { FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
 
 /** Map a confluence direction/lean string to a .fin-* text color class. */
@@ -90,11 +87,11 @@ function ComponentBar({ components }: { components: Record<string, number> }) {
 }
 
 function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const colorClass = directionColorClass(idea.direction);
   const components = useMemo(() => asComponents(idea.components), [idea.components]);
-  const briefKeys = useMemo(() => asStringList(idea.brief_keys), [idea.brief_keys]);
+  // brief_keys holds the SUPPORTING DESK names behind this idea (broker names,
+  // not source_file document keys), so we list them rather than link to a brief.
+  const supportingDesks = useMemo(() => asStringList(idea.brief_keys), [idea.brief_keys]);
   const nBrokers = asNumber(components.n_brokers);
   const daysToCatalyst = asNumber(components.days_to_catalyst);
 
@@ -125,37 +122,28 @@ function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
 
       {Object.keys(components).length > 0 ? <ComponentBar components={components} /> : null}
 
-      {(nBrokers != null || daysToCatalyst != null || briefKeys.length > 0) ? (
-        <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border-subtle/60 pt-2 text-[11px] text-text-muted">
-          {nBrokers != null ? (
-            <span className="flex items-center gap-1.5">
-              <Users size={12} aria-hidden />
-              <span className="qn-metric tabular-nums text-text-secondary">{nBrokers}</span>
-              desks
-            </span>
-          ) : null}
-          {daysToCatalyst != null ? (
-            <span className="flex items-center gap-1.5">
-              <CalendarClock size={12} aria-hidden />
-              <span className="qn-metric tabular-nums text-text-secondary">{daysToCatalyst}</span>
-              {daysToCatalyst === 1 ? 'day to catalyst' : 'days to catalyst'}
-            </span>
-          ) : null}
-          {briefKeys.length > 0 ? (
-            <Link
-              href={briefHref(
-                pathname,
-                new URLSearchParams(searchParams.toString()),
-                briefKeys[0],
-                idea.run_date
-              )}
-              scroll={false}
-              className="ml-auto flex items-center gap-1 truncate text-fin-blue hover:underline"
-              title={`Open brief ${briefKeys[0]}`}
-            >
-              <FileText size={12} aria-hidden />
-              {briefKeys.length} source{briefKeys.length === 1 ? '' : 's'}
-            </Link>
+      {(nBrokers != null || daysToCatalyst != null || supportingDesks.length > 0) ? (
+        <div className="mt-auto flex flex-col gap-1.5 border-t border-border-subtle/60 pt-2 text-[11px] text-text-muted">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+            {nBrokers != null ? (
+              <span className="flex items-center gap-1.5">
+                <Users size={12} aria-hidden />
+                <span className="qn-metric tabular-nums text-text-secondary">{nBrokers}</span>
+                desks
+              </span>
+            ) : null}
+            {daysToCatalyst != null ? (
+              <span className="flex items-center gap-1.5">
+                <CalendarClock size={12} aria-hidden />
+                <span className="qn-metric tabular-nums text-text-secondary">{daysToCatalyst}</span>
+                {daysToCatalyst === 1 ? 'day to catalyst' : 'days to catalyst'}
+              </span>
+            ) : null}
+          </div>
+          {supportingDesks.length > 0 ? (
+            <p className="truncate text-text-muted" title={supportingDesks.join(', ')}>
+              <span className="text-text-secondary">Desks:</span> {supportingDesks.join(', ')}
+            </p>
           ) : null}
         </div>
       ) : null}

--- a/frontend/olympus/components/twelve-x/LedgerTab.tsx
+++ b/frontend/olympus/components/twelve-x/LedgerTab.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
 import { ScrollText } from 'lucide-react';
 
-import { briefHref } from './BriefPanel';
 import { G10_CURRENCIES } from '@/lib/twelve-x/types';
 import type { FxLedgerRow } from '@/lib/twelve-x/types';
 
@@ -45,14 +42,23 @@ function safeNum(v: number): number {
   return Number.isFinite(v) ? v : 0;
 }
 
-/** Stacked w_time·w_event·w_review bar (CSS, no recharts) sized by each factor. */
+/** Stacked w_time·w_event·w_review bar (CSS, no recharts) sized by each factor.
+ *
+ * When the three factors are equal (the common case while the relevance review is
+ * un-differentiated — every desk currently scores 1·1·1), a proportional bar would
+ * draw three identical thirds that imply a breakdown that isn't there. In that case
+ * we render a flat single bar + a "uniform" tag so the visual is honest; only when
+ * the factors actually differ do we draw the proportional stack. */
 function WeightBar({ row }: { row: FxLedgerRow }) {
   const segments = WEIGHT_SEGMENTS.map((s) => ({ ...s, value: Math.max(0, safeNum(row[s.key])) }));
   const total = segments.reduce((sum, s) => sum + s.value, 0);
+  const uniform =
+    segments.length > 0 && segments.every((s) => Math.abs(s.value - segments[0].value) < 1e-9);
+
   return (
     <div className="space-y-1">
       <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-white/[0.05]">
-        {total > 0
+        {total > 0 && !uniform
           ? segments.map((s) =>
               s.value > 0 ? (
                 <div
@@ -63,16 +69,22 @@ function WeightBar({ row }: { row: FxLedgerRow }) {
                 />
               ) : null
             )
-          : null}
+          : total > 0 ? (
+              <div className="h-full w-full rounded-full bg-white/15" title="time · event · review weights are uniform" />
+            ) : null}
       </div>
-      <div className="flex flex-wrap gap-x-2.5 gap-y-0.5">
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-0.5">
         {segments.map((s) => (
           <span key={s.key} className="flex items-center gap-1 text-[10px] text-text-muted">
-            <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: s.color }} />
+            <span
+              className="inline-block h-2 w-2 rounded-sm"
+              style={{ backgroundColor: uniform ? 'rgba(255,255,255,0.2)' : s.color }}
+            />
             {s.label}
             <span className="tabular-nums text-text-secondary">{s.value.toFixed(2)}</span>
           </span>
         ))}
+        {uniform ? <span className="text-[10px] text-text-muted/70">uniform</span> : null}
       </div>
     </div>
   );
@@ -83,28 +95,28 @@ export default function LedgerTab({
   runDate,
   runDates,
   onSelectRun,
+  ccy,
+  onOpenBrief,
 }: {
   rows: FxLedgerRow[];
   runDate: string | null;
   runDates: string[];
   onSelectRun: (runDate: string) => void;
+  // A "why this weight?" drill from a consensus cell pre-filters the ledger to this
+  // currency (owned by the parent so it survives tab switches; no URL coupling).
+  ccy: string | null;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
 }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  // A "why this weight?" cross-link from a consensus/matrix cell can pre-filter
-  // the ledger to a currency via ?ledgerCcy=<ccy>.
-  const ledgerCcyParam = searchParams.get('ledgerCcy');
-
   const [classFilter, setClassFilter] = useState<string>('all');
-  const [ccyFilter, setCcyFilter] = useState<string>(ledgerCcyParam ?? 'all');
+  const [ccyFilter, setCcyFilter] = useState<string>(ccy ?? 'all');
 
-  // Re-apply the currency filter whenever the cross-link param changes. Adjusting
+  // Re-apply the currency filter whenever the drill-down currency changes. Adjusting
   // state during render (rather than in an effect) avoids an extra commit + the
   // cascading-render lint — see https://react.dev/learn/you-might-not-need-an-effect.
-  const [lastCcyParam, setLastCcyParam] = useState<string | null>(ledgerCcyParam);
-  if (ledgerCcyParam && ledgerCcyParam !== lastCcyParam) {
-    setLastCcyParam(ledgerCcyParam);
-    setCcyFilter(ledgerCcyParam);
+  const [lastCcy, setLastCcy] = useState<string | null>(ccy);
+  if (ccy && ccy !== lastCcy) {
+    setLastCcy(ccy);
+    setCcyFilter(ccy);
   }
 
   // Distinct classifications / currencies present, for the filter chips.
@@ -221,19 +233,14 @@ export default function LedgerTab({
                     style={{ gridTemplateColumns: gridCols }}
                   >
                     {/* Desk → drill to brief */}
-                    <Link
-                      href={briefHref(
-                        pathname,
-                        new URLSearchParams(searchParams.toString()),
-                        r.source_file,
-                        r.run_date
-                      )}
-                      scroll={false}
-                      className="truncate font-medium text-text-primary hover:text-fin-blue hover:underline"
+                    <button
+                      type="button"
+                      onClick={() => onOpenBrief(r.source_file, r.run_date)}
+                      className="truncate text-left font-medium text-text-primary hover:text-fin-blue hover:underline"
                       title={`${r.broker_name ?? 'Unknown desk'} — why this weight? open brief ${r.source_file}`}
                     >
                       {r.broker_name ?? 'Unknown'}
-                    </Link>
+                    </button>
                     <span className="font-mono text-text-secondary">{r.currency}</span>
                     <span className={`text-xs font-medium ${directionColorClass(r.direction)}`}>
                       {r.direction || '—'}

--- a/frontend/olympus/components/twelve-x/MatrixTab.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.tsx
@@ -1,33 +1,41 @@
 'use client';
 
-import { useMemo } from 'react';
-import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { Grid3x3 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { ChevronRight, Grid3x3 } from 'lucide-react';
 
-import { briefHref } from './BriefPanel';
 import { G10_CURRENCIES } from '@/lib/twelve-x/types';
 import type { MatrixCell } from '@/lib/twelve-x/types';
 
-/** Map a currency-view direction to a .fin-* color + glyph for the matrix cell. */
-function directionStyle(direction: string): { text: string; bg: string; border: string; glyph: string } {
+const SCORE_MAX = 2;
+const LEAN_BAND = 0.35;
+const STRONG_BAND = 1.25;
+
+type Bucket = 'bull' | 'bear' | 'watch' | 'neutral';
+
+/** Map a currency-view direction onto a coarse bucket. */
+function directionBucket(direction: string): Bucket {
   const d = direction.trim().toLowerCase();
-  if (d === 'bullish' || d === 'long' || d === 'buy')
-    return { text: 'text-fin-green', bg: 'bg-fin-green/10', border: 'border-fin-green/30', glyph: '▲' };
-  if (d === 'bearish' || d === 'short' || d === 'sell')
-    return { text: 'text-fin-red', bg: 'bg-fin-red/10', border: 'border-fin-red/30', glyph: '▼' };
-  if (d === 'watch')
-    return { text: 'text-fin-amber', bg: 'bg-fin-amber/10', border: 'border-fin-amber/30', glyph: '◆' };
-  return { text: 'text-text-secondary', bg: 'bg-white/[0.03]', border: 'border-border-subtle', glyph: '•' };
+  if (d === 'bullish' || d === 'long' || d === 'buy') return 'bull';
+  if (d === 'bearish' || d === 'short' || d === 'sell') return 'bear';
+  if (d === 'watch') return 'watch';
+  return 'neutral';
 }
 
-/** Conviction → opacity weight so high-conviction cells read louder. */
-function convictionOpacity(conviction: string): number {
+/** Bucket → glyph + .fin-* text color for the per-desk rows. */
+function bucketStyle(bucket: Bucket): { text: string; glyph: string } {
+  if (bucket === 'bull') return { text: 'text-fin-green', glyph: '▲' };
+  if (bucket === 'bear') return { text: 'text-fin-red', glyph: '▼' };
+  if (bucket === 'watch') return { text: 'text-fin-amber', glyph: '◆' };
+  return { text: 'text-text-secondary', glyph: '•' };
+}
+
+/** Conviction → weight (matches the twelve-x consensus weighting). */
+function convictionWeight(conviction: string): number {
   const c = conviction.trim().toLowerCase();
   if (c === 'high') return 1;
-  if (c === 'medium' || c === 'mid') return 0.8;
-  if (c === 'low') return 0.6;
-  return 0.7;
+  if (c === 'medium' || c === 'mid') return 0.65;
+  if (c === 'low') return 0.35;
+  return 0.65;
 }
 
 function convictionLabel(conviction: string): string {
@@ -36,151 +44,259 @@ function convictionLabel(conviction: string): string {
   return c.charAt(0).toUpperCase() + c.slice(1).toLowerCase();
 }
 
-export default function MatrixTab({ cells }: { cells: MatrixCell[] }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+/** Plain-English net read — same bands as ConsensusTab so the suite stays consistent. */
+function scoreLabel(score: number): string {
+  if (score >= STRONG_BAND) return 'Strong bull';
+  if (score >= LEAN_BAND) return 'Bullish lean';
+  if (score <= -STRONG_BAND) return 'Strong bear';
+  if (score <= -LEAN_BAND) return 'Bearish lean';
+  return 'Neutral';
+}
 
-  // Brokers present (rows), alphabetical. Currencies (cols) in canonical G10
-  // order, falling back to any extras seen in the data.
-  const brokers = useMemo(
-    () => [...new Set(cells.map((c) => c.broker))].sort((a, b) => a.localeCompare(b)),
-    [cells]
+function scoreColorClass(score: number): string {
+  if (score >= LEAN_BAND) return 'text-fin-green';
+  if (score <= -LEAN_BAND) return 'text-fin-red';
+  return 'text-text-secondary';
+}
+
+interface CurrencyAgg {
+  currency: string;
+  cells: MatrixCell[];
+  bull: number;
+  bear: number;
+  watch: number;
+  neutral: number;
+  nDesks: number;
+  score: number;
+  thin: boolean;
+}
+
+/** Aggregate one currency's desk cells into a net lean + a split, porting the
+ * consensus score shape (tilt × (1 + agreement)) so the Matrix net lean doesn't
+ * visibly disagree with the Consensus tab. */
+function aggregate(currency: string, cells: MatrixCell[]): CurrencyAgg {
+  let bull = 0;
+  let bear = 0;
+  let watch = 0;
+  let neutral = 0;
+  let tiltSum = 0;
+  for (const c of cells) {
+    const b = directionBucket(c.direction);
+    if (b === 'bull') bull++;
+    else if (b === 'bear') bear++;
+    else if (b === 'watch') watch++;
+    else neutral++;
+    const dir = b === 'bull' ? 1 : b === 'bear' ? -1 : 0;
+    tiltSum += dir * convictionWeight(c.conviction);
+  }
+  const n = cells.length;
+  const tilt = n > 0 ? tiltSum / n : 0;
+  const directional = bull + bear;
+  const agreement = directional > 0 ? Math.min(1, Math.max(0, (Math.max(bull, bear) / directional - 0.5) / 0.5)) : 0;
+  const score = Math.min(SCORE_MAX, Math.max(-SCORE_MAX, tilt * (1 + agreement)));
+  const nDesks = new Set(cells.map((c) => c.broker)).size;
+  return { currency, cells, bull, bear, watch, neutral, nDesks, score, thin: nDesks < 2 };
+}
+
+/** Order the per-desk rows within an expanded currency: bull, bear, then watch/neutral. */
+const BUCKET_ORDER: Bucket[] = ['bull', 'bear', 'watch', 'neutral'];
+
+function DeskRow({
+  cell,
+  onOpenBrief,
+}: {
+  cell: MatrixCell;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+}) {
+  const bucket = directionBucket(cell.direction);
+  const s = bucketStyle(bucket);
+  const date = cell.report_date || cell.run_date;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenBrief(cell.source_file, cell.run_date)}
+      className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+      title={`${cell.broker} · ${cell.direction}${cell.conviction ? ` (${cell.conviction})` : ''}${
+        cell.signal ? ` — ${cell.signal}` : ''
+      } · ${date} — open brief`}
+    >
+      <span className={`w-3 shrink-0 text-center text-sm leading-none ${s.text}`} aria-hidden>
+        {s.glyph}
+      </span>
+      <span className="w-40 shrink-0 truncate text-sm font-medium text-text-primary">{cell.broker}</span>
+      {cell.conviction ? (
+        <span className="shrink-0 rounded border border-border-subtle bg-white/[0.04] px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-text-muted">
+          {convictionLabel(cell.conviction)}
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">{cell.signal || ''}</span>
+      <span className="shrink-0 font-mono text-[10px] text-text-muted/70">{date?.slice(5) ?? ''}</span>
+    </button>
   );
+}
 
-  const currencies = useMemo<string[]>(() => {
-    const present = new Set(cells.map((c) => c.currency));
-    const ordered: string[] = G10_CURRENCIES.filter((c) => present.has(c));
-    const orderedSet = new Set(ordered);
-    const extras = [...present].filter((c) => !orderedSet.has(c)).sort();
-    return [...ordered, ...extras];
+function CurrencyAccordion({
+  agg,
+  open,
+  onToggle,
+  onOpenBrief,
+}: {
+  agg: CurrencyAgg;
+  open: boolean;
+  onToggle: () => void;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+}) {
+  const frac = Math.min(1, Math.abs(agg.score) / SCORE_MAX);
+  const bullish = agg.score >= 0;
+  const colorClass = scoreColorClass(agg.score);
+
+  return (
+    <div className={agg.thin ? 'opacity-60' : ''}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="grid w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/[0.02]"
+        style={{ gridTemplateColumns: 'minmax(56px,64px) minmax(120px,1fr) 96px minmax(120px,180px) 64px 20px' }}
+        aria-expanded={open}
+      >
+        {/* Currency */}
+        <span className="font-mono text-sm font-semibold text-text-primary">{agg.currency}</span>
+
+        {/* Net-lean bar (centered zero, fills right=bull / left=bear) */}
+        <div className="flex items-center gap-2">
+          <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-white/[0.05]">
+            <div className="absolute inset-y-0 left-1/2 w-px bg-white/20" />
+            <div
+              className={`absolute inset-y-0 ${bullish ? 'left-1/2' : 'right-1/2'} ${
+                bullish ? 'bg-fin-green' : 'bg-fin-red'
+              }`}
+              style={{ width: `${frac * 50}%` }}
+            />
+          </div>
+          <span className={`qn-metric w-10 shrink-0 text-right tabular-nums ${colorClass}`}>
+            {agg.score.toFixed(2)}
+          </span>
+        </div>
+
+        {/* Plain-English label */}
+        <span className={`text-xs font-medium ${colorClass}`}>{scoreLabel(agg.score)}</span>
+
+        {/* Split chip — desk counts by direction */}
+        <span className="flex items-center gap-2 text-[11px] tabular-nums">
+          <span className="text-fin-green">▲{agg.bull}</span>
+          <span className="text-fin-red">▼{agg.bear}</span>
+          {agg.watch > 0 ? <span className="text-fin-amber">◆{agg.watch}</span> : null}
+          {agg.neutral > 0 ? <span className="text-text-muted">•{agg.neutral}</span> : null}
+        </span>
+
+        {/* Coverage */}
+        <span className="text-right text-[11px] text-text-muted">
+          {agg.nDesks} desk{agg.nDesks === 1 ? '' : 's'}
+          {agg.thin ? <span className="ml-1 text-text-muted/60">· thin</span> : null}
+        </span>
+
+        <ChevronRight
+          size={14}
+          aria-hidden
+          className={`text-text-muted transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+      </button>
+
+      {open ? (
+        <div className="space-y-3 border-t border-border-subtle/60 bg-white/[0.01] px-3 py-3">
+          {BUCKET_ORDER.map((bucket) => {
+            const inBucket = agg.cells
+              .filter((c) => directionBucket(c.direction) === bucket)
+              .sort((a, b) => a.broker.localeCompare(b.broker));
+            if (inBucket.length === 0) return null;
+            const heading =
+              bucket === 'bull' ? 'Bull' : bucket === 'bear' ? 'Bear' : bucket === 'watch' ? 'Watch' : 'Neutral';
+            const headColor = bucketStyle(bucket).text;
+            return (
+              <div key={bucket}>
+                <p className={`px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider ${headColor}`}>
+                  {heading} · {inBucket.length}
+                </p>
+                <div className="space-y-0.5">
+                  {inBucket.map((cell) => (
+                    <DeskRow key={`${cell.broker}-${cell.run_date}`} cell={cell} onOpenBrief={onOpenBrief} />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function MatrixTab({
+  cells,
+  onOpenBrief,
+}: {
+  cells: MatrixCell[];
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+}) {
+  // One aggregate per currency the desks actually cover, ordered by conviction
+  // strength (largest absolute net lean first) so the strongest reads sit on top.
+  const perCurrency = useMemo<CurrencyAgg[]>(() => {
+    const byCcy = new Map<string, MatrixCell[]>();
+    for (const c of cells) {
+      const list = byCcy.get(c.currency) ?? [];
+      list.push(c);
+      byCcy.set(c.currency, list);
+    }
+    const order = (ccy: string) => {
+      const i = (G10_CURRENCIES as readonly string[]).indexOf(ccy);
+      return i === -1 ? G10_CURRENCIES.length : i;
+    };
+    return [...byCcy.entries()]
+      .map(([ccy, list]) => aggregate(ccy, list))
+      .sort((a, b) => {
+        const d = Math.abs(b.score) - Math.abs(a.score);
+        if (Math.abs(d) > 1e-9) return d;
+        return order(a.currency) - order(b.currency);
+      });
   }, [cells]);
 
-  // (broker, currency) → cell lookup.
-  const byCell = useMemo(() => {
-    const m = new Map<string, MatrixCell>();
-    for (const c of cells) m.set(`${c.broker}\u001f${c.currency}`, c);
-    return m;
-  }, [cells]);
-
-  const hasData = brokers.length > 0 && currencies.length > 0;
-
-  // CSS grid template: a sticky broker label column + one column per currency.
-  const gridTemplate = `minmax(140px, 200px) repeat(${currencies.length}, minmax(64px, 1fr))`;
+  const [openCcy, setOpenCcy] = useState<string | null>(null);
+  const hasData = perCurrency.length > 0;
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3 px-1">
         <Grid3x3 size={18} className="shrink-0 text-fin-blue" aria-hidden />
-        <h2 className="text-base font-semibold text-text-primary md:text-lg">Desk view matrix</h2>
+        <h2 className="text-base font-semibold text-text-primary md:text-lg">Desk view by currency</h2>
       </div>
 
       <p className="max-w-2xl px-1 text-xs text-text-muted">
-        Each desk&apos;s latest standing view per G10 currency over a recent window. Cells are colored
-        by direction and shaded by conviction; click any cell to drill into the source brief.
+        The street&apos;s net read per G10 currency over a recent window — scannable at a glance, ranked
+        by conviction. Expand a currency to see the desks behind it (bull / bear / watch) and click any
+        desk to open its brief.
       </p>
 
       {hasData ? (
         <div className="glass-card overflow-hidden p-0">
-          <div className="overflow-x-auto">
-            <div role="table" className="min-w-[680px] text-sm" aria-label="Broker by currency view matrix">
-              {/* Header row */}
-              <div
-                role="row"
-                className="grid items-stretch border-b border-border-subtle bg-bg-secondary"
-                style={{ gridTemplateColumns: gridTemplate }}
-              >
-                <div
-                  role="columnheader"
-                  className="sticky left-0 z-10 bg-bg-secondary px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted"
-                >
-                  Desk
-                </div>
-                {currencies.map((ccy) => (
-                  <div
-                    key={ccy}
-                    role="columnheader"
-                    className="px-2 py-2.5 text-center font-mono text-[11px] font-semibold text-text-secondary"
-                  >
-                    {ccy}
-                  </div>
-                ))}
-              </div>
-
-              {/* Body rows */}
-              <div role="rowgroup" className="divide-y divide-border-subtle">
-                {brokers.map((broker) => (
-                  <div
-                    key={broker}
-                    role="row"
-                    className="grid items-stretch"
-                    style={{ gridTemplateColumns: gridTemplate }}
-                  >
-                    <div
-                      role="rowheader"
-                      className="sticky left-0 z-10 flex items-center truncate bg-bg-secondary px-4 py-2 font-medium text-text-primary"
-                      title={broker}
-                    >
-                      <span className="truncate">{broker}</span>
-                    </div>
-                    {currencies.map((ccy) => {
-                      const cell = byCell.get(`${broker}\u001f${ccy}`);
-                      if (!cell) {
-                        return (
-                          <div
-                            key={ccy}
-                            role="cell"
-                            className="flex items-center justify-center px-1 py-2 text-text-muted/40"
-                            aria-label={`${broker} ${ccy}: no view`}
-                          >
-                            <span aria-hidden>·</span>
-                          </div>
-                        );
-                      }
-                      const s = directionStyle(cell.direction);
-                      return (
-                        <div key={ccy} role="cell" className="p-1">
-                          <Link
-                            href={briefHref(
-                              pathname,
-                              new URLSearchParams(searchParams.toString()),
-                              cell.source_file,
-                              cell.run_date
-                            )}
-                            scroll={false}
-                            className={`flex h-full flex-col items-center justify-center gap-0.5 rounded-md border ${s.bg} ${s.border} px-1 py-1.5 text-center transition-colors hover:border-fin-blue/50 hover:bg-white/[0.05]`}
-                            style={{ opacity: convictionOpacity(cell.conviction) }}
-                            title={`${broker} · ${ccy} · ${cell.direction}${
-                              cell.conviction ? ` (${cell.conviction})` : ''
-                            }${cell.signal ? ` — ${cell.signal}` : ''} · ${cell.run_date}`}
-                          >
-                            <span className={`text-sm leading-none ${s.text}`} aria-hidden>
-                              {s.glyph}
-                            </span>
-                            {cell.conviction ? (
-                              <span className="text-[9px] uppercase leading-none text-text-muted">
-                                {convictionLabel(cell.conviction)}
-                              </span>
-                            ) : null}
-                            <span className="font-mono text-[9px] leading-none text-text-muted/70">
-                              {cell.run_date.slice(5)}
-                            </span>
-                          </Link>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ))}
-              </div>
-            </div>
+          <div className="divide-y divide-border-subtle">
+            {perCurrency.map((agg) => (
+              <CurrencyAccordion
+                key={agg.currency}
+                agg={agg}
+                open={openCcy === agg.currency}
+                onToggle={() => setOpenCcy((cur) => (cur === agg.currency ? null : agg.currency))}
+                onOpenBrief={onOpenBrief}
+              />
+            ))}
           </div>
 
           {/* Legend */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border-subtle bg-bg-secondary px-4 py-2.5 text-[11px] text-text-muted">
             <span className="flex items-center gap-1.5">
-              <span className="text-fin-green" aria-hidden>▲</span> Bullish
+              <span className="text-fin-green" aria-hidden>▲</span> Bull
             </span>
             <span className="flex items-center gap-1.5">
-              <span className="text-fin-red" aria-hidden>▼</span> Bearish
+              <span className="text-fin-red" aria-hidden>▼</span> Bear
             </span>
             <span className="flex items-center gap-1.5">
               <span className="text-fin-amber" aria-hidden>◆</span> Watch
@@ -188,7 +304,7 @@ export default function MatrixTab({ cells }: { cells: MatrixCell[] }) {
             <span className="flex items-center gap-1.5">
               <span className="text-text-secondary" aria-hidden>•</span> Neutral
             </span>
-            <span className="ml-auto">Brighter = higher conviction · date = latest view</span>
+            <span className="ml-auto">Bar = net lean · click a currency to expand its desks</span>
           </div>
         </div>
       ) : (

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   CalendarClock,
   CalendarDays,
@@ -46,6 +45,9 @@ type TwelveXTab = 'today' | 'consensus' | 'intelligence' | 'events' | 'matrix' |
 
 type DigestData = Awaited<ReturnType<typeof getLatestDigest>>;
 
+/** A brief drill-down target: the source_file key plus the run that owns it. */
+export type BriefTarget = { sourceFile: string; runDate: string | null };
+
 interface TwelveXData {
   digest: DigestData;
   confluence: FxConfluenceSnapshotRow[];
@@ -67,11 +69,34 @@ function resolveTab(urlTab: string | null): TwelveXTab {
   return 'today';
 }
 
-function TwelveXInner({ urlTab }: { urlTab: string | null }) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+/** Read a query param from the live URL (client only) — used once to seed state. */
+function readParam(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get(key);
+}
 
+/**
+ * Sync in-page state (tab / open brief / ledger currency) to the URL with
+ * history.replaceState — NOT the Next router. Under this suite's static export
+ * (output:'export' + trailingSlash) router.replace query-nav is unreliable and
+ * was the cause of tabs not switching / blank pages, so all control flow is
+ * local React state and the URL is mirrored only for deep-link/shareability.
+ */
+function syncUrl(tab: TwelveXTab, brief: BriefTarget | null, ledgerCcy: string | null): void {
+  if (typeof window === 'undefined') return;
+  const p = new URLSearchParams();
+  if (tab !== 'today') p.set('tab', tab);
+  if (brief?.sourceFile) {
+    p.set('brief', brief.sourceFile);
+    if (brief.runDate) p.set('briefDate', brief.runDate);
+  }
+  if (ledgerCcy) p.set('ledgerCcy', ledgerCcy);
+  const qs = p.toString();
+  const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+  window.history.replaceState(window.history.state, '', url);
+}
+
+export default function TwelveXClient() {
   // Resolve configuration once, synchronously, so the effect never has to call
   // setState in its body (which triggers cascading renders).
   const [configured] = useState(() => isTwelveXConfigured());
@@ -79,40 +104,50 @@ function TwelveXInner({ urlTab }: { urlTab: string | null }) {
   const [loading, setLoading] = useState(configured);
   const [error, setError] = useState<string | null>(configured ? null : 'unconfigured');
 
+  // In-page navigation state — local, seeded once from the URL for deep links.
+  const [tab, setTabState] = useState<TwelveXTab>(() => resolveTab(readParam('tab')));
+  const [brief, setBrief] = useState<BriefTarget | null>(() => {
+    const sf = readParam('brief');
+    return sf ? { sourceFile: sf, runDate: readParam('briefDate') } : null;
+  });
+  const [ledgerCcy, setLedgerCcy] = useState<string | null>(() => readParam('ledgerCcy'));
+
   // Ledger (P4) loads lazily by selected run_date so the audit table can be
   // re-pointed without refetching the whole workspace.
   const [ledgerRun, setLedgerRun] = useState<string | null>(null);
   const [ledgerRows, setLedgerRows] = useState<FxLedgerRow[]>([]);
 
-  const tab: TwelveXTab = resolveTab(urlTab);
-
-  const replaceQuery = useCallback(
-    (mutate: (p: URLSearchParams) => void) => {
-      const p = new URLSearchParams(searchParams.toString());
-      mutate(p);
-      const s = p.toString();
-      router.replace(s ? `${pathname}?${s}` : pathname, { scroll: false });
-    },
-    [pathname, router, searchParams]
-  );
-
   const setTab = useCallback(
     (next: TwelveXTab) => {
-      replaceQuery((p) => p.set('tab', next));
+      setTabState(next);
+      syncUrl(next, brief, ledgerCcy);
     },
-    [replaceQuery]
+    [brief, ledgerCcy]
   );
 
+  const openBrief = useCallback(
+    (sourceFile: string, runDate: string | null) => {
+      const next = { sourceFile, runDate };
+      setBrief(next);
+      syncUrl(tab, next, ledgerCcy);
+    },
+    [tab, ledgerCcy]
+  );
+
+  const closeBrief = useCallback(() => {
+    setBrief(null);
+    syncUrl(tab, null, ledgerCcy);
+  }, [tab, ledgerCcy]);
+
   // "Why this weight?" from a consensus cell → jump to the ledger tab, pre-filtered
-  // to that currency (ledgerCcy is read by LedgerTab as its initial currency filter).
+  // to that currency.
   const drillToLedger = useCallback(
     (currency: string) => {
-      replaceQuery((p) => {
-        p.set('tab', 'ledger');
-        p.set('ledgerCcy', currency);
-      });
+      setTabState('ledger');
+      setLedgerCcy(currency);
+      syncUrl('ledger', brief, currency);
     },
-    [replaceQuery]
+    [brief]
   );
 
   useEffect(() => {
@@ -296,29 +331,31 @@ function TwelveXInner({ urlTab }: { urlTab: string | null }) {
             events={data?.upcomingEvents ?? []}
             opinions={data?.eventOpinions ?? []}
             runDate={eventOpinionsDate}
+            onOpenBrief={openBrief}
           />
         ) : tab === 'matrix' ? (
-          <MatrixTab cells={data?.matrix ?? []} />
+          <MatrixTab cells={data?.matrix ?? []} onOpenBrief={openBrief} />
         ) : tab === 'ledger' ? (
           <LedgerTab
             rows={ledgerRows}
             runDate={ledgerRun}
             runDates={data?.ledgerRunDates ?? []}
             onSelectRun={selectLedgerRun}
+            ccy={ledgerCcy}
+            onOpenBrief={openBrief}
           />
         ) : (
           <TodayTab digest={data?.digest ?? null} confluence={data?.confluence ?? []} />
         )}
       </div>
 
-      {/* Slide-over brief panel — opens on ?brief=<source_file> from any tab. */}
-      <BriefPanel />
+      {/* Slide-over brief panel — local state, no router. */}
+      <BriefPanel
+        open={!!brief}
+        sourceFile={brief?.sourceFile ?? null}
+        runDate={brief?.runDate ?? null}
+        onClose={closeBrief}
+      />
     </div>
   );
-}
-
-export default function TwelveXClient() {
-  const searchParams = useSearchParams();
-  const urlTab = searchParams.get('tab');
-  return <TwelveXInner urlTab={urlTab} />;
 }


### PR DESCRIPTION
Fixes the reported tab-navigation bug, simplifies the Matrix, and clears the high-severity findings from the per-tab review pass.

**Tab nav (the bug):** in-page state (tab / brief slide-over / ledger currency) was driven by `router.replace('?tab=')`. Under static export + `trailingSlash`, `usePathname()` returns `/twelve-x` while the only exported HTML is `/twelve-x/`, so the soft navigation no-ops (tab doesn't switch) or tears down the subtree (blank page). Moved all in-page state to **local React state** synced to the URL via `history.replaceState` — no Next router — matching the working Observability pattern. `BriefPanel` is now prop-driven; cell drill-downs are buttons calling `onOpenBrief`.

**Matrix:** replaced the dense desk×currency grid with a **per-currency accordion** — one scannable row per G10 currency (net-lean bar + plain label + bull/bear/watch/neutral counts + coverage), ranked by conviction, expandable into the desk-by-desk calls with brief drill-down. Mirrors the Notion consensus pivot.

**Review fixes:**
- **Intelligence:** `brief_keys` are supporting *desk names*, not `source_file` keys — the "N sources" link never resolved. Now rendered as a desk list.
- **Events:** ~half of catalysts dropped their broker opinions (snapshot "US FOMC Statement" vs calendar "FOMC Statement"). Added a country-stripped, country-qualified fallback match.
- **Ledger:** `w_time/w_event/w_review` are uniform (all 1.0) in the data, so the stacked bar implied a breakdown that isn't there — now a flat bar + "uniform" tag when equal. (Upstream: the relevance decomposition isn't differentiating; flagged for the pipeline.)

`next build` green (incl. `/twelve-x`); vitest 106/106; tsc + eslint clean.

Part of #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)