### PR TITLE
fix(olympus): fx_research_history table rename

### DIFF
--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -394,12 +394,14 @@ type PositionEventRowPick = Pick<
 async function fetchPositionEventsForDashboard(): Promise<PositionEventRowPick[]> {
   if (!supabase) return [];
   return paginatedFetch<PositionEventRowPick>(
-    (offset, pageSize) =>
-      supabase!
+    async (offset, pageSize) => {
+      const { data, error } = await supabase!
         .from('position_events')
         .select('date,ticker,event,weight_pct,prev_weight_pct,price,thesis_id,reason')
         .order('date', { ascending: false })
-        .range(offset, offset + pageSize - 1),
+        .range(offset, offset + pageSize - 1);
+      return { data, error };
+    },
     POSITION_EVENTS_PAGE,
     POSITION_EVENTS_MAX,
     'position_events',
@@ -415,12 +417,14 @@ type DocumentsIndexRow = Pick<
 async function fetchDocumentsIndexForDashboard(): Promise<DocumentsIndexRow[]> {
   if (!supabase) return [];
   return paginatedFetch<DocumentsIndexRow>(
-    (offset, pageSize) =>
-      supabase!
+    async (offset, pageSize) => {
+      const { data, error } = await supabase!
         .from('documents')
         .select('id, date, title, doc_type, phase, category, segment, sector, run_type, document_key')
         .order('date', { ascending: false })
-        .range(offset, offset + pageSize - 1),
+        .range(offset, offset + pageSize - 1);
+      return { data, error };
+    },
     DOCUMENTS_INDEX_PAGE,
     DOCUMENTS_INDEX_MAX,
     'documents index',

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -380,8 +380,7 @@ export function boardColumn(currency: string): MatrixColumn | null {
  * (broker, board-column) over a recent window (default 14 days), filed under its
  * base G10 currency via boardColumn (pairs land under the numerator; non-G10 /
  * non-currency instruments are dropped). Newest brief (run_date, then report_date)
- * wins per cell. Reads from `fx_research_history.currency_views`. Returns `[]`
- * when unconfigured.
+ * wins per cell. Returns `[]` when unconfigured.
  */
 export async function getMatrix(windowDays = 14): Promise<MatrixCell[]> {
   const briefs = await getBriefs(windowDays);

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -277,7 +277,7 @@ export async function getEventOpinions(runDate: string): Promise<FxEventSnapshot
 }
 
 /* ------------------------------------------------------------------ *
- * P3 — Traceability + Matrix (fx_research_history_v2)
+ * P3 — Traceability + Matrix (fx_research_history)
  * ------------------------------------------------------------------ */
 
 const BRIEF_COLUMNS =
@@ -317,7 +317,7 @@ export async function getBriefs(windowDays = 14): Promise<FxBriefRow[]> {
   const rows = await querySupabase<FxBriefRow[]>(
     (sb) =>
       sb
-        .from('fx_research_history_v2')
+        .from('fx_research_history')
         .select(BRIEF_COLUMNS)
         .gte('run_date', start)
         .order('run_date', { ascending: false })
@@ -342,7 +342,7 @@ export async function getBrief(
   if (!isTwelveXConfigured() || !twelveXSupabase) return null;
   if (!sourceFile) return null;
   const rows = await querySupabase<FxBriefRow[]>((sb) => {
-    let q = sb.from('fx_research_history_v2').select(BRIEF_COLUMNS).eq('source_file', sourceFile);
+    let q = sb.from('fx_research_history').select(BRIEF_COLUMNS).eq('source_file', sourceFile);
     if (runDate) q = q.eq('run_date', runDate);
     return q.order('run_date', { ascending: false }).limit(1) as unknown as PromiseLike<{
       data: FxBriefRow[] | null;
@@ -380,7 +380,8 @@ export function boardColumn(currency: string): MatrixColumn | null {
  * (broker, board-column) over a recent window (default 14 days), filed under its
  * base G10 currency via boardColumn (pairs land under the numerator; non-G10 /
  * non-currency instruments are dropped). Newest brief (run_date, then report_date)
- * wins per cell. Returns `[]` when unconfigured.
+ * wins per cell. Reads from `fx_research_history.currency_views`. Returns `[]`
+ * when unconfigured.
  */
 export async function getMatrix(windowDays = 14): Promise<MatrixCell[]> {
   const briefs = await getBriefs(windowDays);

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -138,7 +138,7 @@ export interface FxEconomicCalendarRow {
 
 /**
  * One element of a brief's `currency_views` jsonb array
- * (`fx_research_history_v2.currency_views`). One desk view of one currency.
+ * (`fx_research_history.currency_views`). One desk view of one currency.
  */
 export interface CurrencyView {
   currency: string;
@@ -151,7 +151,7 @@ export interface CurrencyView {
 }
 
 /**
- * `fx_research_history_v2` — one row per broker document per run (P3 brief).
+ * `fx_research_history` — one row per broker document per run (P3 brief).
  * The Traceability link key across surfaces is `source_file`; a brief is the
  * pair (run_date, source_file). `currency_views` is the per-desk view array.
  * PRIMARY KEY/UPSERT on (file_id, run_date).
@@ -200,7 +200,7 @@ export interface FxLedgerRow {
 /**
  * One cell of the broker×G10 matrix — the LATEST currency_view a desk holds on a
  * currency over a recent window. Derived in TS (display grouping, not consensus
- * math) from `fx_research_history_v2.currency_views`.
+ * math) from `fx_research_history.currency_views`.
  */
 export interface MatrixCell {
   broker: string;

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -137,8 +137,7 @@ export interface FxEconomicCalendarRow {
 }
 
 /**
- * One element of a brief's `currency_views` jsonb array
- * (`fx_research_history.currency_views`). One desk view of one currency.
+ * One element of a brief's `currency_views` jsonb array.
  */
 export interface CurrencyView {
   currency: string;
@@ -199,8 +198,8 @@ export interface FxLedgerRow {
 
 /**
  * One cell of the broker×G10 matrix — the LATEST currency_view a desk holds on a
- * currency over a recent window. Derived in TS (display grouping, not consensus
- * math) from `fx_research_history.currency_views`.
+ * currency over a recent window. Derived in TS from brief `currency_views`
+ * (display grouping, not consensus math).
  */
 export interface MatrixCell {
   broker: string;


### PR DESCRIPTION
Fixes #811

## Summary

- Updates `lib/twelve-x/fetch.ts` and `types.ts` to query `fx_research_history` instead of `fx_research_history_v2`
- Fixes `lib/queries.ts` `paginatedFetch` callbacks to be `async` (typecheck regression on develop)
- Pairs with [twelve-x#36](https://github.com/digithings-ai/twelve-x/pull/36) follow-up commit `46fcd65` and Supabase migration `010_rename_briefs_table` (already applied on prod)

## Test plan

- [ ] FX Research suite loads briefs and matrix for a recent run date
- [ ] `getBriefs` / `getBriefBySourceFile` return data (no PostgREST 404 on old table name)