### PR TITLE
fix(digiquant): route beliefs distillation through OpenRouter

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -82,6 +82,7 @@ phase_capabilities:
   master-digest: reasoning
   monthly-digest: reasoning
   hermes/portfolio/pm-direction: reasoning
+  beliefs-distillation: research
 
 phase_capability_prefixes:
   alt-: extraction

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -43,9 +43,7 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
     assert get_model_for_phase("hermes/portfolio/pm-direction") == (
         "openrouter/deepseek/deepseek-chat"
     )
-    assert get_model_for_phase("beliefs-distillation") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
+    assert get_model_for_phase("beliefs-distillation") == ("openrouter/deepseek/deepseek-chat")
 
 
 @pytest.mark.unit

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -43,6 +43,9 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
     assert get_model_for_phase("hermes/portfolio/pm-direction") == (
         "openrouter/deepseek/deepseek-chat"
     )
+    assert get_model_for_phase("beliefs-distillation") == (
+        "openrouter/deepseek/deepseek-chat"
+    )
 
 
 @pytest.mark.unit

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -35,6 +35,7 @@ _STATIC_PHASE_SLUGS = (
     "risk-conservative",
     "phase9-evolution",
     "decision-reflector",
+    "beliefs-distillation",
 )
 
 # Dynamic per-ticker slugs, prefix-matched in olympus_models.yaml ("<prefix>-").


### PR DESCRIPTION
## Summary
- Follow-up to #960: `beliefs-distillation` phase_slug was still unmapped in `olympus_models.yaml`, so `refresh_scope=beliefs` would fall through to `get_model_for_mode()` → unauthenticated OpenAI in CI.
- Add `beliefs-distillation: research` capability entry and extend routing coverage tests.

Fixes #942

## Test plan
- [x] `pytest tests/dq/hermes tests/dq/atlas/test_model_routing_coverage.py tests/dg/test_olympus_models.py -q -x`
- [x] `ruff check` on touched Python files