### PR TITLE
fix(olympus): polish settings routing, a11y, and scroll UX (#843)

### DIFF
--- a/frontend/olympus/app/architecture/page.test.ts
+++ b/frontend/olympus/app/architecture/page.test.ts
@@ -1,0 +1,17 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import ArchitecturePage from './page';
+
+describe('ArchitecturePage', () => {
+  it('renders the top-level title, clearer phase label, and path tokens', () => {
+    const html = renderToStaticMarkup(createElement(ArchitecturePage));
+
+    expect(html).toContain('<h1');
+    expect(html).toContain('Atlas Architecture');
+    expect(html).toContain('Agent Phase Map');
+    expect(html).not.toContain('Phase Graph');
+    expect(html).toContain('<code');
+    expect(html).toContain('atlas/phases/phase1_altdata.py');
+  });
+});

--- a/frontend/olympus/app/architecture/page.tsx
+++ b/frontend/olympus/app/architecture/page.tsx
@@ -68,8 +68,19 @@ const AGENTS: AgentEntry[] = [
 export default function ArchitecturePage() {
   return (
     <div className={`${SUBPAGE_MAX} space-y-8 py-4 md:py-6`}>
+      <header className="space-y-2">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+          System guide
+        </p>
+        <h1 className="text-3xl font-black tracking-tight text-text-primary sm:text-4xl">
+          Atlas Architecture
+        </h1>
+        <p className="max-w-3xl text-sm leading-relaxed text-text-secondary">
+          How Olympus moves from scheduled market research to validated portfolio decisions and UI-ready data.
+        </p>
+      </header>
 
-        {/* Intro */}
+      {/* Intro */}
         <div className="glass-card p-6">
           <p className="text-sm text-text-secondary leading-relaxed max-w-3xl">
             <strong className="text-white">Atlas</strong> is a daily market intelligence system driven by a
@@ -185,7 +196,7 @@ export default function ArchitecturePage() {
         <div>
           <div className="flex items-center gap-2 mb-4">
             <Bot size={16} className="text-fin-green" />
-            <h2 className="text-base font-semibold">Phase Graph</h2>
+            <h2 className="text-base font-semibold">Agent Phase Map</h2>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {AGENTS.map(a => (
@@ -195,7 +206,9 @@ export default function ArchitecturePage() {
                   {a.name}
                 </h3>
                 <p className="text-xs text-text-secondary leading-relaxed">{a.role}</p>
-                <p className="text-[10px] text-text-muted font-mono mt-2">{a.file}</p>
+                <code className="mt-2 inline-block rounded-md border border-border-subtle bg-bg-secondary px-1.5 py-1 font-mono text-[10px] text-text-muted">
+                  {a.file}
+                </code>
               </div>
             ))}
           </div>

--- a/frontend/olympus/app/page.tsx
+++ b/frontend/olympus/app/page.tsx
@@ -632,8 +632,8 @@ export default function OverviewPage() {
                         {t.id}
                       </Link>
                     </td>
-                    <td className="px-5 py-3 font-medium max-w-[220px]">
-                      <span className="line-clamp-1">{t.name}</span>
+                    <td className="px-5 py-3 font-medium max-w-[220px]" title={t.name}>
+                      <span className="line-clamp-2 leading-snug">{t.name}</span>
                     </td>
                     <td className="hidden px-5 py-3 font-mono text-xs text-text-secondary sm:table-cell">
                       {t.vehicle}

--- a/frontend/olympus/components/overview/decision-trail-panel.tsx
+++ b/frontend/olympus/components/overview/decision-trail-panel.tsx
@@ -106,7 +106,9 @@ export function DecisionTrailPanel({
                 <Icon size={15} className="text-text-muted group-hover:text-fin-blue transition-colors shrink-0" />
                 <div className="min-w-0 flex-1">
                   <div className="text-sm font-medium text-text-primary">{r.label}</div>
-                  <div className="text-xs text-text-muted truncate">{r.detail}</div>
+                  <div className="line-clamp-2 text-xs leading-snug text-text-muted" title={r.detail}>
+                    {r.detail}
+                  </div>
                 </div>
                 <span className="text-fin-blue/60 group-hover:text-fin-blue text-xs shrink-0">→</span>
               </Link>

--- a/frontend/olympus/components/overview/deliberations-strip.test.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.test.tsx
@@ -70,4 +70,13 @@ describe('DeliberationsStrip', () => {
     expect(html).toContain('NVDA');
     expect(html).toContain('Risk debate');
   });
+
+  it('labels the horizontal debate scroller and visible hint', () => {
+    const html = render([NVDA]);
+    expect(html).toContain('Scroll horizontally to review every ticker debate.');
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Ticker deliberations"');
+    expect(html).toContain('aria-describedby="deliberations-scroll-hint"');
+    expect(html).toContain('tabindex="0"');
+  });
 });

--- a/frontend/olympus/components/overview/deliberations-strip.tsx
+++ b/frontend/olympus/components/overview/deliberations-strip.tsx
@@ -24,6 +24,8 @@ const STANCE: Record<string, string> = {
   neutral: 'text-fin-blue border-fin-blue/40 bg-fin-blue/10',
 };
 
+const SCROLL_HINT_ID = 'deliberations-scroll-hint';
+
 function s(v: unknown): string {
   return v == null ? '' : String(v);
 }
@@ -146,10 +148,25 @@ export function DeliberationsStrip({
         </Link>
       </div>
       {debates.length > 0 && (
-        <div className="flex gap-3 overflow-x-auto p-4">
-          {debates.map((d, i) => (
-            <DebateCard key={`${d.ticker}-${i}`} doc={d} />
-          ))}
+        <div className="relative">
+          <p id={SCROLL_HINT_ID} className="px-4 pt-3 text-[10px] text-text-muted">
+            Scroll horizontally to review every ticker debate.
+          </p>
+          <div
+            className="flex gap-3 overflow-x-auto p-4 pt-2 scroll-smooth"
+            role="region"
+            aria-label="Ticker deliberations"
+            aria-describedby={SCROLL_HINT_ID}
+            tabIndex={0}
+          >
+            {debates.map((d, i) => (
+              <DebateCard key={`${d.ticker}-${i}`} doc={d} />
+            ))}
+          </div>
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-bg-glass to-transparent"
+            aria-hidden
+          />
         </div>
       )}
       {hasRisk && <RiskDebateCard payload={riskDebate as Record<string, unknown>} />}

--- a/frontend/olympus/components/overview/top-assets-pulse.test.tsx
+++ b/frontend/olympus/components/overview/top-assets-pulse.test.tsx
@@ -1,0 +1,32 @@
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { BenchmarkHistoryMap } from '@/lib/types';
+import TopAssetsPulse from './top-assets-pulse';
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+  LineChart: ({ children }: { children: ReactNode }) => createElement('svg', null, children),
+  Line: () => createElement('path'),
+  YAxis: () => null,
+}));
+
+const BENCHMARKS: BenchmarkHistoryMap = {
+  SPY: { current: 101, history: [{ date: '2026-06-17', price: 100 }, { date: '2026-06-18', price: 101 }] },
+  QQQ: { current: 203, history: [{ date: '2026-06-17', price: 200 }, { date: '2026-06-18', price: 203 }] },
+  DIA: { current: 299, history: [{ date: '2026-06-17', price: 300 }, { date: '2026-06-18', price: 299 }] },
+  IWM: { current: 91, history: [{ date: '2026-06-17', price: 90 }, { date: '2026-06-18', price: 91 }] },
+};
+
+describe('TopAssetsPulse', () => {
+  it('exposes discoverable scroll controls and a keyboard-focusable region', () => {
+    const html = renderToStaticMarkup(createElement(TopAssetsPulse, { benchmarks: BENCHMARKS }));
+
+    expect(html).toContain('aria-label="Scroll left (loops to end)"');
+    expect(html).toContain('aria-label="Scroll right (loops to start)"');
+    expect(html).toContain('title="Scroll market pulse left"');
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Market pulse assets"');
+    expect(html).toContain('tabindex="0"');
+  });
+});

--- a/frontend/olympus/components/overview/top-assets-pulse.tsx
+++ b/frontend/olympus/components/overview/top-assets-pulse.tsx
@@ -1,6 +1,6 @@
  'use client';
  
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { Line, LineChart, ResponsiveContainer, YAxis } from 'recharts';
 import type { BenchmarkHistoryMap } from '@/lib/types';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -97,16 +97,18 @@ export default function TopAssetsPulse({ benchmarks }: { benchmarks: BenchmarkHi
           <button
             type="button"
             onClick={() => scrollByTiles(-1)}
-            className="absolute left-0 top-1/2 -translate-y-1/2 z-10 hidden sm:grid place-items-center h-10 w-10 rounded-full border border-border-subtle bg-bg-glass/90 backdrop-blur opacity-0 pointer-events-none transition-opacity duration-200 sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto hover:bg-white/[0.06]"
+            className="absolute left-0 top-1/2 -translate-y-1/2 z-10 hidden sm:grid place-items-center h-10 w-10 rounded-full border border-border-subtle bg-bg-glass/95 backdrop-blur opacity-90 shadow-glass transition-colors duration-200 hover:bg-white/[0.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-fin-blue"
             aria-label="Scroll left (loops to end)"
+            title="Scroll market pulse left"
           >
             <ChevronLeft size={18} className="text-text-secondary" />
           </button>
           <button
             type="button"
             onClick={() => scrollByTiles(1)}
-            className="absolute right-0 top-1/2 -translate-y-1/2 z-10 hidden sm:grid place-items-center h-10 w-10 rounded-full border border-border-subtle bg-bg-glass/90 backdrop-blur opacity-0 pointer-events-none transition-opacity duration-200 sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto hover:bg-white/[0.06]"
+            className="absolute right-0 top-1/2 -translate-y-1/2 z-10 hidden sm:grid place-items-center h-10 w-10 rounded-full border border-border-subtle bg-bg-glass/95 backdrop-blur opacity-90 shadow-glass transition-colors duration-200 hover:bg-white/[0.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-fin-blue"
             aria-label="Scroll right (loops to start)"
+            title="Scroll market pulse right"
           >
             <ChevronRight size={18} className="text-text-secondary" />
           </button>
@@ -116,6 +118,9 @@ export default function TopAssetsPulse({ benchmarks }: { benchmarks: BenchmarkHi
       <div
         ref={scrollerRef}
         className="overflow-x-auto scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="region"
+        aria-label="Market pulse assets"
+        tabIndex={canScroll ? 0 : undefined}
       >
         <div className="flex gap-4 min-w-max pb-2 pr-1">
           {items.map(({ ticker, history }) => {

--- a/frontend/olympus/components/portfolio/tabs/ActivityTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/ActivityTab.tsx
@@ -358,10 +358,10 @@ export default function ActivityTab(props: {
         return (
           <td
             key={`${col}-${i}`}
-            className={`${cellWrapperClass(col)} max-w-[min(28rem,40vw)] truncate px-3 py-3 text-xs text-text-muted md:px-5 lg:max-w-md`}
+            className={`${cellWrapperClass(col)} max-w-[min(28rem,40vw)] px-3 py-3 align-top text-xs text-text-muted md:px-5 lg:max-w-md`}
             title={ev.reason ?? undefined}
           >
-            {ev.reason ?? '—'}
+            <span className="line-clamp-2 leading-snug">{ev.reason ?? '—'}</span>
           </td>
         );
       case 'price':

--- a/frontend/olympus/components/portfolio/tabs/ThesesTab.tsx
+++ b/frontend/olympus/components/portfolio/tabs/ThesesTab.tsx
@@ -246,7 +246,9 @@ export default function ThesesTab(props: {
                             }}
                             className={`hover:bg-white/[0.02] cursor-pointer transition-colors ${statusAccent}`}
                           >
-                            <td className="px-4 py-3 font-medium md:px-5">{label}</td>
+                            <td className="px-4 py-3 font-medium md:px-5" title={label}>
+                              <span className="line-clamp-2 leading-snug">{label}</span>
+                            </td>
                             <td className="px-4 py-3 text-right font-mono font-semibold tabular-nums md:px-5">
                               {row.weight.toFixed(1)}%
                             </td>
@@ -336,7 +338,9 @@ export default function ThesesTab(props: {
                                                   <td className="px-4 py-2 font-mono whitespace-nowrap align-top">
                                                     {h.date}
                                                   </td>
-                                                  <td className="px-4 py-2 align-top">{h.name}</td>
+                                                  <td className="px-4 py-2 align-top" title={h.name}>
+                                                    <span className="line-clamp-2 leading-snug">{h.name}</span>
+                                                  </td>
                                                   <td className="px-4 py-2 align-top whitespace-nowrap">
                                                     {h.status ?? '—'}
                                                   </td>

--- a/frontend/olympus/components/settings-content.test.tsx
+++ b/frontend/olympus/components/settings-content.test.tsx
@@ -1,0 +1,44 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsContent } from './settings-content';
+
+const mocks = vi.hoisted(() => ({
+  pathname: '/settings/',
+  theme: 'dark' as 'auto' | 'dark' | 'light',
+  setTheme: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mocks.pathname,
+}));
+
+vi.mock('@/components/theme-provider', () => ({
+  useAtlasTheme: () => ({
+    theme: mocks.theme,
+    setTheme: mocks.setTheme,
+  }),
+}));
+
+function render(): string {
+  return renderToStaticMarkup(createElement(SettingsContent));
+}
+
+describe('SettingsContent', () => {
+  beforeEach(() => {
+    mocks.pathname = '/settings/';
+    mocks.theme = 'dark';
+    mocks.setTheme.mockClear();
+  });
+
+  it('hides the redundant All settings link on the trailing-slash settings route', () => {
+    expect(render()).not.toContain('All settings');
+  });
+
+  it('marks the active theme button with aria-pressed', () => {
+    const html = render();
+    expect(html).toMatch(/aria-pressed="true"[^>]*>Dark/);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>Auto/);
+    expect(html).toMatch(/aria-pressed="false"[^>]*>Light/);
+  });
+});

--- a/frontend/olympus/components/settings-content.tsx
+++ b/frontend/olympus/components/settings-content.tsx
@@ -4,15 +4,22 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Database, Keyboard } from 'lucide-react';
 import { useAtlasTheme } from '@/components/theme-provider';
+import { normalizePathname } from '@/lib/pathname';
 
 function architectureActive(pathname: string): boolean {
-  return /\/architecture(\/|$)/.test(pathname);
+  const path = normalizePathname(pathname);
+  return path === '/architecture' || path.startsWith('/architecture/');
+}
+
+function settingsActive(pathname: string): boolean {
+  return normalizePathname(pathname) === '/settings';
 }
 
 export function SettingsContent({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname();
   const { theme, setTheme } = useAtlasTheme();
   const arch = architectureActive(pathname);
+  const settings = settingsActive(pathname);
 
   return (
     <div className="space-y-5">
@@ -30,7 +37,7 @@ export function SettingsContent({ onNavigate }: { onNavigate?: () => void }) {
           <Database size={16} className="shrink-0" />
           Architecture
         </Link>
-        {pathname !== '/settings' ? (
+        {!settings ? (
           <Link
             href="/settings"
             onClick={onNavigate}
@@ -47,6 +54,7 @@ export function SettingsContent({ onNavigate }: { onNavigate?: () => void }) {
           <div className="grid grid-cols-3 rounded-lg border border-border-subtle overflow-hidden text-xs">
             <button
               type="button"
+              aria-pressed={theme === 'auto'}
               onClick={() => setTheme('auto')}
               className={`px-2 py-2 font-medium transition-colors ${
                 theme === 'auto' ? 'bg-fin-blue/20 text-fin-blue' : 'text-text-muted hover:bg-white/[0.04]'
@@ -56,6 +64,7 @@ export function SettingsContent({ onNavigate }: { onNavigate?: () => void }) {
             </button>
             <button
               type="button"
+              aria-pressed={theme === 'dark'}
               onClick={() => setTheme('dark')}
               className={`px-2 py-2 font-medium border-l border-border-subtle transition-colors ${
                 theme === 'dark' ? 'bg-fin-blue/20 text-fin-blue' : 'text-text-muted hover:bg-white/[0.04]'
@@ -65,6 +74,7 @@ export function SettingsContent({ onNavigate }: { onNavigate?: () => void }) {
             </button>
             <button
               type="button"
+              aria-pressed={theme === 'light'}
               onClick={() => setTheme('light')}
               className={`px-2 py-2 font-medium border-l border-border-subtle transition-colors ${
                 theme === 'light' ? 'bg-fin-blue/20 text-fin-blue' : 'text-text-muted hover:bg-white/[0.04]'

--- a/frontend/olympus/components/sidebar-settings.tsx
+++ b/frontend/olympus/components/sidebar-settings.tsx
@@ -11,8 +11,10 @@ import {
   type CSSProperties,
 } from 'react';
 import { Settings } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 import { useAppShell } from '@/components/app-shell-context';
 import { SettingsContent } from '@/components/settings-content';
+import { normalizePathname } from '@/lib/pathname';
 
 const PANEL_W = 280;
 const GAP = 8;
@@ -51,12 +53,14 @@ function panelStyle(
 
 export default function SidebarSettings({ sidebarCollapsed }: { sidebarCollapsed: boolean }) {
   const mounted = useClientMounted();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [panelStyleState, setPanelStyleState] = useState<CSSProperties | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const { setMobileNavOpen } = useAppShell();
+  const settingsPageActive = normalizePathname(pathname) === '/settings';
 
   const updatePosition = useCallback(() => {
     const btn = buttonRef.current;
@@ -128,7 +132,14 @@ export default function SidebarSettings({ sidebarCollapsed }: { sidebarCollapsed
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (settingsPageActive) {
+            setOpen(false);
+            setMobileNavOpen(false);
+            return;
+          }
+          setOpen((v) => !v);
+        }}
         title="Settings"
         aria-expanded={open}
         aria-haspopup="dialog"

--- a/frontend/olympus/lib/pathname.test.ts
+++ b/frontend/olympus/lib/pathname.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePathname } from './pathname';
+
+describe('normalizePathname', () => {
+  it('strips trailing slashes and preserves root', () => {
+    expect(normalizePathname('/settings/')).toBe('/settings');
+    expect(normalizePathname('/')).toBe('/');
+    expect(normalizePathname('')).toBe('/');
+  });
+});

--- a/frontend/olympus/lib/pathname.ts
+++ b/frontend/olympus/lib/pathname.ts
@@ -1,0 +1,5 @@
+/** Strip trailing slashes so `/settings` and `/settings/` compare equal. */
+export function normalizePathname(pathname: string): string {
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized || '/';
+}


### PR DESCRIPTION
## Summary
- Normalize settings trailing-slash paths and "All settings" navigation
- Add aria-pressed on toggles, fix duplicate flyout
- Architecture H1 date normalization and scroll/truncation polish

Fixes #843

## Test plan
- [x] `npm run test --workspace olympus`
- [x] `npm run lint --workspace olympus`
- [x] `npm run build --workspace olympus`

Made with [Cursor](https://cursor.com)