### PR TITLE
fix(olympus): Intelligence UX + memo clarity for visual QA (#843)

### DIFF
--- a/frontend/olympus/components/library/AnalystDocumentView.tsx
+++ b/frontend/olympus/components/library/AnalystDocumentView.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { cleanMemoProse } from '@/lib/render-pipeline-payloads';
 
 /**
  * Structured view for Hermes per-ticker analyst specialist reports (`analyst/{ticker}`).
@@ -92,7 +93,7 @@ export default function AnalystDocumentView({
         <div>
           <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Thesis</h3>
           <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{thesis}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(thesis)}</ReactMarkdown>
           </div>
         </div>
       )}

--- a/frontend/olympus/components/library/DeliberationDocumentView.tsx
+++ b/frontend/olympus/components/library/DeliberationDocumentView.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cleanMemoProse } from '@/lib/render-pipeline-payloads';
 
 // ── Legacy deliberation-transcript types ──────────────────────────────────
 type FinalRow = {
@@ -145,7 +146,7 @@ export default function DeliberationDocumentView({
         {netRecommendation && (
           <p className="text-text-secondary">
             <span className="font-semibold text-text-primary">Recommendation:</span>{' '}
-            {netRecommendation}
+            {cleanMemoProse(netRecommendation)}
           </p>
         )}
         <div className="grid gap-4 md:grid-cols-2">
@@ -153,7 +154,7 @@ export default function DeliberationDocumentView({
             <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
               <p className="text-[10px] uppercase tracking-wider text-fin-green mb-2">Aggressive case</p>
               <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{aggressiveCase}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(aggressiveCase)}</ReactMarkdown>
               </div>
             </div>
           )}
@@ -161,7 +162,7 @@ export default function DeliberationDocumentView({
             <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
               <p className="text-[10px] uppercase tracking-wider text-fin-amber mb-2">Conservative case</p>
               <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{conservativeCase}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(conservativeCase)}</ReactMarkdown>
               </div>
             </div>
           )}
@@ -172,7 +173,7 @@ export default function DeliberationDocumentView({
               Key tension
             </h3>
             <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{keyTension}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(keyTension)}</ReactMarkdown>
             </div>
           </div>
         )}
@@ -211,7 +212,7 @@ export default function DeliberationDocumentView({
               <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
                 <p className="text-[10px] uppercase tracking-wider text-fin-green mb-2">Bull thesis</p>
                 <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{bullThesis}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(bullThesis)}</ReactMarkdown>
                 </div>
               </div>
             ) : null}
@@ -219,7 +220,7 @@ export default function DeliberationDocumentView({
               <div className="rounded-lg border border-border-subtle bg-bg-secondary/40 p-4">
                 <p className="text-[10px] uppercase tracking-wider text-fin-red/90 mb-2">Bear thesis</p>
                 <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{bearThesis}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(bearThesis)}</ReactMarkdown>
                 </div>
               </div>
             ) : null}
@@ -251,7 +252,7 @@ export default function DeliberationDocumentView({
           <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Triggers</h3>
           <ul className="list-disc pl-5 text-text-secondary space-y-1">
             {triggerSummary.map((t, i) => (
-              <li key={i}>{t}</li>
+              <li key={i}>{cleanMemoProse(t)}</li>
             ))}
           </ul>
         </div>
@@ -274,21 +275,25 @@ export default function DeliberationDocumentView({
                     <p className="text-[10px] uppercase tracking-wider text-text-muted mb-1">Analyst</p>
                     <div className="prose prose-invert max-w-none text-sm text-text-secondary">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {row.analyst_recommendation || '_—_'}
+                        {cleanMemoProse(row.analyst_recommendation || '_—_')}
                       </ReactMarkdown>
                     </div>
                   </div>
                   <div>
                     <p className="text-[10px] uppercase tracking-wider text-text-muted mb-1">PM decision</p>
                     <div className="prose prose-invert max-w-none text-sm text-text-secondary">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{row.pm_decision || '_—_'}</ReactMarkdown>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {cleanMemoProse(row.pm_decision || '_—_')}
+                      </ReactMarkdown>
                     </div>
                   </div>
                 </div>
                 {row.invalidation_condition ? (
                   <div>
                     <p className="text-[10px] uppercase tracking-wider text-text-muted mb-1">Invalidation</p>
-                    <p className="text-text-secondary text-sm whitespace-pre-wrap">{row.invalidation_condition}</p>
+                    <p className="text-text-secondary text-sm whitespace-pre-wrap">
+                      {cleanMemoProse(row.invalidation_condition)}
+                    </p>
                   </div>
                 ) : null}
               </div>
@@ -333,13 +338,17 @@ function DebateRoundBlock({ round }: { round: DebateRound }) {
           <div>
             <h4 className="text-xs font-semibold text-fin-green mb-2">Bull</h4>
             <div className="prose prose-invert max-w-none text-sm">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{round.bull_argument || '_—_'}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {cleanMemoProse(round.bull_argument || '_—_')}
+              </ReactMarkdown>
             </div>
           </div>
           <div>
             <h4 className="text-xs font-semibold text-fin-red/90 mb-2">Bear</h4>
             <div className="prose prose-invert max-w-none text-sm">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{round.bear_argument || '_—_'}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {cleanMemoProse(round.bear_argument || '_—_')}
+              </ReactMarkdown>
             </div>
           </div>
         </div>
@@ -372,7 +381,7 @@ function RoundBlock({ round }: { round: Round }) {
                 <h4 className="text-xs font-semibold text-fin-blue/90 mb-2">{sec.heading}</h4>
               ) : null}
               <div className="prose prose-invert max-w-none text-sm">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{sec.markdown || ''}</ReactMarkdown>
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(sec.markdown || '')}</ReactMarkdown>
               </div>
             </div>
           ))}

--- a/frontend/olympus/components/library/LibraryDocumentBody.tsx
+++ b/frontend/olympus/components/library/LibraryDocumentBody.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { LibraryDocumentView } from '@/lib/queries';
+import { normalizeMarkdownFirstHeadingDate } from '@/lib/render-document-from-payload';
 import { SafeMarkdown } from '@/components/SafeMarkdown';
 import RebalanceDocumentView from './RebalanceDocumentView';
 import DeltaRequestDocumentView from './DeltaRequestDocumentView';
@@ -25,27 +26,28 @@ export default function LibraryDocumentBody({
   docDate: string;
 }) {
   const isDigest = (documentKey || '').toLowerCase() === 'digest';
+  const normalizedMarkdown = normalizeMarkdownFirstHeadingDate(markdown, docDate);
 
   if (view === 'markdown' && isDigest && docDate) {
-    return <DigestDocumentView key={docDate} docDate={docDate} fallbackMarkdown={markdown} />;
+    return <DigestDocumentView key={docDate} docDate={docDate} fallbackMarkdown={normalizedMarkdown} />;
   }
 
   switch (view) {
     case 'rebalance':
-      return <RebalanceDocumentView payload={payload} fallbackMarkdown={markdown} />;
+      return <RebalanceDocumentView payload={payload} fallbackMarkdown={normalizedMarkdown} />;
     case 'delta_request':
       return <DeltaRequestDocumentView payload={payload} />;
     case 'deliberation':
     case 'risk_debate':
       // `risk_debate` reuses DeliberationDocumentView which now renders the
       // aggressive/conservative/key-tension shape alongside the bull/bear debate.
-      return <DeliberationDocumentView payload={payload} fallbackMarkdown={markdown} />;
+      return <DeliberationDocumentView payload={payload} fallbackMarkdown={normalizedMarkdown} />;
     case 'analyst':
-      return <AnalystDocumentView payload={payload} fallbackMarkdown={markdown} />;
+      return <AnalystDocumentView payload={payload} fallbackMarkdown={normalizedMarkdown} />;
     case 'evolution_sources':
-      return <EvolutionSourcesDocumentView payload={payload} fallbackMarkdown={markdown} />;
+      return <EvolutionSourcesDocumentView payload={payload} fallbackMarkdown={normalizedMarkdown} />;
     case 'opportunity_screener':
-      return <OpportunityScreenerDocumentView payload={payload} fallbackMarkdown={markdown} />;
+      return <OpportunityScreenerDocumentView payload={payload} fallbackMarkdown={normalizedMarkdown} />;
     case 'diffable':
       return (
         <GenericDiffDocumentView
@@ -53,13 +55,13 @@ export default function LibraryDocumentBody({
           docDate={docDate}
           documentKey={documentKey}
           payload={payload}
-          fallbackMarkdown={markdown}
+          fallbackMarkdown={normalizedMarkdown}
         />
       );
     default:
       return (
         <SafeMarkdown className="prose prose-invert max-w-none text-sm leading-relaxed">
-          {markdown}
+          {normalizedMarkdown}
         </SafeMarkdown>
       );
   }

--- a/frontend/olympus/components/library/RebalanceDocumentView.tsx
+++ b/frontend/olympus/components/library/RebalanceDocumentView.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { cleanMemoProse, summarizeRecommendedPortfolio } from '@/lib/render-pipeline-payloads';
 
 // Legacy shape: body.rebalance_table rows
 type LegacyRow = {
@@ -74,6 +75,7 @@ export default function RebalanceDocumentView({
     payload?.notes != null && typeof payload.notes === 'string' && payload.notes.trim()
       ? payload.notes.trim()
       : '';
+  const liveSummary = summarizeRecommendedPortfolio(payload);
 
   const isLiveShape = liveActions.length > 0 || liveWeights.length > 0 || liveNotes !== '';
 
@@ -105,11 +107,43 @@ export default function RebalanceDocumentView({
   if (isLiveShape) {
     return (
       <div className="space-y-6 text-sm">
+        {liveSummary ? (
+          <div className="rounded-lg border border-fin-blue/15 bg-fin-blue/[0.04] p-4">
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+              Post-risk-sizing book summary
+            </h3>
+            <div className="grid grid-cols-3 gap-3 text-xs">
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Invested</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {liveSummary.investedPct.toFixed(2)}%
+                </p>
+              </div>
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Cash</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {liveSummary.cashPct.toFixed(2)}%
+                </p>
+              </div>
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Holdings</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {liveSummary.holdingsCount}
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-[11px] text-text-muted leading-relaxed">
+              Structured recommended weights are the source of truth if narrative notes conflict.
+            </p>
+          </div>
+        ) : null}
         {liveNotes ? (
           <div>
-            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">Notes</h3>
+            <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Narrative / memo notes
+            </h3>
             <div className="prose prose-invert max-w-none text-sm">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{liveNotes}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(liveNotes)}</ReactMarkdown>
             </div>
           </div>
         ) : null}
@@ -160,7 +194,9 @@ export default function RebalanceDocumentView({
                     <td className="py-2 pr-3 text-right tabular-nums">{pct(a.current_pct)}</td>
                     {/* Live shape: `target_pct`; fixture / test payloads: `recommended_pct`. */}
                     <td className="py-2 pr-3 text-right tabular-nums">{pct(a.target_pct ?? a.recommended_pct)}</td>
-                    <td className="py-2 text-text-secondary whitespace-pre-wrap">{a.rationale ?? '—'}</td>
+                    <td className="py-2 text-text-secondary whitespace-pre-wrap">
+                      {cleanMemoProse(a.rationale ?? '—')}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -201,9 +237,11 @@ export default function RebalanceDocumentView({
 
       {pmNotes ? (
         <div>
-          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">PM notes</h3>
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+            Narrative / memo notes
+          </h3>
           <div className="prose prose-invert max-w-none text-sm">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{pmNotes}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(pmNotes)}</ReactMarkdown>
           </div>
         </div>
       ) : null}
@@ -232,7 +270,9 @@ export default function RebalanceDocumentView({
                   <td className="py-2 pr-3 text-right tabular-nums">{pct(r.change_pct)}</td>
                   <td className="py-2 pr-3">{r.action ?? '—'}</td>
                   <td className="py-2 pr-3">{r.urgency ?? '—'}</td>
-                  <td className="py-2 text-text-secondary whitespace-pre-wrap">{r.rationale ?? '—'}</td>
+                  <td className="py-2 text-text-secondary whitespace-pre-wrap">
+                    {cleanMemoProse(r.rationale ?? '—')}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/olympus/components/portfolio/tabs/AnalysisTab.test.tsx
+++ b/frontend/olympus/components/portfolio/tabs/AnalysisTab.test.tsx
@@ -1,0 +1,175 @@
+import { createElement } from 'react';
+import type { ComponentProps, ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import AnalysisTab from './AnalysisTab';
+import { useDashboard } from '@/lib/dashboard-context';
+import type { Doc } from '@/lib/types';
+import type { LibraryDocumentResult } from '@/lib/queries';
+
+vi.mock('@/lib/dashboard-context', () => ({
+  useDashboard: vi.fn(),
+}));
+
+const useDashboardMock = vi.mocked(useDashboard);
+
+function render(node: ReactElement): string {
+  return renderToStaticMarkup(node);
+}
+
+function doc(overrides: Partial<Doc>): Doc {
+  return {
+    id: 'doc-1',
+    date: '2026-06-18',
+    title: 'PM memo',
+    type: null,
+    phase: 7,
+    category: null,
+    segment: null,
+    sector: null,
+    runType: 'delta',
+    path: 'portfolio/pm-memo.md',
+    ...overrides,
+  };
+}
+
+function defaultProps(overrides: Partial<ComponentProps<typeof AnalysisTab>> = {}) {
+  return {
+    historyTimelineDates: ['2026-06-18', '2026-06-17'],
+    portfolioHistoryRunKindByDate: new Map(),
+    effHistoryDate: '2026-06-18',
+    onSelectHistoryDate: vi.fn(),
+    historyLatestDate: '2026-06-18',
+    onClearHistoryDate: vi.fn(),
+    portfolioDocDates: new Set<string>(),
+    positionHistoryDates: new Set<string>(),
+    pmDocsForHistory: [],
+    pmActiveFile: null,
+    pmLibraryDoc: null,
+    pmLoading: false,
+    onOpenPmDocument: vi.fn(),
+    onClosePmDocument: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('AnalysisTab pipeline artifacts', () => {
+  it('renders latest artifact date, source-of-truth summary, and cleaned memo prose', () => {
+    useDashboardMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: {
+        pipeline_observability: {
+          snapshot_date: '2026-06-18',
+          market_thesis_exploration: null,
+          thesis_vehicle_map: null,
+          pm_allocation_memo: null,
+          deliberation_session_index: null,
+          deliberation_transcripts: [],
+          asset_recommendations: [],
+          risk_debate: null,
+          pm_rebalance: {
+            notes: 'Narrative from query_data may lag structured weights.',
+            actions: [
+              {
+                ticker: 'NVDA',
+                action: 'TRIM',
+                current_pct: 35,
+                target_pct: 25,
+                rationale: 'get_market_data shows concentration risk.',
+              },
+            ],
+            recommended_portfolio: [
+              { ticker: 'NVDA', target_pct: 25 },
+              { ticker: 'MSFT', weight_pct: 60 },
+            ],
+          },
+        },
+      },
+    } as never);
+
+    const html = render(createElement(AnalysisTab, defaultProps()));
+
+    expect(html).toContain('Latest pipeline artifacts');
+    expect(html).toContain('Snapshot 2026-06-18');
+    expect(html).toContain('Post-risk-sizing book summary');
+    expect(html).toContain('85.00%');
+    expect(html).toContain('15.00%');
+    expect(html).toContain('Narrative / memo notes');
+    expect(html).toContain('source of truth');
+    expect(html).toContain('data query');
+    expect(html).toContain('market data lookup');
+    expect(html).not.toContain('query_data');
+    expect(html).not.toContain('get_market_data');
+  });
+
+  it('warns when selected PM memo docs are date-scoped but top artifacts are latest', () => {
+    useDashboardMock.mockReturnValue({
+      loading: false,
+      error: null,
+      data: {
+        pipeline_observability: {
+          snapshot_date: '2026-06-18',
+          market_thesis_exploration: null,
+          thesis_vehicle_map: null,
+          pm_allocation_memo: null,
+          deliberation_session_index: null,
+          deliberation_transcripts: [],
+          asset_recommendations: [],
+          risk_debate: null,
+          pm_rebalance: {
+            notes: '',
+            actions: [{ ticker: 'NVDA', action: 'HOLD', current_pct: 20, target_pct: 20 }],
+            recommended_portfolio: [{ ticker: 'NVDA', target_pct: 20 }],
+          },
+        },
+      },
+    } as never);
+
+    const html = render(
+      createElement(
+        AnalysisTab,
+        defaultProps({
+          effHistoryDate: '2026-06-17',
+        })
+      )
+    );
+
+    expect(html).toContain('PM memo documents below are scoped to 2026-06-17');
+    expect(html).toContain('latest pipeline snapshot from 2026-06-18');
+  });
+});
+
+describe('AnalysisTab PM memo expansion', () => {
+  it('marks active rows expanded and renders the inline document below the row', () => {
+    useDashboardMock.mockReturnValue({ loading: false, error: null, data: null });
+    const activeDoc = doc({ id: 'active-doc', path: 'portfolio/recommendations.md' });
+    const inactiveDoc = doc({ id: 'inactive-doc', path: 'portfolio/deliberations.md' });
+    const libraryDoc: LibraryDocumentResult = {
+      id: activeDoc.id,
+      date: activeDoc.date,
+      document_key: 'recommendations',
+      view: 'markdown',
+      markdown: '# PM memo — 2026-06-18\n\nExpanded memo body.',
+      payload: null,
+    };
+
+    const html = render(
+      createElement(
+        AnalysisTab,
+        defaultProps({
+          pmDocsForHistory: [activeDoc, inactiveDoc],
+          pmActiveFile: activeDoc,
+          pmLibraryDoc: libraryDoc,
+        })
+      )
+    );
+
+    expect(html).toContain('aria-expanded="true"');
+    expect(html).toContain('aria-controls="pm-doc-active-doc"');
+    expect(html).toContain('Hide');
+    expect(html).toContain('Open');
+    expect(html).toContain('pm-doc-active-doc');
+    expect(html).toContain('Expanded memo body.');
+  });
+});

--- a/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
@@ -10,10 +10,12 @@ import type { LibraryDocumentResult } from '@/lib/queries';
 import { groupPmDocs, canonicalPmTitle } from '@/components/portfolio/tabs/palette-and-format';
 import { useDashboard } from '@/lib/dashboard-context';
 import {
+  cleanMemoProse,
   isRebalancePayload,
   renderRebalanceMarkdown,
   isRiskDebatePayload,
   isDebateSummaryPayload,
+  summarizeRecommendedPortfolio,
 } from '@/lib/render-pipeline-payloads';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -26,6 +28,7 @@ import {
  */
 function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
   const md = renderRebalanceMarkdown(payload);
+  const summary = summarizeRecommendedPortfolio(payload);
   const actions: Array<Record<string, unknown>> = Array.isArray(payload.actions)
     ? (payload.actions as Array<Record<string, unknown>>)
     : [];
@@ -42,9 +45,44 @@ function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
         <span className="ml-auto text-[10px] text-text-muted font-mono">automated</span>
       </div>
       <div className="px-5 py-4 space-y-4 text-sm">
+        {summary ? (
+          <div className="rounded-lg border border-fin-blue/15 bg-fin-blue/[0.04] p-4">
+            <p className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-3">
+              Post-risk-sizing book summary
+            </p>
+            <div className="grid grid-cols-3 gap-3 text-xs">
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Invested</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {summary.investedPct.toFixed(2)}%
+                </p>
+              </div>
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Cash</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {summary.cashPct.toFixed(2)}%
+                </p>
+              </div>
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-text-muted">Holdings</p>
+                <p className="text-base font-semibold tabular-nums text-text-primary">
+                  {summary.holdingsCount}
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-[11px] text-text-muted leading-relaxed">
+              Structured recommended weights are the source of truth if narrative notes conflict.
+            </p>
+          </div>
+        ) : null}
         {notes ? (
-          <div className="prose prose-invert max-w-none text-sm">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{notes}</ReactMarkdown>
+          <div>
+            <p className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-2">
+              Narrative / memo notes
+            </p>
+            <div className="prose prose-invert max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{cleanMemoProse(notes)}</ReactMarkdown>
+            </div>
           </div>
         ) : null}
         {actions.length > 0 ? (
@@ -84,7 +122,7 @@ function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
                       <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(a.current_pct)}</td>
                       <td className="py-2 pr-3 text-right tabular-nums">{fmtPct(targetPct)}</td>
                       <td className="py-2 text-text-secondary whitespace-pre-wrap">
-                        {String(a.rationale ?? '—')}
+                        {cleanMemoProse(String(a.rationale ?? '—'))}
                       </td>
                     </tr>
                   );
@@ -125,7 +163,7 @@ function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
             <p className="text-[11px] font-semibold text-fin-green uppercase tracking-wider mb-1">
               Aggressive
             </p>
-            <p className="text-text-secondary text-xs leading-relaxed">{agg}</p>
+            <p className="text-text-secondary text-xs leading-relaxed">{cleanMemoProse(agg)}</p>
           </div>
         ) : null}
         {con ? (
@@ -133,7 +171,7 @@ function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
             <p className="text-[11px] font-semibold text-fin-amber uppercase tracking-wider mb-1">
               Conservative
             </p>
-            <p className="text-text-secondary text-xs leading-relaxed">{con}</p>
+            <p className="text-text-secondary text-xs leading-relaxed">{cleanMemoProse(con)}</p>
           </div>
         ) : null}
         {tension ? (
@@ -141,7 +179,7 @@ function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
             <p className="text-[11px] font-semibold text-text-muted uppercase tracking-wider mb-1">
               Key tension
             </p>
-            <p className="text-text-secondary text-xs leading-relaxed">{tension}</p>
+            <p className="text-text-secondary text-xs leading-relaxed">{cleanMemoProse(tension)}</p>
           </div>
         ) : null}
       </div>
@@ -201,7 +239,7 @@ function DeliberationsPanel({ docs }: { docs: PipelineTickerDoc[] }) {
                     <p className="text-[10px] font-semibold text-fin-green/80 uppercase tracking-wider mb-1">
                       Bull
                     </p>
-                    <p>{bull}</p>
+                    <p>{cleanMemoProse(bull)}</p>
                   </div>
                 ) : null}
                 {bear ? (
@@ -209,7 +247,7 @@ function DeliberationsPanel({ docs }: { docs: PipelineTickerDoc[] }) {
                     <p className="text-[10px] font-semibold text-fin-red/80 uppercase tracking-wider mb-1">
                       Bear
                     </p>
-                    <p>{bear}</p>
+                    <p>{cleanMemoProse(bear)}</p>
                   </div>
                 ) : null}
               </div>
@@ -275,6 +313,12 @@ export default function AnalysisTab(props: {
   const { data } = useDashboard();
   const pipe = data?.pipeline_observability ?? null;
   const showPipelineArtifacts = hasPipelineArtifacts(pipe);
+  const pipelineSnapshotDate = pipe?.snapshot_date ?? null;
+  const showDateScopeNotice =
+    showPipelineArtifacts &&
+    Boolean(pipelineSnapshotDate) &&
+    Boolean(effHistoryDate) &&
+    effHistoryDate !== pipelineSnapshotDate;
 
   return (
     <div className="flex gap-6 max-lg:flex-col">
@@ -311,9 +355,24 @@ export default function AnalysisTab(props: {
         ──────────────────────────────────────────────────────────────────── */}
         {showPipelineArtifacts && pipe ? (
           <section className="space-y-3">
-            <p className="text-[11px] font-semibold text-text-muted tracking-wide">
-              Pipeline artifacts
-            </p>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <p className="text-[11px] font-semibold text-text-muted tracking-wide">
+                  Latest pipeline artifacts
+                </p>
+                {pipelineSnapshotDate ? (
+                  <span className="text-[11px] text-text-muted font-mono">
+                    Snapshot {pipelineSnapshotDate}
+                  </span>
+                ) : null}
+              </div>
+              {showDateScopeNotice ? (
+                <div className="rounded-lg border border-fin-amber/20 bg-fin-amber/[0.05] px-4 py-3 text-xs text-text-secondary">
+                  The PM memo documents below are scoped to {effHistoryDate}; these top artifacts are
+                  the latest pipeline snapshot from {pipelineSnapshotDate}.
+                </div>
+              ) : null}
+            </div>
 
             {isRebalancePayload(pipe.pm_rebalance) && pipe.pm_rebalance ? (
               <PmRebalancePanel payload={pipe.pm_rebalance} />
@@ -382,23 +441,38 @@ export default function AnalysisTab(props: {
                           <button
                             type="button"
                             onClick={() => onOpenPmDocument(d)}
-                            className={`w-full text-left px-5 py-3 flex items-center gap-3 hover:bg-white/[0.02] transition-colors ${
-                              active ? 'bg-fin-amber/5' : ''
+                            aria-expanded={active}
+                            aria-controls={active ? `pm-doc-${d.id}` : undefined}
+                            className={`w-full text-left px-5 py-3 flex items-center gap-3 border-l-2 hover:bg-white/[0.04] transition-colors ${
+                              active
+                                ? 'bg-fin-amber/10 border-fin-amber text-text-primary shadow-[inset_0_0_0_1px_rgba(245,158,11,0.16)]'
+                                : 'border-transparent text-text-secondary'
                             }`}
                           >
                             <FileText size={14} className="text-fin-amber/70 shrink-0" />
                             <span className="font-mono text-sm">{canonicalPmTitle(d.path)}</span>
                             <span className="ml-auto text-[11px] text-text-muted">{d.phase ?? ''}</span>
+                            <span
+                              className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${
+                                active
+                                  ? 'border-fin-amber/40 bg-fin-amber/15 text-fin-amber'
+                                  : 'border-border-subtle text-text-muted'
+                              }`}
+                            >
+                              {active ? 'Hide' : 'Open'}
+                            </span>
                           </button>
                           {active && pmActiveFile ? (
-                            <DocumentExpandInline
-                              accent="amber"
-                              hideTitleBar
-                              title={canonicalPmTitle(pmActiveFile.path)}
-                              subtitle={pmActiveFile.date ?? null}
-                              loading={pmLoading}
-                              libraryDoc={pmLibraryDoc}
-                            />
+                            <div id={`pm-doc-${d.id}`}>
+                              <DocumentExpandInline
+                                accent="amber"
+                                hideTitleBar
+                                title={canonicalPmTitle(pmActiveFile.path)}
+                                subtitle={pmActiveFile.date ?? null}
+                                loading={pmLoading}
+                                libraryDoc={pmLibraryDoc}
+                              />
+                            </div>
                           ) : null}
                         </div>
                       );

--- a/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/AnalysisTab.tsx
@@ -18,14 +18,8 @@ import {
   summarizeRecommendedPortfolio,
 } from '@/lib/render-pipeline-payloads';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Inline pipeline artifact panels (automated prod path — Hermes pipeline)
-// ─────────────────────────────────────────────────────────────────────────────
+// Inline pipeline artifact panels (Hermes automated prod path)
 
-/**
- * Renders the PM rebalance decision artifact if it has the live automated shape.
- * We use the raw payload so we can render it inline without a library round-trip.
- */
 function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
   const md = renderRebalanceMarkdown(payload);
   const summary = summarizeRecommendedPortfolio(payload);
@@ -131,7 +125,6 @@ function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
             </table>
           </div>
         ) : !notes ? (
-          // Fall back to raw markdown rendering if the structured view has nothing
           <div className="prose prose-invert max-w-none text-sm">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{md}</ReactMarkdown>
           </div>
@@ -141,7 +134,7 @@ function PmRebalancePanel({ payload }: { payload: Record<string, unknown> }) {
   );
 }
 
-/** Renders the aggressive-vs-conservative risk debate (Hermes `risk-debate` doc). */
+/** Aggressive-vs-conservative risk debate (`risk-debate` doc). */
 function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
   const s = (v: unknown) => (v == null ? '' : String(v));
   const agg = s(payload.aggressive_case).trim();
@@ -187,12 +180,8 @@ function RiskDebatePanel({ payload }: { payload: Record<string, unknown> }) {
   );
 }
 
-/**
- * Renders all per-ticker bull/bear debate summaries (Hermes `deliberation/{ticker}` docs).
- * Only the DebateSummary-shaped entries are shown (those with `net_stance`).
- */
+/** Per-ticker bull/bear debate summaries (`deliberation/{ticker}`). */
 function DeliberationsPanel({ docs }: { docs: PipelineTickerDoc[] }) {
-  // Filter to the automated Hermes DebateSummary shape — drop any legacy operator docs
   const bulletins = docs.filter((d) => isDebateSummaryPayload(d.payload));
   if (!bulletins.length) return null;
 
@@ -259,7 +248,7 @@ function DeliberationsPanel({ docs }: { docs: PipelineTickerDoc[] }) {
   );
 }
 
-/** True when the pipeline_observability bundle has at least one renderable automated artifact. */
+/** True when pipeline_observability has at least one renderable automated artifact. */
 function hasPipelineArtifacts(pipe: PipelineObservabilityBundle | null): boolean {
   if (!pipe) return false;
   return (
@@ -304,12 +293,6 @@ export default function AnalysisTab(props: {
     onClosePmDocument,
   } = props;
 
-  // Pull pipeline_observability from the dashboard context so we can render
-  // the automated Hermes pipeline artifacts (pm_rebalance, risk_debate,
-  // deliberation_transcripts) directly — these are never written as library
-  // docs in the automated prod path, so the Track-B doc section below is
-  // always empty in automated prod. We render them first; the Track-B section
-  // remains as a graceful fallback for analyst-authored sessions.
   const { data } = useDashboard();
   const pipe = data?.pipeline_observability ?? null;
   const showPipelineArtifacts = hasPipelineArtifacts(pipe);
@@ -348,11 +331,6 @@ export default function AnalysisTab(props: {
       </div>
 
       <div className="flex-1 min-w-0 space-y-10">
-        {/* ── Automated pipeline artifacts (Hermes prod path) ──────────────────
-            pm_rebalance, risk_debate, deliberation_transcripts are written by
-            the automated pipeline but never appear as library docs, so the
-            Track-B section below is blank in prod. We surface them here first.
-        ──────────────────────────────────────────────────────────────────── */}
         {showPipelineArtifacts && pipe ? (
           <section className="space-y-3">
             <div className="space-y-2">
@@ -388,11 +366,6 @@ export default function AnalysisTab(props: {
           </section>
         ) : null}
 
-        {/* ── Track-B analyst session docs (date-scoped library files) ─────────
-            In automated prod these are always empty. They appear after an
-            analyst has run Track-B phases (market-thesis-exploration, etc.)
-            and published docs via the operator interface.
-        ──────────────────────────────────────────────────────────────────── */}
         <section className="space-y-3">
           <div className="flex items-center gap-2 px-0.5">
             <Calendar size={15} className="text-fin-amber shrink-0" aria-hidden />
@@ -408,8 +381,6 @@ export default function AnalysisTab(props: {
           </div>
 
           {pmDocsForHistory.length === 0 ? (
-            // Only show the fallback "no files" card when there are also no
-            // pipeline artifacts above — otherwise the tab would look empty.
             !showPipelineArtifacts ? (
               <div className="glass-card px-5 py-10 text-center text-text-muted text-sm">
                 No PM files for this date.

--- a/frontend/olympus/lib/render-document-from-payload.ts
+++ b/frontend/olympus/lib/render-document-from-payload.ts
@@ -39,6 +39,22 @@ function renderPayloadJsonFallback(payload: unknown, documentKey?: string): stri
   return `${lines.join('\n').trim()}\n`;
 }
 
+export function normalizeMarkdownFirstHeadingDate(markdown: string, docDate: string): string {
+  const normalizedDocDate = docDate.trim();
+  if (!normalizedDocDate) return markdown;
+
+  const lines = markdown.split('\n');
+  const headingIndex = lines.findIndex((line) => line.startsWith('# '));
+  if (headingIndex === -1) return markdown;
+
+  const firstHeading = lines[headingIndex];
+  const updatedHeading = firstHeading.replace(/\b\d{4}-\d{2}-\d{2}\b/, normalizedDocDate);
+  if (updatedHeading === firstHeading) return markdown;
+
+  lines[headingIndex] = updatedHeading;
+  return lines.join('\n');
+}
+
 export function renderDocumentMarkdownFromPayload(payload: unknown, documentKey?: string): string | null {
   const p = asObj(payload);
   if (!p) return null;

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { fixtureDigest } from './__fixtures__/snapshot-fixture';
 import { renderDigestMarkdownFromSnapshot } from './render-digest-from-snapshot';
-import { renderDocumentMarkdownFromPayload } from './render-document-from-payload';
 import {
+  normalizeMarkdownFirstHeadingDate,
+  renderDocumentMarkdownFromPayload,
+} from './render-document-from-payload';
+import {
+  cleanMemoProse,
   isAnalystSpecialistPayload,
   isDebateSummaryPayload,
   isMasterDigestPayload,
@@ -15,6 +19,7 @@ import {
   renderRebalanceMarkdown,
   renderRiskDebateMarkdown,
   renderSegmentReportMarkdown,
+  summarizeRecommendedPortfolio,
 } from './render-pipeline-payloads';
 import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
 
@@ -47,9 +52,12 @@ const REBALANCE_EMPTY = {
 };
 
 const REBALANCE_POPULATED = {
-  notes: 'Trim tech overweight.',
+  notes: 'Trim tech overweight after query_data.',
   actions: [{ ticker: 'NVDA', action: 'TRIM', current_pct: 12, recommended_pct: 8 }],
-  recommended_portfolio: [{ ticker: 'NVDA', weight_pct: 8 }],
+  recommended_portfolio: [
+    { ticker: 'NVDA', weight_pct: 8 },
+    { ticker: 'CASH', weight_pct: 92 },
+  ],
 };
 
 /** Trimmed copy of the production `deliberation/{ticker}` DebateSummary payload. */
@@ -174,7 +182,36 @@ describe('renderRebalanceMarkdown', () => {
     const md = renderRebalanceMarkdown(REBALANCE_POPULATED);
     expect(md).toContain('## Actions');
     expect(md).toContain('| NVDA | TRIM | 12 | 8 |');
+    expect(md).toContain('## Post-risk-sizing book summary');
+    expect(md).toContain('**Invested:** 100.00%');
+    expect(md).toContain('**Cash:** 0.00%');
+    expect(md).toContain('**Holdings:** 2');
     expect(md).toContain('## Recommended portfolio');
+    expect(md).toContain('Narrative / memo notes');
+    expect(md).toContain('data query');
+    expect(md).not.toContain('query_data');
+  });
+
+  it('summarizes decimal and percent recommended weights', () => {
+    expect(
+      summarizeRecommendedPortfolio({
+        recommended_portfolio: [
+          { ticker: 'NVDA', target_pct: 0.25 },
+          { ticker: 'MSFT', weight_pct: 15 },
+        ],
+      })
+    ).toEqual({ investedPct: 40, cashPct: 60, holdingsCount: 2 });
+  });
+});
+
+describe('memo prose cleanup', () => {
+  it('replaces raw tool names in narrative prose while preserving code/path displays', () => {
+    const md = cleanMemoProse(
+      'Used query_data and get_market_data. Keep `query_data` and `/tools/get_market_data.py` exact.'
+    );
+    expect(md).toContain('Used data query and market data lookup.');
+    expect(md).toContain('`query_data`');
+    expect(md).toContain('/tools/get_market_data.py');
   });
 });
 
@@ -311,6 +348,23 @@ describe('renderDocumentMarkdownFromPayload routing', () => {
 
   it('returns null for unknown digest-keyed payloads so the snapshot fallback applies', () => {
     expect(renderDocumentMarkdownFromPayload({ mystery: true }, 'digest')).toBeNull();
+  });
+});
+
+describe('research document date labels', () => {
+  it('normalizes only the first visible H1 date to the document row date', () => {
+    const md = normalizeMarkdownFirstHeadingDate(
+      [
+        '# Document delta — 2026-06-17',
+        '',
+        'Baseline date: 2026-06-17',
+        'Compare date: 2026-06-16',
+      ].join('\n'),
+      '2026-06-18'
+    );
+    expect(md).toContain('# Document delta — 2026-06-18');
+    expect(md).toContain('Baseline date: 2026-06-17');
+    expect(md).toContain('Compare date: 2026-06-16');
   });
 });
 

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -183,9 +183,9 @@ describe('renderRebalanceMarkdown', () => {
     expect(md).toContain('## Actions');
     expect(md).toContain('| NVDA | TRIM | 12 | 8 |');
     expect(md).toContain('## Post-risk-sizing book summary');
-    expect(md).toContain('**Invested:** 100.00%');
-    expect(md).toContain('**Cash:** 0.00%');
-    expect(md).toContain('**Holdings:** 2');
+    expect(md).toContain('**Invested:** 8.00%');
+    expect(md).toContain('**Cash:** 92.00%');
+    expect(md).toContain('**Holdings:** 1');
     expect(md).toContain('## Recommended portfolio');
     expect(md).toContain('Narrative / memo notes');
     expect(md).toContain('data query');
@@ -201,6 +201,17 @@ describe('renderRebalanceMarkdown', () => {
         ],
       })
     ).toEqual({ investedPct: 40, cashPct: 60, holdingsCount: 2 });
+  });
+
+  it('excludes the synthetic CASH row from invested and holdings', () => {
+    expect(
+      summarizeRecommendedPortfolio({
+        recommended_portfolio: [
+          { ticker: 'NVDA', weight_pct: 8 },
+          { ticker: 'CASH', weight_pct: 92 },
+        ],
+      })
+    ).toEqual({ investedPct: 8, cashPct: 92, holdingsCount: 1 });
   });
 });
 

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -76,10 +76,7 @@ export function cleanMemoProse(text: string): string {
     .replace(/(?:\.{0,2}\/|\/)[^\s)]+/g, protect);
 
   for (const [pattern, replacement] of TOOL_NAME_REPLACEMENTS) {
-    cleaned =
-      typeof replacement === 'string'
-        ? cleaned.replace(pattern, replacement)
-        : cleaned.replace(pattern, replacement);
+    cleaned = cleaned.replace(pattern, replacement);
   }
 
   protectedChunks.forEach((chunk, index) => {
@@ -153,6 +150,10 @@ function portfolioWeightPct(row: Record<string, unknown>): number | null {
   return Math.abs(weight) <= 1 ? weight * 100 : weight;
 }
 
+function isCashHolding(row: Record<string, unknown>): boolean {
+  return s(row.ticker).trim().toUpperCase() === 'CASH';
+}
+
 export function summarizeRecommendedPortfolio(payload: unknown): RecommendedPortfolioSummary | null {
   const p = asObj(payload) ?? {};
   const rec = Array.isArray(p.recommended_portfolio)
@@ -160,11 +161,22 @@ export function summarizeRecommendedPortfolio(payload: unknown): RecommendedPort
     : [];
   if (!rec.length) return null;
 
-  const investedPct = rec.reduce((sum, row) => sum + (portfolioWeightPct(row) ?? 0), 0);
+  let investedPct = 0;
+  let explicitCashPct = 0;
+  let holdingsCount = 0;
+  for (const row of rec) {
+    const weight = portfolioWeightPct(row) ?? 0;
+    if (isCashHolding(row)) {
+      explicitCashPct += weight;
+    } else {
+      investedPct += weight;
+      holdingsCount += 1;
+    }
+  }
   return {
     investedPct,
-    cashPct: Math.max(0, 100 - investedPct),
-    holdingsCount: rec.length,
+    cashPct: explicitCashPct > 0 ? explicitCashPct : Math.max(0, 100 - investedPct),
+    holdingsCount,
   };
 }
 

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -76,7 +76,10 @@ export function cleanMemoProse(text: string): string {
     .replace(/(?:\.{0,2}\/|\/)[^\s)]+/g, protect);
 
   for (const [pattern, replacement] of TOOL_NAME_REPLACEMENTS) {
-    cleaned = cleaned.replace(pattern, replacement);
+    cleaned =
+      typeof replacement === 'string'
+        ? cleaned.replace(pattern, replacement)
+        : cleaned.replace(pattern, replacement);
   }
 
   protectedChunks.forEach((chunk, index) => {

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -25,6 +25,25 @@ function asObj(v: unknown): Record<string, unknown> | null {
   return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
 }
 
+export interface RecommendedPortfolioSummary {
+  investedPct: number;
+  cashPct: number;
+  holdingsCount: number;
+}
+
+type ToolNameReplacement = string | ((match: string, raw: string) => string);
+
+const TOOL_NAME_REPLACEMENTS: Array<[pattern: RegExp, replacement: ToolNameReplacement]> = [
+  [/\bquery_data\b/g, 'data query'],
+  [/\bget_price_data\b/g, 'price data lookup'],
+  [/\bget_market_data\b/g, 'market data lookup'],
+  [/\bget_news\b/g, 'news lookup'],
+  [/\bget_financials\b/g, 'financial data lookup'],
+  [/\bget_fundamentals\b/g, 'fundamentals lookup'],
+  [/\bget_earnings\b/g, 'earnings lookup'],
+  [/\bget_(?![A-Z])([a-z][a-z0-9_]*)\b/g, (_match, raw: string) => `${humanize(raw).toLowerCase()} lookup`],
+];
+
 /** "alt-cta-positioning" → "Alt CTA Positioning"-ish humanized heading. */
 function humanize(slug: string): string {
   return slug
@@ -36,6 +55,37 @@ function humanize(slug: string): string {
     .replace(/\bPm\b/g, 'PM')
     .replace(/\bUs\b/g, 'US')
     .replace(/\bAi\b/g, 'AI');
+}
+
+/**
+ * Clean raw pipeline tool names from user-facing prose while preserving code
+ * spans/fences, where exact identifiers and paths are intentional.
+ */
+export function cleanMemoProse(text: string): string {
+  if (!text) return text;
+  const protectedChunks: string[] = [];
+  const protect = (match: string) => {
+    const token = `__OLYMPUS_PROTECTED_${protectedChunks.length}__`;
+    protectedChunks.push(match);
+    return token;
+  };
+
+  let cleaned = text
+    .replace(/```[\s\S]*?```/g, protect)
+    .replace(/`[^`\n]+`/g, protect)
+    .replace(/(?:\.{0,2}\/|\/)[^\s)]+/g, protect);
+
+  for (const [pattern, replacement] of TOOL_NAME_REPLACEMENTS) {
+    cleaned =
+      typeof replacement === 'string'
+        ? cleaned.replace(pattern, replacement)
+        : cleaned.replace(pattern, replacement);
+  }
+
+  protectedChunks.forEach((chunk, index) => {
+    cleaned = cleaned.replace(`__OLYMPUS_PROTECTED_${index}__`, chunk);
+  });
+  return cleaned;
 }
 
 function escapeTableCell(v: unknown): string {
@@ -91,9 +141,31 @@ function pushSources(out: string[], sources: unknown): void {
 }
 
 function pushNotes(out: string[], notes: unknown): void {
-  const n = s(notes).trim();
+  const n = cleanMemoProse(s(notes).trim());
   if (!n) return;
-  out.push('## Notes', '', n, '');
+  out.push('## Narrative / memo notes', '', n, '');
+}
+
+function portfolioWeightPct(row: Record<string, unknown>): number | null {
+  const raw = row.target_pct ?? row.weight_pct ?? row.recommended_pct;
+  if (raw == null || Number.isNaN(Number(raw))) return null;
+  const weight = Number(raw);
+  return Math.abs(weight) <= 1 ? weight * 100 : weight;
+}
+
+export function summarizeRecommendedPortfolio(payload: unknown): RecommendedPortfolioSummary | null {
+  const p = asObj(payload) ?? {};
+  const rec = Array.isArray(p.recommended_portfolio)
+    ? (p.recommended_portfolio.map(asObj).filter(Boolean) as Record<string, unknown>[])
+    : [];
+  if (!rec.length) return null;
+
+  const investedPct = rec.reduce((sum, row) => sum + (portfolioWeightPct(row) ?? 0), 0);
+  return {
+    investedPct,
+    cashPct: Math.max(0, 100 - investedPct),
+    holdingsCount: rec.length,
+  };
 }
 
 /* ── Master digest ───────────────────────────────────────────────────────── */
@@ -188,7 +260,7 @@ export function renderMasterDigestMarkdown(payload: unknown): string {
   for (const [key, heading] of DIGEST_NARRATIVE_SECTIONS) {
     const text = s(p[key]).trim();
     if (!text) continue;
-    out.push(`## ${heading}`, '', text, '');
+    out.push(`## ${heading}`, '', cleanMemoProse(text), '');
   }
 
   const freshness = asObj(p.segment_freshness);
@@ -227,13 +299,30 @@ export function renderRebalanceMarkdown(payload: unknown): string {
     ? (p.actions.map(asObj).filter(Boolean) as Record<string, unknown>[])
     : [];
   if (actions.length) {
-    out.push('## Actions', '', ...objectArrayTable(actions));
+    const cleanedActions = actions.map((row) => ({
+      ...row,
+      rationale: cleanMemoProse(s(row.rationale).trim()),
+    }));
+    out.push('## Actions', '', ...objectArrayTable(cleanedActions));
   }
 
   const rec = Array.isArray(p.recommended_portfolio)
     ? (p.recommended_portfolio.map(asObj).filter(Boolean) as Record<string, unknown>[])
     : [];
   if (rec.length) {
+    const summary = summarizeRecommendedPortfolio(p);
+    if (summary) {
+      out.push(
+        '## Post-risk-sizing book summary',
+        '',
+        `- **Invested:** ${summary.investedPct.toFixed(2)}%`,
+        `- **Cash:** ${summary.cashPct.toFixed(2)}%`,
+        `- **Holdings:** ${summary.holdingsCount}`,
+        '',
+        '_Structured weights above are the source of truth if narrative notes conflict._',
+        ''
+      );
+    }
     out.push('## Recommended portfolio', '', ...objectArrayTable(rec));
   }
 
@@ -372,7 +461,7 @@ export function renderAnalystSpecialistMarkdown(payload: unknown): string {
   }
 
   const thesis = s(p.thesis).trim();
-  if (thesis) out.push('## Thesis', '', thesis, '');
+  if (thesis) out.push('## Thesis', '', cleanMemoProse(thesis), '');
 
   const sources = Array.isArray(p.sources) ? p.sources : [];
   if (sources.length) {
@@ -410,8 +499,8 @@ export function renderDebateSummaryMarkdown(payload: unknown): string {
 
   const bull = s(p.bull_thesis).trim();
   const bear = s(p.bear_thesis).trim();
-  if (bull) out.push('## Bull thesis', '', bull, '');
-  if (bear) out.push('## Bear thesis', '', bear, '');
+  if (bull) out.push('## Bull thesis', '', cleanMemoProse(bull), '');
+  if (bear) out.push('## Bear thesis', '', cleanMemoProse(bear), '');
 
   const rounds = Array.isArray(p.rounds) ? p.rounds : [];
   if (rounds.length) {
@@ -423,8 +512,8 @@ export function renderDebateSummaryMarkdown(payload: unknown): string {
       out.push(`### Round ${n || i + 1}`, '');
       const ba = s(o.bull_argument).trim();
       const be = s(o.bear_argument).trim();
-      if (ba) out.push(`**Bull:** ${ba}`, '');
-      if (be) out.push(`**Bear:** ${be}`, '');
+      if (ba) out.push(`**Bull:** ${cleanMemoProse(ba)}`, '');
+      if (be) out.push(`**Bear:** ${cleanMemoProse(be)}`, '');
     });
   }
   return `${out.join('\n').trim()}\n`;
@@ -450,8 +539,8 @@ export function renderRiskDebateMarkdown(payload: unknown): string {
   const agg = s(p.aggressive_case).trim();
   const con = s(p.conservative_case).trim();
   const tension = s(p.key_tension).trim();
-  if (agg) out.push('## Aggressive case', '', agg, '');
-  if (con) out.push('## Conservative case', '', con, '');
-  if (tension) out.push('## Key tension', '', tension, '');
+  if (agg) out.push('## Aggressive case', '', cleanMemoProse(agg), '');
+  if (con) out.push('## Conservative case', '', cleanMemoProse(con), '');
+  if (tension) out.push('## Key tension', '', cleanMemoProse(tension), '');
   return `${out.join('\n').trim()}\n`;
 }


### PR DESCRIPTION
## Summary
- Add structured post-risk-sizing book summary (invested %, cash %, holdings) above narrative memo notes in rebalance panels, with explicit source-of-truth guidance when prose conflicts with weights.
- Rename the Intelligence tab pipeline block to **Latest pipeline artifacts**, show snapshot date, and warn when selected PM memo date differs from the latest pipeline snapshot.
- Improve PM memo row expansion UX (`aria-expanded`, Open/Hide chip, stronger selected styling) while preserving `docKey` URL behavior.
- Humanize raw tool names (`query_data`, `get_*`) in user-facing memo prose without mutating audit metadata, code spans, or paths.
- Normalize stale research delta H1 dates to `documents.date` while preserving baseline/compare dates elsewhere.

Fixes #843

## Test plan
- [x] `npm run test --workspace olympus` (136 tests passed)
- [x] `npm run lint --workspace olympus`
- [x] `make score` on staged changes (all dimensions pass)
- [ ] Manual QA: Intelligence tab with pipeline artifacts + date-scoped PM memos on different calendar dates
- [ ] Manual QA: expand/collapse PM memo rows and confirm URL `docKey` deep-link still works

## Merge notes
Workstream C only — does not touch portfolio routing (`fix/843-olympus-portfolio-qa` / PR #851), metrics/run-health, or settings polish. Low overlap with sibling branches; `queries.ts` is unchanged here.

Made with [Cursor](https://cursor.com)