### PR TITLE
fix(olympus): MotionLayer reveals client-navigated/tab-switched cards

### DIFF
--- a/frontend/olympus/components/motion-layer.tsx
+++ b/frontend/olympus/components/motion-layer.tsx
@@ -2,10 +2,22 @@
 /**
  * MotionLayer — non-invasive "comes to life" scroll reveals for the dashboard.
  * Adds `html.motion-on` only when motion is allowed (JS active + not reduced),
- * then reveals `.glass-card` and `[data-reveal]` elements as they scroll into
- * view. With JS off or reduced-motion, nothing is hidden (content always shown).
- * Pure CSS + IntersectionObserver — no animation library, no edits to the
- * data components, CSP-safe.
+ * then reveals `.glass-card` and `[data-reveal]` elements. With JS off or
+ * reduced-motion, nothing is hidden (content always shown). Pure CSS +
+ * IntersectionObserver — no animation library, no edits to data components,
+ * CSP-safe.
+ *
+ * `motion-on` hides un-revealed cards (opacity:0), so the reveal MUST be
+ * bullet-proof or content silently disappears. This effect runs once and the
+ * layout never remounts, so client-side navigation and tab switches mount fresh
+ * cards into a live DOM. Two rules keep those visible:
+ *   1. Cards already in the viewport at scan time are revealed immediately
+ *      instead of waiting on the observer — an above-the-fold card mounted by a
+ *      tab switch would otherwise never receive an intersection callback and
+ *      stay invisible until a hard refresh.
+ *   2. The MutationObserver lives for the page's lifetime (rAF-debounced) so
+ *      panels that mount after navigation are always re-scanned. It previously
+ *      self-disconnected after 8s, which left anything mounted later hidden.
  */
 import { useEffect } from "react";
 
@@ -28,21 +40,46 @@ export default function MotionLayer() {
       { rootMargin: "0px 0px -8% 0px", threshold: 0.08 }
     );
 
+    const inViewport = (el: HTMLElement) => {
+      const r = el.getBoundingClientRect();
+      return r.bottom > 0 && r.top < (window.innerHeight || document.documentElement.clientHeight);
+    };
+
     const observe = () => {
       document.querySelectorAll<HTMLElement>(".glass-card, [data-reveal]").forEach((el) => {
         if (seen.has(el)) return;
         seen.add(el);
-        // already-visible-on-load elements reveal immediately (no flash of empty)
-        io.observe(el);
+        // Reveal anything already on-screen now (initial load, or a card mounted
+        // above the fold by client-side nav / a tab switch); only defer to the
+        // observer for cards genuinely below the fold.
+        if (inViewport(el)) {
+          el.classList.add("reveal-in");
+        } else {
+          io.observe(el);
+        }
       });
     };
     observe();
-    // re-scan as client-rendered data panels mount
-    const mo = new MutationObserver(observe);
-    mo.observe(document.body, { childList: true, subtree: true });
-    const stop = setTimeout(() => mo.disconnect(), 8000);
 
-    return () => { io.disconnect(); mo.disconnect(); clearTimeout(stop); root.classList.remove("motion-on"); };
+    // Re-scan as client-rendered data panels mount — for the page's lifetime,
+    // debounced to one scan per frame so a busy dashboard stays cheap.
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        observe();
+      });
+    };
+    const mo = new MutationObserver(schedule);
+    mo.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      io.disconnect();
+      mo.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+      root.classList.remove("motion-on");
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
Fast-tracks the MotionLayer reveal fix straight to `develop` so it deploys across the whole Olympus app now. This is the cherry-picked commit from **#815** (same one-file change, original authorship preserved) — landing on develop directly because the bug is live and hitting every page.

**Bug:** on client-side navigation / tab switches, static text renders but DB-backed `.glass-card` panels stay invisible until a hard refresh. `MotionLayer` hides un-revealed cards (`opacity:0` via `html.motion-on`); its effect ran once and its MutationObserver self-disconnected after 8s, so any card mounted by a navigation after the first 8s never got revealed.

**Fix (`components/motion-layer.tsx`):** reveal cards already in the viewport at scan time immediately (don't wait on the observer), and keep the MutationObserver alive for the page's lifetime (rAF-debounced). Reduced-motion / no-IO behavior unchanged.

Resolves the issue on all Olympus pages + the twelve-x tabs. lint + tsc clean locally; CI build/test to confirm.

Supersedes #815 for the develop deploy (cross-referenced there).

Part of #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)