### PR TITLE
fix(digiquant): replace stale Qwen extraction model on OpenRouter

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -26,7 +26,6 @@
 #   llm_calls: 147 | cost: $11.95 (bare Auto Router → openai/gpt-5.5 — now blocked)
 #
 # ── PRICING (OpenRouter pass-through, per 1M tokens, Jun 2026) ─────────────
-#   qwen3-235b-a22b-instruct-2507  $0.071 in / $0.10 out  [structured_outputs ✓]
 #   deepseek-chat (V3)               $0.20 in / $0.80 out  [structured_outputs ✓]
 #   llama-4-maverick                 $0.15 in / $0.60 out  [structured_outputs ✓]
 #   deepseek-r1                      $0.70 in / $2.50 out  [structured_outputs ✓]
@@ -47,14 +46,14 @@ openrouter_defaults:
 tiers:
   cheap:
     models:
-      extraction: "openrouter/qwen/qwen3-235b-a22b-instruct-2507"  # $0.071/$0.10
+      extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       reasoning: "openrouter/deepseek/deepseek-chat"               # $0.20/$0.80
     grounding_model: "openrouter/deepseek/deepseek-chat"
 
   balanced:
     models:
-      extraction: "openrouter/qwen/qwen3-235b-a22b-instruct-2507"  # $0.071/$0.10
+      extraction: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       reasoning: "openrouter/meta-llama/llama-4-maverick"            # $0.15/$0.60, 1M ctx
     grounding_model: "openrouter/deepseek/deepseek-chat"

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -20,6 +20,15 @@ from digigraph.model_config import (
 
 _REPO_CONFIG = str(Path(__file__).parents[2] / "config")
 
+# OpenRouter slugs verified in CI (OPENROUTER_API_KEY only — no direct OpenAI).
+_KNOWN_GOOD_OPENROUTER_MODELS = frozenset(
+    {
+        "openrouter/deepseek/deepseek-chat",
+        "openrouter/deepseek/deepseek-r1",
+        "openrouter/meta-llama/llama-4-maverick",
+    }
+)
+
 
 @pytest.fixture(autouse=True)
 def _repo_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,7 +47,7 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
         "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("hermes/portfolio/asset-analyst-AAPL") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("hermes/portfolio/pm-direction") == (
         "openrouter/deepseek/deepseek-chat"
@@ -47,14 +56,26 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
+def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H5 asset-analyst must not pin stale/invalid OpenRouter slugs (CI run 27950332738)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    model = get_model_for_phase("hermes/portfolio/asset-analyst-AAPL")
+    assert model is not None
+    assert model.startswith("openrouter/")
+    assert model in _KNOWN_GOOD_OPENROUTER_MODELS
+
+
+@pytest.mark.unit
 def test_cheap_tier_resolves_extraction_and_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     assert get_model_for_phase("alt-sentiment-news") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("monthly-digest") == "openrouter/deepseek/deepseek-chat"
     assert get_model_for_phase("technical-analyst-AAPL") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
 
 
@@ -136,7 +157,7 @@ def test_phase_models_open_weight_override_wins(
         ("openrouter/openai/gpt-5.5", True),
         ("openrouter/anthropic/claude-sonnet-4", True),
         ("openrouter/deepseek/deepseek-chat", False),
-        ("openrouter/qwen/qwen3-235b-a22b-instruct-2507", False),
+        ("openrouter/meta-llama/llama-4-maverick", False),
     ],
 )
 def test_flagship_detection(model: str, flagship: bool) -> None:


### PR DESCRIPTION
## Summary
- Replace invalid OpenRouter slug `qwen/qwen3-235b-a22b-instruct-2507` with `deepseek/deepseek-chat` for cheap/balanced extraction tiers in `config/olympus_models.yaml`
- Fixes Olympus CI failure run 27950332738 during `hermes/portfolio/asset-analyst-worker` (H5)
- Add regression test ensuring asset-analyst slug resolves to a known-good OpenRouter model

## Test plan
- [x] `pytest tests/dg/test_olympus_models.py tests/dq/atlas/test_model_routing_coverage.py -q` (23 passed)


Made with [Cursor](https://cursor.com)