### PR TITLE
docs(workflow): sync module branches with develop before branching (#814)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,17 @@ main ← develop ← module/<component> ← task/<N>-slug
 
 Use `make task ISSUE=N` to create a `task/N-slug` branch from the right module branch. Task branches PR into their module branch; module branches PR into develop. Never do module-specific work on `develop` directly.
 
+**Sync the module branch with develop *before* you branch off it.** Module branches drift behind `develop` fast because we iterate on develop constantly — and a task branch cut from a stale module branch edits dead code. (Real incident, 2026-06-17: `module/digiquant` was ~2 months / ~400 commits behind, predating the `apps/digiquant-atlas → digiquant/src/digiquant/olympus` migration; backend PRs cut from it touched files that no longer exist on develop.) `make task ISSUE=N` does **not** sync for you — check first:
+
+```bash
+git fetch origin
+git rev-list --count origin/module/<component>..origin/develop   # 0 = current; >0 = stale, sync before branching
+```
+
+Module branches are guarded by the `module-branch-protection` ruleset: **no force-push, no deletion, PR required (0 approvals)**. So you cannot `git push --force` to refresh a stale module branch. To sync one, open a normal PR into `base=module/<component>` — either `head=develop`, or a `chore/sync-*` branch whose tree equals develop (a `-s ours` merge with the index reset to develop's tree preserves the module branch's prior history) — and merge it (no approval needed). Branch names must match `{feat,fix,docs,chore}/<slug>` or `task/<N>-slug`.
+
+The **Check linkage** CI gate (the `Require Fixes` check) is separate from the branch-name rule: it only auto-links a PR via a `task/<N>-slug` branch **or** a `Fixes/Closes/Resolves #N` keyword in the body. A `feat|fix|docs|chore/<slug>` branch passes the name rule but still **fails linkage** unless the body says `Fixes #N` — so prefer `task/<N>-slug` for issue-linked work (and never `Closes #N` against an umbrella tracking issue you don't want auto-closed).
+
 ## Liveness vs status
 
 - `GET /healthz` — liveness probe, auth-exempt, always `{"ok": true}`, no downstream checks


### PR DESCRIPTION
Adds the guardrail after the module/digiquant staleness incident. (Re-cut from a task/814- branch so the Check-linkage gate passes; supersedes #822.)

CLAUDE.md → Branching model now requires checking `git rev-list --count origin/module/<c>..origin/develop` before cutting a task branch, documents the `module-branch-protection` ruleset (no force-push/deletion, PR-required/0-approvals) + how to sync via PR, and notes the Check-linkage gate (task/<N>- branch or Fixes #N).

Part of #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)