### PR TITLE
chore(security): gitleaks allowlist — FP fixtures + dead-key env example (#814)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -34,6 +34,24 @@ paths = [
 
   # Top-level README and top-level markdown examples mirror the docs/ policy.
   '''^[A-Z]+\.md$''',
+
+  # Frontend/JS unit-test fixtures (*.test.tsx/ts/js): canned payloads with fake
+  # field values (e.g. `key_tension: '...'`) that trip the generic-api-key rule.
+  # No production secrets live in test files (mirrors the ^tests/ Python policy).
+  '''\.test\.(ts|tsx|js|jsx)$''',
+
+  # Confidential research vaults (Obsidian markdown briefs under projects/*/vault/):
+  # research prose that occasionally matches the aws-access-token regex. Not
+  # deployable code; never pushed to public remotes (see CLAUDE.md).
+  '''^projects/[^/]+/vault/''',
+
+  # DELETED file (removed in the apps/digiquant-atlas -> digiquant/src migration)
+  # that historically held real free-tier data-API keys (FRED / CoinGecko /
+  # Alpha Vantage). Owner confirmed these keys are dead/rotated (2026-06-18); no
+  # live credential remains. The file is absent at HEAD on develop; history can't
+  # be rewritten cheaply for dead free-tier keys, so the historical path is
+  # allowlisted. NOT a fixture — see SECURITY.md "Secrets scanning".
+  '''^apps/digiquant-atlas/config/mcp\.secrets\.env\.example$''',
 ]
 
 # Known-safe example/dummy tokens that gitleaks' default rules flag. Each


### PR DESCRIPTION
Makes the full-history gitleaks scan green by allowlisting: FE test fixtures, projects research-brief markdown (regex FPs), and the deleted mcp.secrets.env.example (real free-tier keys confirmed dead/rotated by owner). Unblocks develop->main. Part of #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)