### PR TITLE
fix(digiquant): route Hermes thesis/portfolio phases via OpenRouter

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -81,6 +81,7 @@ phase_capabilities:
   pm-rebalance: reasoning
   master-digest: reasoning
   monthly-digest: reasoning
+  hermes/portfolio/pm-direction: reasoning
 
 phase_capability_prefixes:
   alt-: extraction
@@ -93,3 +94,8 @@ phase_capability_prefixes:
   bull-researcher-: research
   bear-researcher-: research
   research-manager-: research
+  hermes/thesis/market-: research
+  hermes/thesis/vehicle-: research
+  hermes/portfolio/asset-analyst-: extraction
+  h6_pm_challenge-: research
+  h6_analyst_response-: research

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -29,6 +29,23 @@ def _repo_config(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hermes H1–H7 slugs must resolve via olympus_models (CI has OPENROUTER_API_KEY only)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    assert get_model_for_phase("hermes/thesis/market-review") == (
+        "openrouter/deepseek/deepseek-chat"
+    )
+    assert get_model_for_phase("hermes/portfolio/asset-analyst-AAPL") == (
+        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+    )
+    assert get_model_for_phase("hermes/portfolio/pm-direction") == (
+        "openrouter/deepseek/deepseek-chat"
+    )
+
+
+@pytest.mark.unit
 def test_cheap_tier_resolves_extraction_and_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     assert get_model_for_phase("alt-sentiment-news") == (

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -37,7 +37,7 @@ _STATIC_PHASE_SLUGS = (
     "decision-reflector",
 )
 
-# Dynamic per-ticker slugs, prefix-matched in model_modes.yaml ("<prefix>-").
+# Dynamic per-ticker slugs, prefix-matched in olympus_models.yaml ("<prefix>-").
 _DYNAMIC_SLUG_EXAMPLES = (
     "technical-analyst-AAPL",
     "sentiment-analyst-AAPL",
@@ -48,12 +48,31 @@ _DYNAMIC_SLUG_EXAMPLES = (
     "research-manager-AAPL",
 )
 
+# Hermes H1–H7 phase_slug literals (see digiquant/olympus/hermes/phases/*).
+_HERMES_STATIC_SLUGS = (
+    "hermes/thesis/market-review",
+    "hermes/thesis/market-exploration",
+    "hermes/thesis/vehicle-map",
+    "hermes/portfolio/pm-direction",
+)
+
+_HERMES_DYNAMIC_SLUG_EXAMPLES = (
+    "hermes/portfolio/asset-analyst-AAPL",
+    "h6_pm_challenge-AAPL",
+    "h6_analyst_response-AAPL",
+)
+
 
 def _all_slugs() -> list[str]:
     specs = (*ALT_SPECS, *INST_SPECS, MACRO_SPEC, *ASSET_SPECS)
     slugs = [spec.segment_slug for spec in specs]
     slugs += [sector.slug for sector in load_sectors()]
-    slugs += [*_STATIC_PHASE_SLUGS, *_DYNAMIC_SLUG_EXAMPLES]
+    slugs += [
+        *_STATIC_PHASE_SLUGS,
+        *_DYNAMIC_SLUG_EXAMPLES,
+        *_HERMES_STATIC_SLUGS,
+        *_HERMES_DYNAMIC_SLUG_EXAMPLES,
+    ]
     return slugs
 
 


### PR DESCRIPTION
## Summary
- Hermes H1–H7 `phase_slug` values (`hermes/thesis/*`, `hermes/portfolio/*`, `h6_*`) were absent from `config/olympus_models.yaml`, so `get_model_for_phase()` fell through to `get_model_for_mode()` → unauthenticated OpenAI client in CI (`OPENAI_API_KEY=not-set`, 401).
- Add capability prefix/exact entries so cheap-tier calls use `openrouter/*` models (same path as Atlas segments).
- Extend `test_model_routing_coverage` and add a focused Hermes routing unit test to prevent regressions.

Fixes Olympus baseline CI failure run 27948786775 (`hermes/thesis/market-review`).

## Test plan
- [x] `pytest tests/dg/test_olympus_models.py tests/dq/atlas/test_model_routing_coverage.py -m unit -v`
- [ ] Re-dispatch `olympus.yml` after merge


Made with [Cursor](https://cursor.com)