### PR TITLE
fix(hermes): real conviction_delta + multi-round deliberation (#814)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -38,6 +38,7 @@ from digiquant.olympus.atlas.phases.triage_phase import TriageDeps
 from digiquant.olympus.atlas.state import AtlasResearchState, PhaseError
 from digiquant.olympus.atlas import diagnostics as _diagnostics
 from digiquant.olympus.hermes.graph import HermesGraphDeps, Phase9Deps, build_hermes_graph
+from digiquant.olympus.hermes.phases.phase7cd_debate import clamp_debate_rounds
 
 from digigraph import usage as _usage
 
@@ -212,19 +213,13 @@ def run_atlas_then_hermes(
     + idempotent upserts).
 
     ``debate_rounds``: compile-time upper bound on Bull/Bear debate rounds.
-    ``None`` (default) defers to ``atlas_input.config.preferences["debate_rounds"]``
-    so the operator can configure multi-round debate via the investment profile
-    without a code change (#814). Explicit non-None overrides preferences.
+    ``None`` defers to ``atlas_input.config.preferences["debate_rounds"]`` (clamped
+    to [1, 5] via ``clamp_debate_rounds``). Explicit non-None overrides preferences.
     """
-    # Resolve the compile-time debate round count from preferences when no
-    # explicit override was supplied.  Bounds clamped identically to
-    # ``_round_count`` in phase7cd_debate.py (1..5).
     if debate_rounds is None:
-        _pref_raw = atlas_input.config.preferences.get("debate_rounds", 1)
-        try:
-            debate_rounds = max(1, min(5, int(_pref_raw)))
-        except (TypeError, ValueError):
-            debate_rounds = 1
+        debate_rounds = clamp_debate_rounds(
+            atlas_input.config.preferences.get("debate_rounds", 1)
+        )
 
     # Atlas: research only, no publish.
     atlas_deps = AtlasGraphDeps(

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -192,7 +192,7 @@ def run_atlas_then_hermes(
     *,
     atlas_input: AtlasInput,
     deps: ChainDeps,
-    debate_rounds: int = 1,
+    debate_rounds: int | None = None,
     checkpointer: Any = None,
     thread_base: str | None = None,
     hermes_watchlist: list[str] | None = None,
@@ -210,7 +210,22 @@ def run_atlas_then_hermes(
     **distinct** thread ids (``{thread_base}::atlas`` / ``::hermes``) so each
     resumes from its own checkpoint (#665); publish is never checkpointed (cheap
     + idempotent upserts).
+
+    ``debate_rounds``: compile-time upper bound on Bull/Bear debate rounds.
+    ``None`` (default) defers to ``atlas_input.config.preferences["debate_rounds"]``
+    so the operator can configure multi-round debate via the investment profile
+    without a code change (#814). Explicit non-None overrides preferences.
     """
+    # Resolve the compile-time debate round count from preferences when no
+    # explicit override was supplied.  Bounds clamped identically to
+    # ``_round_count`` in phase7cd_debate.py (1..5).
+    if debate_rounds is None:
+        _pref_raw = atlas_input.config.preferences.get("debate_rounds", 1)
+        try:
+            debate_rounds = max(1, min(5, int(_pref_raw)))
+        except (TypeError, ValueError):
+            debate_rounds = 1
+
     # Atlas: research only, no publish.
     atlas_deps = AtlasGraphDeps(
         preflight=deps.atlas.preflight,

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
@@ -95,16 +95,23 @@ class DebateSummary(BaseModel):
     )
 
 
+def clamp_debate_rounds(raw: Any, *, default: int = _DEFAULT_DEBATE_ROUNDS) -> int:
+    """Clamp ``raw`` to [1, 5], falling back to ``default`` on bad input.
+
+    Returns values in [1, 5] — TradingAgents uses 1–2; headroom prevents
+    misconfig from producing 100-round debates.
+    """
+    try:
+        return max(1, min(5, int(raw)))
+    except (TypeError, ValueError):
+        return default
+
+
 def _round_count(state: HermesState) -> int:
     """Resolve the configured round count from preferences (default 1)."""
-    raw = state.config.preferences.get("debate_rounds", _DEFAULT_DEBATE_ROUNDS)
-    try:
-        n = int(raw)
-    except (TypeError, ValueError):
-        return _DEFAULT_DEBATE_ROUNDS
-    # Bound at 1..5 — TradingAgents typically uses 1-2; leave headroom
-    # without letting a misconfig produce 100-round debates.
-    return max(1, min(5, n))
+    return clamp_debate_rounds(
+        state.config.preferences.get("debate_rounds", _DEFAULT_DEBATE_ROUNDS)
+    )
 
 
 def _analyst_for(state: HermesState, ticker: str) -> dict[str, Any]:
@@ -220,29 +227,37 @@ def _bear_node_factory(ticker: str):
     return _node
 
 
-def _deterministic_conviction_delta(net_stance: str, analyst_conviction_score: int) -> int:
-    """Compute conviction_delta deterministically from the debate outcome.
+def _deterministic_conviction_delta(
+    net_stance: Literal["bullish", "neutral", "bearish"],
+    analyst_conviction_score: int,
+) -> int:
+    """Compute conviction_delta from the debate outcome.
 
     The LLM research-manager returns a qualitative ``net_stance``; the delta is
-    derived from that stance against the pre-debate analyst conviction so the
-    output is reproducible and never silently defaults to 0.
+    derived deterministically so it is reproducible and never silently defaults to 0.
 
-    Rules:
-    - ``bullish`` → +1, or +2 when the pre-debate score was already very
-      negative (≤ −3) to allow a larger correction.
-    - ``bearish``  → −1, or −2 when the pre-debate score was already very
-      positive (≥ +3).
-    - ``neutral``  → 0 (the debate did not shift the picture).
+    - ``bullish`` → +1 (or +2 when pre-debate score ≤ −3, allowing a larger correction)
+    - ``bearish``  → −1 (or −2 when pre-debate score ≥ +3)
+    - ``neutral``  → 0
 
-    Clamped to [−2, +2] to satisfy ``DebateSummary.conviction_delta`` bounds.
+    Returns values in [−2, +2] matching ``DebateSummary.conviction_delta`` bounds.
     """
     if net_stance == "bullish":
-        # Stronger correction when the analyst was already very bearish.
         return 2 if analyst_conviction_score <= -3 else 1
     if net_stance == "bearish":
-        # Stronger correction when the analyst was already very bullish.
         return -2 if analyst_conviction_score >= 3 else -1
     return 0
+
+
+def _debate_output(summary_dict: dict[str, Any], rounds_count: int) -> dict[str, Any]:
+    """Attach the ``rounds_count`` convenience field and return the dict.
+
+    ``rounds_count`` is consumed by the Olympus dashboard and is NOT part of
+    the ``DebateSummary`` schema; it is appended here so deliberation/{ticker}
+    documents always carry it.
+    """
+    summary_dict["rounds_count"] = rounds_count
+    return summary_dict
 
 
 def _research_manager_node_factory(ticker: str):
@@ -264,9 +279,7 @@ def _research_manager_node_factory(ticker: str):
                 net_stance="neutral",
                 conviction_delta=0,
             )
-            out = summary.model_dump(mode="json")
-            out["rounds_count"] = 0
-            return {"phase7cd_debates": {ticker: out}}
+            return {"phase7cd_debates": {ticker: _debate_output(summary.model_dump(mode="json"), 0)}}
 
         analyst = _analyst_for(state, ticker)
         analyst_conviction_score = int(analyst.get("conviction_score") or 0)
@@ -289,28 +302,18 @@ def _research_manager_node_factory(ticker: str):
             tools=tools,
             execute_tool=execute_tool,
         )
-        # The skill is told to return rounds verbatim; if it doesn't, we
-        # overwrite with the deterministic record from state to keep
-        # the audit trail intact.
+        # Overwrite rounds with the deterministic record from state (the skill
+        # is told to echo them verbatim, but state is authoritative for audit).
         canonical_rounds = [DebateRound.model_validate(r) for r in rounds]
-        # conviction_delta: always computed deterministically from net_stance vs.
-        # the pre-debate analyst conviction_score so it never silently defaults to
-        # 0 regardless of what the LLM returns (#814).
-        deterministic_delta = _deterministic_conviction_delta(
-            result.net_stance, analyst_conviction_score
-        )
         merged = result.model_copy(
             update={
                 "rounds": canonical_rounds,
-                "conviction_delta": deterministic_delta,
+                "conviction_delta": _deterministic_conviction_delta(
+                    result.net_stance, analyst_conviction_score
+                ),
             }
         )
-        out = merged.model_dump(mode="json")
-        # rounds_count is a convenience field consumed by the dashboard; it is
-        # NOT part of DebateSummary schema (not required downstream) but is
-        # appended here so deliberation/{ticker} documents always carry it.
-        out["rounds_count"] = len(canonical_rounds)
-        return {"phase7cd_debates": {ticker: out}}
+        return {"phase7cd_debates": {ticker: _debate_output(merged.model_dump(mode="json"), len(canonical_rounds))}}
 
     return _node
 
@@ -411,7 +414,7 @@ __all__ = [
     "DebateRound",
     "DebateRoundContribution",
     "DebateSummary",
-    "_deterministic_conviction_delta",
+    "clamp_debate_rounds",
     "build_phase7cd",
     "build_phase7cd_research_manager",
     "build_phase7cd_round",

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7cd_debate.py
@@ -220,6 +220,31 @@ def _bear_node_factory(ticker: str):
     return _node
 
 
+def _deterministic_conviction_delta(net_stance: str, analyst_conviction_score: int) -> int:
+    """Compute conviction_delta deterministically from the debate outcome.
+
+    The LLM research-manager returns a qualitative ``net_stance``; the delta is
+    derived from that stance against the pre-debate analyst conviction so the
+    output is reproducible and never silently defaults to 0.
+
+    Rules:
+    - ``bullish`` → +1, or +2 when the pre-debate score was already very
+      negative (≤ −3) to allow a larger correction.
+    - ``bearish``  → −1, or −2 when the pre-debate score was already very
+      positive (≥ +3).
+    - ``neutral``  → 0 (the debate did not shift the picture).
+
+    Clamped to [−2, +2] to satisfy ``DebateSummary.conviction_delta`` bounds.
+    """
+    if net_stance == "bullish":
+        # Stronger correction when the analyst was already very bearish.
+        return 2 if analyst_conviction_score <= -3 else 1
+    if net_stance == "bearish":
+        # Stronger correction when the analyst was already very bullish.
+        return -2 if analyst_conviction_score >= 3 else -1
+    return 0
+
+
 def _research_manager_node_factory(ticker: str):
     from digigraph.graph.research_agent import run_research_agent
 
@@ -239,14 +264,19 @@ def _research_manager_node_factory(ticker: str):
                 net_stance="neutral",
                 conviction_delta=0,
             )
-            return {"phase7cd_debates": {ticker: summary.model_dump(mode="json")}}
+            out = summary.model_dump(mode="json")
+            out["rounds_count"] = 0
+            return {"phase7cd_debates": {ticker: out}}
+
+        analyst = _analyst_for(state, ticker)
+        analyst_conviction_score = int(analyst.get("conviction_score") or 0)
 
         skill_text = load_skill("research-manager")
         phase_inputs: dict[str, Any] = {
             "segment": f"research-manager-{ticker}",
             "ticker": ticker,
             "rounds": rounds,
-            "analyst_payload": _analyst_for(state, ticker),
+            "analyst_payload": analyst,
             "bias_row": state.phase6_bias_row or {},
         }
         tools, execute_tool, _ = _debate_tools(state)
@@ -262,10 +292,25 @@ def _research_manager_node_factory(ticker: str):
         # The skill is told to return rounds verbatim; if it doesn't, we
         # overwrite with the deterministic record from state to keep
         # the audit trail intact.
-        merged = result.model_copy(
-            update={"rounds": [DebateRound.model_validate(r) for r in rounds]}
+        canonical_rounds = [DebateRound.model_validate(r) for r in rounds]
+        # conviction_delta: always computed deterministically from net_stance vs.
+        # the pre-debate analyst conviction_score so it never silently defaults to
+        # 0 regardless of what the LLM returns (#814).
+        deterministic_delta = _deterministic_conviction_delta(
+            result.net_stance, analyst_conviction_score
         )
-        return {"phase7cd_debates": {ticker: merged.model_dump(mode="json")}}
+        merged = result.model_copy(
+            update={
+                "rounds": canonical_rounds,
+                "conviction_delta": deterministic_delta,
+            }
+        )
+        out = merged.model_dump(mode="json")
+        # rounds_count is a convenience field consumed by the dashboard; it is
+        # NOT part of DebateSummary schema (not required downstream) but is
+        # appended here so deliberation/{ticker} documents always carry it.
+        out["rounds_count"] = len(canonical_rounds)
+        return {"phase7cd_debates": {ticker: out}}
 
     return _node
 
@@ -366,6 +411,7 @@ __all__ = [
     "DebateRound",
     "DebateRoundContribution",
     "DebateSummary",
+    "_deterministic_conviction_delta",
     "build_phase7cd",
     "build_phase7cd_research_manager",
     "build_phase7cd_round",

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -1,4 +1,4 @@
-"""Phase 7C-D Bull/Bear adversarial debate tests (#429).
+"""Phase 7C-D Bull/Bear adversarial debate tests (#429, #814).
 
 Covers:
 - Bull node opens round 1, writes ``pending`` to state.
@@ -10,6 +10,8 @@ Covers:
 - Empty watchlist installs no-op nodes.
 - Phase factories return correct phase counts (1 round → 3 phases:
   bull, bear, research-manager).
+- conviction_delta is non-zero when the debate shifts conviction (#814).
+- Multi-round graph (rounds=2) runs both rounds when configured (#814).
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ from digigraph.graph.pipeline_builder import build_pipeline
 from digiquant.olympus.hermes.phases.phase7cd_debate import (
     DebateRound,
     DebateSummary,
+    _deterministic_conviction_delta,
     _round_count,
     build_phase7cd,
     build_phase7cd_research_manager,
@@ -370,3 +373,161 @@ class TestPmConsumesDebateSummaries:
         ):
             update = _pm_node(state)
         assert update["phase7d_rebalance"]["notes"] == "no-debate"
+
+
+# ─── Deterministic conviction_delta (#814) ──────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDeterministicConvictionDelta:
+    """_deterministic_conviction_delta must produce non-zero values when the
+    debate's net_stance conflicts with or reinforces the pre-debate analyst
+    conviction (#814 — conviction_delta was always 0 before this fix)."""
+
+    def test_bullish_stance_gives_positive_delta(self) -> None:
+        # Any bullish outcome should shift delta up.
+        assert _deterministic_conviction_delta("bullish", 2) == 1
+
+    def test_bearish_stance_gives_negative_delta(self) -> None:
+        assert _deterministic_conviction_delta("bearish", 2) == -1
+
+    def test_neutral_stance_gives_zero_delta(self) -> None:
+        assert _deterministic_conviction_delta("neutral", 2) == 0
+
+    def test_bullish_stance_stronger_correction_when_analyst_very_bearish(self) -> None:
+        # Large negative pre-debate score → debate turned the table, use +2.
+        assert _deterministic_conviction_delta("bullish", -4) == 2
+        assert _deterministic_conviction_delta("bullish", -3) == 2
+
+    def test_bearish_stance_stronger_correction_when_analyst_very_bullish(self) -> None:
+        assert _deterministic_conviction_delta("bearish", 3) == -2
+        assert _deterministic_conviction_delta("bearish", 4) == -2
+
+    def test_delta_nonzero_for_spy_strong_buy_bearish_stance(self) -> None:
+        # Explicit regression for the reported case: SPY analyst conviction +4 buy →
+        # delta was always 0 before #814.  A bearish debate outcome must produce a
+        # non-zero, negative delta.
+        delta = _deterministic_conviction_delta("bearish", 4)
+        assert delta != 0, "SPY conviction +4 buy with bearish debate must give non-zero delta"
+        assert delta < 0
+
+    def test_manager_node_produces_nonzero_delta_when_stance_is_bearish(self) -> None:
+        """End-to-end: research manager node computes non-zero delta when LLM
+        returns a bearish net_stance against a buy-biased analyst (#814)."""
+        compiled = build_pipeline(
+            AtlasResearchState,
+            [build_phase7cd_research_manager(["SPY"])],
+        )
+        state = _state(("SPY",))
+        # Analyst is strongly bullish (+4) — but the debate outcome is bearish.
+        state.phase7c_analysts = {
+            "SPY": {
+                "ticker": "SPY",
+                "conviction_score": 4,
+                "stance": "buy",
+                "thesis": "Strong momentum setup",
+                "risks": "",
+                "sources": [],
+            }
+        }
+        state.phase7cd_debates = {
+            "SPY": {
+                "rounds": [
+                    {
+                        "round_number": 1,
+                        "bull_argument": "Momentum is strong",
+                        "bear_argument": "Overvalued on every metric; Fed still tightening",
+                    }
+                ]
+            }
+        }
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            # LLM says bearish — manager node must override conviction_delta to -2.
+            return json.dumps(
+                {
+                    "ticker": "SPY",
+                    "rounds": [],
+                    "bull_thesis": "momentum play",
+                    "bear_thesis": "overvalued; rate headwinds",
+                    "net_stance": "bearish",
+                    "conviction_delta": 0,  # LLM-returned 0 must be overridden
+                }
+            )
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        summary = final.phase7cd_debates["SPY"]
+        assert summary["net_stance"] == "bearish"
+        # Pre-debate conviction was +4 (≥ 3) and net_stance is bearish → expected delta = -2.
+        assert summary["conviction_delta"] != 0, (
+            "conviction_delta must not be 0 when stance ≠ neutral"
+        )
+        assert summary["conviction_delta"] == -2
+        # rounds_count must also be present (#814).
+        assert summary.get("rounds_count") == 1
+
+
+# ─── Multi-round debate (#814) ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMultiRoundDebate:
+    """Compile with rounds=2; assert both rounds run and rounds_count > 1."""
+
+    def test_two_round_pipeline_runs_both_rounds(self) -> None:
+        compiled = build_pipeline(
+            AtlasResearchState,
+            list(build_phase7cd(["AAPL"], rounds=2)),
+        )
+        state = _state(("AAPL",), debate_rounds=2)
+
+        def fake(_m: str, msgs: list[dict[str, Any]], **_: Any) -> str:
+            user_block = msgs[1]["content"]
+            inputs_part = next(
+                p
+                for p in user_block
+                if isinstance(p, dict) and p["text"].startswith("PHASE_INPUTS")
+            )
+            body = json.loads(inputs_part["text"].split(":", 1)[1].strip())
+            seg = body["segment"]
+            if seg.startswith("bull-researcher-"):
+                return _bull_payload(body["ticker"], body["round_number"])
+            if seg.startswith("bear-researcher-"):
+                return _bear_payload(body["ticker"], body["round_number"])
+            # research-manager
+            return json.dumps(
+                {
+                    "ticker": body["ticker"],
+                    "rounds": [],
+                    "bull_thesis": "strong bull case",
+                    "bear_thesis": "mild bear case",
+                    "net_stance": "bullish",
+                    "conviction_delta": 1,
+                }
+            )
+
+        with patch("digigraph.graph.research_agent.completion_text", side_effect=fake):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+        summary = final.phase7cd_debates["AAPL"]
+        # Both rounds must have run — rounds list has 2 entries.
+        assert len(summary["rounds"]) == 2, (
+            f"Expected 2 debate rounds, got {len(summary['rounds'])}"
+        )
+        assert summary["rounds"][0]["round_number"] == 1
+        assert summary["rounds"][1]["round_number"] == 2
+        # rounds_count convenience field must equal the round list length.
+        assert summary.get("rounds_count") == 2
+
+    def test_preferences_debate_rounds_honored_by_compile_time_phases(self) -> None:
+        """round count > 1 is honored: 2 rounds → 5 phases (2×bull+bear + manager)."""
+        phases = build_phase7cd(["AAPL"], rounds=2)
+        assert len(phases) == 5
+        node_names = [n.name for phase in phases for n in phase.nodes]
+        # Both round 1 and round 2 bull/bear nodes must be present.
+        assert any("r1" in name for name in node_names)
+        assert any("r2" in name for name in node_names)

--- a/tests/dq/hermes/test_phase7cd_debate.py
+++ b/tests/dq/hermes/test_phase7cd_debate.py
@@ -34,6 +34,7 @@ from digiquant.olympus.hermes.phases.phase7cd_debate import (
     build_phase7cd,
     build_phase7cd_research_manager,
     build_phase7cd_round,
+    clamp_debate_rounds,
 )
 from digiquant.olympus.atlas.state import (
     AtlasConfigBundle,
@@ -259,6 +260,7 @@ class TestResearchManager:
         summary = final.phase7cd_debates["AAPL"]
         assert summary["net_stance"] == "neutral"
         assert summary["conviction_delta"] == 0
+        assert summary.get("rounds_count") == 0
 
 
 # ─── Full debate pipeline ───────────────────────────────────────────────────
@@ -373,6 +375,35 @@ class TestPmConsumesDebateSummaries:
         ):
             update = _pm_node(state)
         assert update["phase7d_rebalance"]["notes"] == "no-debate"
+
+
+# ─── clamp_debate_rounds ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestClampDebateRounds:
+    """clamp_debate_rounds must enforce [1, 5] and handle bad input."""
+
+    def test_typical_values_pass_through(self) -> None:
+        assert clamp_debate_rounds(1) == 1
+        assert clamp_debate_rounds(3) == 3
+        assert clamp_debate_rounds(5) == 5
+
+    def test_below_one_clamped_to_one(self) -> None:
+        assert clamp_debate_rounds(0) == 1
+        assert clamp_debate_rounds(-3) == 1
+
+    def test_above_five_clamped_to_five(self) -> None:
+        assert clamp_debate_rounds(10) == 5
+        assert clamp_debate_rounds(100) == 5
+
+    def test_bad_type_returns_default(self) -> None:
+        assert clamp_debate_rounds(None) == 1
+        assert clamp_debate_rounds("abc") == 1
+        assert clamp_debate_rounds(None, default=2) == 2
+
+    def test_string_int_coerced(self) -> None:
+        assert clamp_debate_rounds("3") == 3
 
 
 # ─── Deterministic conviction_delta (#814) ──────────────────────────────────


### PR DESCRIPTION
## Summary

- **`conviction_delta` always 0 (root cause a):** The LLM research-manager consistently returned `conviction_delta=0` because the skill discourages extreme values and the LLM takes the safe path. Fix: `_deterministic_conviction_delta()` computes the delta from `net_stance` vs. the pre-debate analyst `conviction_score` — bullish stance → `+1`/`+2`, bearish → `-1`/`-2`, neutral → `0`. The LLM output is overridden post-call, so the value always reflects the real debate outcome.
- **Multi-round debate never ran (root cause b):** `run_atlas_then_hermes` defaulted `debate_rounds=1` and the CLI never forwarded it from `config.preferences`, so the graph was always compiled with a single round even if `preferences["debate_rounds"]=2`. Fix: `run_atlas_then_hermes` now reads `debate_rounds` from `atlas_input.config.preferences` when no explicit argument is supplied.
- **`rounds_count` missing from document:** The `deliberation/{ticker}` document now includes a `rounds_count` convenience field so the dashboard doesn't need to count the rounds list.

## Test plan

- [ ] All 204 existing Hermes unit tests pass (`pytest tests/dq/hermes/ -m unit`)
- [ ] 9 new tests in `TestDeterministicConvictionDelta` and `TestMultiRoundDebate` assert: non-zero delta for bearish stance against strong-buy analyst (SPY regression), `+2`/`-2` for extreme pre-debate scores, 2-round pipeline runs both rounds and produces `rounds_count=2`, phase factory shape correct for `rounds=2`
- [ ] `make score` → Security 10, Quality 10, Optimization 10, Accuracy 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)