### PR TITLE
fix(olympus): stabilize portfolio visual QA

### DIFF
--- a/frontend/olympus/components/portfolio/AllocationsPositionsTable.tsx
+++ b/frontend/olympus/components/portfolio/AllocationsPositionsTable.tsx
@@ -6,10 +6,11 @@ import { Badge, pnlColor } from '@/components/ui';
 import type { DashboardPositionEvent, Position, PositionHistoryRow, Thesis } from '@/lib/types';
 import PositionDrilldown from '@/components/portfolio/PositionDrilldown';
 import { formatAllocationCategory } from '@/components/portfolio/tabs/palette-and-format';
+import { normalizeThesisId } from '@/lib/thesis-id';
 
 function thesisNames(ids: string[], thesisById: Map<string, Thesis>): string {
   if (!ids.length) return '—';
-  return ids.map((id) => thesisById.get(id)?.name ?? id).join(', ');
+  return ids.map((id) => thesisById.get(normalizeThesisId(id))?.name ?? id).join(', ');
 }
 
 export default function AllocationsPositionsTable(props: {

--- a/frontend/olympus/components/portfolio/PortfolioShellInner.tsx
+++ b/frontend/olympus/components/portfolio/PortfolioShellInner.tsx
@@ -18,35 +18,19 @@ import {
   tickerStackLabel,
   type SleeveStackMode,
 } from '@/lib/portfolio-aggregates';
+import {
+  canonicalizeLegacyPortfolioSearch,
+  hrefWithQuery,
+  mapPortfolioTabFromUrl,
+  replaceBrowserUrl,
+  VALID_PORTFOLIO_TABS,
+  type PortfolioTabId,
+} from '@/lib/portfolio-url-state';
 import AllocationsTab from './tabs/AllocationsTab';
 import PerformanceTab from './tabs/PerformanceTab';
 import AnalysisTab from './tabs/AnalysisTab';
 import ActivityTab from './tabs/ActivityTab';
 import AtlasLoader from '@/components/AtlasLoader';
-
-type TabId = 'allocations' | 'performance' | 'analysis' | 'activity';
-
-const VALID_TABS: TabId[] = ['allocations', 'performance', 'analysis', 'activity'];
-
-const LEGACY_TAB_ALIASES = new Set([
-  'summary',
-  'history',
-  'pm_process',
-  'thesis',
-  'positions',
-  'theses',
-  'pm_analysis',
-]);
-
-function mapPortfolioTabFromUrl(raw: string | null): TabId {
-  if (!raw || raw === 'summary') return 'allocations';
-  if (raw === 'history' || raw === 'pm_process') return 'analysis';
-  if (raw === 'thesis' || raw === 'theses' || raw === 'pm_analysis' || raw === 'positions') {
-    return 'allocations';
-  }
-  if (VALID_TABS.includes(raw as TabId)) return raw as TabId;
-  return 'allocations';
-}
 
 function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKind {
   let sawBaseline = false;
@@ -62,14 +46,25 @@ function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKin
   return 'unknown';
 }
 
+function currentSearchParams(params: { toString(): string }): URLSearchParams {
+  if (typeof window !== 'undefined') return new URLSearchParams(window.location.search);
+  return new URLSearchParams(params.toString());
+}
+
+function currentPathname(fallback: string): string {
+  if (typeof window !== 'undefined') return window.location.pathname;
+  return fallback;
+}
+
 export default function PortfolioShellInner() {
   const { data, loading, error } = useDashboard();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
   const urlTab = searchParams.get('tab');
-  const urlDocKey = searchParams.get('docKey');
-  const tab = useMemo(() => mapPortfolioTabFromUrl(urlTab), [urlTab]);
+  const [tab, setTab] = useState<PortfolioTabId>(() => mapPortfolioTabFromUrl(urlTab));
+  const [dateParam, setDateParam] = useState(() => searchParams.get('date'));
+  const [docKeyParam, setDocKeyParam] = useState(() => searchParams.get('docKey'));
   const [sleeveStackMode, setSleeveStackMode] = useState<SleeveStackMode>('ticker');
 
   const positions = useMemo(() => data?.positions ?? [], [data]);
@@ -125,22 +120,20 @@ export default function PortfolioShellInner() {
     return historyTimelineDates[0] ?? null;
   }, [lastUpdated, historyDateSet, historyTimelineDates]);
 
-  const dateParam = searchParams.get('date');
-
   const effHistoryDate = useMemo(() => {
     if (dateParam && historyDateSet.has(dateParam)) return dateParam;
     return defaultHistoryDate;
   }, [dateParam, historyDateSet, defaultHistoryDate]);
 
   const pmActiveFile = useMemo(() => {
-    if (tab !== 'analysis' || !effHistoryDate || !data?.docs || !urlDocKey) return null;
+    if (tab !== 'analysis' || !effHistoryDate || !data?.docs || !docKeyParam) return null;
     return (
       data.docs.find(
         (d) =>
-          d.date === effHistoryDate && d.path === urlDocKey && getDocLibraryTier(d) === 'portfolio'
+          d.date === effHistoryDate && d.path === docKeyParam && getDocLibraryTier(d) === 'portfolio'
       ) ?? null
     );
-  }, [tab, effHistoryDate, data?.docs, urlDocKey]);
+  }, [tab, effHistoryDate, data?.docs, docKeyParam]);
 
   const { data: pmLibraryDoc, loading: pmLoading } = useLibraryDocument(pmActiveFile);
 
@@ -179,65 +172,53 @@ export default function PortfolioShellInner() {
   );
 
   useEffect(() => {
-    const raw = urlTab;
-    if (!raw || VALID_TABS.includes(raw as TabId) || !LEGACY_TAB_ALIASES.has(raw)) return;
-
-    const p = new URLSearchParams(searchParams.toString());
-    if (raw === 'summary') {
-      p.delete('tab');
-      p.delete('docKey');
-      p.delete('date');
-      p.delete('thesis');
-    } else if (raw === 'positions') {
-      p.delete('tab');
-      p.delete('docKey');
-      p.delete('date');
-      p.delete('thesis');
-    } else if (raw === 'history') {
-      p.set('tab', 'analysis');
-      if (!p.get('date') && defaultHistoryDate) p.set('date', defaultHistoryDate);
-    } else if (raw === 'pm_process') {
-      p.set('tab', 'analysis');
-      if (!p.get('date') && data?.docs && lastUpdated) {
-        const dk = p.get('docKey');
-        if (dk) {
-          const matches = data.docs
-            .filter((d) => d.path === dk && getDocLibraryTier(d) === 'portfolio')
-            .sort((a, b) => b.date.localeCompare(a.date));
-          p.set('date', matches[0]?.date ?? lastUpdated);
-        } else {
-          p.set('date', lastUpdated);
-        }
-      }
-    } else if (raw === 'thesis') {
-      const thesis = p.get('thesis');
-      p.delete('tab');
-      p.delete('date');
-      p.delete('docKey');
-      p.delete('thesis');
-      if (thesis) {
-        router.replace(`/portfolio/theses/${encodeURIComponent(thesis)}`);
-        return;
-      }
-      router.replace('/portfolio/theses');
-      return;
-    } else if (raw === 'theses' || raw === 'pm_analysis') {
-      p.delete('tab');
-      p.delete('docKey');
-      p.delete('date');
-      p.delete('thesis');
-      const q = p.toString();
-      router.replace(q ? `/portfolio/theses?${q}` : '/portfolio/theses');
+    if (urlTab && VALID_PORTFOLIO_TABS.includes(urlTab as PortfolioTabId)) {
+      queueMicrotask(() => {
+        setTab(urlTab as PortfolioTabId);
+        setDateParam(searchParams.get('date'));
+        setDocKeyParam(searchParams.get('docKey'));
+      });
       return;
     }
-    const target = p.toString();
-    router.replace(target ? `${pathname}?${target}` : pathname, { scroll: false });
+
+    const p = new URLSearchParams(searchParams.toString());
+    const dk = p.get('docKey');
+    const docDate =
+      dk && data?.docs
+        ? data.docs
+            .filter((d) => d.path === dk && getDocLibraryTier(d) === 'portfolio')
+            .sort((a, b) => b.date.localeCompare(a.date))[0]?.date
+        : null;
+    const target = canonicalizeLegacyPortfolioSearch(currentPathname(pathname), p, {
+      defaultHistoryDate,
+      lastUpdated,
+      docDate,
+    });
+    if (!target) {
+      queueMicrotask(() => {
+        setTab(mapPortfolioTabFromUrl(urlTab));
+        setDateParam(searchParams.get('date'));
+        setDocKeyParam(searchParams.get('docKey'));
+      });
+      return;
+    }
+    if (target.kind === 'path') {
+      router.replace(target.href);
+      return;
+    }
+    replaceBrowserUrl(target.href);
+    const nextUrl = new URL(target.href, 'https://olympus.local');
+    queueMicrotask(() => {
+      setTab(mapPortfolioTabFromUrl(nextUrl.searchParams.get('tab')));
+      setDateParam(nextUrl.searchParams.get('date'));
+      setDocKeyParam(nextUrl.searchParams.get('docKey'));
+    });
   }, [urlTab, searchParams, pathname, router, data?.docs, lastUpdated, defaultHistoryDate]);
 
   function openPmDocument(doc: Doc) {
-    const p = new URLSearchParams(searchParams.toString());
-    const curKey = p.get('docKey');
-    const curDate = p.get('date');
+    const p = currentSearchParams(searchParams);
+    const curKey = docKeyParam;
+    const curDate = dateParam;
     if (curKey === doc.path && curDate === doc.date && tab === 'analysis') {
       closePmDocument();
       return;
@@ -246,38 +227,48 @@ export default function PortfolioShellInner() {
     p.set('date', doc.date);
     p.set('docKey', doc.path);
     p.delete('thesis');
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setTab('analysis');
+    setDateParam(doc.date);
+    setDocKeyParam(doc.path);
   }
 
   function closePmDocument() {
-    const p = new URLSearchParams(searchParams.toString());
+    const p = currentSearchParams(searchParams);
     p.delete('docKey');
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setDocKeyParam(null);
   }
 
   function selectAnalysisDate(iso: string) {
     if (!historyDateSet.has(iso)) return;
-    const p = new URLSearchParams(searchParams.toString());
+    const p = currentSearchParams(searchParams);
     p.set('tab', 'analysis');
     p.set('date', iso);
     p.delete('docKey');
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setTab('analysis');
+    setDateParam(iso);
+    setDocKeyParam(null);
   }
 
   /** Sets `date` without switching away from the current tab (e.g. sleeve chart on Allocations). */
   function selectPortfolioHistoryDate(iso: string) {
     if (!historyDateSet.has(iso)) return;
-    const p = new URLSearchParams(searchParams.toString());
+    const p = currentSearchParams(searchParams);
     p.set('date', iso);
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setDateParam(iso);
   }
 
   function clearHistoryDateParam() {
-    const p = new URLSearchParams(searchParams.toString());
+    const p = currentSearchParams(searchParams);
     p.delete('date');
     p.delete('docKey');
     p.set('tab', tab);
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setDateParam(null);
+    setDocKeyParam(null);
   }
 
   const sectionActive: PortfolioSectionId =

--- a/frontend/olympus/components/portfolio/PortfolioShellInner.tsx
+++ b/frontend/olympus/components/portfolio/PortfolioShellInner.tsx
@@ -20,12 +20,16 @@ import {
 } from '@/lib/portfolio-aggregates';
 import {
   canonicalizeLegacyPortfolioSearch,
+  currentPathname,
+  currentSearchParams,
   hrefWithQuery,
   mapPortfolioTabFromUrl,
   replaceBrowserUrl,
+  searchParamsFromHref,
   VALID_PORTFOLIO_TABS,
   type PortfolioTabId,
 } from '@/lib/portfolio-url-state';
+import { normalizeThesisId } from '@/lib/thesis-id';
 import AllocationsTab from './tabs/AllocationsTab';
 import PerformanceTab from './tabs/PerformanceTab';
 import AnalysisTab from './tabs/AnalysisTab';
@@ -46,16 +50,6 @@ function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKin
   return 'unknown';
 }
 
-function currentSearchParams(params: { toString(): string }): URLSearchParams {
-  if (typeof window !== 'undefined') return new URLSearchParams(window.location.search);
-  return new URLSearchParams(params.toString());
-}
-
-function currentPathname(fallback: string): string {
-  if (typeof window !== 'undefined') return window.location.pathname;
-  return fallback;
-}
-
 export default function PortfolioShellInner() {
   const { data, loading, error } = useDashboard();
   const searchParams = useSearchParams();
@@ -74,7 +68,10 @@ export default function PortfolioShellInner() {
   const positionEvents = useMemo(() => data?.position_events ?? [], [data]);
   const lastUpdated = data?.portfolio?.meta?.last_updated ?? null;
 
-  const thesisById = useMemo(() => new Map(theses.map((t) => [t.id, t])), [theses]);
+  const thesisById = useMemo(
+    () => new Map(theses.map((t) => [normalizeThesisId(t.id), t])),
+    [theses]
+  );
 
   const { data: sleeveData, keys: sleeveKeys } = useMemo(
     () => buildSleeveStackSeries(positionHistory, sleeveStackMode),
@@ -90,7 +87,7 @@ export default function PortfolioShellInner() {
     [sleeveStackMode, theses]
   );
 
-  const activityEvents = useMemo(() => positionEvents, [positionEvents]);
+  const activityEvents = positionEvents;
 
   const portfolioDocDates = useMemo(() => {
     const s = new Set<string>();
@@ -207,13 +204,24 @@ export default function PortfolioShellInner() {
       return;
     }
     replaceBrowserUrl(target.href);
-    const nextUrl = new URL(target.href, 'https://olympus.local');
+    const nextParams = searchParamsFromHref(target.href);
     queueMicrotask(() => {
-      setTab(mapPortfolioTabFromUrl(nextUrl.searchParams.get('tab')));
-      setDateParam(nextUrl.searchParams.get('date'));
-      setDocKeyParam(nextUrl.searchParams.get('docKey'));
+      setTab(mapPortfolioTabFromUrl(nextParams.get('tab')));
+      setDateParam(nextParams.get('date'));
+      setDocKeyParam(nextParams.get('docKey'));
     });
   }, [urlTab, searchParams, pathname, router, data?.docs, lastUpdated, defaultHistoryDate]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      const p = new URLSearchParams(window.location.search);
+      setTab(mapPortfolioTabFromUrl(p.get('tab')));
+      setDateParam(p.get('date'));
+      setDocKeyParam(p.get('docKey'));
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
 
   function openPmDocument(doc: Doc) {
     const p = currentSearchParams(searchParams);

--- a/frontend/olympus/components/portfolio/PositionDrilldown.tsx
+++ b/frontend/olympus/components/portfolio/PositionDrilldown.tsx
@@ -31,11 +31,12 @@ import {
 } from '@/lib/position-drilldown';
 import type { DashboardPositionEvent, Position, PositionHistoryRow, Thesis } from '@/lib/types';
 import { formatAllocationCategory } from '@/components/portfolio/tabs/palette-and-format';
+import { normalizeThesisId } from '@/lib/thesis-id';
 import { pnlColor } from '@/components/ui';
 
 function thesisNames(ids: string[], thesisById: Map<string, Thesis>): string {
   if (!ids.length) return '—';
-  return ids.map((id) => thesisById.get(id)?.name ?? id).join(', ');
+  return ids.map((id) => thesisById.get(normalizeThesisId(id))?.name ?? id).join(', ');
 }
 
 function eventMarkerColor(ev: DashboardPositionEvent['event']): string {

--- a/frontend/olympus/components/portfolio/tabs/ActivityTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/ActivityTab.tsx
@@ -5,6 +5,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical } from 'lucide-react';
 import { Badge } from '@/components/ui';
 import { ActivityTickerMultiSelect } from '@/components/portfolio/activity-ticker-multi-select';
 import type { DashboardPositionEvent, Thesis } from '@/lib/types';
+import { normalizeThesisId } from '@/lib/thesis-id';
 
 const EVENT_TYPES = ['OPEN', 'EXIT', 'TRIM', 'ADD', 'HOLD'] as const;
 type LedgerEventType = (typeof EVENT_TYPES)[number];
@@ -541,7 +542,7 @@ export default function ActivityTab(props: {
             {sortedEvents.map((ev, i) => {
               const detailParts = [
                 ev.reason ? `Reason: ${ev.reason}` : null,
-                ev.thesis_id ? thesisById.get(ev.thesis_id)?.name ?? ev.thesis_id : null,
+                ev.thesis_id ? thesisById.get(normalizeThesisId(ev.thesis_id))?.name ?? ev.thesis_id : null,
                 ev.price != null ? `Price: $${Number(ev.price).toFixed(2)}` : null,
               ].filter(Boolean);
               const rowTitle = detailParts.length ? detailParts.join('\n') : undefined;

--- a/frontend/olympus/components/portfolio/tabs/palette-and-format.ts
+++ b/frontend/olympus/components/portfolio/tabs/palette-and-format.ts
@@ -134,7 +134,9 @@ const CATEGORY_LABELS: Record<string, string> = {
   equity_sector: 'Equity Sector',
   equity_broad: 'Broad Equity',
   fixed_income_cash: 'Cash',
+  fixed_income_core: 'Core Bonds',
   fixed_income_short: 'Short Duration',
+  fixed_income_intermediate: 'Intermediate Duration',
   fixed_income_long: 'Long Duration',
   fixed_income_tips: 'TIPS',
   crypto: 'Crypto',
@@ -144,7 +146,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 export function formatAllocationCategory(cat: string | null | undefined): string {
-  if (!cat) return '—';
+  if (!cat) return 'Uncategorized';
   return CATEGORY_LABELS[cat] || cat.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 

--- a/frontend/olympus/components/portfolio/theses/ThesesPageInner.tsx
+++ b/frontend/olympus/components/portfolio/theses/ThesesPageInner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useDashboard } from '@/lib/dashboard-context';
 import { SUBPAGE_MAX } from '@/components/subpage-tab-bar';
@@ -11,6 +11,12 @@ import type { Doc, Position, Thesis } from '@/lib/types';
 import type { MiniCalendarRunKind } from '@/components/library/MiniCalendar';
 import { getDocLibraryTier } from '@/lib/library-doc-tier';
 import { aggregateWeightByThesis } from '@/lib/portfolio-aggregates';
+import {
+  canonicalizeLegacyThesesSearch,
+  hrefWithQuery,
+  replaceBrowserUrl,
+} from '@/lib/portfolio-url-state';
+import { normalizeThesisId } from '@/lib/thesis-id';
 
 function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKind {
   let sawBaseline = false;
@@ -26,11 +32,22 @@ function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKin
   return 'unknown';
 }
 
+function currentSearchParams(params: { toString(): string }): URLSearchParams {
+  if (typeof window !== 'undefined') return new URLSearchParams(window.location.search);
+  return new URLSearchParams(params.toString());
+}
+
+function currentPathname(fallback: string): string {
+  if (typeof window !== 'undefined') return window.location.pathname;
+  return fallback;
+}
+
 export default function ThesesPageInner() {
   const { data, loading, error } = useDashboard();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const [dateParam, setDateParam] = useState(() => searchParams.get('date'));
   const theses = useMemo(() => data?.portfolio?.strategy?.theses ?? [], [data]);
   const positionHistory = useMemo(() => data?.position_history ?? [], [data]);
   const lastUpdated = data?.portfolio?.meta?.last_updated ?? null;
@@ -63,7 +80,21 @@ export default function ThesesPageInner() {
     return historyTimelineDates[0] ?? null;
   }, [lastUpdated, historyDateSet, historyTimelineDates]);
 
-  const dateParam = searchParams.get('date');
+  useEffect(() => {
+    const target = canonicalizeLegacyThesesSearch(
+      new URLSearchParams(searchParams.toString()),
+      currentPathname(pathname)
+    );
+    if (!target) return;
+    if (target.kind === 'path') {
+      router.replace(target.href);
+      return;
+    }
+    replaceBrowserUrl(target.href);
+    queueMicrotask(() => {
+      setDateParam(new URL(target.href, 'https://olympus.local').searchParams.get('date'));
+    });
+  }, [pathname, router, searchParams]);
 
   const effHistoryDate = useMemo(() => {
     if (dateParam && historyDateSet.has(dateParam)) return dateParam;
@@ -88,7 +119,7 @@ export default function ThesesPageInner() {
   const thesisBookRowsForHistoryDate = useMemo(() => {
     const rows: { id: string; thesis: Thesis | null; weight: number }[] = [];
     for (const t of theses) {
-      rows.push({ id: t.id, thesis: t, weight: byThesisWeightForHistoryDate.get(t.id) ?? 0 });
+      rows.push({ id: t.id, thesis: t, weight: byThesisWeightForHistoryDate.get(normalizeThesisId(t.id)) ?? 0 });
     }
     const unlinked = byThesisWeightForHistoryDate.get('_unlinked') ?? 0;
     if (unlinked > 0.005) {
@@ -118,18 +149,20 @@ export default function ThesesPageInner() {
   const selectAnalysisDate = useCallback(
     (iso: string) => {
       if (!historyDateSet.has(iso)) return;
-      const p = new URLSearchParams(searchParams.toString());
+      const p = currentSearchParams(searchParams);
       p.set('date', iso);
-      router.replace(`${pathname}?${p.toString()}`, { scroll: false });
+      replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+      setDateParam(iso);
     },
-    [historyDateSet, pathname, router, searchParams]
+    [historyDateSet, pathname, searchParams]
   );
 
   const clearHistoryDateParam = useCallback(() => {
-    const p = new URLSearchParams(searchParams.toString());
+    const p = currentSearchParams(searchParams);
     p.delete('date');
-    router.replace(`${pathname}?${p.toString()}`, { scroll: false });
-  }, [pathname, router, searchParams]);
+    replaceBrowserUrl(hrefWithQuery(currentPathname(pathname), p));
+    setDateParam(null);
+  }, [pathname, searchParams]);
 
   if (loading) return <AtlasLoader />;
   if (error || !data)

--- a/frontend/olympus/components/portfolio/theses/ThesesPageInner.tsx
+++ b/frontend/olympus/components/portfolio/theses/ThesesPageInner.tsx
@@ -13,8 +13,11 @@ import { getDocLibraryTier } from '@/lib/library-doc-tier';
 import { aggregateWeightByThesis } from '@/lib/portfolio-aggregates';
 import {
   canonicalizeLegacyThesesSearch,
+  currentPathname,
+  currentSearchParams,
   hrefWithQuery,
   replaceBrowserUrl,
+  searchParamsFromHref,
 } from '@/lib/portfolio-url-state';
 import { normalizeThesisId } from '@/lib/thesis-id';
 
@@ -30,16 +33,6 @@ function aggregateRunKindForPortfolioDocs(docsOnDate: Doc[]): MiniCalendarRunKin
   if (sawBaseline) return 'baseline';
   if (sawDelta) return 'delta';
   return 'unknown';
-}
-
-function currentSearchParams(params: { toString(): string }): URLSearchParams {
-  if (typeof window !== 'undefined') return new URLSearchParams(window.location.search);
-  return new URLSearchParams(params.toString());
-}
-
-function currentPathname(fallback: string): string {
-  if (typeof window !== 'undefined') return window.location.pathname;
-  return fallback;
 }
 
 export default function ThesesPageInner() {
@@ -85,16 +78,27 @@ export default function ThesesPageInner() {
       new URLSearchParams(searchParams.toString()),
       currentPathname(pathname)
     );
-    if (!target) return;
+    if (!target) {
+      queueMicrotask(() => setDateParam(searchParams.get('date')));
+      return;
+    }
     if (target.kind === 'path') {
       router.replace(target.href);
       return;
     }
     replaceBrowserUrl(target.href);
     queueMicrotask(() => {
-      setDateParam(new URL(target.href, 'https://olympus.local').searchParams.get('date'));
+      setDateParam(searchParamsFromHref(target.href).get('date'));
     });
   }, [pathname, router, searchParams]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      setDateParam(new URLSearchParams(window.location.search).get('date'));
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
 
   const effHistoryDate = useMemo(() => {
     if (dateParam && historyDateSet.has(dateParam)) return dateParam;

--- a/frontend/olympus/components/portfolio/theses/ThesisDetailPageInner.tsx
+++ b/frontend/olympus/components/portfolio/theses/ThesisDetailPageInner.tsx
@@ -14,6 +14,7 @@ import { SUBPAGE_MAX } from '@/components/subpage-tab-bar';
 import PortfolioSectionNav from '@/components/portfolio/PortfolioSectionNav';
 import AtlasLoader from '@/components/AtlasLoader';
 import { ArrowLeft } from 'lucide-react';
+import { thesisIdEquals } from '@/lib/thesis-id';
 
 export default function ThesisDetailPageInner({ thesisId }: { thesisId: string }) {
   const { data, loading, error } = useDashboard();
@@ -23,7 +24,10 @@ export default function ThesisDetailPageInner({ thesisId }: { thesisId: string }
   );
 
   const theses = useMemo(() => data?.portfolio?.strategy?.theses ?? [], [data]);
-  const thesis = useMemo(() => (thesisId === '_unlinked' ? null : theses.find((t) => t.id === thesisId) ?? null), [theses, thesisId]);
+  const thesis = useMemo(
+    () => (thesisId === '_unlinked' ? null : theses.find((t) => thesisIdEquals(t.id, thesisId)) ?? null),
+    [theses, thesisId]
+  );
   const positionHistory = useMemo(() => data?.position_history ?? [], [data]);
   const positionEvents = useMemo(() => data?.position_events ?? [], [data]);
   const lastUpdated = data?.portfolio?.meta?.last_updated ?? null;
@@ -51,7 +55,7 @@ export default function ThesisDetailPageInner({ thesisId }: { thesisId: string }
 
   const latestHistoryDate = useMemo(() => {
     const rows = positionHistory.filter((r) =>
-      thesisId === '_unlinked' ? !r.thesis_id : r.thesis_id === thesisId
+      thesisId === '_unlinked' ? !r.thesis_id : thesisIdEquals(r.thesis_id, thesisId)
     );
     if (!rows.length) return null;
     return [...new Set(rows.map((r) => r.date))].sort().reverse()[0] ?? null;
@@ -64,7 +68,7 @@ export default function ThesisDetailPageInner({ thesisId }: { thesisId: string }
       if (r.date !== latestHistoryDate) continue;
       if (thesisId === '_unlinked') {
         if (!r.thesis_id) s.add(r.ticker);
-      } else if (r.thesis_id === thesisId) {
+      } else if (thesisIdEquals(r.thesis_id, thesisId)) {
         s.add(r.ticker);
       }
     }
@@ -112,7 +116,9 @@ export default function ThesisDetailPageInner({ thesisId }: { thesisId: string }
           >
             <ArrowLeft size={16} /> Back to Theses
           </Link>
-          <p className="text-text-muted">No thesis found for <span className="font-mono">{thesisId}</span>.</p>
+          <p className="text-text-muted">
+            No thesis metadata row found for <span className="font-mono">{thesisId}</span>.
+          </p>
         </div>
       </div>
     );

--- a/frontend/olympus/lib/portfolio-aggregates.test.ts
+++ b/frontend/olympus/lib/portfolio-aggregates.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildSleeveStackSeries, categoryStackLabel } from './portfolio-aggregates';
+import { inferPortfolioCategory } from './portfolio-categories';
+import type { PositionHistoryRow } from './types';
+
+describe('portfolio category aggregation', () => {
+  it('infers deterministic categories for common ETFs', () => {
+    expect(inferPortfolioCategory('SHY', null)).toBe('fixed_income_short');
+    expect(inferPortfolioCategory('XLK', '—')).toBe('equity_sector');
+    expect(inferPortfolioCategory('MYSTERY', null)).toBe('uncategorized');
+  });
+
+  it('builds a visible category sleeve when history has sparse categories', () => {
+    const rows: PositionHistoryRow[] = [
+      { date: '2026-06-17', ticker: 'SHY', weight_pct: 35, category: null, thesis_id: 'defense' },
+      { date: '2026-06-17', ticker: 'XLK', weight_pct: 15, category: '—', thesis_id: 'growth' },
+      { date: '2026-06-18', ticker: 'SHY', weight_pct: 30, category: null, thesis_id: 'defense' },
+      { date: '2026-06-18', ticker: 'ABC', weight_pct: 5, category: null, thesis_id: null },
+    ];
+
+    const { data, keys } = buildSleeveStackSeries(rows, 'category');
+
+    expect(keys).toContain('fixed_income_short');
+    expect(keys).toContain('equity_sector');
+    expect(keys).toContain('uncategorized');
+    expect(data[0].fixed_income_short).toBe(35);
+    expect(categoryStackLabel('uncategorized')).toBe('Uncategorized');
+  });
+});

--- a/frontend/olympus/lib/portfolio-aggregates.ts
+++ b/frontend/olympus/lib/portfolio-aggregates.ts
@@ -1,4 +1,4 @@
-import { categoryStackLabel, inferPortfolioCategory } from './portfolio-categories';
+import { inferPortfolioCategory } from './portfolio-categories';
 import { normalizeThesisId, thesisIdEquals } from './thesis-id';
 import type { Position, PositionHistoryRow, Thesis } from './types';
 
@@ -110,7 +110,8 @@ export function thesisStackLabel(key: string, theses: Thesis[]): string {
   const t = theses.find((x) => thesisIdEquals(x.id, key));
   return t?.name ?? key;
 }
-export { categoryStackLabel };
+
+export { categoryStackLabel } from './portfolio-categories';
 
 /** Weight % per thesis_id from holdings (live positions or a single history slice). */
 export function aggregateWeightByThesis(

--- a/frontend/olympus/lib/portfolio-aggregates.ts
+++ b/frontend/olympus/lib/portfolio-aggregates.ts
@@ -1,3 +1,5 @@
+import { categoryStackLabel, inferPortfolioCategory } from './portfolio-categories';
+import { normalizeThesisId, thesisIdEquals } from './thesis-id';
 import type { Position, PositionHistoryRow, Thesis } from './types';
 
 /** Max distinct tickers in stacked history before merging the rest into `_other`. */
@@ -6,9 +8,8 @@ export const SLEEVE_TOP_N_TICKERS = 10;
 export type SleeveStackMode = 'category' | 'thesis' | 'ticker';
 
 function sleeveKey(row: PositionHistoryRow, mode: Exclude<SleeveStackMode, 'ticker'>): string {
-  if (mode === 'thesis') return row.thesis_id || '_unlinked';
-  if (row.ticker === 'CASH') return 'cash';
-  return row.category || 'uncategorized';
+  if (mode === 'thesis') return normalizeThesisId(row.thesis_id) || '_unlinked';
+  return inferPortfolioCategory(row.ticker, row.category);
 }
 
 /**
@@ -106,15 +107,10 @@ export function tickerStackLabel(key: string): string {
 
 export function thesisStackLabel(key: string, theses: Thesis[]): string {
   if (key === '_unlinked') return 'Unlinked';
-  const t = theses.find((x) => x.id === key);
+  const t = theses.find((x) => thesisIdEquals(x.id, key));
   return t?.name ?? key;
 }
-
-export function categoryStackLabel(key: string): string {
-  if (key === 'cash') return 'Cash';
-  if (key === 'uncategorized') return 'Uncategorized';
-  return key.replace(/_/g, ' ');
-}
+export { categoryStackLabel };
 
 /** Weight % per thesis_id from holdings (live positions or a single history slice). */
 export function aggregateWeightByThesis(
@@ -125,7 +121,7 @@ export function aggregateWeightByThesis(
     const ids = p.thesis_ids?.length ? p.thesis_ids : ['_unlinked'];
     const share = (p.weight_actual ?? 0) / ids.length;
     for (const id of ids) {
-      const k = id || '_unlinked';
+      const k = normalizeThesisId(id) || '_unlinked';
       m.set(k, (m.get(k) ?? 0) + share);
     }
   }

--- a/frontend/olympus/lib/portfolio-categories.ts
+++ b/frontend/olympus/lib/portfolio-categories.ts
@@ -1,0 +1,57 @@
+const ETF_CATEGORY_BY_TICKER: Record<string, string> = {
+  AGG: 'fixed_income_core',
+  BIL: 'fixed_income_cash',
+  BND: 'fixed_income_core',
+  GLD: 'commodity_gold',
+  GOVT: 'fixed_income_core',
+  IEF: 'fixed_income_intermediate',
+  IWM: 'equity_broad',
+  QQQ: 'equity_broad',
+  SGOV: 'fixed_income_cash',
+  SHV: 'fixed_income_cash',
+  SHY: 'fixed_income_short',
+  SPY: 'equity_broad',
+  TLT: 'fixed_income_long',
+  VTI: 'equity_broad',
+  XLB: 'equity_sector',
+  XLC: 'equity_sector',
+  XLE: 'equity_sector',
+  XLF: 'equity_sector',
+  XLI: 'equity_sector',
+  XLK: 'equity_sector',
+  XLP: 'equity_sector',
+  XLRE: 'equity_sector',
+  XLU: 'equity_sector',
+  XLV: 'equity_sector',
+  XLY: 'equity_sector',
+};
+
+const UNKNOWN_CATEGORY_VALUES = new Set(['', '-', '—', 'unknown', 'uncategorized', 'null']);
+
+export function normalizePortfolioCategory(raw: string | null | undefined): string | null {
+  const value = String(raw ?? '').trim();
+  if (!value || UNKNOWN_CATEGORY_VALUES.has(value.toLowerCase())) return null;
+  return value;
+}
+
+export function inferPortfolioCategory(ticker: string | null | undefined, raw: string | null | undefined): string {
+  const explicit = normalizePortfolioCategory(raw);
+  if (explicit) return explicit;
+
+  const t = String(ticker ?? '').trim().toUpperCase();
+  if (t === 'CASH') return 'cash';
+  return ETF_CATEGORY_BY_TICKER[t] ?? 'uncategorized';
+}
+
+export function categoryStackLabel(key: string): string {
+  if (key === 'cash') return 'Cash';
+  if (key === 'uncategorized') return 'Uncategorized';
+  if (key === 'fixed_income_cash') return 'Cash';
+  if (key === 'fixed_income_short') return 'Short Duration';
+  if (key === 'fixed_income_intermediate') return 'Intermediate Duration';
+  if (key === 'fixed_income_core') return 'Core Bonds';
+  if (key === 'fixed_income_long') return 'Long Duration';
+  if (key === 'equity_broad') return 'Broad Equity';
+  if (key === 'equity_sector') return 'Equity Sector';
+  return key.replace(/_/g, ' ');
+}

--- a/frontend/olympus/lib/portfolio-url-state.test.ts
+++ b/frontend/olympus/lib/portfolio-url-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeLegacyPortfolioSearch,
+  canonicalizeLegacyThesesSearch,
+  mapPortfolioTabFromUrl,
+} from './portfolio-url-state';
+
+describe('portfolio-url-state', () => {
+  it('maps legacy thesis tabs away from shell-owned tabs', () => {
+    expect(mapPortfolioTabFromUrl('theses')).toBe('allocations');
+    expect(mapPortfolioTabFromUrl('thesis')).toBe('allocations');
+    expect(mapPortfolioTabFromUrl('activity')).toBe('activity');
+  });
+
+  it('canonicalizes legacy thesis deep links to the thesis route', () => {
+    const target = canonicalizeLegacyPortfolioSearch(
+      '/olympus/portfolio',
+      new URLSearchParams('tab=thesis&thesis=SHY&date=2026-06-17')
+    );
+
+    expect(target).toEqual({ kind: 'path', href: '/olympus/portfolio/theses/SHY' });
+  });
+
+  it('canonicalizes legacy theses tab once on the theses page', () => {
+    const target = canonicalizeLegacyThesesSearch(new URLSearchParams('tab=theses&date=2026-06-17'));
+
+    expect(target).toEqual({ kind: 'query', href: '/portfolio/theses?date=2026-06-17' });
+  });
+
+  it('rewrites historical aliases without path navigation', () => {
+    const target = canonicalizeLegacyPortfolioSearch('/portfolio', new URLSearchParams('tab=history'), {
+      defaultHistoryDate: '2026-06-18',
+    });
+
+    expect(target).toEqual({ kind: 'query', href: '/portfolio?tab=analysis&date=2026-06-18' });
+  });
+});

--- a/frontend/olympus/lib/portfolio-url-state.ts
+++ b/frontend/olympus/lib/portfolio-url-state.ts
@@ -1,3 +1,5 @@
+const URL_PARSE_BASE = 'https://olympus.local';
+
 export type PortfolioTabId = 'allocations' | 'performance' | 'analysis' | 'activity';
 
 export const VALID_PORTFOLIO_TABS: readonly PortfolioTabId[] = [
@@ -46,6 +48,20 @@ export function portfolioThesesPath(pathname: string): string {
 export function replaceBrowserUrl(href: string): void {
   if (typeof window === 'undefined') return;
   window.history.replaceState(window.history.state, '', href);
+}
+
+export function currentSearchParams(fallback: { toString(): string }): URLSearchParams {
+  if (typeof window !== 'undefined') return new URLSearchParams(window.location.search);
+  return new URLSearchParams(fallback.toString());
+}
+
+export function currentPathname(fallback: string): string {
+  if (typeof window !== 'undefined') return window.location.pathname;
+  return fallback;
+}
+
+export function searchParamsFromHref(href: string): URLSearchParams {
+  return new URL(href, URL_PARSE_BASE).searchParams;
 }
 
 export function canonicalizeLegacyPortfolioSearch(

--- a/frontend/olympus/lib/portfolio-url-state.ts
+++ b/frontend/olympus/lib/portfolio-url-state.ts
@@ -1,0 +1,120 @@
+export type PortfolioTabId = 'allocations' | 'performance' | 'analysis' | 'activity';
+
+export const VALID_PORTFOLIO_TABS: readonly PortfolioTabId[] = [
+  'allocations',
+  'performance',
+  'analysis',
+  'activity',
+];
+
+export const LEGACY_PORTFOLIO_TAB_ALIASES = new Set([
+  'summary',
+  'history',
+  'pm_process',
+  'thesis',
+  'positions',
+  'theses',
+  'pm_analysis',
+]);
+
+export type PortfolioCanonicalTarget =
+  | { kind: 'path'; href: string }
+  | { kind: 'query'; href: string };
+
+export function mapPortfolioTabFromUrl(raw: string | null): PortfolioTabId {
+  if (!raw || raw === 'summary') return 'allocations';
+  if (raw === 'history' || raw === 'pm_process') return 'analysis';
+  if (raw === 'thesis' || raw === 'theses' || raw === 'pm_analysis' || raw === 'positions') {
+    return 'allocations';
+  }
+  if (VALID_PORTFOLIO_TABS.includes(raw as PortfolioTabId)) return raw as PortfolioTabId;
+  return 'allocations';
+}
+
+export function hrefWithQuery(pathname: string, params: URLSearchParams): string {
+  const q = params.toString();
+  return q ? `${pathname}?${q}` : pathname;
+}
+
+export function portfolioThesesPath(pathname: string): string {
+  const clean = pathname.replace(/\/+$/, '');
+  if (clean.endsWith('/portfolio/theses')) return clean;
+  if (clean.endsWith('/portfolio')) return `${clean}/theses`;
+  return '/portfolio/theses';
+}
+
+export function replaceBrowserUrl(href: string): void {
+  if (typeof window === 'undefined') return;
+  window.history.replaceState(window.history.state, '', href);
+}
+
+export function canonicalizeLegacyPortfolioSearch(
+  pathname: string,
+  params: URLSearchParams,
+  opts: { defaultHistoryDate?: string | null; lastUpdated?: string | null; docDate?: string | null } = {}
+): PortfolioCanonicalTarget | null {
+  const raw = params.get('tab');
+  if (!raw || VALID_PORTFOLIO_TABS.includes(raw as PortfolioTabId) || !LEGACY_PORTFOLIO_TAB_ALIASES.has(raw)) {
+    return null;
+  }
+
+  const p = new URLSearchParams(params.toString());
+  const thesesPath = portfolioThesesPath(pathname);
+  if (raw === 'summary' || raw === 'positions') {
+    p.delete('tab');
+    p.delete('docKey');
+    p.delete('date');
+    p.delete('thesis');
+    return { kind: 'query', href: hrefWithQuery(pathname, p) };
+  }
+
+  if (raw === 'history') {
+    p.set('tab', 'analysis');
+    if (!p.get('date') && opts.defaultHistoryDate) p.set('date', opts.defaultHistoryDate);
+    return { kind: 'query', href: hrefWithQuery(pathname, p) };
+  }
+
+  if (raw === 'pm_process') {
+    p.set('tab', 'analysis');
+    if (!p.get('date')) p.set('date', opts.docDate ?? opts.lastUpdated ?? opts.defaultHistoryDate ?? '');
+    if (!p.get('date')) p.delete('date');
+    return { kind: 'query', href: hrefWithQuery(pathname, p) };
+  }
+
+  if (raw === 'thesis') {
+    const thesis = p.get('thesis');
+    p.delete('tab');
+    p.delete('date');
+    p.delete('docKey');
+    p.delete('thesis');
+    if (thesis) return { kind: 'path', href: `${thesesPath}/${encodeURIComponent(thesis)}` };
+    return { kind: 'path', href: thesesPath };
+  }
+
+  if (raw === 'theses' || raw === 'pm_analysis') {
+    p.delete('tab');
+    p.delete('docKey');
+    p.delete('date');
+    p.delete('thesis');
+    return { kind: 'path', href: hrefWithQuery(thesesPath, p) };
+  }
+
+  return null;
+}
+
+export function canonicalizeLegacyThesesSearch(
+  params: URLSearchParams,
+  pathname = '/portfolio/theses'
+): PortfolioCanonicalTarget | null {
+  const raw = params.get('tab');
+  if (raw !== 'thesis' && raw !== 'theses') return null;
+
+  const p = new URLSearchParams(params.toString());
+  const thesis = raw === 'thesis' ? p.get('thesis') : null;
+  p.delete('tab');
+  p.delete('thesis');
+  const thesesPath = portfolioThesesPath(pathname);
+
+  if (thesis) return { kind: 'path', href: `${thesesPath}/${encodeURIComponent(thesis)}` };
+  return { kind: 'query', href: hrefWithQuery(thesesPath, p) };
+}

--- a/frontend/olympus/lib/position-events.test.ts
+++ b/frontend/olympus/lib/position-events.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePositionEvent } from './position-events';
+
+describe('normalizePositionEvent', () => {
+  it('normalizes OPEN prior weight and delta from the current weight', () => {
+    expect(
+      normalizePositionEvent({
+        date: '2026-06-18',
+        ticker: 'XLK',
+        event: 'OPEN',
+        weight_pct: 12.5,
+        prev_weight_pct: null,
+        price: null,
+        thesis_id: 'growth',
+        reason: 'New sleeve',
+      })
+    ).toMatchObject({
+      prev_weight_pct: 0,
+      weight_change_pct: 12.5,
+    });
+  });
+
+  it('preserves explicit prior weights for non-open events', () => {
+    expect(
+      normalizePositionEvent({
+        date: '2026-06-18',
+        ticker: 'SHY',
+        event: 'ADD',
+        weight_pct: '35',
+        prev_weight_pct: '30',
+        price: '82.5',
+        thesis_id: null,
+        reason: null,
+      })
+    ).toMatchObject({
+      weight_pct: 35,
+      prev_weight_pct: 30,
+      weight_change_pct: 5,
+      price: 82.5,
+    });
+  });
+});

--- a/frontend/olympus/lib/position-events.ts
+++ b/frontend/olympus/lib/position-events.ts
@@ -1,0 +1,36 @@
+import type { DashboardPositionEvent } from './types';
+
+export type RawPositionEventLike = {
+  date: string;
+  ticker: string;
+  event: DashboardPositionEvent['event'];
+  weight_pct: number | string | null;
+  prev_weight_pct: number | string | null;
+  price: number | string | null;
+  thesis_id: string | null;
+  reason: string | null;
+};
+
+function n(value: number | string | null): number | null {
+  if (value == null) return null;
+  const num = Number(value);
+  return Number.isNaN(num) ? null : num;
+}
+
+export function normalizePositionEvent(row: RawPositionEventLike): DashboardPositionEvent {
+  const weight = n(row.weight_pct);
+  const rawPrev = n(row.prev_weight_pct);
+  const prev = row.event === 'OPEN' && rawPrev == null && weight != null ? 0 : rawPrev;
+
+  return {
+    date: row.date,
+    ticker: row.ticker,
+    event: row.event,
+    weight_pct: weight,
+    prev_weight_pct: prev,
+    weight_change_pct: weight != null && prev != null ? weight - prev : null,
+    price: n(row.price),
+    thesis_id: row.thesis_id ?? null,
+    reason: row.reason ?? null,
+  };
+}

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -33,6 +33,9 @@ import { DASHBOARD_BENCHMARK_TICKERS, sortTickerUniverse } from './benchmark-tic
 import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
 import { MACRO_PREVIEW_SERIES_IDS } from './macro-curated';
 import { getDocLibraryTier } from './library-doc-tier';
+import { inferPortfolioCategory } from './portfolio-categories';
+import { normalizePositionEvent, type RawPositionEventLike } from './position-events';
+import { thesisIdEquals } from './thesis-id';
 
 type SB = SupabaseClient<Database>;
 
@@ -562,21 +565,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
   const position_events: DashboardPositionEvent[] = (
     eventsRaw as TableRow<'position_events'>[]
   )
-    .map((e) => ({
-      date: e.date,
-      ticker: e.ticker,
-      event: e.event,
-      weight_pct: e.weight_pct != null ? Number(e.weight_pct) : null,
-      prev_weight_pct: e.prev_weight_pct != null ? Number(e.prev_weight_pct) : null,
-      // weight_change_pct column dropped (#714) — derive at read time.
-      weight_change_pct:
-        e.weight_pct != null && e.prev_weight_pct != null
-          ? Number(e.weight_pct) - Number(e.prev_weight_pct)
-          : null,
-      price: e.price != null ? Number(e.price) : null,
-      thesis_id: e.thesis_id ?? null,
-      reason: e.reason ?? null,
-    }))
+    .map((e) => normalizePositionEvent(e as RawPositionEventLike))
     .sort((a, b) => b.date.localeCompare(a.date) || a.ticker.localeCompare(b.ticker));
 
   const server_portfolio_metrics: ServerPortfolioMetrics | null =
@@ -888,7 +877,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
     entry_date: p.entry_date ?? null,
     rationale: p.rationale ?? '',
     thesis_ids: p.thesis_id ? [p.thesis_id] : [],
-    category: p.category ?? '',
+    category: inferPortfolioCategory(p.ticker, p.category),
     pm_notes: p.pm_notes ?? '',
     stats: {},
     unrealized_pnl_pct: (() => {
@@ -1056,7 +1045,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       current_positions: effectiveCurrentPositions.map((p) => ({
         ticker: p.ticker,
         name: p.name ?? p.ticker,
-        category: p.category ?? '',
+        category: inferPortfolioCategory(p.ticker, p.category),
         weight_pct: Number(p.weight_pct ?? 0),
         thesis_ids: p.thesis_id ? [p.thesis_id] : [],
         entry_date: p.entry_date ?? null,
@@ -1076,7 +1065,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
       date: p.date,
       ticker: p.ticker,
       weight_pct: Number(p.weight_pct ?? 0),
-      category: p.category ?? null,
+      category: inferPortfolioCategory(p.ticker, p.category),
       thesis_id: p.thesis_id ?? null,
     })),
     position_events,
@@ -1122,7 +1111,7 @@ export async function getThesisHistoryById(thesisId: string): Promise<ThesisHist
   const { data, error } = await supabase
     .from('theses')
     .select('date,thesis_id,name,status,notes')
-    .eq('thesis_id', id)
+    .ilike('thesis_id', id)
     .order('date', { ascending: true });
   if (error) {
     console.error('Supabase theses history query:', error);
@@ -1148,7 +1137,7 @@ export function aggregateThesisWeightsByDate(
   if (!id || id === '_unlinked') return [];
   const byDate = new Map<string, number>();
   for (const r of positionHistory) {
-    if (r.thesis_id !== id) continue;
+    if (!thesisIdEquals(r.thesis_id, id)) continue;
     const d = r.date;
     const w = Number(r.weight_pct ?? 0);
     byDate.set(d, (byDate.get(d) ?? 0) + w);

--- a/frontend/olympus/lib/queries.ts
+++ b/frontend/olympus/lib/queries.ts
@@ -34,7 +34,7 @@ import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-co
 import { MACRO_PREVIEW_SERIES_IDS } from './macro-curated';
 import { getDocLibraryTier } from './library-doc-tier';
 import { inferPortfolioCategory } from './portfolio-categories';
-import { normalizePositionEvent, type RawPositionEventLike } from './position-events';
+import { normalizePositionEvent } from './position-events';
 import { thesisIdEquals } from './thesis-id';
 
 type SB = SupabaseClient<Database>;
@@ -565,7 +565,7 @@ export async function getFullDashboardData(): Promise<DashboardData> {
   const position_events: DashboardPositionEvent[] = (
     eventsRaw as TableRow<'position_events'>[]
   )
-    .map((e) => normalizePositionEvent(e as RawPositionEventLike))
+    .map((e) => normalizePositionEvent(e))
     .sort((a, b) => b.date.localeCompare(a.date) || a.ticker.localeCompare(b.ticker));
 
   const server_portfolio_metrics: ServerPortfolioMetrics | null =

--- a/frontend/olympus/lib/thesis-id.test.ts
+++ b/frontend/olympus/lib/thesis-id.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateThesisWeightsByDate } from './queries';
+import { thesisPipelineNarrativeFromPayloads } from './thesis-pipeline-snapshot';
+import { thesisIdEquals } from './thesis-id';
+import type { PositionHistoryRow } from './types';
+
+describe('thesis-id matching', () => {
+  it('compares thesis ids case-insensitively', () => {
+    expect(thesisIdEquals('SHY', 'shy')).toBe(true);
+    expect(thesisIdEquals(' shy ', 'SHY')).toBe(true);
+  });
+
+  it('aggregates position history independent of thesis id case', () => {
+    const rows: PositionHistoryRow[] = [
+      { date: '2026-06-17', ticker: 'SHY', weight_pct: 25, category: null, thesis_id: 'shy' },
+      { date: '2026-06-17', ticker: 'BIL', weight_pct: 10, category: null, thesis_id: 'SHY' },
+      { date: '2026-06-18', ticker: 'XLK', weight_pct: 15, category: null, thesis_id: 'growth' },
+    ];
+
+    expect(aggregateThesisWeightsByDate(rows, 'SHY')).toEqual([
+      { date: '2026-06-17', weight_pct: 35 },
+    ]);
+  });
+
+  it('matches pipeline narratives independent of thesis id case', () => {
+    const result = thesisPipelineNarrativeFromPayloads(
+      'SHY',
+      { body: { theses: [{ thesis_id: 'shy', title: 'Defense', statement: 'Own duration.' }] } },
+      { body: { mappings: [{ thesis_id: 'sHy', rationale: 'Use SHY.', candidate_tickers: ['SHY'] }] } }
+    );
+
+    expect(result.exploration).toContain('Defense');
+    expect(result.vehicles).toContain('Use SHY.');
+  });
+});

--- a/frontend/olympus/lib/thesis-id.ts
+++ b/frontend/olympus/lib/thesis-id.ts
@@ -1,0 +1,9 @@
+export function normalizeThesisId(id: string | null | undefined): string {
+  return String(id ?? '').trim().toUpperCase();
+}
+
+export function thesisIdEquals(a: string | null | undefined, b: string | null | undefined): boolean {
+  const left = normalizeThesisId(a);
+  const right = normalizeThesisId(b);
+  return Boolean(left && right && left === right);
+}

--- a/frontend/olympus/lib/thesis-pipeline-snapshot.ts
+++ b/frontend/olympus/lib/thesis-pipeline-snapshot.ts
@@ -1,4 +1,5 @@
 import type { PipelineObservabilityBundle } from '@/lib/types';
+import { thesisIdEquals } from '@/lib/thesis-id';
 
 function s(v: unknown): string {
   return v == null ? '' : String(v);
@@ -26,7 +27,7 @@ export function thesisPipelineNarrativeFromPayloads(
     const theses = Array.isArray(body?.theses) ? body.theses : [];
     for (const t of theses) {
       const th = asObj(t);
-      if (!th || s(th.thesis_id) !== thesisId) continue;
+      if (!th || !thesisIdEquals(s(th.thesis_id), thesisId)) continue;
       const lines: string[] = [];
       const title = s(th.title).trim();
       if (title) lines.push(title);
@@ -47,7 +48,7 @@ export function thesisPipelineNarrativeFromPayloads(
     const mappings = Array.isArray(body?.mappings) ? body.mappings : [];
     for (const row of mappings) {
       const m = asObj(row);
-      if (!m || s(m.thesis_id) !== thesisId) continue;
+      if (!m || !thesisIdEquals(s(m.thesis_id), thesisId)) continue;
       const lines: string[] = [];
       const rat = s(m.rationale).trim();
       if (rat) lines.push(rat);


### PR DESCRIPTION
## Summary
- Stabilizes portfolio thesis URL ownership under static export by canonicalizing legacy thesis tabs and mirroring query-only state with browser history.
- Adds deterministic portfolio category inference for common ETFs and normalizes uncategorized allocation display.
- Normalizes thesis ID matching and OPEN activity weights in query/helper layers with focused Vitest coverage.

## Test plan
- npm run lint --workspace olympus
- npm run test --workspace olympus
- make score

Fixes #843

Made with [Cursor](https://cursor.com)