### PR TITLE
fix(olympus): surface Sharpe/Calmar and meaningful run health (#843)

### DIFF
--- a/digiquant/scripts/atlas/refresh_performance_metrics.py
+++ b/digiquant/scripts/atlas/refresh_performance_metrics.py
@@ -30,6 +30,7 @@ Environment: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (see config/supabase.env)
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import sys
 from datetime import date, datetime, timedelta, timezone
@@ -173,6 +174,50 @@ def _nav_history_count(sb, as_of: str) -> int:
     return len(getattr(res, "data", None) or [])
 
 
+def _risk_metrics_from_nav_history(sb, as_of: str) -> dict[str, float] | None:
+    """Compute Sharpe, annualized vol %, and max drawdown % from nav_history through ``as_of``."""
+    res = (
+        sb.table("nav_history")
+        .select("date,nav")
+        .lte("date", as_of)
+        .order("date")
+        .execute()
+    )
+    rows = getattr(res, "data", None) or []
+    navs = [float(r["nav"]) for r in rows if r.get("nav") is not None]
+    if len(navs) < _MIN_HISTORY_ROWS:
+        return None
+
+    returns = [
+        (navs[i] - navs[i - 1]) / navs[i - 1]
+        for i in range(1, len(navs))
+        if navs[i - 1] > 0
+    ]
+    if len(returns) < 2:
+        return None
+    mean = sum(returns) / len(returns)
+    variance = sum((r - mean) ** 2 for r in returns) / len(returns)
+    std = math.sqrt(variance)
+    sharpe = (mean / std) * math.sqrt(252) if std > 0 else 0.0
+    volatility = std * math.sqrt(252) * 100.0
+
+    peak = navs[0]
+    max_drawdown = 0.0
+    for nav in navs:
+        if nav > peak:
+            peak = nav
+        if peak > 0:
+            dd = (nav - peak) / peak
+            if dd < max_drawdown:
+                max_drawdown = dd
+
+    return {
+        "sharpe": round(sharpe, 6),
+        "volatility": round(volatility, 6),
+        "max_drawdown": round(max_drawdown * 100.0, 6),
+    }
+
+
 def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
     """Ensure one ``portfolio_metrics`` row per calendar day (dashboard continuity).
 
@@ -186,11 +231,10 @@ def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
       row — NOT ``nav - 100`` (which would be total-return-since-inception and wrong
       on any day past inception).  When no prior nav row exists the fallback yields
       None rather than a misleading value.
-    - ``sharpe`` / ``volatility`` / ``max_drawdown`` / ``alpha`` written as NULL
-      (not carried forward) when nav_history has < 20 rows — insufficient history
-      to produce reliable risk metrics.  ``computed_from`` is set to
-      ``'refresh_script_insufficient_history'`` in that case so callers can surface
-      it without misreading a DATE column as a text marker.
+    - ``sharpe`` / ``volatility`` / ``max_drawdown`` computed from nav_history when
+      there are >= 20 rows; otherwise NULL.  ``alpha`` is carried from the prior row
+      when history is sufficient.  ``computed_from`` is
+      ``'refresh_script_insufficient_history'`` when the history gate fails.
     """
     ex = sb.table("portfolio_metrics").select("computed_from").eq("date", as_of).limit(1).execute()
     if getattr(ex, "data", None) and ex.data[0].get("computed_from") == "tearsheet":
@@ -234,15 +278,20 @@ def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
         if t and t != "CASH":
             total_invested += float(p.get("weight_pct") or 0)
 
-    # Risk metrics (sharpe/vol/max_dd/alpha): only carry meaningful values when there is
-    # enough history. With < 20 nav_history rows the estimates are noise; write NULL and
-    # mark the row so the dashboard can surface "insufficient history" instead of a fake 0.
-    history_rows = _nav_history_count(sb, as_of)
-    has_sufficient_history = history_rows >= _MIN_HISTORY_ROWS
-    if has_sufficient_history:
+    # Risk metrics (sharpe/vol/max_dd): compute from NAV history once the existing
+    # 20-row gate is met. With less history, write NULL so the dashboard doesn't
+    # display misleading zeros.
+    risk_metrics = _risk_metrics_from_nav_history(sb, as_of)
+    has_sufficient_history = risk_metrics is not None
+    sharpe = volatility = max_drawdown = None
+    alpha = None
+    if risk_metrics is not None:
+        sharpe = risk_metrics["sharpe"]
+        volatility = risk_metrics["volatility"]
+        max_drawdown = risk_metrics["max_drawdown"]
         prev_m = (
             sb.table("portfolio_metrics")
-            .select("sharpe,volatility,max_drawdown,alpha")
+            .select("alpha")
             .lt("date", as_of)
             .order("date", desc=True)
             .limit(1)
@@ -250,13 +299,7 @@ def upsert_portfolio_metrics_daily(sb, as_of: str) -> None:
         )
         pmd = getattr(prev_m, "data", None) or []
         prev = pmd[0] if pmd else {}
-        sharpe = prev.get("sharpe")
-        volatility = prev.get("volatility")
-        max_drawdown = prev.get("max_drawdown")
         alpha = prev.get("alpha")
-    else:
-        # Insufficient history: write NULL so the dashboard doesn't display misleading zeros.
-        sharpe = volatility = max_drawdown = alpha = None
 
     ts = datetime.now(tz=timezone.utc).isoformat()
     computed_from = (

--- a/digiquant/src/digiquant/olympus/atlas/diagnostics.py
+++ b/digiquant/src/digiquant/olympus/atlas/diagnostics.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Any  # noqa  # scored-lint: duck-typed Supabase client + rows
 
 from digiquant.olympus.atlas.phases.fail_soft import NODE_FAILED_REASON
@@ -204,6 +204,8 @@ def _row(
     model: str | None,
     usage_snapshot: Mapping[str, Any] | None,
     summary: RunSummary,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
 ) -> dict[str, Any]:
     usage = dict(usage_snapshot or {})
     breakdown = dict(summary.breakdown)
@@ -227,6 +229,13 @@ def _row(
         "run_date": run_date.isoformat(),
         "model": resolved_model,
         "status": summary.status,
+        "started_at": started_at.isoformat() if started_at is not None else None,
+        "finished_at": finished_at.isoformat() if finished_at is not None else None,
+        "duration_s": (
+            round((finished_at - started_at).total_seconds(), 3)
+            if started_at is not None and finished_at is not None
+            else None
+        ),
         "llm_calls": usage.get("llm_calls"),
         "prompt_tokens": usage.get("prompt_tokens"),
         "completion_tokens": usage.get("completion_tokens"),
@@ -254,6 +263,8 @@ def write_row(
     model: str | None = None,
     usage_snapshot: Mapping[str, Any] | None = None,
     degraded_pct: float = _DEGRADED_PCT_DEFAULT,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
 ) -> RunSummary | None:
     """Upsert one ``atlas_run_diagnostics`` row (on ``run_id``). Fail-soft → ``None`` on any
     error (telemetry never breaks a run). Returns the :class:`RunSummary` on success.
@@ -267,6 +278,8 @@ def write_row(
             model=model,
             usage_snapshot=usage_snapshot,
             summary=summary,
+            started_at=started_at,
+            finished_at=finished_at,
         )
         client.table("atlas_run_diagnostics").upsert(row, on_conflict="run_id").execute()
     except Exception as exc:  # noqa: BLE001 — telemetry write must never crash the run

--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from typing import Any  # noqa  # scored-lint suppression: opaque LangGraph checkpointer/graph
 
 from digiquant.olympus.atlas.graph import (
@@ -233,6 +233,7 @@ def run_atlas_then_hermes(
     state = initial_state(atlas_input)
     # Capture LLM usage for the whole run and ALWAYS write the diagnostics row + reset on
     # the way out (telemetry is fail-soft inside write_row, so this never crashes the run).
+    started_at = datetime.now(tz=timezone.utc)
     _usage.start()
     try:
         state = _safe_invoke_graph(atlas_graph, state, checkpointer, thread_base, "atlas")
@@ -270,6 +271,7 @@ def run_atlas_then_hermes(
         return state
     finally:
         if deps.diagnostics is not None:
+            finished_at = datetime.now(tz=timezone.utc)
             _diagnostics.write_row(
                 deps.diagnostics.client,
                 state=state,
@@ -278,6 +280,8 @@ def run_atlas_then_hermes(
                 run_date=atlas_input.run_date,
                 model=deps.diagnostics.model,
                 usage_snapshot=_usage.snapshot(),
+                started_at=started_at,
+                finished_at=finished_at,
             )
         _usage.reset()
 

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -32,7 +32,7 @@ import { AsOfBadge } from '@/components/overview/as-of-badge';
 import HeldTickerPricesPanel from '@/components/overview/held-ticker-prices-panel';
 import { isRiskDebatePayload } from '@/lib/render-pipeline-payloads';
 import AtlasLoader from '@/components/AtlasLoader';
-import { computeRiskRatiosFromNavSnaps } from '@/lib/portfolio-risk-metrics';
+import { computeEffectivePortfolioRiskMetrics } from '@/lib/portfolio-risk-metrics';
 
 // ─── Regime config ────────────────────────────────────────────────────────────
 
@@ -262,12 +262,11 @@ export default function OverviewPage() {
     return inceptionVsBenchmark(data.portfolio.snapshots, data.benchmarks);
   }, [data]);
 
-  /** Align with Advanced stats / tearsheet: Sharpe from daily NAV returns (Rf = 0). */
-  const overviewSharpeFromNav = useMemo(() => {
+  const overviewRiskMetrics = useMemo(() => {
     const snaps = data?.portfolio?.snapshots;
     if (!snaps?.length) return null;
-    return computeRiskRatiosFromNavSnaps(snaps)?.sharpe ?? null;
-  }, [data?.portfolio?.snapshots]);
+    return computeEffectivePortfolioRiskMetrics(data?.server_portfolio_metrics, snaps);
+  }, [data?.portfolio?.snapshots, data?.server_portfolio_metrics]);
 
   // 7-day position activity count (non-HOLD events in last 7 calendar days from last_updated)
   const recentActivityCount = useMemo(() => {
@@ -453,11 +452,9 @@ export default function OverviewPage() {
         <StatCardEnhanced
           label="Sharpe"
           value={
-            overviewSharpeFromNav != null
-              ? overviewSharpeFromNav.toFixed(2)
-              : metrics.sharpe != null
-                ? metrics.sharpe.toFixed(2)
-                : '—'
+            overviewRiskMetrics?.sharpe != null
+              ? overviewRiskMetrics.sharpe.toFixed(2)
+              : '—'
           }
           icon={PieChart}
           iconColor="text-fin-amber"

--- a/frontend/olympus/components/observability/RunHealthTab.tsx
+++ b/frontend/olympus/components/observability/RunHealthTab.tsx
@@ -18,6 +18,15 @@ function fmtDuration(s: number | null): string {
   return `${(s / 60).toFixed(1)}m`;
 }
 
+function hasSegmentTelemetry(row: ViewRow<'atlas_run_health'>): boolean {
+  return (row.segments_total ?? 0) > 0;
+}
+
+function fmtSegmentsOk(row: ViewRow<'atlas_run_health'>): string {
+  if (!hasSegmentTelemetry(row)) return 'No segment telemetry';
+  return `${fmtNum(row.segments_ok)}/${fmtNum(row.segments_total)}`;
+}
+
 export default function RunHealthTab({
   runHealth,
   available,
@@ -57,8 +66,8 @@ export default function RunHealthTab({
         <StatTile label="Run type" value={latest.run_type ?? '—'} />
         <StatTile
           label="Segments OK"
-          value={`${fmtNum(latest.segments_ok)}/${fmtNum(latest.segments_total)}`}
-          color="text-fin-green"
+          value={fmtSegmentsOk(latest)}
+          color={hasSegmentTelemetry(latest) ? 'text-fin-green' : 'text-text-secondary'}
         />
         <StatTile label="Carried" value={fmtNum(latest.segments_carried)} color="text-fin-amber" />
         <StatTile
@@ -94,14 +103,25 @@ export default function RunHealthTab({
                   <td className="py-2 pr-4 text-text-primary">{r.run_date ?? '—'}</td>
                   <td className="py-2 pr-4 text-text-secondary">{r.run_type ?? '—'}</td>
                   <td className={`py-2 pr-4 ${statusColor(r.status)}`}>{r.status ?? '—'}</td>
-                  <td className="py-2 pr-4 text-right text-fin-green">{fmtNum(r.segments_ok)}</td>
-                  <td className="py-2 pr-4 text-right text-fin-amber">{fmtNum(r.segments_carried)}</td>
-                  <td
-                    className={`py-2 pr-4 text-right ${(r.segments_failed ?? 0) > 0 ? 'text-fin-red' : 'text-text-secondary'}`}
-                  >
-                    {fmtNum(r.segments_failed)}
-                  </td>
-                  <td className="py-2 pr-4 text-right text-text-secondary">{fmtNum(r.segments_total)}</td>
+                  {hasSegmentTelemetry(r) ? (
+                    <>
+                      <td className="py-2 pr-4 text-right text-fin-green">{fmtNum(r.segments_ok)}</td>
+                      <td className="py-2 pr-4 text-right text-fin-amber">{fmtNum(r.segments_carried)}</td>
+                      <td
+                        className={`py-2 pr-4 text-right ${(r.segments_failed ?? 0) > 0 ? 'text-fin-red' : 'text-text-secondary'}`}
+                      >
+                        {fmtNum(r.segments_failed)}
+                      </td>
+                      <td className="py-2 pr-4 text-right text-text-secondary">{fmtNum(r.segments_total)}</td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="py-2 pr-4 text-right text-text-secondary">No segment telemetry</td>
+                      <td className="py-2 pr-4 text-right text-text-secondary">—</td>
+                      <td className="py-2 pr-4 text-right text-text-secondary">—</td>
+                      <td className="py-2 pr-4 text-right text-text-secondary">—</td>
+                    </>
+                  )}
                   <td className="py-2 pr-4 text-text-muted truncate max-w-[180px]">{r.model ?? '—'}</td>
                   <td className="py-2 text-right text-text-secondary">{fmtDuration(r.duration_s)}</td>
                 </tr>

--- a/frontend/olympus/components/portfolio/advanced-stats-panel.tsx
+++ b/frontend/olympus/components/portfolio/advanced-stats-panel.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useMemo } from 'react';
-import type { BenchmarkHistoryMap, NavChartPoint } from '@/lib/types';
+import type { BenchmarkHistoryMap, NavChartPoint, ServerPortfolioMetrics } from '@/lib/types';
 import {
   dailySimpleReturnsFromNavs,
   sharpeRatioFromDailyReturns,
   sortinoRatioFromDailyReturns,
   annualizedVolatilityPctFromDailyReturns,
+  computeEffectivePortfolioRiskMetrics,
 } from '@/lib/portfolio-risk-metrics';
 
 interface MetricProps {
@@ -59,9 +60,11 @@ interface ComputedStats {
 export function AdvancedStatsPanel({
   snaps,
   benchmarks,
+  serverMetrics,
 }: {
   snaps: NavChartPoint[];
   benchmarks: BenchmarkHistoryMap;
+  serverMetrics?: ServerPortfolioMetrics | null;
 }) {
   const stats = useMemo<ComputedStats | null>(() => {
     if (!snaps || snaps.length < 2) return null;
@@ -77,8 +80,9 @@ export function AdvancedStatsPanel({
     const annFactor = tradingDays > 0 ? 252 / tradingDays : 1;
     const annReturn = ((1 + totalReturn / 100) ** annFactor - 1) * 100;
 
-    const annVol = annualizedVolatilityPctFromDailyReturns(returns);
-    const sharpe = sharpeRatioFromDailyReturns(returns);
+    const effectiveRisk = computeEffectivePortfolioRiskMetrics(serverMetrics, snaps);
+    const annVol = effectiveRisk.annVolPct ?? annualizedVolatilityPctFromDailyReturns(returns);
+    const sharpe = effectiveRisk.sharpe ?? sharpeRatioFromDailyReturns(returns);
     const sortino = sortinoRatioFromDailyReturns(returns);
 
     const downReturns = returns.filter((r) => r < 0);
@@ -111,7 +115,9 @@ export function AdvancedStatsPanel({
       downDays > 0 ? (downReturns.reduce((a, b) => a + b, 0) / downDays) * 100 : 0;
     const profitFactor = avgLoss !== 0 ? Math.abs((avgWin * upDays) / (avgLoss * downDays)) : 0;
 
-    const calmar = maxDd !== 0 ? annReturn / (Math.abs(maxDd) * 100) : 0;
+    const effectiveMaxDdPct = effectiveRisk.maxDrawdownPct ?? maxDd * 100;
+    const calmar =
+      effectiveMaxDdPct !== 0 ? annReturn / Math.abs(effectiveMaxDdPct) : 0;
     const bestDay = Math.max(...returns) * 100;
     const worstDay = Math.min(...returns) * 100;
     const currDd = peak > 0 ? ((lastNav - peak) / peak) * 100 : 0;
@@ -176,7 +182,7 @@ export function AdvancedStatsPanel({
       annVol,
       sharpe,
       sortino,
-      maxDd: maxDd * 100,
+      maxDd: effectiveMaxDdPct,
       ddStart,
       ddEnd,
       currDd,
@@ -195,7 +201,7 @@ export function AdvancedStatsPanel({
       trackingError,
       infoRatio,
     };
-  }, [snaps, benchmarks]);
+  }, [snaps, benchmarks, serverMetrics]);
 
   if (!stats) {
     return (

--- a/frontend/olympus/components/portfolio/server-metrics-strip.tsx
+++ b/frontend/olympus/components/portfolio/server-metrics-strip.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import type { ServerPortfolioMetrics } from '@/lib/types';
+import type { EffectivePortfolioRiskMetrics } from '@/lib/portfolio-risk-metrics';
 
-export function ServerMetricsStrip({ m }: { m: ServerPortfolioMetrics }) {
+export function ServerMetricsStrip({
+  m,
+  effectiveRisk,
+}: {
+  m: ServerPortfolioMetrics;
+  effectiveRisk: EffectivePortfolioRiskMetrics;
+}) {
   return (
     <div className="px-6 py-4 border-b border-border-subtle bg-bg-secondary/80">
       <p className="text-[11px] text-text-muted mb-2">
@@ -20,19 +27,19 @@ export function ServerMetricsStrip({ m }: { m: ServerPortfolioMetrics }) {
         <span className="text-text-secondary">
           Sharpe:{' '}
           <span className="qn-metric text-text-primary">
-            {m.sharpe != null ? m.sharpe.toFixed(2) : '—'}
+            {effectiveRisk.sharpe != null ? effectiveRisk.sharpe.toFixed(2) : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Vol:{' '}
           <span className="qn-metric text-text-primary">
-            {m.volatility != null ? `${m.volatility.toFixed(2)}%` : '—'}
+            {effectiveRisk.annVolPct != null ? `${effectiveRisk.annVolPct.toFixed(2)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">
           Max DD:{' '}
-          <span className={`qn-metric ${m.max_drawdown != null && m.max_drawdown < 0 ? 'qn-down' : 'text-text-primary'}`}>
-            {m.max_drawdown != null ? `${m.max_drawdown.toFixed(2)}%` : '—'}
+          <span className={`qn-metric ${effectiveRisk.maxDrawdownPct != null && effectiveRisk.maxDrawdownPct < 0 ? 'qn-down' : 'text-text-primary'}`}>
+            {effectiveRisk.maxDrawdownPct != null ? `${effectiveRisk.maxDrawdownPct.toFixed(2)}%` : '—'}
           </span>
         </span>
         <span className="text-text-secondary">

--- a/frontend/olympus/components/portfolio/tabs/PerformanceTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/PerformanceTab.tsx
@@ -23,6 +23,7 @@ import {
   type DateRangeKey,
   type PerformanceChartView,
 } from '@/lib/performance-series';
+import { computeEffectivePortfolioRiskMetrics } from '@/lib/portfolio-risk-metrics';
 
 const MAX_COMPARABLES = 8;
 
@@ -228,6 +229,10 @@ export default function PerformanceTab() {
   const drawdownData = useMemo(() => buildDrawdownSeries(snaps), [snaps]);
   const rollingWindow = useMemo(() => computeEffectiveRollingWindow(snaps.length, 21), [snaps.length]);
   const rollingData = useMemo(() => buildRollingSharpeVol(snaps, 21), [snaps]);
+  const effectiveRiskMetrics = useMemo(
+    () => computeEffectivePortfolioRiskMetrics(serverMetrics, snaps),
+    [serverMetrics, snaps]
+  );
 
   const onAddComparable = useCallback(
     (t: string) => {
@@ -377,8 +382,16 @@ export default function PerformanceTab() {
               <ChevronDown size={18} className="text-text-muted" />
             )}
           </button>
-          {showAdvanced && serverMetrics && <ServerMetricsStrip m={serverMetrics} />}
-          {showAdvanced && <AdvancedStatsPanel snaps={snaps} benchmarks={benchmarks} />}
+          {showAdvanced && serverMetrics && (
+            <ServerMetricsStrip m={serverMetrics} effectiveRisk={effectiveRiskMetrics} />
+          )}
+          {showAdvanced && (
+            <AdvancedStatsPanel
+              snaps={snaps}
+              benchmarks={benchmarks}
+              serverMetrics={serverMetrics}
+            />
+          )}
         </div>
       </section>
     </div>

--- a/frontend/olympus/lib/portfolio-risk-metrics.ts
+++ b/frontend/olympus/lib/portfolio-risk-metrics.ts
@@ -1,4 +1,4 @@
-import type { NavChartPoint } from './types';
+import type { NavChartPoint, ServerPortfolioMetrics } from './types';
 
 /** Daily simple returns from consecutive NAV levels. */
 export function dailySimpleReturnsFromNavs(navs: number[]): number[] {
@@ -30,6 +30,21 @@ export function annualizedVolatilityPctFromDailyReturns(returns: number[]): numb
   return Math.sqrt(variance) * Math.sqrt(252) * 100;
 }
 
+/** Maximum peak-to-trough drawdown from NAV levels, returned as a negative percentage. */
+export function maxDrawdownPctFromNavs(navs: number[]): number {
+  if (navs.length < 2 || navs[0] <= 0) return 0;
+  let peak = navs[0];
+  let maxDd = 0;
+  for (const nav of navs) {
+    if (nav > peak) peak = nav;
+    if (peak > 0) {
+      const dd = (nav - peak) / peak;
+      if (dd < maxDd) maxDd = dd;
+    }
+  }
+  return maxDd * 100;
+}
+
 /**
  * Sortino (MAR = 0): annualized mean return / annualized downside deviation.
  * Downside deviation uses sqrt(mean(min(0, r)²)) over all days.
@@ -47,13 +62,35 @@ export function computeRiskRatiosFromNavSnaps(snaps: NavChartPoint[]): {
   sharpe: number;
   sortino: number;
   annVolPct: number;
+  maxDrawdownPct: number;
 } | null {
   if (!snaps?.length || snaps.length < 2) return null;
-  const returns = dailySimpleReturnsFromNavs(snaps.map((s) => s.nav));
+  const navs = snaps.map((s) => s.nav);
+  const returns = dailySimpleReturnsFromNavs(navs);
   if (returns.length < 2) return null;
   return {
     sharpe: sharpeRatioFromDailyReturns(returns),
     sortino: sortinoRatioFromDailyReturns(returns),
     annVolPct: annualizedVolatilityPctFromDailyReturns(returns),
+    maxDrawdownPct: maxDrawdownPctFromNavs(navs),
+  };
+}
+
+export interface EffectivePortfolioRiskMetrics {
+  sharpe: number | null;
+  annVolPct: number | null;
+  maxDrawdownPct: number | null;
+}
+
+/** Prefer persisted portfolio_metrics values, falling back to NAV-derived values when absent. */
+export function computeEffectivePortfolioRiskMetrics(
+  serverMetrics: Pick<ServerPortfolioMetrics, 'sharpe' | 'volatility' | 'max_drawdown'> | null | undefined,
+  snaps: NavChartPoint[]
+): EffectivePortfolioRiskMetrics {
+  const navMetrics = computeRiskRatiosFromNavSnaps(snaps);
+  return {
+    sharpe: serverMetrics?.sharpe ?? navMetrics?.sharpe ?? null,
+    annVolPct: serverMetrics?.volatility ?? navMetrics?.annVolPct ?? null,
+    maxDrawdownPct: serverMetrics?.max_drawdown ?? navMetrics?.maxDrawdownPct ?? null,
   };
 }

--- a/tests/dq/atlas/test_diagnostics.py
+++ b/tests/dq/atlas/test_diagnostics.py
@@ -7,7 +7,7 @@ NODE_FAILED_REASON) counts as failed; a deliberate carry does not.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -155,12 +155,16 @@ def test_is_degraded_matches_status() -> None:
 def test_write_row_upserts_with_usage_and_counts() -> None:
     client = FakeSupabaseClient()
     state = _state(phase1={"macro": _today("macro")}, phase5={"x": _carried(NODE_FAILED_REASON)})
+    started_at = datetime(2026, 6, 12, 10, 0, tzinfo=timezone.utc)
+    finished_at = datetime(2026, 6, 12, 10, 2, 3, 456000, tzinfo=timezone.utc)
     summary = diagnostics.write_row(
         client,
         state=state,
         run_id="baseline-2026-06-12-local",
         run_type="baseline",
         run_date=RUN_DATE,
+        started_at=started_at,
+        finished_at=finished_at,
         usage_snapshot={
             "llm_calls": 12,
             "prompt_tokens": 3400,
@@ -181,6 +185,9 @@ def test_write_row_upserts_with_usage_and_counts() -> None:
     assert row["segments_failed"] == 1
     assert row["model"] == "x-ai/grok-4"  # derived from usage snapshot models
     assert row["breakdown"]["models"] == ["x-ai/grok-4"]
+    assert row["started_at"] == "2026-06-12T10:00:00+00:00"
+    assert row["finished_at"] == "2026-06-12T10:02:03.456000+00:00"
+    assert row["duration_s"] == pytest.approx(123.456)
 
 
 def test_write_row_is_fail_soft() -> None:

--- a/tests/dq/atlas/test_refresh_performance_metrics.py
+++ b/tests/dq/atlas/test_refresh_performance_metrics.py
@@ -52,6 +52,7 @@ def _load_module():
 _mod = _load_module()
 _sum_attribution_pnl = _mod._sum_attribution_pnl
 _nav_history_count = _mod._nav_history_count
+_risk_metrics_from_nav_history = _mod._risk_metrics_from_nav_history
 upsert_portfolio_metrics_daily = _mod.upsert_portfolio_metrics_daily
 refresh_positions_metrics = _mod.refresh_positions_metrics
 _MIN_HISTORY_ROWS = _mod._MIN_HISTORY_ROWS
@@ -271,8 +272,8 @@ class TestUpsertPortfolioMetricsDaily:
         row = sb.store["portfolio_metrics"][0]
         assert row["computed_from"] == "refresh_script"
 
-    def test_risk_metrics_carried_when_sufficient_history(self) -> None:
-        # >= 20 rows → previous sharpe/vol/etc are carried forward.
+    def test_risk_metrics_computed_from_nav_when_sufficient_history(self) -> None:
+        # >= 20 rows → sharpe/vol/max_dd are computed from nav_history, not carried forward.
         prev_metrics = [
             {
                 "date": "2026-06-11",
@@ -293,11 +294,16 @@ class TestUpsertPortfolioMetricsDaily:
                 "positions": [],
             }
         )
+        expected = _risk_metrics_from_nav_history(sb, "2026-06-12")
         upsert_portfolio_metrics_daily(sb, "2026-06-12")
         row = sb.store["portfolio_metrics"][0]
-        assert row["sharpe"] == 1.2
-        assert row["volatility"] == 0.15
-        assert row["max_drawdown"] == -0.05
+        assert expected is not None
+        assert row["sharpe"] == pytest.approx(expected["sharpe"], abs=1e-6)
+        assert row["volatility"] == pytest.approx(expected["volatility"], abs=1e-6)
+        assert row["max_drawdown"] == pytest.approx(expected["max_drawdown"], abs=1e-6)
+        assert row["sharpe"] != 1.2
+        assert row["volatility"] != 0.15
+        assert row["max_drawdown"] != -0.05
         assert row["alpha"] == 0.02
 
     def test_skips_tearsheet_row(self) -> None:


### PR DESCRIPTION
## Summary
- Compute Calmar ratio from annualized return and max drawdown
- Show Sharpe in Overview and Performance headers when data exists
- Render meaningful segment telemetry on failed/partial pipeline runs

Fixes #843

## Test plan
- [x] `pytest tests/dq/atlas/test_diagnostics.py tests/dq/atlas/test_refresh_performance_metrics.py`
- [x] `npm run test --workspace olympus`

Made with [Cursor](https://cursor.com)