### PR TITLE
chore: sync develop → main (Olympus OpenRouter model fix)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -26,7 +26,6 @@
 #   llm_calls: 147 | cost: $11.95 (bare Auto Router → openai/gpt-5.5 — now blocked)
 #
 # ── PRICING (OpenRouter pass-through, per 1M tokens, Jun 2026) ─────────────
-#   qwen3-235b-a22b-instruct-2507  $0.071 in / $0.10 out  [structured_outputs ✓]
 #   deepseek-chat (V3)               $0.20 in / $0.80 out  [structured_outputs ✓]
 #   llama-4-maverick                 $0.15 in / $0.60 out  [structured_outputs ✓]
 #   deepseek-r1                      $0.70 in / $2.50 out  [structured_outputs ✓]
@@ -47,14 +46,14 @@ openrouter_defaults:
 tiers:
   cheap:
     models:
-      extraction: "openrouter/qwen/qwen3-235b-a22b-instruct-2507"  # $0.071/$0.10
+      extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       reasoning: "openrouter/deepseek/deepseek-chat"               # $0.20/$0.80
     grounding_model: "openrouter/deepseek/deepseek-chat"
 
   balanced:
     models:
-      extraction: "openrouter/qwen/qwen3-235b-a22b-instruct-2507"  # $0.071/$0.10
+      extraction: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       reasoning: "openrouter/meta-llama/llama-4-maverick"            # $0.15/$0.60, 1M ctx
     grounding_model: "openrouter/deepseek/deepseek-chat"

--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -82,6 +82,7 @@ phase_capabilities:
   master-digest: reasoning
   monthly-digest: reasoning
   hermes/portfolio/pm-direction: reasoning
+  beliefs-distillation: research
 
 phase_capability_prefixes:
   alt-: extraction

--- a/docs/agent-backlog/generated-snapshot.md
+++ b/docs/agent-backlog/generated-snapshot.md
@@ -1,5 +1,5 @@
 # Agent backlog snapshot
 
-**Generated:** 2026-06-15 12:20 UTC · **repo:** `digithings-ai/digithings` · **label:** `agent-task`
+**Generated:** 2026-06-22 12:09 UTC · **repo:** `digithings-ai/digithings` · **label:** `agent-task`
 
 *No open issues with label `agent-task`.*

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -43,6 +43,7 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
     assert get_model_for_phase("hermes/portfolio/pm-direction") == (
         "openrouter/deepseek/deepseek-chat"
     )
+    assert get_model_for_phase("beliefs-distillation") == ("openrouter/deepseek/deepseek-chat")
 
 
 @pytest.mark.unit

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -20,6 +20,15 @@ from digigraph.model_config import (
 
 _REPO_CONFIG = str(Path(__file__).parents[2] / "config")
 
+# OpenRouter slugs verified in CI (OPENROUTER_API_KEY only — no direct OpenAI).
+_KNOWN_GOOD_OPENROUTER_MODELS = frozenset(
+    {
+        "openrouter/deepseek/deepseek-chat",
+        "openrouter/deepseek/deepseek-r1",
+        "openrouter/meta-llama/llama-4-maverick",
+    }
+)
+
 
 @pytest.fixture(autouse=True)
 def _repo_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,7 +47,7 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
         "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("hermes/portfolio/asset-analyst-AAPL") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("hermes/portfolio/pm-direction") == (
         "openrouter/deepseek/deepseek-chat"
@@ -47,14 +56,26 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
+def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H5 asset-analyst must not pin stale/invalid OpenRouter slugs (CI run 27950332738)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    model = get_model_for_phase("hermes/portfolio/asset-analyst-AAPL")
+    assert model is not None
+    assert model.startswith("openrouter/")
+    assert model in _KNOWN_GOOD_OPENROUTER_MODELS
+
+
+@pytest.mark.unit
 def test_cheap_tier_resolves_extraction_and_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     assert get_model_for_phase("alt-sentiment-news") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
     assert get_model_for_phase("monthly-digest") == "openrouter/deepseek/deepseek-chat"
     assert get_model_for_phase("technical-analyst-AAPL") == (
-        "openrouter/qwen/qwen3-235b-a22b-instruct-2507"
+        "openrouter/deepseek/deepseek-chat"
     )
 
 
@@ -136,7 +157,7 @@ def test_phase_models_open_weight_override_wins(
         ("openrouter/openai/gpt-5.5", True),
         ("openrouter/anthropic/claude-sonnet-4", True),
         ("openrouter/deepseek/deepseek-chat", False),
-        ("openrouter/qwen/qwen3-235b-a22b-instruct-2507", False),
+        ("openrouter/meta-llama/llama-4-maverick", False),
     ],
 )
 def test_flagship_detection(model: str, flagship: bool) -> None:

--- a/tests/dq/atlas/test_model_routing_coverage.py
+++ b/tests/dq/atlas/test_model_routing_coverage.py
@@ -35,6 +35,7 @@ _STATIC_PHASE_SLUGS = (
     "risk-conservative",
     "phase9-evolution",
     "decision-reflector",
+    "beliefs-distillation",
 )
 
 # Dynamic per-ticker slugs, prefix-matched in olympus_models.yaml ("<prefix>-").


### PR DESCRIPTION
## Summary
- Sync develop into main so Olympus CI (checks out main) picks up the OpenRouter extraction model fix
- Replaces invalid `qwen/qwen3-235b-a22b-instruct-2507` with `deepseek/deepseek-chat` for cheap/balanced extraction tiers

Fixes #678

## Test plan
- [x] `pytest tests/dg/test_olympus_models.py tests/dq/atlas/test_model_routing_coverage.py -q`