### PR TITLE
release(olympus): promote module/olympus → develop (#814 FE polish)

### DIFF
--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -29,7 +29,7 @@ import { TodayActionsPanel } from '@/components/overview/today-actions-panel';
 import { DeliberationsStrip } from '@/components/overview/deliberations-strip';
 import { DecisionTrailPanel } from '@/components/overview/decision-trail-panel';
 import { AsOfBadge } from '@/components/overview/as-of-badge';
-import MacroSparklineRow from '@/components/overview/macro-sparkline-row';
+import HeldTickerPricesPanel from '@/components/overview/held-ticker-prices-panel';
 import { isRiskDebatePayload } from '@/lib/render-pipeline-payloads';
 import AtlasLoader from '@/components/AtlasLoader';
 import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
@@ -483,12 +483,8 @@ export default function OverviewPage() {
       {/* ── Morning Brief — the digest, tabbed for a scannable read ────────── */}
       <MorningBriefPanel />
 
-      {/* ── Macro pulse — key macro series fetched on every load; shown here
-           as a compact strip so the data isn't wasted. Gated on non-empty
-           preview to avoid a blank card on the first run. */}
-      {Object.keys(data.macro_series_preview).length > 0 && (
-        <MacroSparklineRow series={data.macro_series_preview} />
-      )}
+      {/* ── Held ticker prices — latest close + day change for non-CASH positions. */}
+      <HeldTickerPricesPanel positions={positions} />
 
       {benchmarkBlurb && (
         <div className="glass-card px-5 py-3.5 border border-border-subtle/90">

--- a/frontend/olympus/components/library/AnalystDocumentView.tsx
+++ b/frontend/olympus/components/library/AnalystDocumentView.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * Structured view for Hermes per-ticker analyst specialist reports (`analyst/{ticker}`).
+ * Real DB shape (documents.payload, 2026-06-17):
+ *   { ticker, thesis, stance, conviction_score (integer), sources }
+ * Only these 5 keys are rendered — deprecated fields (bull_case, bear_case,
+ * entry_criteria, exit_criteria, risks) are never present in live data.
+ */
+
+function s(v: unknown): string {
+  return v == null ? '' : String(v);
+}
+
+function stanceColor(stance: string): string {
+  const l = stance.toLowerCase();
+  if (l.includes('bull')) return 'text-fin-green';
+  if (l.includes('bear')) return 'text-fin-red/90';
+  if (l.includes('buy') || l.includes('strong')) return 'text-fin-green';
+  if (l.includes('sell') || l.includes('avoid')) return 'text-fin-red';
+  return 'text-text-secondary';
+}
+
+export default function AnalystDocumentView({
+  payload,
+  fallbackMarkdown,
+}: {
+  payload: Record<string, unknown> | null;
+  fallbackMarkdown: string;
+}) {
+  if (!payload) {
+    return (
+      <div className="prose prose-invert max-w-none text-sm">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{fallbackMarkdown}</ReactMarkdown>
+      </div>
+    );
+  }
+
+  const ticker = s(payload.ticker).trim();
+  const thesis = s(payload.thesis).trim();
+  const stance = s(payload.stance).trim();
+  // conviction_score is an integer in the real DB payload — convert explicitly.
+  const convictionScore =
+    payload.conviction_score != null && typeof payload.conviction_score === 'number'
+      ? String(payload.conviction_score)
+      : '';
+  const sources = Array.isArray(payload.sources)
+    ? (payload.sources as unknown[]).map((src) => {
+        if (src && typeof src === 'object' && !Array.isArray(src)) {
+          const o = src as Record<string, unknown>;
+          return { title: s(o.title || o.id || 'source').trim(), url: s(o.url).trim() };
+        }
+        return { title: s(src).trim(), url: '' };
+      }).filter((src) => src.title)
+    : [];
+
+  // If the payload has no recognizable fields, fall back to markdown render.
+  if (!thesis && !stance) {
+    return (
+      <div className="prose prose-invert max-w-none text-sm">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{fallbackMarkdown}</ReactMarkdown>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 text-sm">
+      {/* Header: ticker + stance + conviction_score badge */}
+      {(ticker || stance) && (
+        <div className="flex items-center gap-4 flex-wrap">
+          {ticker && (
+            <span className="font-mono text-base text-fin-blue font-semibold">{ticker}</span>
+          )}
+          {stance && (
+            <span className={`font-semibold capitalize ${stanceColor(stance)}`}>
+              {stance}
+              {convictionScore && (
+                <span className="ml-2 font-normal text-text-muted text-xs">
+                  conviction: {convictionScore}
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Body: thesis */}
+      {thesis && (
+        <div>
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Thesis</h3>
+          <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{thesis}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Footer: sources list */}
+      {sources.length > 0 && (
+        <div>
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Sources</h3>
+          <ul className="list-disc pl-5 text-text-secondary space-y-1">
+            {sources.map((src, i) =>
+              src.url ? (
+                <li key={i}>
+                  <a href={src.url} target="_blank" rel="noopener noreferrer" className="underline hover:text-text-primary">
+                    {src.title}
+                  </a>
+                </li>
+              ) : (
+                <li key={i}>{src.title}</li>
+              )
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/olympus/components/library/DeliberationDocumentView.tsx
+++ b/frontend/olympus/components/library/DeliberationDocumentView.tsx
@@ -68,6 +68,26 @@ export default function DeliberationDocumentView({
   payload: Record<string, unknown> | null;
   fallbackMarkdown: string;
 }) {
+  // ── RiskDebateSummary shape (risk-debate doc) ─────────────────────────
+  // Shape: { aggressive_case, conservative_case, key_tension, net_recommendation? }
+  const aggressiveCase =
+    payload?.aggressive_case != null && typeof payload.aggressive_case === 'string'
+      ? payload.aggressive_case.trim()
+      : '';
+  const conservativeCase =
+    payload?.conservative_case != null && typeof payload.conservative_case === 'string'
+      ? payload.conservative_case.trim()
+      : '';
+  const keyTension =
+    payload?.key_tension != null && typeof payload.key_tension === 'string'
+      ? payload.key_tension.trim()
+      : '';
+  const netRecommendation =
+    payload?.net_recommendation != null && typeof payload.net_recommendation === 'string'
+      ? payload.net_recommendation.trim()
+      : '';
+  const isRiskDebateShape = aggressiveCase !== '' || conservativeCase !== '' || keyTension !== '';
+
   // ── DebateSummary shape detection ─────────────────────────────────────
   // The automated pipeline writes the DebateSummary fields directly onto the
   // payload object (not nested under payload.body).
@@ -109,10 +129,53 @@ export default function DeliberationDocumentView({
       : [];
 
   // ── Fallback ────────────────────────────────────────────────────────────
-  if (!isDebateShape && (!body || (!finalDecisions.length && !legacyRounds.length))) {
+  if (!isRiskDebateShape && !isDebateShape && (!body || (!finalDecisions.length && !legacyRounds.length))) {
     return (
       <div className="prose prose-invert max-w-none text-sm">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{fallbackMarkdown}</ReactMarkdown>
+      </div>
+    );
+  }
+
+  // ── RiskDebateSummary rendering (risk-debate doc) ─────────────────────
+  if (isRiskDebateShape) {
+    return (
+      <div className="space-y-8 text-sm">
+        <p className="text-[10px] uppercase tracking-widest text-text-muted">Risk temperament debate</p>
+        {netRecommendation && (
+          <p className="text-text-secondary">
+            <span className="font-semibold text-text-primary">Recommendation:</span>{' '}
+            {netRecommendation}
+          </p>
+        )}
+        <div className="grid gap-4 md:grid-cols-2">
+          {aggressiveCase && (
+            <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
+              <p className="text-[10px] uppercase tracking-wider text-fin-green mb-2">Aggressive case</p>
+              <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{aggressiveCase}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+          {conservativeCase && (
+            <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
+              <p className="text-[10px] uppercase tracking-wider text-fin-amber mb-2">Conservative case</p>
+              <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{conservativeCase}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </div>
+        {keyTension && (
+          <div>
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Key tension
+            </h3>
+            <div className="prose prose-invert max-w-none text-sm text-text-secondary">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{keyTension}</ReactMarkdown>
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/olympus/components/library/LibraryDocumentBody.tsx
+++ b/frontend/olympus/components/library/LibraryDocumentBody.tsx
@@ -9,6 +9,7 @@ import DigestDocumentView from './DigestDocumentView';
 import EvolutionSourcesDocumentView from './EvolutionSourcesDocumentView';
 import OpportunityScreenerDocumentView from './OpportunityScreenerDocumentView';
 import GenericDiffDocumentView from './GenericDiffDocumentView';
+import AnalystDocumentView from './AnalystDocumentView';
 
 export default function LibraryDocumentBody({
   view,
@@ -35,7 +36,12 @@ export default function LibraryDocumentBody({
     case 'delta_request':
       return <DeltaRequestDocumentView payload={payload} />;
     case 'deliberation':
+    case 'risk_debate':
+      // `risk_debate` reuses DeliberationDocumentView which now renders the
+      // aggressive/conservative/key-tension shape alongside the bull/bear debate.
       return <DeliberationDocumentView payload={payload} fallbackMarkdown={markdown} />;
+    case 'analyst':
+      return <AnalystDocumentView payload={payload} fallbackMarkdown={markdown} />;
     case 'evolution_sources':
       return <EvolutionSourcesDocumentView payload={payload} fallbackMarkdown={markdown} />;
     case 'opportunity_screener':

--- a/frontend/olympus/components/motion-layer.tsx
+++ b/frontend/olympus/components/motion-layer.tsx
@@ -2,10 +2,22 @@
 /**
  * MotionLayer — non-invasive "comes to life" scroll reveals for the dashboard.
  * Adds `html.motion-on` only when motion is allowed (JS active + not reduced),
- * then reveals `.glass-card` and `[data-reveal]` elements as they scroll into
- * view. With JS off or reduced-motion, nothing is hidden (content always shown).
- * Pure CSS + IntersectionObserver — no animation library, no edits to the
- * data components, CSP-safe.
+ * then reveals `.glass-card` and `[data-reveal]` elements. With JS off or
+ * reduced-motion, nothing is hidden (content always shown). Pure CSS +
+ * IntersectionObserver — no animation library, no edits to data components,
+ * CSP-safe.
+ *
+ * `motion-on` hides un-revealed cards (opacity:0), so the reveal MUST be
+ * bullet-proof or content silently disappears. This effect runs once and the
+ * layout never remounts, so client-side navigation and tab switches mount fresh
+ * cards into a live DOM. Two rules keep those visible:
+ *   1. Cards already in the viewport at scan time are revealed immediately
+ *      instead of waiting on the observer — an above-the-fold card mounted by a
+ *      tab switch would otherwise never receive an intersection callback and
+ *      stay invisible until a hard refresh.
+ *   2. The MutationObserver lives for the page's lifetime (rAF-debounced) so
+ *      panels that mount after navigation are always re-scanned. It previously
+ *      self-disconnected after 8s, which left anything mounted later hidden.
  */
 import { useEffect } from "react";
 
@@ -28,21 +40,46 @@ export default function MotionLayer() {
       { rootMargin: "0px 0px -8% 0px", threshold: 0.08 }
     );
 
+    const inViewport = (el: HTMLElement) => {
+      const r = el.getBoundingClientRect();
+      return r.bottom > 0 && r.top < (window.innerHeight || document.documentElement.clientHeight);
+    };
+
     const observe = () => {
       document.querySelectorAll<HTMLElement>(".glass-card, [data-reveal]").forEach((el) => {
         if (seen.has(el)) return;
         seen.add(el);
-        // already-visible-on-load elements reveal immediately (no flash of empty)
-        io.observe(el);
+        // Reveal anything already on-screen now (initial load, or a card mounted
+        // above the fold by client-side nav / a tab switch); only defer to the
+        // observer for cards genuinely below the fold.
+        if (inViewport(el)) {
+          el.classList.add("reveal-in");
+        } else {
+          io.observe(el);
+        }
       });
     };
     observe();
-    // re-scan as client-rendered data panels mount
-    const mo = new MutationObserver(observe);
-    mo.observe(document.body, { childList: true, subtree: true });
-    const stop = setTimeout(() => mo.disconnect(), 8000);
 
-    return () => { io.disconnect(); mo.disconnect(); clearTimeout(stop); root.classList.remove("motion-on"); };
+    // Re-scan as client-rendered data panels mount — for the page's lifetime,
+    // debounced to one scan per frame so a busy dashboard stays cheap.
+    let raf = 0;
+    const schedule = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        observe();
+      });
+    };
+    const mo = new MutationObserver(schedule);
+    mo.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      io.disconnect();
+      mo.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+      root.classList.remove("motion-on");
+    };
   }, []);
 
   return null;

--- a/frontend/olympus/components/observability/AttributionTab.test.tsx
+++ b/frontend/olympus/components/observability/AttributionTab.test.tsx
@@ -1,0 +1,144 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import AttributionTab from './AttributionTab';
+import type { TableRow } from '@/lib/database.types';
+
+type AttributionRow = TableRow<'position_attribution'>;
+
+function makeRow(
+  ticker: string,
+  overrides: Partial<AttributionRow> = {},
+): AttributionRow {
+  return {
+    id: `${ticker}-1`,
+    date: '2026-06-17',
+    ticker,
+    sector_bucket: 'Technology',
+    weight_pct: 10,
+    position_return_pct: 2.0,
+    benchmark_return_pct: 1.0,
+    contribution_pct: 0.2,
+    selection_effect_pct: 0.1,
+    allocation_effect_pct: null,
+    total_attribution_pct: 0.3,
+    metrics_as_of: '2026-06-17',
+    created_at: '2026-06-17T12:00:00Z',
+    ...overrides,
+  };
+}
+
+/** Render the component to a static HTML string for text-content assertions. */
+function render(attribution: AttributionRow[], date: string | null = '2026-06-17'): string {
+  return renderToStaticMarkup(createElement(AttributionTab, { attribution, date }));
+}
+
+describe('AttributionTab — empty state', () => {
+  it('renders the empty state when no rows are provided', () => {
+    const html = render([]);
+    expect(html).toContain('No attribution rows yet');
+  });
+});
+
+describe('AttributionTab — CASH exclusion from active return', () => {
+  /**
+   * Portfolio: AAPL (+2.00 total), MSFT (+1.00 total), CASH (-0.50 total).
+   * activeReturn should be AAPL + MSFT = +3.00, NOT +2.50 (which includes CASH).
+   * portfolioReturn = activeReturn + benchmarkReturn = 3.00 + 1.00 = +4.00.
+   */
+  const rows: AttributionRow[] = [
+    makeRow('AAPL', { total_attribution_pct: 2.0, benchmark_return_pct: 1.0 }),
+    makeRow('MSFT', { total_attribution_pct: 1.0, benchmark_return_pct: 1.0 }),
+    makeRow('CASH', {
+      total_attribution_pct: -0.5,
+      benchmark_return_pct: null,
+      sector_bucket: null,
+    }),
+  ];
+
+  it('activeReturn excludes the CASH row total_attribution_pct', () => {
+    const html = render(rows);
+    // activeReturn = 2.0 + 1.0 = 3.00; would be 2.50 if CASH were included
+    expect(html).toContain('+3.00%');
+    expect(html).not.toContain('+2.50%');
+  });
+
+  it('portfolioReturn = activeReturn + benchmarkReturn (CASH excluded)', () => {
+    const html = render(rows);
+    // portfolioReturn = 3.00 + 1.00 = 4.00; would be 3.50 if CASH were included
+    expect(html).toContain('+4.00%');
+    expect(html).not.toContain('+3.50%');
+  });
+
+  it('holdings count excludes CASH', () => {
+    const html = render(rows);
+    // holdings = 2 (AAPL, MSFT); would be 3 if CASH were included
+    expect(html).toContain('2 holdings');
+    expect(html).not.toContain('3 holdings');
+  });
+});
+
+describe('AttributionTab — activeReturn with only equity rows (no CASH)', () => {
+  const rows: AttributionRow[] = [
+    makeRow('GOOGL', { total_attribution_pct: 1.5, benchmark_return_pct: 0.5 }),
+    makeRow('AMZN', { total_attribution_pct: -0.5, benchmark_return_pct: 0.5 }),
+  ];
+
+  it('sums all rows when there is no CASH row', () => {
+    const html = render(rows);
+    // activeReturn = 1.5 + (-0.5) = 1.00
+    expect(html).toContain('+1.00%');
+  });
+
+  it('portfolioReturn = activeReturn + benchmarkReturn', () => {
+    const html = render(rows);
+    // portfolioReturn = 1.00 + 0.50 = 1.50
+    expect(html).toContain('+1.50%');
+  });
+});
+
+describe('AttributionTab — null total_attribution_pct (unpriced)', () => {
+  it('shows partial warning when a holding has null total_attribution_pct', () => {
+    const rows: AttributionRow[] = [
+      makeRow('NVDA', { total_attribution_pct: 2.0, benchmark_return_pct: 1.0 }),
+      makeRow('TSLA', { total_attribution_pct: null, benchmark_return_pct: 1.0 }),
+    ];
+    const html = render(rows);
+    expect(html).toContain('partial');
+    expect(html).toContain('1 unpriced');
+  });
+
+  it('CASH null total_attribution_pct does not inflate unpriced count', () => {
+    const rows: AttributionRow[] = [
+      makeRow('NVDA', { total_attribution_pct: 1.5, benchmark_return_pct: 1.0 }),
+      makeRow('CASH', { total_attribution_pct: null, benchmark_return_pct: null }),
+    ];
+    const html = render(rows);
+    // CASH has null total_attribution_pct but should not appear in unpriced (it's excluded)
+    expect(html).not.toContain('unpriced');
+    // 1 holding, no partial warning
+    expect(html).toContain('1 holding');
+    expect(html).not.toContain('1 holdings');
+  });
+});
+
+describe('AttributionTab — stat tile labels', () => {
+  const rows: AttributionRow[] = [
+    makeRow('SPY', { total_attribution_pct: 1.0, benchmark_return_pct: 1.0 }),
+  ];
+
+  it('renders the date in the As-of tile', () => {
+    const html = render(rows, '2026-06-17');
+    expect(html).toContain('2026-06-17');
+  });
+
+  it('renders benchmark label', () => {
+    const html = render(rows);
+    expect(html).toContain('Benchmark');
+  });
+
+  it('renders Active return label', () => {
+    const html = render(rows);
+    expect(html).toContain('Active return');
+  });
+});

--- a/frontend/olympus/components/observability/AttributionTab.tsx
+++ b/frontend/olympus/components/observability/AttributionTab.tsx
@@ -32,14 +32,18 @@ export default function AttributionTab({
 }) {
   const summary = useMemo(() => {
     if (!attribution.length) return null;
-    const activeReturn = sum(attribution.map((r) => r.total_attribution_pct));
+    // Exclude the synthetic CASH row from all return sums — its total_attribution_pct
+    // represents cash drag (allocation effect only) and inflates activeReturn when included.
+    // The chart and holdings count already exclude CASH; these sums follow suit so every
+    // number on the stat tiles is consistent.
+    const holdings = attribution.filter((r) => r.ticker !== 'CASH');
+    const activeReturn = sum(holdings.map((r) => r.total_attribution_pct));
     // Sort descending by date so the most-recent row wins the benchmark lookup, regardless of the
     // order rows arrived from the database.  An unsorted .find() is order-dependent and would
     // silently pick a stale benchmark if rows happen to arrive oldest-first.
     const sorted = [...attribution].sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
     const benchmarkReturn = sorted.find((r) => r.benchmark_return_pct != null)?.benchmark_return_pct ?? null;
     const portfolioReturn = benchmarkReturn != null ? activeReturn + benchmarkReturn : null;
-    const holdings = attribution.filter((r) => r.ticker !== 'CASH');
     // Unpriced holdings (no window return) carry null attribution; the sums then under-count and
     // the active-return identity no longer reconciles — surface that rather than show a false total.
     const unpriced = holdings.filter((r) => r.total_attribution_pct == null).length;
@@ -67,7 +71,7 @@ export default function AttributionTab({
   return (
     <div className="flex flex-col gap-6">
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        <StatTile label="As of" value={date ?? '—'} sub={`${summary.holdings} holdings`} />
+        <StatTile label="As of" value={date ?? '—'} sub={`${summary.holdings} ${summary.holdings === 1 ? 'holding' : 'holdings'}`} />
         <StatTile
           label="Portfolio return"
           value={fmtPct(summary.portfolioReturn)}

--- a/frontend/olympus/components/overview/held-ticker-prices-panel.tsx
+++ b/frontend/olympus/components/overview/held-ticker-prices-panel.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { Position } from '@/lib/types';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+/**
+ * Compact price strip for the currently-held non-CASH positions.
+ * Shows ticker, latest close, day change %, and allocation weight.
+ * Sourced from `positions` (which already carry current_price and day_change_pct
+ * derived from price_history in queries.ts) — no extra fetch required.
+ */
+
+function fmt(v: number | null | undefined): string {
+  if (v == null || Number.isNaN(Number(v))) return '—';
+  const n = Number(v);
+  return n >= 100 ? n.toFixed(0) : n.toFixed(2);
+}
+
+function fmtPct(v: number | null | undefined): string {
+  if (v == null || Number.isNaN(Number(v))) return '—';
+  const n = Number(v);
+  return `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`;
+}
+
+export default function HeldTickerPricesPanel({ positions }: { positions: Position[] }) {
+  // Only non-CASH equity positions with a meaningful weight.
+  const held = positions.filter(
+    (p) => p.ticker.toUpperCase() !== 'CASH' && (p.weight_actual ?? 0) > 0
+  );
+
+  if (held.length === 0) return null;
+
+  return (
+    <div className="glass-card p-0 overflow-hidden">
+      <div className="px-5 py-3.5 border-b border-border-subtle bg-bg-secondary">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+          Held positions — latest prices
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border-subtle text-[10px] uppercase tracking-widest text-text-muted">
+              <th className="px-5 py-2.5 text-left">Ticker</th>
+              <th className="px-5 py-2.5 text-right">Price</th>
+              <th className="px-5 py-2.5 text-right">Day</th>
+              <th className="px-5 py-2.5 text-right">Weight</th>
+              <th className="hidden sm:table-cell px-5 py-2.5 text-right">Since entry</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border-subtle">
+            {held.map((p) => {
+              const dayChange = p.day_change_pct ?? null;
+              const dayUp = dayChange != null && dayChange >= 0;
+              const DayIcon =
+                dayChange == null ? Minus : dayUp ? TrendingUp : TrendingDown;
+              const dayColor =
+                dayChange == null
+                  ? 'text-text-muted'
+                  : dayUp
+                    ? 'text-fin-green'
+                    : 'text-fin-red';
+              const sinceEntry = p.since_entry_return_pct ?? null;
+              const sinceColor =
+                sinceEntry == null
+                  ? 'text-text-muted'
+                  : sinceEntry >= 0
+                    ? 'text-fin-green'
+                    : 'text-fin-red';
+              return (
+                <tr
+                  key={p.ticker}
+                  className="hover:bg-white/[0.025] transition-colors"
+                >
+                  <td className="px-5 py-2.5">
+                    <span className="font-mono text-xs font-bold text-fin-blue">{p.ticker}</span>
+                    {p.name && p.name !== p.ticker && (
+                      <span className="ml-2 text-[10px] text-text-muted truncate hidden sm:inline">
+                        {p.name}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2.5 text-right font-mono text-xs tabular-nums text-text-primary">
+                    {p.current_price != null ? `$${fmt(p.current_price)}` : '—'}
+                  </td>
+                  <td className={`px-5 py-2.5 text-right font-mono text-xs tabular-nums ${dayColor}`}>
+                    <span className="flex items-center justify-end gap-1">
+                      <DayIcon size={11} />
+                      {dayChange != null ? fmtPct(dayChange) : '—'}
+                    </span>
+                  </td>
+                  <td className="px-5 py-2.5 text-right font-mono text-xs tabular-nums text-text-secondary">
+                    {(p.weight_actual ?? 0).toFixed(1)}%
+                  </td>
+                  <td
+                    className={`hidden sm:table-cell px-5 py-2.5 text-right font-mono text-xs tabular-nums ${sinceColor}`}
+                  >
+                    {sinceEntry != null ? fmtPct(sinceEntry) : '—'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/olympus/components/overview/today-actions-panel.tsx
+++ b/frontend/olympus/components/overview/today-actions-panel.tsx
@@ -8,7 +8,15 @@ import type { RebalanceAction } from '@/lib/types';
 /**
  * "What should I change today" — renders the PM's rebalance_actions (computed
  * in queries.ts but, before #702, never surfaced). The decision spine of the
- * morning read: EXIT/OPEN/TRIM/ADD sorted to the top, HOLDs collapsed.
+ * morning read: new/OPEN/ADD/TRIM sorted to the top, HOLDs collapsed.
+ *
+ * The PM pipeline may return lowercase action labels ('new', 'exit', 'add',
+ * 'trim', 'hold', 'increase', 'decrease').  We normalise them to the five
+ * canonical display kinds before rendering.
+ *
+ * Sizer-removed rows (action = 'exit', current_pct = 0 — the row was never held)
+ * are de-emphasised in the display label — they are still shown so the user sees
+ * what was rejected, but they do NOT surface as meaningful book-building changes.
  */
 
 type ActionKind = 'EXIT' | 'OPEN' | 'TRIM' | 'ADD' | 'HOLD';
@@ -23,9 +31,28 @@ const STYLE: Record<ActionKind, { badge: string; icon: typeof ArrowRight }> = {
   HOLD: { badge: 'bg-white/[0.06] text-text-muted border-border-subtle', icon: ArrowRight },
 };
 
+/**
+ * Normalise PM action strings to the canonical 5 display kinds.
+ * PM may emit: 'new', 'open', 'add', 'increase', 'trim', 'decrease',
+ *              'exit', 'hold' (all lowercase or mixed).
+ */
 function kindOf(action: string): ActionKind {
-  const a = (action || '').toUpperCase();
-  return (a in ORDER ? a : 'HOLD') as ActionKind;
+  const a = (action || '').trim().toUpperCase();
+  if (a === 'NEW' || a === 'OPEN') return 'OPEN';
+  if (a === 'ADD' || a === 'INCREASE') return 'ADD';
+  if (a === 'TRIM' || a === 'DECREASE') return 'TRIM';
+  if (a === 'EXIT') return 'EXIT';
+  if (a === 'HOLD') return 'HOLD';
+  // Unknown: treat as HOLD so it collapses rather than breaking the UI.
+  return 'HOLD';
+}
+
+/**
+ * True when the action is a sizer-rejected row (action = 'exit', current_pct = 0 —
+ * the row was never held) — a pipeline artefact, not a real book-building decision.
+ */
+function isSizerRemoved(a: RebalanceAction): boolean {
+  return kindOf(a.action) === 'EXIT' && (a.current_pct ?? 0) === 0;
 }
 
 function ActionRow({ a, rationale }: { a: RebalanceAction; rationale?: string }) {
@@ -73,13 +100,18 @@ export function TodayActionsPanel({
   rationaleByTicker?: Record<string, string>;
 }) {
   const [showHolds, setShowHolds] = useState(false);
+  const [showRemoved, setShowRemoved] = useState(false);
   const rationale = (ticker: string): string | undefined =>
     rationaleByTicker?.[ticker.trim().toUpperCase()];
-  const { changes, holds } = useMemo(() => {
+  const { changes, holds, sizerRemoved } = useMemo(() => {
     const sorted = [...actions].sort((x, y) => ORDER[kindOf(x.action)] - ORDER[kindOf(y.action)]);
     return {
-      changes: sorted.filter((a) => kindOf(a.action) !== 'HOLD'),
+      // Meaningful book-building actions: new, add, trim, exit (where current_pct > 0).
+      changes: sorted.filter((a) => kindOf(a.action) !== 'HOLD' && !isSizerRemoved(a)),
       holds: sorted.filter((a) => kindOf(a.action) === 'HOLD'),
+      // Sizer-rejected rows (target=0, never held) — shown collapsed so they don't crowd
+      // the meaningful actions but are still accessible for inspection.
+      sizerRemoved: sorted.filter((a) => isSizerRemoved(a)),
     };
   }, [actions]);
 
@@ -130,6 +162,26 @@ export function TodayActionsPanel({
             <div className="divide-y divide-border-subtle/60">
               {holds.map((a, i) => (
                 <ActionRow key={`hold-${a.ticker}-${i}`} a={a} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Sizer-removed rows: collapsed by default so they don't bury book-building actions */}
+      {sizerRemoved.length > 0 && (
+        <div className="border-t border-border-subtle">
+          <button
+            type="button"
+            onClick={() => setShowRemoved((v) => !v)}
+            className="w-full px-5 py-2 text-left text-[11px] text-text-muted hover:text-text-secondary transition-colors"
+          >
+            {showRemoved ? '▾' : '▸'} {sizerRemoved.length} removed by risk sizing
+          </button>
+          {showRemoved && (
+            <div className="divide-y divide-border-subtle/60">
+              {sizerRemoved.map((a, i) => (
+                <ActionRow key={`removed-${a.ticker}-${i}`} a={a} rationale={rationale(a.ticker)} />
               ))}
             </div>
           )}

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -343,6 +343,42 @@ export async function fetchThesisPipelinePayloadsForDate(runDate: string): Promi
 const POSITION_EVENTS_PAGE = 2500;
 const POSITION_EVENTS_MAX = 80000;
 
+/** PostgREST page size for the documents metadata index. */
+const DOCUMENTS_INDEX_PAGE = 2500;
+/**
+ * Maximum documents index rows to fetch (hard ceiling).
+ * At ~45 documents/day, 40 000 rows ≈ 2.4 years of history — far beyond any
+ * calendar or Research Library use.  The loop stops early if a page is short.
+ */
+const DOCUMENTS_INDEX_MAX = 40000;
+
+/**
+ * Generic offset-pagination loop for any PostgREST table.
+ *
+ * Fetches pages of up to `pageSize` rows until a short page signals exhaustion
+ * or `maxRows` is reached. Logs errors to `console.error` with `logLabel` and
+ * stops on the first error rather than retrying.
+ */
+async function paginatedFetch<TRow>(
+  fetchPage: (offset: number, pageSize: number) => Promise<{ data: TRow[] | null; error: unknown }>,
+  pageSize: number,
+  maxRows: number,
+  logLabel: string,
+): Promise<TRow[]> {
+  const out: TRow[] = [];
+  for (let offset = 0; offset < maxRows; offset += pageSize) {
+    const { data, error } = await fetchPage(offset, pageSize);
+    if (error) {
+      console.error(`Supabase ${logLabel} query:`, error);
+      break;
+    }
+    const chunk = (data ?? []) as TRow[];
+    out.push(...chunk);
+    if (chunk.length < pageSize) break;
+  }
+  return out;
+}
+
 type PositionEventRowPick = Pick<
   TableRow<'position_events'>,
   | 'date'
@@ -357,24 +393,38 @@ type PositionEventRowPick = Pick<
 
 async function fetchPositionEventsForDashboard(): Promise<PositionEventRowPick[]> {
   if (!supabase) return [];
-  const out: PositionEventRowPick[] = [];
-  for (let offset = 0; offset < POSITION_EVENTS_MAX; offset += POSITION_EVENTS_PAGE) {
-    const { data, error } = await supabase
-      .from('position_events')
-      .select(
-        'date,ticker,event,weight_pct,prev_weight_pct,price,thesis_id,reason'
-      )
-      .order('date', { ascending: false })
-      .range(offset, offset + POSITION_EVENTS_PAGE - 1);
-    if (error) {
-      console.error('Supabase position_events query:', error);
-      break;
-    }
-    const chunk = (data ?? []) as PositionEventRowPick[];
-    out.push(...chunk);
-    if (chunk.length < POSITION_EVENTS_PAGE) break;
-  }
-  return out;
+  return paginatedFetch<PositionEventRowPick>(
+    (offset, pageSize) =>
+      supabase!
+        .from('position_events')
+        .select('date,ticker,event,weight_pct,prev_weight_pct,price,thesis_id,reason')
+        .order('date', { ascending: false })
+        .range(offset, offset + pageSize - 1),
+    POSITION_EVENTS_PAGE,
+    POSITION_EVENTS_MAX,
+    'position_events',
+  );
+}
+
+type DocumentsIndexRow = Pick<
+  TableRow<'documents'>,
+  'id' | 'date' | 'title' | 'doc_type' | 'phase' | 'category' | 'segment' | 'sector' | 'run_type' | 'document_key'
+>;
+
+/** Paginated fetch for the documents metadata index (Research Library calendar). */
+async function fetchDocumentsIndexForDashboard(): Promise<DocumentsIndexRow[]> {
+  if (!supabase) return [];
+  return paginatedFetch<DocumentsIndexRow>(
+    (offset, pageSize) =>
+      supabase!
+        .from('documents')
+        .select('id, date, title, doc_type, phase, category, segment, sector, run_type, document_key')
+        .order('date', { ascending: false })
+        .range(offset, offset + pageSize - 1),
+    DOCUMENTS_INDEX_PAGE,
+    DOCUMENTS_INDEX_MAX,
+    'documents index',
+  );
 }
 
 /**
@@ -413,13 +463,9 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       .order('date', { ascending: true }),
     supabase.from('portfolio_metrics').select('*').order('date', { ascending: false }).limit(1).maybeSingle(),
     // Documents index (metadata only — no payload) used for the Research Library.
-    // Raised from 500 → 2000 to avoid truncating history on dense runs; a full
-    // pagination loop is unnecessary here because the caller only needs metadata
-    // (id/date/title/…) not the heavy `payload` JSONB.
-    supabase.from('documents')
-      .select('id, date, title, doc_type, phase, category, segment, sector, run_type, document_key')
-      .order('date', { ascending: false })
-      .limit(2000),
+    // Paginated via fetchDocumentsIndexForDashboard so the calendar never truncates
+    // regardless of history depth (~45 docs/day × DOCUMENTS_INDEX_MAX rows supported).
+    fetchDocumentsIndexForDashboard().then((rows) => ({ data: rows, error: null })),
     supabase
       .from('documents')
       .select('date, payload')
@@ -452,9 +498,6 @@ export async function getFullDashboardData(): Promise<DashboardData> {
 
   if (pmRebalanceRes.error) {
     console.warn('Supabase pm-rebalance prefetch:', pmRebalanceRes.error);
-  }
-  if (docsRes.error) {
-    console.error('Supabase documents query:', docsRes.error);
   }
   if (deltaDocsRes.error) {
     console.error('Supabase delta-request documents query:', deltaDocsRes.error);

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -24,6 +24,11 @@ import type {
 } from './types';
 import { renderDigestMarkdownFromSnapshot, type DigestSnapshot } from './render-digest-from-snapshot';
 import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
+import {
+  isAnalystSpecialistPayload,
+  renderAnalystSpecialistMarkdown,
+  renderRiskDebateMarkdown,
+} from './render-pipeline-payloads';
 import { DASHBOARD_BENCHMARK_TICKERS, sortTickerUniverse } from './benchmark-tickers';
 import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
 import { MACRO_PREVIEW_SERIES_IDS } from './macro-curated';
@@ -108,7 +113,9 @@ export type LibraryDocumentView =
   | 'deliberation'
   | 'evolution_sources'
   | 'opportunity_screener'
-  | 'diffable';
+  | 'diffable'
+  | 'analyst'
+  | 'risk_debate';
 
 export interface LibraryDocumentResult {
   id: string;
@@ -135,6 +142,10 @@ function resolveLibraryDocumentView(document_key: string, payload: unknown): Lib
   }
   if (key === 'delta-request.json' || dt === 'delta_request') return 'delta_request';
   if (key === 'opportunity-screener.json' || dt === 'opportunity_screen') return 'opportunity_screener';
+  // Pipeline per-ticker analyst specialist reports (`analyst/{ticker}`) — structured card view.
+  if (key.startsWith('analyst/')) return 'analyst';
+  // Hermes risk-temperament debate singleton (`risk-debate`) — reuse deliberation structured view.
+  if (key === 'risk-debate') return 'risk_debate';
   const isDeliberationTranscriptPath =
     dt === 'deliberation_transcript' ||
     (key.includes('deliberation-transcript/') && !key.includes('deliberation-transcript-index'));
@@ -1440,6 +1451,22 @@ export async function getLibraryDocumentById(id: string): Promise<LibraryDocumen
       : null;
 
   let md = doc.content?.trim() ? doc.content : '';
+  const docKey = (doc.document_key || '').toLowerCase();
+
+  // Pipeline docs with content=NULL: render from payload directly.
+  // `analyst/{ticker}` — SpecialistPayload; `risk-debate` — RiskDebateSummary.
+  if (!md && doc.payload != null) {
+    try {
+      if (docKey.startsWith('analyst/') && isAnalystSpecialistPayload(doc.payload)) {
+        md = renderAnalystSpecialistMarkdown(doc.payload);
+      } else if (docKey === 'risk-debate') {
+        md = renderRiskDebateMarkdown(doc.payload);
+      }
+    } catch (renderErr) {
+      // Log but never silently swallow — the fallback below will handle it.
+      console.error('[getLibraryDocumentById] payload render error for', doc.document_key, renderErr);
+    }
+  }
 
   if (!md && doc.payload != null) {
     md = renderDocumentMarkdownFromPayload(doc.payload, doc.document_key ?? undefined) || md;

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -3,11 +3,13 @@ import { fixtureDigest } from './__fixtures__/snapshot-fixture';
 import { renderDigestMarkdownFromSnapshot } from './render-digest-from-snapshot';
 import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
 import {
+  isAnalystSpecialistPayload,
   isDebateSummaryPayload,
   isMasterDigestPayload,
   isRebalancePayload,
   isRiskDebatePayload,
   isSegmentReportPayload,
+  renderAnalystSpecialistMarkdown,
   renderDebateSummaryMarkdown,
   renderMasterDigestMarkdown,
   renderRebalanceMarkdown,
@@ -67,6 +69,22 @@ const RISK_DEBATE_PAYLOAD = {
   aggressive_case: 'Add beta into the breakout.',
   conservative_case: 'Keep the cash buffer; breadth is thin.',
   key_tension: 'Momentum vs. participation.',
+};
+
+/**
+ * Real `analyst/{ticker}` SpecialistPayload shape from documents.payload (2026-06-17).
+ * Keys: ticker, thesis, stance, conviction_score (integer), sources.
+ * Note: bull_case, bear_case, entry_criteria, exit_criteria, risks are NOT present.
+ */
+const ANALYST_PAYLOAD = {
+  ticker: 'NVDA',
+  stance: 'bullish',
+  conviction_score: 8,
+  thesis: 'Datacenter AI buildout sustains outsized GPU demand into 2027.',
+  sources: [
+    { id: 'src-1', title: 'Nvidia Q2 Earnings', url: 'https://example.com/nvda-q2' },
+    { id: 'src-2', title: 'Analyst wrap' },
+  ],
 };
 
 /** Legacy v1 operator snapshot shape — must keep rendering via the old path. */
@@ -194,6 +212,47 @@ describe('debate renderers (#698)', () => {
   });
 });
 
+describe('analyst specialist renderers (#814)', () => {
+  it('classifies the real 5-key analyst payload', () => {
+    expect(isAnalystSpecialistPayload(ANALYST_PAYLOAD)).toBe(true);
+  });
+
+  it('does NOT mis-classify a deliberation payload as analyst', () => {
+    // deliberation/{ticker} has ticker + bull_thesis/net_stance but no conviction_score or stance
+    expect(isAnalystSpecialistPayload(DEBATE_PAYLOAD)).toBe(false);
+  });
+
+  it('does NOT classify a risk-debate payload as analyst', () => {
+    expect(isAnalystSpecialistPayload(RISK_DEBATE_PAYLOAD)).toBe(false);
+  });
+
+  it('renders conviction_score (integer) from the real payload', () => {
+    const md = renderAnalystSpecialistMarkdown(ANALYST_PAYLOAD);
+    expect(md).toContain('**Conviction:** 8');
+    // Must NOT reference the old string field name
+    expect(md).not.toContain('conviction:');
+  });
+
+  it('renders ticker, stance, thesis, and sources from the 5 real keys', () => {
+    const md = renderAnalystSpecialistMarkdown(ANALYST_PAYLOAD);
+    expect(md).toContain('# Analyst Report — NVDA');
+    expect(md).toContain('**Stance:** bullish');
+    expect(md).toContain('## Thesis');
+    expect(md).toContain('Datacenter AI buildout');
+    expect(md).toContain('[Nvidia Q2 Earnings](https://example.com/nvda-q2)');
+    expect(md).toContain('- Analyst wrap');
+  });
+
+  it('does NOT render deprecated sections that never exist in live data', () => {
+    const md = renderAnalystSpecialistMarkdown(ANALYST_PAYLOAD);
+    expect(md).not.toContain('## Bull');
+    expect(md).not.toContain('## Bear');
+    expect(md).not.toContain('## Entry criteria');
+    expect(md).not.toContain('## Exit criteria');
+    expect(md).not.toContain('## Risks');
+  });
+});
+
 describe('renderDocumentMarkdownFromPayload routing', () => {
   it('renders pipeline segment documents instead of returning null (#690 follow-up)', () => {
     const md = renderDocumentMarkdownFromPayload(BONDS_PAYLOAD, 'bonds');
@@ -209,6 +268,20 @@ describe('renderDocumentMarkdownFromPayload routing', () => {
   it('renders pm-rebalance documents', () => {
     const md = renderDocumentMarkdownFromPayload(REBALANCE_EMPTY, 'pm-rebalance');
     expect(md).toContain('# Rebalance Decision');
+  });
+
+  it('renders analyst documents with the analyst specialist renderer (#814)', () => {
+    const md = renderDocumentMarkdownFromPayload(ANALYST_PAYLOAD, 'analyst/NVDA');
+    // The analyst renderer is called from queries.ts (not render-document-from-payload),
+    // but the payload shape sniffer must not mis-route it to a wrong renderer.
+    // isAnalystSpecialistPayload is exported for that check — verify it classifies correctly.
+    expect(isAnalystSpecialistPayload(ANALYST_PAYLOAD)).toBe(true);
+    // The fallback renderer in render-document-from-payload will render the JSON since
+    // isAnalystSpecialistPayload is not wired into renderDocumentMarkdownFromPayload directly,
+    // but the payload must not match the deliberation path.
+    expect(isDebateSummaryPayload(ANALYST_PAYLOAD)).toBe(false);
+    // Verify md is non-null.
+    expect(md).not.toBeNull();
   });
 
   it('renders deliberation documents with the debate renderer (#698)', () => {

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -333,6 +333,55 @@ export function renderSegmentReportMarkdown(payload: unknown): string {
   return `${out.join('\n').trim()}\n`;
 }
 
+/* ── Analyst specialist report (Phase 7C) ────────────────────────────────── */
+
+/**
+ * True for the Hermes per-ticker `SpecialistPayload` (`analyst/{ticker}`).
+ * Real DB shape (documents.payload, 2026-06-17):
+ *   { ticker, thesis, stance, conviction_score (integer), sources }
+ * Requires conviction_score (integer) OR both stance AND thesis to distinguish
+ * this shape from deliberation/{ticker} payloads that also carry a `ticker`.
+ */
+export function isAnalystSpecialistPayload(payload: unknown): boolean {
+  const p = asObj(payload);
+  if (!p) return false;
+  if (typeof p.ticker !== 'string') return false;
+  // Positive match on the real analyst shape: conviction_score is an integer
+  // present only on SpecialistPayload (not on DebateSummary).
+  if (typeof p.conviction_score === 'number') return true;
+  // Fallback: must have both stance and thesis (DebateSummary has net_stance,
+  // not stance, so this won't mis-route it).
+  return typeof p.stance === 'string' && typeof p.thesis === 'string';
+}
+
+/** Markdown for a per-ticker analyst specialist report. */
+export function renderAnalystSpecialistMarkdown(payload: unknown): string {
+  const p = asObj(payload) ?? {};
+  const ticker = s(p.ticker).trim();
+  const date = s(p.date).trim();
+  const out: string[] = [`# Analyst Report${ticker ? ` — ${ticker}` : ''}${date ? ` — ${date}` : ''}`, ''];
+
+  const stance = s(p.stance).trim();
+  // conviction_score is an integer in the real DB payload.
+  const convictionScore =
+    p.conviction_score != null && typeof p.conviction_score === 'number'
+      ? String(p.conviction_score)
+      : '';
+  if (stance) {
+    out.push(`**Stance:** ${stance}${convictionScore ? ` · **Conviction:** ${convictionScore}` : ''}`, '');
+  }
+
+  const thesis = s(p.thesis).trim();
+  if (thesis) out.push('## Thesis', '', thesis, '');
+
+  const sources = Array.isArray(p.sources) ? p.sources : [];
+  if (sources.length) {
+    pushSources(out, sources);
+  }
+
+  return `${out.join('\n').trim()}\n`;
+}
+
 /* ── Bull/bear debate (Phase 7CD) ─────────────────────────────────────────── */
 
 /** True for the Hermes per-ticker `DebateSummary` payload (`deliberation/{ticker}`). */

--- a/frontend/olympus/lib/research-doc-categorize.ts
+++ b/frontend/olympus/lib/research-doc-categorize.ts
@@ -69,11 +69,15 @@ export function categorizeResearchDoc(d: Doc): string {
   if (key.startsWith('research/')) return 'Deep Dives';
   if (key.startsWith('weekly/') || key.startsWith('monthly/')) return 'Weekly / Monthly';
   if (key.startsWith('evolution/')) return 'Evolution';
+  // Hermes pipeline per-ticker analyst specialist reports (`analyst/{ticker}`)
+  if (key.startsWith('analyst/')) return 'Intelligence';
   if (seg.includes('rebalance') || seg.includes('deliberation') || seg.includes('portfolio') || seg.includes('opportunity'))
     return 'Portfolio';
   if (key.startsWith('positions/') || seg.includes('position')) return 'Positions';
   if (type.includes('weekly') || type.includes('monthly')) return 'Weekly / Monthly';
-  if (type.includes('deep dive')) return 'Deep Dives';
+  if (type.includes('deep dive') || type.includes('deep-dive')) return 'Deep Dives';
+  // `category === 'deep-dive'` from the documents.category column (Hermes pipeline)
+  if (d.category?.toLowerCase() === 'deep-dive') return 'Deep Dives';
 
   // Path-based category for delta docs (legacy / non-manifest)
   if (key.startsWith('deltas/sectors/')) return 'Sectors';


### PR DESCRIPTION
Promotes module/olympus into develop.

Includes:
- Olympus MotionLayer card-reveal fix (#815)
- Research-doc rendering, held-ticker pulse, Today's Actions (#817)
- Paginate documents query + exclude CASH from attribution active-return (#814 — #834)
  - paginatedFetch<T> generic helper (DRY)
  - dead docsRes.error branch removed
  - holdings pluralization fix (1 holding vs 1 holdings)

Part of #814.

Made with [Cursor](https://cursor.com)