### PR TITLE
fix(hermes): coerce LangGraph dict state on checkpoint resume

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/chain.py
+++ b/digiquant/src/digiquant/olympus/hermes/chain.py
@@ -87,6 +87,11 @@ class DiagnosticsDeps:
     model: str | None = None
 
 
+def _coerce_atlas_state(result: Any) -> AtlasResearchState:
+    """LangGraph ``invoke`` may return a plain dict (notably on checkpoint resume)."""
+    return AtlasResearchState.model_validate(result) if isinstance(result, dict) else result
+
+
 def _acquire_checkpointer() -> Any:
     """Return a checkpointer when ``DIGI_CHECKPOINTER`` is set, else ``None``.
 
@@ -119,7 +124,7 @@ def _invoke_resumable(
     checkpoint, invoke(None) to continue from where it died; otherwise invoke(state).
     """
     if checkpointer is None or not thread_base:
-        return graph.invoke(state)
+        return _coerce_atlas_state(graph.invoke(state))
     cfg = {"configurable": {"thread_id": f"{thread_base}::{suffix}"}}
     resuming = False
     try:
@@ -130,7 +135,7 @@ def _invoke_resumable(
         _logger.info(
             "resuming %s from checkpoint thread %s", suffix, cfg["configurable"]["thread_id"]
         )
-    return graph.invoke(None if resuming else state, cfg)
+    return _coerce_atlas_state(graph.invoke(None if resuming else state, cfg))
 
 
 def _degraded_run_pct() -> float:
@@ -182,7 +187,9 @@ def _run_terminal_phase(
     from digiquant.olympus.hermes.pipeline_builder import build_pipeline
 
     try:
-        return build_pipeline(AtlasResearchState, [build_phase(phase_deps)]).invoke(state)
+        return _coerce_atlas_state(
+            build_pipeline(AtlasResearchState, [build_phase(phase_deps)]).invoke(state)
+        )
     except Exception as exc:  # noqa: BLE001 — one terminal phase failing must not abort the rest
         _logger.exception("chain: terminal phase %s failed; continuing", label)
         _record_chain_error(state, label, exc)

--- a/tests/dq/hermes/test_chain_safety_net.py
+++ b/tests/dq/hermes/test_chain_safety_net.py
@@ -11,8 +11,13 @@ from datetime import date
 
 import pytest
 
-from digiquant.olympus.atlas.state import AtlasResearchState
-from digiquant.olympus.hermes.chain import _record_chain_error, _run_terminal_phase
+from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState
+from digiquant.olympus.hermes.chain import (
+    _coerce_atlas_state,
+    _record_chain_error,
+    _run_terminal_phase,
+)
+from digiquant.olympus.hermes.phases.phase7cd_debate import clamp_debate_rounds
 
 pytestmark = pytest.mark.unit
 
@@ -49,3 +54,17 @@ def test_record_chain_error_appends_phase_error() -> None:
     assert state.errors[-1].phase == "chain"
     assert state.errors[-1].node == "atlas"
     assert "graph crash" in state.errors[-1].message
+
+
+def test_coerce_atlas_state_normalizes_langgraph_dict() -> None:
+    state = _state()
+    state.config = AtlasConfigBundle(preferences={"debate_rounds": 3})
+    raw = state.model_dump(mode="json")
+    coerced = _coerce_atlas_state(raw)
+    assert isinstance(coerced, AtlasResearchState)
+    assert clamp_debate_rounds(coerced.config.preferences.get("debate_rounds", 1)) == 3
+
+
+def test_coerce_atlas_state_passthrough_model() -> None:
+    state = _state()
+    assert _coerce_atlas_state(state) is state


### PR DESCRIPTION
## Summary
- Add `_coerce_atlas_state()` to normalize LangGraph dict returns when resuming Hermes from checkpoint after Atlas pass.
- Fixes `AttributeError: 'dict' object has no attribute 'config'` on Olympus delta resume (2026-06-19).

## Test plan
- [x] `pytest tests/dq/hermes/test_chain_safety_net.py tests/dq/hermes/test_chain_atlas_then_hermes.py -q`

Fixes #740

Made with [Cursor](https://cursor.com)