### PR TITLE
fix(olympus): Matrix matches the Notion board — broker rows × G10 columns

### DIFF
--- a/frontend/olympus/components/twelve-x/MatrixTab.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.tsx
@@ -1,234 +1,30 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import { ChevronRight, Grid3x3 } from 'lucide-react';
+import { useMemo } from 'react';
+import { Grid3x3 } from 'lucide-react';
 
-import { G10_CURRENCIES } from '@/lib/twelve-x/types';
+import { MATRIX_COLUMNS } from '@/lib/twelve-x/types';
 import type { MatrixCell } from '@/lib/twelve-x/types';
 
-const SCORE_MAX = 2;
-const LEAN_BAND = 0.35;
-const STRONG_BAND = 1.25;
-
-type Bucket = 'bull' | 'bear' | 'watch' | 'neutral';
-
-/** Map a currency-view direction onto a coarse bucket. */
-function directionBucket(direction: string): Bucket {
+/** Map a currency-view direction to a .fin-* color + glyph for the matrix cell. */
+function directionStyle(direction: string): { text: string; bg: string; border: string; glyph: string } {
   const d = direction.trim().toLowerCase();
-  if (d === 'bullish' || d === 'long' || d === 'buy') return 'bull';
-  if (d === 'bearish' || d === 'short' || d === 'sell') return 'bear';
-  if (d === 'watch') return 'watch';
-  return 'neutral';
+  if (d === 'bullish' || d === 'long' || d === 'buy')
+    return { text: 'text-fin-green', bg: 'bg-fin-green/10', border: 'border-fin-green/30', glyph: '▲' };
+  if (d === 'bearish' || d === 'short' || d === 'sell')
+    return { text: 'text-fin-red', bg: 'bg-fin-red/10', border: 'border-fin-red/30', glyph: '▼' };
+  if (d === 'watch')
+    return { text: 'text-fin-amber', bg: 'bg-fin-amber/10', border: 'border-fin-amber/30', glyph: '◆' };
+  return { text: 'text-text-secondary', bg: 'bg-white/[0.03]', border: 'border-border-subtle', glyph: '•' };
 }
 
-/** Bucket → glyph + .fin-* text color for the per-desk rows. */
-function bucketStyle(bucket: Bucket): { text: string; glyph: string } {
-  if (bucket === 'bull') return { text: 'text-fin-green', glyph: '▲' };
-  if (bucket === 'bear') return { text: 'text-fin-red', glyph: '▼' };
-  if (bucket === 'watch') return { text: 'text-fin-amber', glyph: '◆' };
-  return { text: 'text-text-secondary', glyph: '•' };
-}
-
-/** Conviction → weight (matches the twelve-x consensus weighting). */
-function convictionWeight(conviction: string): number {
+/** Conviction → opacity weight so high-conviction cells read louder. */
+function convictionOpacity(conviction: string): number {
   const c = conviction.trim().toLowerCase();
   if (c === 'high') return 1;
-  if (c === 'medium' || c === 'mid') return 0.65;
-  if (c === 'low') return 0.35;
-  return 0.65;
-}
-
-function convictionLabel(conviction: string): string {
-  const c = conviction.trim();
-  if (!c) return '';
-  return c.charAt(0).toUpperCase() + c.slice(1).toLowerCase();
-}
-
-/** Plain-English net read — same bands as ConsensusTab so the suite stays consistent. */
-function scoreLabel(score: number): string {
-  if (score >= STRONG_BAND) return 'Strong bull';
-  if (score >= LEAN_BAND) return 'Bullish lean';
-  if (score <= -STRONG_BAND) return 'Strong bear';
-  if (score <= -LEAN_BAND) return 'Bearish lean';
-  return 'Neutral';
-}
-
-function scoreColorClass(score: number): string {
-  if (score >= LEAN_BAND) return 'text-fin-green';
-  if (score <= -LEAN_BAND) return 'text-fin-red';
-  return 'text-text-secondary';
-}
-
-interface CurrencyAgg {
-  currency: string;
-  cells: MatrixCell[];
-  bull: number;
-  bear: number;
-  watch: number;
-  neutral: number;
-  nDesks: number;
-  score: number;
-  thin: boolean;
-}
-
-/** Aggregate one currency's desk cells into a net lean + a split, porting the
- * consensus score shape (tilt × (1 + agreement)) so the Matrix net lean doesn't
- * visibly disagree with the Consensus tab. */
-function aggregate(currency: string, cells: MatrixCell[]): CurrencyAgg {
-  let bull = 0;
-  let bear = 0;
-  let watch = 0;
-  let neutral = 0;
-  let tiltSum = 0;
-  for (const c of cells) {
-    const b = directionBucket(c.direction);
-    if (b === 'bull') bull++;
-    else if (b === 'bear') bear++;
-    else if (b === 'watch') watch++;
-    else neutral++;
-    const dir = b === 'bull' ? 1 : b === 'bear' ? -1 : 0;
-    tiltSum += dir * convictionWeight(c.conviction);
-  }
-  const n = cells.length;
-  const tilt = n > 0 ? tiltSum / n : 0;
-  const directional = bull + bear;
-  const agreement = directional > 0 ? Math.min(1, Math.max(0, (Math.max(bull, bear) / directional - 0.5) / 0.5)) : 0;
-  const score = Math.min(SCORE_MAX, Math.max(-SCORE_MAX, tilt * (1 + agreement)));
-  const nDesks = new Set(cells.map((c) => c.broker)).size;
-  return { currency, cells, bull, bear, watch, neutral, nDesks, score, thin: nDesks < 2 };
-}
-
-/** Order the per-desk rows within an expanded currency: bull, bear, then watch/neutral. */
-const BUCKET_ORDER: Bucket[] = ['bull', 'bear', 'watch', 'neutral'];
-
-function DeskRow({
-  cell,
-  onOpenBrief,
-}: {
-  cell: MatrixCell;
-  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
-}) {
-  const bucket = directionBucket(cell.direction);
-  const s = bucketStyle(bucket);
-  const date = cell.report_date || cell.run_date;
-  return (
-    <button
-      type="button"
-      onClick={() => onOpenBrief(cell.source_file, cell.run_date)}
-      className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
-      title={`${cell.broker} · ${cell.direction}${cell.conviction ? ` (${cell.conviction})` : ''}${
-        cell.signal ? ` — ${cell.signal}` : ''
-      } · ${date} — open brief`}
-    >
-      <span className={`w-3 shrink-0 text-center text-sm leading-none ${s.text}`} aria-hidden>
-        {s.glyph}
-      </span>
-      <span className="w-40 shrink-0 truncate text-sm font-medium text-text-primary">{cell.broker}</span>
-      {cell.conviction ? (
-        <span className="shrink-0 rounded border border-border-subtle bg-white/[0.04] px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-text-muted">
-          {convictionLabel(cell.conviction)}
-        </span>
-      ) : null}
-      <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">{cell.signal || ''}</span>
-      <span className="shrink-0 font-mono text-[10px] text-text-muted/70">{date?.slice(5) ?? ''}</span>
-    </button>
-  );
-}
-
-function CurrencyAccordion({
-  agg,
-  open,
-  onToggle,
-  onOpenBrief,
-}: {
-  agg: CurrencyAgg;
-  open: boolean;
-  onToggle: () => void;
-  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
-}) {
-  const frac = Math.min(1, Math.abs(agg.score) / SCORE_MAX);
-  const bullish = agg.score >= 0;
-  const colorClass = scoreColorClass(agg.score);
-
-  return (
-    <div className={agg.thin ? 'opacity-60' : ''}>
-      <button
-        type="button"
-        onClick={onToggle}
-        className="grid w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/[0.02]"
-        style={{ gridTemplateColumns: 'minmax(56px,64px) minmax(120px,1fr) 96px minmax(120px,180px) 64px 20px' }}
-        aria-expanded={open}
-      >
-        {/* Currency */}
-        <span className="font-mono text-sm font-semibold text-text-primary">{agg.currency}</span>
-
-        {/* Net-lean bar (centered zero, fills right=bull / left=bear) */}
-        <div className="flex items-center gap-2">
-          <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-white/[0.05]">
-            <div className="absolute inset-y-0 left-1/2 w-px bg-white/20" />
-            <div
-              className={`absolute inset-y-0 ${bullish ? 'left-1/2' : 'right-1/2'} ${
-                bullish ? 'bg-fin-green' : 'bg-fin-red'
-              }`}
-              style={{ width: `${frac * 50}%` }}
-            />
-          </div>
-          <span className={`qn-metric w-10 shrink-0 text-right tabular-nums ${colorClass}`}>
-            {agg.score.toFixed(2)}
-          </span>
-        </div>
-
-        {/* Plain-English label */}
-        <span className={`text-xs font-medium ${colorClass}`}>{scoreLabel(agg.score)}</span>
-
-        {/* Split chip — desk counts by direction */}
-        <span className="flex items-center gap-2 text-[11px] tabular-nums">
-          <span className="text-fin-green">▲{agg.bull}</span>
-          <span className="text-fin-red">▼{agg.bear}</span>
-          {agg.watch > 0 ? <span className="text-fin-amber">◆{agg.watch}</span> : null}
-          {agg.neutral > 0 ? <span className="text-text-muted">•{agg.neutral}</span> : null}
-        </span>
-
-        {/* Coverage */}
-        <span className="text-right text-[11px] text-text-muted">
-          {agg.nDesks} desk{agg.nDesks === 1 ? '' : 's'}
-          {agg.thin ? <span className="ml-1 text-text-muted/60">· thin</span> : null}
-        </span>
-
-        <ChevronRight
-          size={14}
-          aria-hidden
-          className={`text-text-muted transition-transform ${open ? 'rotate-90' : ''}`}
-        />
-      </button>
-
-      {open ? (
-        <div className="space-y-3 border-t border-border-subtle/60 bg-white/[0.01] px-3 py-3">
-          {BUCKET_ORDER.map((bucket) => {
-            const inBucket = agg.cells
-              .filter((c) => directionBucket(c.direction) === bucket)
-              .sort((a, b) => a.broker.localeCompare(b.broker));
-            if (inBucket.length === 0) return null;
-            const heading =
-              bucket === 'bull' ? 'Bull' : bucket === 'bear' ? 'Bear' : bucket === 'watch' ? 'Watch' : 'Neutral';
-            const headColor = bucketStyle(bucket).text;
-            return (
-              <div key={bucket}>
-                <p className={`px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider ${headColor}`}>
-                  {heading} · {inBucket.length}
-                </p>
-                <div className="space-y-0.5">
-                  {inBucket.map((cell) => (
-                    <DeskRow key={`${cell.broker}-${cell.run_date}`} cell={cell} onOpenBrief={onOpenBrief} />
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
+  if (c === 'medium' || c === 'mid') return 0.85;
+  if (c === 'low') return 0.65;
+  return 0.78;
 }
 
 export default function MatrixTab({
@@ -238,65 +34,139 @@ export default function MatrixTab({
   cells: MatrixCell[];
   onOpenBrief: (sourceFile: string, runDate: string | null) => void;
 }) {
-  // One aggregate per currency the desks actually cover, ordered by conviction
-  // strength (largest absolute net lean first) so the strongest reads sit on top.
-  const perCurrency = useMemo<CurrencyAgg[]>(() => {
-    const byCcy = new Map<string, MatrixCell[]>();
-    for (const c of cells) {
-      const list = byCcy.get(c.currency) ?? [];
-      list.push(c);
-      byCcy.set(c.currency, list);
-    }
-    const order = (ccy: string) => {
-      const i = (G10_CURRENCIES as readonly string[]).indexOf(ccy);
-      return i === -1 ? G10_CURRENCIES.length : i;
-    };
-    return [...byCcy.entries()]
-      .map(([ccy, list]) => aggregate(ccy, list))
-      .sort((a, b) => {
-        const d = Math.abs(b.score) - Math.abs(a.score);
-        if (Math.abs(d) > 1e-9) return d;
-        return order(a.currency) - order(b.currency);
-      });
+  // Brokers present (rows), alphabetical.
+  const brokers = useMemo(
+    () => [...new Set(cells.map((c) => c.broker))].sort((a, b) => a.localeCompare(b)),
+    [cells]
+  );
+
+  // (broker, column) → cell lookup. getMatrix already keeps one freshest cell per
+  // (broker, G10 column), so the column placement matches the Notion matrix.
+  const byCell = useMemo(() => {
+    const m = new Map<string, MatrixCell>();
+    for (const c of cells) m.set(`${c.broker}|${c.column}`, c);
+    return m;
   }, [cells]);
 
-  const [openCcy, setOpenCcy] = useState<string | null>(null);
-  const hasData = perCurrency.length > 0;
+  const hasData = brokers.length > 0;
+
+  // Sticky broker label column + one column per G10 currency (fixed 8).
+  const gridTemplate = `minmax(150px, 220px) repeat(${MATRIX_COLUMNS.length}, minmax(72px, 1fr))`;
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3 px-1">
         <Grid3x3 size={18} className="shrink-0 text-fin-blue" aria-hidden />
-        <h2 className="text-base font-semibold text-text-primary md:text-lg">Desk view by currency</h2>
+        <h2 className="text-base font-semibold text-text-primary md:text-lg">Desk view matrix</h2>
       </div>
 
       <p className="max-w-2xl px-1 text-xs text-text-muted">
-        The street&apos;s net read per G10 currency over a recent window — scannable at a glance, ranked
-        by conviction. Expand a currency to see the desks behind it (bull / bear / watch) and click any
-        desk to open its brief.
+        Each desk&apos;s latest standing view per G10 currency over a recent window — consolidated the
+        same way as the Notion board: a pair files under its base currency (EUR/USD → EUR), shown as
+        stated. Cells are colored by direction and shaded by conviction; click any cell to open the
+        source brief.
       </p>
 
       {hasData ? (
         <div className="glass-card overflow-hidden p-0">
-          <div className="divide-y divide-border-subtle">
-            {perCurrency.map((agg) => (
-              <CurrencyAccordion
-                key={agg.currency}
-                agg={agg}
-                open={openCcy === agg.currency}
-                onToggle={() => setOpenCcy((cur) => (cur === agg.currency ? null : agg.currency))}
-                onOpenBrief={onOpenBrief}
-              />
-            ))}
+          <div className="overflow-x-auto">
+            <div role="table" className="min-w-[760px] text-sm" aria-label="Broker by currency view matrix">
+              {/* Header row */}
+              <div
+                role="row"
+                className="grid items-stretch border-b border-border-subtle bg-bg-secondary"
+                style={{ gridTemplateColumns: gridTemplate }}
+              >
+                <div
+                  role="columnheader"
+                  className="sticky left-0 z-10 bg-bg-secondary px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted"
+                >
+                  Desk
+                </div>
+                {MATRIX_COLUMNS.map((ccy) => (
+                  <div
+                    key={ccy}
+                    role="columnheader"
+                    className="px-2 py-2.5 text-center font-mono text-[11px] font-semibold text-text-secondary"
+                  >
+                    {ccy}
+                  </div>
+                ))}
+              </div>
+
+              {/* Body rows */}
+              <div role="rowgroup" className="divide-y divide-border-subtle">
+                {brokers.map((broker) => (
+                  <div
+                    key={broker}
+                    role="row"
+                    className="grid items-stretch"
+                    style={{ gridTemplateColumns: gridTemplate }}
+                  >
+                    <div
+                      role="rowheader"
+                      className="sticky left-0 z-10 flex items-center truncate bg-bg-secondary px-4 py-2 font-medium text-text-primary"
+                      title={broker}
+                    >
+                      <span className="truncate">{broker}</span>
+                    </div>
+                    {MATRIX_COLUMNS.map((ccy) => {
+                      const cell = byCell.get(`${broker}|${ccy}`);
+                      if (!cell) {
+                        return (
+                          <div
+                            key={ccy}
+                            role="cell"
+                            className="flex items-center justify-center px-1 py-2 text-text-muted/40"
+                            aria-label={`${broker} ${ccy}: no view`}
+                          >
+                            <span aria-hidden>·</span>
+                          </div>
+                        );
+                      }
+                      const s = directionStyle(cell.direction);
+                      // A pair (e.g. EUR/USD filed under EUR) shows the instrument so it's
+                      // never misread as an outright single-currency call.
+                      const isPair = cell.currency.includes('/');
+                      return (
+                        <div key={ccy} role="cell" className="p-1">
+                          <button
+                            type="button"
+                            onClick={() => onOpenBrief(cell.source_file, cell.run_date)}
+                            className={`flex h-full w-full flex-col items-center justify-center gap-0.5 rounded-md border ${s.bg} ${s.border} px-1 py-1.5 text-center transition-colors hover:border-fin-blue/50 hover:bg-white/[0.05]`}
+                            style={{ opacity: convictionOpacity(cell.conviction) }}
+                            title={`${broker} · ${cell.currency} · ${cell.direction}${
+                              cell.conviction ? ` (${cell.conviction})` : ''
+                            }${cell.signal ? ` — ${cell.signal}` : ''} · ${cell.report_date ?? cell.run_date} — open brief`}
+                          >
+                            <span className={`text-sm leading-none ${s.text}`} aria-hidden>
+                              {s.glyph}
+                            </span>
+                            {isPair ? (
+                              <span className="font-mono text-[8px] leading-none text-text-muted/80">
+                                {cell.currency}
+                              </span>
+                            ) : null}
+                            <span className="font-mono text-[9px] leading-none text-text-muted/70">
+                              {(cell.report_date ?? cell.run_date).slice(5)}
+                            </span>
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
 
           {/* Legend */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-border-subtle bg-bg-secondary px-4 py-2.5 text-[11px] text-text-muted">
             <span className="flex items-center gap-1.5">
-              <span className="text-fin-green" aria-hidden>▲</span> Bull
+              <span className="text-fin-green" aria-hidden>▲</span> Bullish
             </span>
             <span className="flex items-center gap-1.5">
-              <span className="text-fin-red" aria-hidden>▼</span> Bear
+              <span className="text-fin-red" aria-hidden>▼</span> Bearish
             </span>
             <span className="flex items-center gap-1.5">
               <span className="text-fin-amber" aria-hidden>◆</span> Watch
@@ -304,7 +174,7 @@ export default function MatrixTab({
             <span className="flex items-center gap-1.5">
               <span className="text-text-secondary" aria-hidden>•</span> Neutral
             </span>
-            <span className="ml-auto">Bar = net lean · click a currency to expand its desks</span>
+            <span className="ml-auto">Brighter = higher conviction · a pair sits under its base ccy</span>
           </div>
         </div>
       ) : (

--- a/frontend/olympus/lib/twelve-x/fetch.test.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeKeyThemes } from './fetch';
+import { boardColumn, normalizeKeyThemes } from './fetch';
+
+/**
+ * `boardColumn` must consolidate broker view currencies into the 8 G10 matrix
+ * columns IDENTICALLY to the twelve-x Notion matrix (`nodes/publish.py`
+ * `_board_column`), so the two surfaces never disagree. This mirrors the
+ * authoritative mapping table in twelve-x `tests/test_publish_node.py`.
+ */
+describe('boardColumn (Notion-matrix-consistent currency consolidation)', () => {
+  it('files a single G10 currency under itself', () => {
+    expect(boardColumn('USD')).toBe('USD');
+    expect(boardColumn('EUR')).toBe('EUR');
+    expect(boardColumn('NZD')).toBe('NZD');
+  });
+
+  it('files a pair under its BASE (numerator) currency — no decomposition, no flip', () => {
+    expect(boardColumn('EUR/USD')).toBe('EUR');
+    expect(boardColumn('CAD/USD')).toBe('CAD');
+    expect(boardColumn('GBP/JPY')).toBe('GBP');
+  });
+
+  it('keeps NOK/SEK as valid legs but never as columns', () => {
+    expect(boardColumn('USD/SEK')).toBe('USD'); // Scandi quote leg is valid → base USD
+    expect(boardColumn('EUR/NOK')).toBe('EUR');
+    expect(boardColumn('NOK/SEK')).toBeNull(); // both legs valid, but base NOK has no column
+  });
+
+  it('drops any view with a leg outside the extended G10 set', () => {
+    expect(boardColumn('USD/IDR')).toBeNull(); // exotic quote
+    expect(boardColumn('EUR/TRY')).toBeNull();
+    expect(boardColumn('XAU/USD')).toBeNull(); // gold, not a currency
+  });
+
+  it('drops non-currency / junk instruments', () => {
+    expect(boardColumn('DXY')).toBeNull();
+    expect(boardColumn('US10Y')).toBeNull();
+    expect(boardColumn('GOLD')).toBeNull();
+    expect(boardColumn('')).toBeNull();
+  });
+
+  it('normalizes case and surrounding whitespace', () => {
+    expect(boardColumn('usd')).toBe('USD');
+    expect(boardColumn('  eur/usd  ')).toBe('EUR');
+  });
+});
 
 /**
  * `key_themes` arrives from Supabase in several shapes depending on whether the

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -12,6 +12,7 @@
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { isTwelveXConfigured, twelveXSupabase } from './supabase';
+import { MATRIX_COLUMNS } from './types';
 import type {
   CurrencyView,
   FxBriefRow,
@@ -22,6 +23,7 @@ import type {
   FxEventSnapshotRow,
   FxLedgerRow,
   MatrixCell,
+  MatrixColumn,
 } from './types';
 
 /**
@@ -350,22 +352,42 @@ export async function getBrief(
   return rows?.[0] ?? null;
 }
 
+// The extended leg-validity set: the 8 matrix columns + NOK/SEK. A pair is a
+// legitimate FX read only if BOTH legs are in this set (mirrors twelve-x
+// _EXTENDED_G10). NOK/SEK count as valid legs but never get their own column.
+const MATRIX_EXTENDED: readonly string[] = [...MATRIX_COLUMNS, 'NOK', 'SEK'];
+
 /**
- * The broker×currency matrix: the LATEST currency_view per (broker, currency)
- * over a recent window (default 14 days). Display grouping derived in TS from
- * `fx_research_history_v2.currency_views` — NOT the consensus math. The newest
- * brief (by run_date, then report_date) wins per cell. Returns `[]` when
- * unconfigured.
+ * Map a broker's view `currency` to its Research Matrix column, matching the
+ * twelve-x Notion matrix exactly (nodes/publish.py `_board_column`):
+ *   - upper/trim, split on "/";
+ *   - drop the view if ANY leg is outside the extended set (pairs with an exotic
+ *     leg, gold/XAU, DXY, indices, blanks -> no column);
+ *   - file under the BASE (numerator) currency only — NO pair decomposition and
+ *     NO direction flip ("EUR/USD bullish" -> EUR column, shown verbatim);
+ *   - the base must itself be one of the 8 columns (e.g. NOK/SEK -> dropped).
+ */
+export function boardColumn(currency: string): MatrixColumn | null {
+  const parts = currency.toUpperCase().trim().split('/');
+  if (parts.some((p) => !MATRIX_EXTENDED.includes(p))) return null;
+  const base = parts[0];
+  return (MATRIX_COLUMNS as readonly string[]).includes(base) ? (base as MatrixColumn) : null;
+}
+
+/**
+ * The broker x G10-currency matrix — the SAME consolidation the twelve-x Notion
+ * "Research Matrix" uses, so the two surfaces agree. The LATEST currency_view per
+ * (broker, board-column) over a recent window (default 14 days), filed under its
+ * base G10 currency via boardColumn (pairs land under the numerator; non-G10 /
+ * non-currency instruments are dropped). Newest brief (run_date, then report_date)
+ * wins per cell. Returns `[]` when unconfigured.
  */
 export async function getMatrix(windowDays = 14): Promise<MatrixCell[]> {
   const briefs = await getBriefs(windowDays);
   if (briefs.length === 0) return [];
 
-  // Walk every brief and keep the FRESHEST view per (broker, currency). ISO
-  // `YYYY-MM-DD` strings compare lexicographically == chronologically, so a
-  // plain `>` is an explicit, correct "is newer" test. Freshness orders by
-  // run_date first, then report_date as the tiebreak. (We don't rely on the
-  // incoming order — the comparison is what guarantees the latest view wins.)
+  // ISO `YYYY-MM-DD` strings compare lexicographically == chronologically, so a
+  // plain `>` is an explicit "is newer" test (run_date first, report_date tiebreak).
   const isNewer = (a: MatrixCell, b: MatrixCell): boolean => {
     if (a.run_date !== b.run_date) return a.run_date > b.run_date;
     return (a.report_date ?? '') > (b.report_date ?? '');
@@ -377,10 +399,13 @@ export async function getMatrix(windowDays = 14): Promise<MatrixCell[]> {
     if (!broker) continue;
     for (const v of asCurrencyViews(b.currency_views)) {
       if (!v.currency || !v.direction) continue;
-      const key = `${broker}\u001f${v.currency}`;
+      const column = boardColumn(v.currency);
+      if (!column) continue; // not a G10-mappable instrument — omitted from the grid
+      const key = `${broker}|${column}`;
       const candidate: MatrixCell = {
         broker,
-        currency: v.currency,
+        column,
+        currency: v.currency, // verbatim instrument (e.g. "EUR/USD") for display
         direction: v.direction,
         conviction: v.conviction,
         signal: v.signal,

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -22,6 +22,17 @@ export const G10_CURRENCIES = [
 export type G10Currency = (typeof G10_CURRENCIES)[number];
 
 /**
+ * The Research Matrix columns — the 8 board currencies, in the SAME order the
+ * twelve-x Notion matrix uses (`nodes/publish.py` `_board_column`). A broker
+ * currency_view is filed under its base currency only (pairs land under the
+ * numerator, e.g. EUR/USD → EUR); views whose legs fall outside the extended
+ * set (these 8 + NOK/SEK) are dropped. Kept deliberately separate from the
+ * 10-entry `G10_CURRENCIES` (which the consensus uses) so the grid matches Notion.
+ */
+export const MATRIX_COLUMNS = ['USD', 'EUR', 'GBP', 'AUD', 'CAD', 'CHF', 'JPY', 'NZD'] as const;
+export type MatrixColumn = (typeof MATRIX_COLUMNS)[number];
+
+/**
  * `fx_consensus_snapshot` — one row per G10 currency per run_date, for the
  * weighted (relevance-weighted live) view AND the unweighted (frozen) view.
  * PRIMARY KEY (run_date, currency, weighted).
@@ -193,7 +204,8 @@ export interface FxLedgerRow {
  */
 export interface MatrixCell {
   broker: string;
-  currency: string;
+  column: MatrixColumn; // the G10 board column this view files under (base currency)
+  currency: string; // the verbatim instrument as stated (e.g. "EUR/USD"), for display
   direction: string;
   conviction: string;
   signal?: string;


### PR DESCRIPTION
Makes the FX Research **Matrix** consistent with the Notion Research Matrix, per request: broker names as rows, the **8 individual G10 currencies as columns** (USD EUR GBP AUD CAD CHF JPY NZD) — no more rows/columns for raw currency *pairs* or non-currency junk.

**Consolidation matches twelve-x `nodes/publish.py` `_board_column` exactly:**
- A view files under its **base** G10 currency — a pair lands under the numerator (EUR/USD → EUR), **no decomposition, no direction flip**, shown verbatim.
- Views with any leg outside the extended set (8 G10 + NOK/SEK) are **dropped** (XAU/gold, DXY, indices, USD/IDR, NOK/SEK, blanks).
- `getMatrix` keys by (broker, board-column); `MatrixCell` gains `column` (G10) + keeps `currency` (verbatim instrument for display).
- `MatrixTab` is the broker × fixed-8-G10 grid (reverting the accordion); a pair shows its instrument in-cell so it isn't misread as an outright. Click → source brief.
- 6 `boardColumn` unit tests mirror twelve-x's authoritative mapping table, locking Notion↔Olympus consistency.

`next build` green; vitest 16/16; tsc + eslint clean.

Part of #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)