### PR TITLE
ci(atlas): production pipeline runs from main + deploy comments → main (#814)

### DIFF
--- a/.github/workflows/atlas-baseline.yml
+++ b/.github/workflows/atlas-baseline.yml
@@ -43,6 +43,11 @@ jobs:
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Production pipeline runs RELEASED code from main (deploy migration #814).
+          # Scheduled triggers still fire from the default branch (develop); only the
+          # checked-out CODE is pinned to main. Releases flow develop -> main.
+          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/atlas-delta.yml
+++ b/.github/workflows/atlas-delta.yml
@@ -41,6 +41,11 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Production pipeline runs RELEASED code from main (deploy migration #814).
+          # Scheduled triggers still fire from the default branch (develop); only the
+          # checked-out CODE is pinned to main. Releases flow develop -> main.
+          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/atlas-monthly.yml
+++ b/.github/workflows/atlas-monthly.yml
@@ -108,6 +108,11 @@ jobs:
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Production pipeline runs RELEASED code from main (deploy migration #814).
+          # Scheduled triggers still fire from the default branch (develop); only the
+          # checked-out CODE is pinned to main. Releases flow develop -> main.
+          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/atlas-refresh-metrics.yml
+++ b/.github/workflows/atlas-refresh-metrics.yml
@@ -33,6 +33,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Production pipeline runs RELEASED code from main (deploy migration #814).
+          # Scheduled triggers still fire from the default branch (develop); only the
+          # checked-out CODE is pinned to main. Releases flow develop -> main.
+          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-digiquant-cloudflare.yml
+++ b/.github/workflows/deploy-digiquant-cloudflare.yml
@@ -1,5 +1,5 @@
 # REM-084: Document and gate digiquant.io Cloudflare Pages build (ADR-0012).
-# Primary deploy is Cloudflare Pages watching `develop` + scripts/build-digiquant.sh.
+# Primary deploy is Cloudflare Pages watching `main` + scripts/build-digiquant.sh.
 # This workflow validates the build script on PRs touching digiquant.io assets.
 name: digiquant.io Cloudflare build check
 

--- a/.github/workflows/deploy-digithings-cloudflare.yml
+++ b/.github/workflows/deploy-digithings-cloudflare.yml
@@ -1,5 +1,5 @@
 # Document and gate the digithings.ai Cloudflare Pages build.
-# Primary deploy is Cloudflare Pages watching `develop` + scripts/build-digithings.sh
+# Primary deploy is Cloudflare Pages watching `main` + scripts/build-digithings.sh
 # (now a Next.js static-export Node build). This workflow validates the build
 # script on PRs touching digithings.ai assets.
 name: digithings.ai Cloudflare build check


### PR DESCRIPTION
Deploy migration: Atlas scheduled workflows now checkout ref: main (run released code); Cloudflare deploy comments updated develop→main. Schedule still fires from develop (default); only checked-out code is main. Part of #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)