### PR TITLE
docs(adr): refine ADR 0019 — DeltaTriageResult + code-grounding (#814)

### DIFF
--- a/docs/adr/0019-unified-atlas-workflow.md
+++ b/docs/adr/0019-unified-atlas-workflow.md
@@ -144,22 +144,21 @@ format) is unconditional.
 
 ### 3 — Delta as a genuine incremental doc-patch
 
-The current delta path re-runs all pipeline phases with `--run-type delta`. The triage
-phase (`atlas/phases/triage_phase.py`) runs first: `TriageDeps` supplies the Supabase
-client + price-lookback window; the node calls `triage.evaluate()` and writes a
+The current delta path re-runs all pipeline phases with `--run-type delta`. After
+preflight (and the optional preflight_reflect phase), a triage phase
+(`atlas/phases/triage_phase.py`) runs: `TriageDeps` supplies the Supabase client +
+price-lookback window; the node calls `triage.evaluate()` and writes a
 `DeltaTriageResult` (`atlas/state.py`) into `AtlasResearchState.triage`. However, even
 gated nodes currently regenerate their full document from scratch when they do run,
 giving the same per-document token cost as a baseline.
 
 The proposed delta strategy is **patch, not regen**:
 
-1. **Triage phase** (already exists) — compares today's market signals to the last
-   baseline snapshot. The triage node (built by `build_triage_node` in
-   `atlas/phases/triage_phase.py`) produces a `DeltaTriageResult`
-   (`atlas/state.py:DeltaTriageResult`) that lists per-segment
-   `DeltaTriageDecision` entries with a `decision: "regenerate" | "carry"` field and
-   a mandatory/high/standard/low tier. The result is stored in
-   `AtlasResearchState.triage`.
+1. **Triage phase** (already exists) — runs after preflight, compares today's market
+   signals to the last baseline snapshot, and populates `AtlasResearchState.triage`
+   with a `DeltaTriageResult` listing per-segment `DeltaTriageDecision` entries
+   (`decision: "regenerate" | "carry"`, priority tier). See
+   `atlas/state.py:DeltaTriageResult` and `atlas/phases/triage_phase.py`.
 
 2. **Selective fan-out** — only segments whose `DeltaTriageDecision.decision ==
    "regenerate"` proceed to their research nodes. All other segments carry the last
@@ -311,12 +310,11 @@ unaffected by either phase.
 ## Links
 
 - Issue: [#814](https://github.com/digithings-ai/digithings/issues/814)
-- Workflow files: `.github/workflows/atlas-baseline.yml`, `.github/workflows/atlas-delta.yml`
-  (both confirmed present on `develop`; `atlas-monthly.yml` also exists — see open question 5)
+- Workflow files: `.github/workflows/atlas-baseline.yml`, `.github/workflows/atlas-delta.yml`,
+  `.github/workflows/atlas-monthly.yml` (see open question 5)
 - Python entry point: `digiquant/src/digiquant/olympus/hermes/chain.py`
-  (run as `python -m digiquant.olympus.hermes.chain`; `digiquant/src/digiquant/olympus/` package
-  confirmed present — `__init__.py` exists at that path)
+  (run as `python -m digiquant.olympus.hermes.chain`)
 - Triage types: `DeltaTriageResult`, `DeltaTriageDecision` in `digiquant/src/digiquant/olympus/atlas/state.py`;
-  `TriageDeps` (dependency container) in `digiquant/src/digiquant/olympus/atlas/phases/triage_phase.py`
+  `TriageDeps` in `digiquant/src/digiquant/olympus/atlas/phases/triage_phase.py`
 - Predecessor: [ADR-0015](0015-atlas-vs-hermes.md) (Atlas/Hermes split)
 - Related: [ADR-0014](0014-atlas-in-digiquant.md) (Atlas in digiquant)

--- a/docs/adr/0019-unified-atlas-workflow.md
+++ b/docs/adr/0019-unified-atlas-workflow.md
@@ -144,20 +144,27 @@ format) is unconditional.
 
 ### 3 — Delta as a genuine incremental doc-patch
 
-The current delta path re-runs all pipeline phases with `--run-type delta`, relying on
-`TriageDeps` to gate individual nodes. However, even gated nodes currently regenerate
-their full document from scratch when they do run, giving the same per-document token
-cost as a baseline.
+The current delta path re-runs all pipeline phases with `--run-type delta`. The triage
+phase (`atlas/phases/triage_phase.py`) runs first: `TriageDeps` supplies the Supabase
+client + price-lookback window; the node calls `triage.evaluate()` and writes a
+`DeltaTriageResult` (`atlas/state.py`) into `AtlasResearchState.triage`. However, even
+gated nodes currently regenerate their full document from scratch when they do run,
+giving the same per-document token cost as a baseline.
 
 The proposed delta strategy is **patch, not regen**:
 
 1. **Triage phase** (already exists) — compares today's market signals to the last
-   baseline snapshot. Produces a `StalenessReport` that identifies which segments
-   (macro, sector, individual tickers) have drifted beyond a configurable threshold.
+   baseline snapshot. The triage node (built by `build_triage_node` in
+   `atlas/phases/triage_phase.py`) produces a `DeltaTriageResult`
+   (`atlas/state.py:DeltaTriageResult`) that lists per-segment
+   `DeltaTriageDecision` entries with a `decision: "regenerate" | "carry"` field and
+   a mandatory/high/standard/low tier. The result is stored in
+   `AtlasResearchState.triage`.
 
-2. **Selective fan-out** — only stale segments proceed to their research nodes. All
-   other segments carry the last baseline document forward unchanged (shallow copy of
-   the Supabase row, `source_run_id` preserved, `updated_at` untouched).
+2. **Selective fan-out** — only segments whose `DeltaTriageDecision.decision ==
+   "regenerate"` proceed to their research nodes. All other segments carry the last
+   baseline document forward unchanged (shallow copy of the Supabase row,
+   `source_run_id` preserved, `updated_at` untouched).
 
 3. **Incremental doc-edit** — for stale segments, the research node receives both the
    prior baseline document and the new signals. The LLM prompt is switched to an
@@ -228,8 +235,9 @@ CI wrapper changes.
 
 1. Add `delta_mode: Literal["patch", "full"] = "full"` to `AtlasInput`. Delta runs
    from CI pass `delta_mode="patch"`; the existing behavior is preserved as `"full"`.
-2. Implement the selective fan-out gate in `triage_phase.py`: skip-and-carry nodes
-   when `delta_mode == "patch"` and the segment is not stale.
+2. Implement the selective fan-out gate in `triage_phase.py` / `graph.py`: skip-and-carry
+   nodes when `delta_mode == "patch"` and the segment's `DeltaTriageDecision.decision ==
+   "carry"` (per `AtlasResearchState.triage`).
 3. Add "edit mode" prompt variants to the affected research skills (Pillar skills for
    each segment type). The prompt switch is conditional on `delta_mode`.
 4. Add an early-exit path in `run_atlas_then_hermes` when triage reports zero stale
@@ -304,6 +312,11 @@ unaffected by either phase.
 
 - Issue: [#814](https://github.com/digithings-ai/digithings/issues/814)
 - Workflow files: `.github/workflows/atlas-baseline.yml`, `.github/workflows/atlas-delta.yml`
+  (both confirmed present on `develop`; `atlas-monthly.yml` also exists — see open question 5)
 - Python entry point: `digiquant/src/digiquant/olympus/hermes/chain.py`
+  (run as `python -m digiquant.olympus.hermes.chain`; `digiquant/src/digiquant/olympus/` package
+  confirmed present — `__init__.py` exists at that path)
+- Triage types: `DeltaTriageResult`, `DeltaTriageDecision` in `digiquant/src/digiquant/olympus/atlas/state.py`;
+  `TriageDeps` (dependency container) in `digiquant/src/digiquant/olympus/atlas/phases/triage_phase.py`
 - Predecessor: [ADR-0015](0015-atlas-vs-hermes.md) (Atlas/Hermes split)
 - Related: [ADR-0014](0014-atlas-in-digiquant.md) (Atlas in digiquant)


### PR DESCRIPTION
## Summary

- Replaces the non-existent `StalenessReport` type with the real `DeltaTriageResult` / `DeltaTriageDecision` types from `digiquant/src/digiquant/olympus/atlas/state.py`
- Clarifies that `TriageDeps` is the dependency-injection container for the triage node (not the output type), and expands the triage step description to reference actual source locations
- Tightens the Phase 2 migration plan step #2 to reference `DeltaTriageDecision.decision == "carry"` directly
- Adds Links section entries confirming `atlas-baseline.yml`, `atlas-delta.yml`, the `olympus/` package, and `hermes/chain.py` all exist on `develop` — addressing a prior reviewer's incorrect claim to the contrary
- Keeps all 5 open questions intact for owner sign-off

## Test plan

- [x] `make doc-check` passes (168 markdown files scanned, OK)
- [x] `make score` passes: Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10
- [x] Grep confirms `StalenessReport` has zero occurrences in the entire codebase
- [x] Grep confirms `DeltaTriageResult` is defined in `atlas/state.py:309` and used in `atlas/triage.py`
- [x] `digiquant/src/digiquant/olympus/__init__.py` confirmed present on `develop`
- [x] `python -m digiquant.olympus.hermes.chain` run command confirmed in both `atlas-baseline.yml` and `atlas-delta.yml`

Fixes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)