### PR TITLE
chore: sync develop → main (Olympus web search fix)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -4,35 +4,28 @@
 # Override the active tier at runtime: OLYMPUS_MODEL_TIER=cheap|balanced|quality
 #
 # ── OPENROUTER ROUTING (Jun 2026) ───────────────────────────────────────────
-# Phases pin open-weight models below (NOT openrouter/auto). Auto Router knobs apply
-# when a call uses openrouter/auto or OPENROUTER_FALLBACK_MODELS — digillm injects:
+# Per-tier ``allowed_models`` pools (NOT single-model pins). Phase routing picks
+# deterministically from the capability pool via hash(phase_slug). Every model in
+# every pool MUST support web search — use ``:online`` suffix or native search
+# providers (perplexity/sonar). Grounding uses ``web_search_models`` from the same
+# search-capable set.
+#
+# Auto Router knobs (``openrouter_defaults``) apply when a call uses openrouter/auto
+# or OPENROUTER_FALLBACK_MODELS — digillm injects:
 #   plugins[{ id: auto-router, allowed_models, cost_quality_tradeoff }]
-#   provider.require_parameters — only for structured-output / tool calls without
-#     a curated allowed_models pool (see digillm client.py).
 #
-# cost_quality_tradeoff (0–10): 0 = favor capability, 10 = favor lowest cost.
-# We always use 10 (maximum cost bias) via openrouter_defaults below.
-#
-# allowed_models: comma-separated slugs/wildcards for the auto-router plugin ONLY.
-# Open-weight providers only — NEVER openai/*, anthropic/*, or frontier IDs.
-#
-# Web grounding: openrouter:web_search (Exa, $0.005/search) via grounding_model.
-# Use a search-capable model for the pre-pass (perplexity/sonar); deepseek-chat does not
-# support server tools when require_parameters is mis-applied. Fail-hard: OLYMPUS_WEB_SEARCH=required.
-# Structured JSON: response_format json_schema + strict:true on pinned models.
+# Web grounding: openrouter:web_search (Exa, $0.005/search) via web_search_models.
+# Fail-hard when unavailable: OLYMPUS_WEB_SEARCH=required.
+# Structured JSON: response_format json_schema + strict:true on pool models.
 #
 # Env contract (unchanged): OPENROUTER_API_KEY only — apply_olympus_openrouter_env()
 # sets OPENROUTER_ALLOWED_MODELS + OPENROUTER_COST_QUALITY_TRADEOFF at chain startup.
 #
-# ── ACTUAL USAGE (Jun 19 2026 delta, run_id 27837632085 — pre-migration) ─────
-#   llm_calls: 147 | cost: $11.95 (bare Auto Router → openai/gpt-5.5 — now blocked)
-#
 # ── PRICING (OpenRouter pass-through, per 1M tokens, Jun 2026) ─────────────
-#   deepseek-chat (V3)               $0.20 in / $0.80 out  [structured_outputs ✓]
-#   llama-4-maverick                 $0.15 in / $0.60 out  [structured_outputs ✓]
-#   deepseek-r1                      $0.70 in / $2.50 out  [structured_outputs ✓]
-#   google/gemma* (budget tier)      varies — allowed in pool only, not default pins
-#   perplexity/sonar                 $1.00 in / $1.00 out  [web search native + server tools ✓]
+#   deepseek-chat:online              $0.20 in / $0.80 out  [structured_outputs ✓, web ✓]
+#   llama-4-maverick:online           $0.15 in / $0.60 out  [structured_outputs ✓, web ✓]
+#   deepseek-r1:online                $0.70 in / $2.50 out  [structured_outputs ✓, web ✓]
+#   perplexity/sonar                  $1.00 in / $1.00 out  [web search native ✓]
 #
 # Capability tiers (see docs/atlas/token-budget.md):
 #   extraction — short structured JSON fan-out (phases 1, 2, 7C)
@@ -43,30 +36,58 @@ default_tier: cheap
 
 # Global OpenRouter Auto Router knobs — inherited by every tier unless overridden.
 openrouter_defaults:
-  allowed_models: "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*"
+  allowed_models: "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*,perplexity/*"
   cost_quality_tradeoff: 10
 
 tiers:
   cheap:
-    models:
-      extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
-      research: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
-      reasoning: "openrouter/deepseek/deepseek-chat"               # $0.20/$0.80
-    grounding_model: "openrouter/perplexity/sonar"
+    allowed_models:
+      extraction:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/perplexity/sonar"
+      research:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/perplexity/sonar"
+      reasoning:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/perplexity/sonar"
+    web_search_models:
+      - "openrouter/perplexity/sonar"
+      - "openrouter/deepseek/deepseek-chat:online"
 
   balanced:
-    models:
-      extraction: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
-      research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
-      reasoning: "openrouter/meta-llama/llama-4-maverick"            # $0.15/$0.60, 1M ctx
-    grounding_model: "openrouter/perplexity/sonar"
+    allowed_models:
+      extraction:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/perplexity/sonar"
+      research:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/perplexity/sonar"
+      reasoning:
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/deepseek/deepseek-r1:online"
+        - "openrouter/perplexity/sonar"
+    web_search_models:
+      - "openrouter/perplexity/sonar"
+      - "openrouter/deepseek/deepseek-chat:online"
 
   quality:
-    models:
-      extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
-      research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
-      reasoning: "openrouter/deepseek/deepseek-r1"                   # $0.70/$2.50
-    grounding_model: "openrouter/perplexity/sonar"
+    allowed_models:
+      extraction:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/perplexity/sonar"
+      research:
+        - "openrouter/deepseek/deepseek-chat:online"
+        - "openrouter/deepseek/deepseek-r1:online"
+        - "openrouter/perplexity/sonar"
+      reasoning:
+        - "openrouter/deepseek/deepseek-r1:online"
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/perplexity/sonar"
+    web_search_models:
+      - "openrouter/perplexity/sonar"
+      - "openrouter/deepseek/deepseek-chat:online"
 
 phase_capabilities:
   macro: research

--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -17,6 +17,8 @@
 # Open-weight providers only — NEVER openai/*, anthropic/*, or frontier IDs.
 #
 # Web grounding: openrouter:web_search (Exa, $0.005/search) via grounding_model.
+# Use a search-capable model for the pre-pass (perplexity/sonar); deepseek-chat does not
+# support server tools when require_parameters is mis-applied. Fail-hard: OLYMPUS_WEB_SEARCH=required.
 # Structured JSON: response_format json_schema + strict:true on pinned models.
 #
 # Env contract (unchanged): OPENROUTER_API_KEY only — apply_olympus_openrouter_env()
@@ -30,6 +32,7 @@
 #   llama-4-maverick                 $0.15 in / $0.60 out  [structured_outputs ✓]
 #   deepseek-r1                      $0.70 in / $2.50 out  [structured_outputs ✓]
 #   google/gemma* (budget tier)      varies — allowed in pool only, not default pins
+#   perplexity/sonar                 $1.00 in / $1.00 out  [web search native + server tools ✓]
 #
 # Capability tiers (see docs/atlas/token-budget.md):
 #   extraction — short structured JSON fan-out (phases 1, 2, 7C)
@@ -49,21 +52,21 @@ tiers:
       extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       reasoning: "openrouter/deepseek/deepseek-chat"               # $0.20/$0.80
-    grounding_model: "openrouter/deepseek/deepseek-chat"
+    grounding_model: "openrouter/perplexity/sonar"
 
   balanced:
     models:
       extraction: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       reasoning: "openrouter/meta-llama/llama-4-maverick"            # $0.15/$0.60, 1M ctx
-    grounding_model: "openrouter/deepseek/deepseek-chat"
+    grounding_model: "openrouter/perplexity/sonar"
 
   quality:
     models:
       extraction: "openrouter/deepseek/deepseek-chat"                # $0.20/$0.80
       research: "openrouter/deepseek/deepseek-chat"                  # $0.20/$0.80
       reasoning: "openrouter/deepseek/deepseek-r1"                   # $0.70/$2.50
-    grounding_model: "openrouter/deepseek/deepseek-chat"
+    grounding_model: "openrouter/perplexity/sonar"
 
 phase_capabilities:
   macro: research

--- a/digigraph/src/digigraph/model_config.py
+++ b/digigraph/src/digigraph/model_config.py
@@ -96,7 +96,7 @@ class OlympusTierConfig(BaseModel):
 
     models: dict[str, str] = Field(default_factory=dict)
     # xAI model for live_search grounding (legacy). Olympus uses openrouter/* only.
-    grounding_model: str = "openrouter/deepseek/deepseek-chat"
+    grounding_model: str = "openrouter/perplexity/sonar"
     openrouter: OlympusOpenRouterTierConfig = Field(default_factory=OlympusOpenRouterTierConfig)
 
 

--- a/digigraph/src/digigraph/model_config.py
+++ b/digigraph/src/digigraph/model_config.py
@@ -21,12 +21,13 @@ BYOK) lives in :mod:`digigraph.llm_auth`.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -94,10 +95,25 @@ class OlympusOpenRouterTierConfig(BaseModel):
 class OlympusTierConfig(BaseModel):
     """One Olympus cost/quality tier (cheap / balanced / quality)."""
 
+    # Legacy single-pin map — migrated into ``allowed_models`` on load when present.
     models: dict[str, str] = Field(default_factory=dict)
-    # xAI model for live_search grounding (legacy). Olympus uses openrouter/* only.
-    grounding_model: str = "openrouter/perplexity/sonar"
+    # Per-capability pools; selection is stable-hash by phase slug (no single-model pins).
+    allowed_models: dict[str, list[str]] = Field(default_factory=dict)
+    # Web-search grounding pool; defaults to the union of ``allowed_models`` when empty.
+    web_search_models: list[str] = Field(default_factory=list)
+    # Legacy single grounding pin — ignored when ``web_search_models`` is set.
+    grounding_model: str = ""
     openrouter: OlympusOpenRouterTierConfig = Field(default_factory=OlympusOpenRouterTierConfig)
+
+    @model_validator(mode="after")
+    def _migrate_legacy_models(self) -> OlympusTierConfig:
+        if self.models and not self.allowed_models:
+            object.__setattr__(
+                self,
+                "allowed_models",
+                {cap: [mdl] for cap, mdl in self.models.items()},
+            )
+        return self
 
 
 class OlympusModelsConfig(BaseModel):
@@ -251,20 +267,22 @@ def _effective_openrouter_config(
 def _warn_flagship_models_in_olympus_config(cfg: OlympusModelsConfig) -> None:
     """Log when olympus_models.yaml pins or pools a frontier model."""
     for tier_name, tier_cfg in cfg.tiers.items():
-        for capability, model in tier_cfg.models.items():
+        for capability, pool in tier_cfg.allowed_models.items():
+            for model in pool:
+                if is_flagship_openrouter_model(model):
+                    logger.warning(
+                        "olympus_models tier=%s capability=%s pools flagship model %r",
+                        tier_name,
+                        capability,
+                        model,
+                    )
+        for model in _tier_web_search_pool(tier_cfg):
             if is_flagship_openrouter_model(model):
                 logger.warning(
-                    "olympus_models tier=%s capability=%s pins flagship model %r",
+                    "olympus_models tier=%s web_search pool contains flagship %r",
                     tier_name,
-                    capability,
                     model,
                 )
-        if tier_cfg.grounding_model and is_flagship_openrouter_model(tier_cfg.grounding_model):
-            logger.warning(
-                "olympus_models tier=%s grounding_model pins flagship %r",
-                tier_name,
-                tier_cfg.grounding_model,
-            )
     pool = sanitize_allowed_models(cfg.openrouter_defaults.allowed_models)
     if pool != cfg.openrouter_defaults.allowed_models.strip():
         logger.warning(
@@ -302,22 +320,72 @@ def _capability_for_phase(phase_slug: str, cfg: OlympusModelsConfig) -> str | No
     return None
 
 
-def _model_for_olympus_capability(capability: str, tier: str) -> str | None:
+def is_web_search_capable_model(model: str) -> bool:
+    """True when *model* can run OpenRouter web search (``:online`` or native search providers)."""
+    slug = _openrouter_slug(model).strip().lower()
+    if not slug:
+        return False
+    if ":online" in slug:
+        return True
+    return slug.startswith("perplexity/")
+
+
+def _pick_from_pool(pool: list[str], key: str) -> str:
+    """Stable deterministic pick from *pool* using *key* (phase slug / segment)."""
+    if not pool:
+        msg = "empty model pool"
+        raise ValueError(msg)
+    digest = hashlib.sha256(key.encode()).hexdigest()
+    return pool[int(digest[:8], 16) % len(pool)]
+
+
+def _tier_capability_pool(tier_cfg: OlympusTierConfig, capability: str) -> list[str]:
+    pool = list(tier_cfg.allowed_models.get(capability) or [])
+    if not pool:
+        legacy = tier_cfg.models.get(capability)
+        if legacy:
+            pool = [legacy]
+    return pool
+
+
+def _tier_web_search_pool(tier_cfg: OlympusTierConfig) -> list[str]:
+    if tier_cfg.web_search_models:
+        return list(tier_cfg.web_search_models)
+    seen: set[str] = set()
+    merged: list[str] = []
+    for capability in ("research", "extraction", "reasoning"):
+        for model in _tier_capability_pool(tier_cfg, capability):
+            if model not in seen:
+                seen.add(model)
+                merged.append(model)
+    if merged:
+        return merged
+    if tier_cfg.grounding_model:
+        return [tier_cfg.grounding_model]
+    return []
+
+
+def _model_for_olympus_capability(capability: str, tier: str, phase_slug: str) -> str | None:
+    if capability not in _VALID_CAPABILITIES:
+        return None
     tier_cfg = _load_olympus_models().tiers.get(tier)
     if tier_cfg is None:
         return None
-    model = tier_cfg.models.get(capability)
-    if model and capability in _VALID_CAPABILITIES:
-        return model
-    return None
+    pool = _tier_capability_pool(tier_cfg, capability)
+    if not pool:
+        return None
+    return _pick_from_pool(pool, phase_slug)
 
 
-def get_grounding_model() -> str | None:
-    """Return the OpenRouter model for ``openrouter:web_search`` grounding pre-passes."""
+def get_grounding_model(*, segment: str = "grounding") -> str | None:
+    """Return an OpenRouter model for ``openrouter:web_search`` grounding pre-passes."""
     tier_cfg = _load_olympus_models().tiers.get(get_olympus_tier())
     if tier_cfg is None:
         return None
-    return tier_cfg.grounding_model or None
+    pool = _tier_web_search_pool(tier_cfg)
+    if not pool:
+        return None
+    return _pick_from_pool(pool, segment)
 
 
 def apply_olympus_openrouter_env(*, force: bool = False) -> str:
@@ -399,7 +467,7 @@ def get_model_for_phase(phase_slug: str) -> str | None:
     olympus = _load_olympus_models()
     capability = _capability_for_phase(phase_slug, olympus)
     if capability is not None:
-        return _model_for_olympus_capability(capability, get_olympus_tier())
+        return _model_for_olympus_capability(capability, get_olympus_tier(), phase_slug)
     return None
 
 

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -676,6 +676,23 @@ def _openrouter_cost_quality_tradeoff() -> int | None:
     return value
 
 
+def _uses_openrouter_server_tools(tools: list[Any] | None) -> bool:
+    """True when every tool is an OpenRouter server tool (``openrouter:*``).
+
+    Server tools (e.g. ``openrouter:web_search``) are executed by OpenRouter, not the
+    underlying model provider. ``provider.require_parameters`` must NOT be set for those
+    requests — it filters to providers that declare support for the tool param, which
+    excludes all providers for server tools → HTTP 404 "Server tool request failed".
+    """
+    if not tools:
+        return False
+    for tool in tools:
+        ttype = tool.get("type", "") if isinstance(tool, dict) else getattr(tool, "type", "")
+        if not (isinstance(ttype, str) and ttype.startswith("openrouter:")):
+            return False
+    return True
+
+
 def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None) -> dict[str, Any]:
     """Merge OpenRouter routing controls into ``extra_body`` for an ``openrouter/`` request:
 
@@ -712,12 +729,20 @@ def _with_openrouter_cost_controls(kwargs: dict[str, Any], provider: str | None)
     constrain_auto = bool(allowed_models) and (kwargs.get("model") or "").endswith("/auto")
     # Structured-output (json_schema) and tool requests empty-fail without require_parameters, so
     # force it for them even when the global toggle is off; plain-prose requests honor the toggle.
-    structured = kwargs.get("response_format") is not None or bool(kwargs.get("tools"))
+    tools = kwargs.get("tools")
+    server_tools_only = _uses_openrouter_server_tools(tools)
+    structured = kwargs.get("response_format") is not None or (
+        bool(tools) and not server_tools_only
+    )
     # allowed_models SUPERSEDES require_parameters: the curated pool is already the capability
     # guarantee, and applying BOTH filters compounds to an empty set → OpenRouter 404
     # "No models match your request and model restrictions" (#802). So when we constrain the auto
     # router, drop require_parameters; otherwise keep the #798 behavior (forced for structured/tool).
-    require_params = (not constrain_auto) and (_openrouter_require_parameters() or structured)
+    require_params = (
+        (not constrain_auto)
+        and (not server_tools_only)
+        and (_openrouter_require_parameters() or structured)
+    )
     if not fallbacks and not prefs and not require_params and not constrain_auto:
         return kwargs
     merged = dict(kwargs)

--- a/digillm/tests/test_digillm.py
+++ b/digillm/tests/test_digillm.py
@@ -321,6 +321,16 @@ def test_require_parameters_forced_for_structured_requests(monkeypatch: pytest.M
     tool_req = {"model": "openrouter/auto", "messages": [], "tools": [{"type": "function"}]}
     out = client_mod._with_openrouter_cost_controls(tool_req, "openrouter")
     assert out["extra_body"] == {"provider": {"require_parameters": True}}
+    # OpenRouter server tools (web search) must NOT get require_parameters — it 404s.
+    server_tool_req = {
+        "model": "perplexity/sonar",
+        "messages": [],
+        "tools": [{"type": "openrouter:web_search", "parameters": {"engine": "exa"}}],
+    }
+    out = client_mod._with_openrouter_cost_controls(server_tool_req, "openrouter")
+    assert "extra_body" not in out or "require_parameters" not in out.get("extra_body", {}).get(
+        "provider", {}
+    )
     # A plain-prose request still honors the opt-out (no extra_body added).
     prose_req = {"model": "openrouter/auto", "messages": []}
     assert client_mod._with_openrouter_cost_controls(prose_req, "openrouter") == prose_req

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -195,8 +195,36 @@ def check_openrouter_structured() -> bool:
         )
 
 
+def check_openrouter_web_search() -> bool:
+    """Validate the OpenRouter ``openrouter:web_search`` server-tool path (Olympus grounding).
+
+    A plain chat ping succeeds even when server tools 404 — that's the alt-/inst-/macro
+    ungrounded failure mode. This exercises the same digillm path as ``fetch_web_grounding``."""
+    print(_bold("\n4. OpenRouter web search (grounding pre-pass)"))
+    if not os.environ.get("OPENROUTER_API_KEY", "").strip():
+        return check("Web search ping", False, "OPENROUTER_API_KEY not set")
+    try:
+        _ensure_importable()
+        from digigraph.model_config import get_grounding_model
+        from digillm import openrouter_web_search
+
+        model = get_grounding_model() or "openrouter/perplexity/sonar"
+        t0 = time.monotonic()
+        result = openrouter_web_search(model, "latest US CPI headline release", max_results=3)
+        elapsed = time.monotonic() - t0
+        ok = result is not None and bool(result[0].strip())
+        detail = (
+            f"{elapsed:.1f}s — model={model}, sources={len(result[1]) if result else 0}"
+            if ok
+            else "no grounding text returned (check server-tool routing / grounding_model)"
+        )
+        return check(f"Web search ({model})", ok, detail)
+    except Exception as exc:  # noqa: BLE001 — diagnostic probe must not crash preflight
+        return check("Web search ping", False, f"{type(exc).__name__}: {exc}")
+
+
 def check_supabase() -> bool:
-    print(_bold("\n4. Supabase connectivity + baseline row"))
+    print(_bold("\n5. Supabase connectivity + baseline row"))
     url = os.environ.get("SUPABASE_URL", "").strip()
     key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
     if not url or not key:
@@ -247,7 +275,7 @@ def check_supabase() -> bool:
 
 
 def check_dry_run(run_type: str) -> bool:
-    print(_bold(f"\n5. Graph dry-run ({run_type})"))
+    print(_bold(f"\n6. Graph dry-run ({run_type})"))
     _ensure_importable()
     today = __import__("datetime").date.today().isoformat()
     cmd = [
@@ -307,6 +335,7 @@ def main() -> int:
     if not args.skip_llm:
         check_openrouter("openrouter/auto")
         check_openrouter_structured()
+        check_openrouter_web_search()
 
     if not args.skip_db:
         check_supabase()

--- a/digiquant/src/digiquant/olympus/atlas/data/web_grounding.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/web_grounding.py
@@ -5,11 +5,13 @@ domain allowlist in ``config/search_domains.yaml``, returning a cited summary
 injected into ``phase_inputs`` before the normal structured-output research call.
 
 Uses OpenRouter's ``openrouter:web_search`` server tool (Exa engine) — requires
-``OPENROUTER_API_KEY`` only. Fails soft on error or missing key.
+``OPENROUTER_API_KEY`` only. Fails soft on error or missing key unless
+``OLYMPUS_WEB_SEARCH=required``.
 """
 
 from __future__ import annotations
 
+import os
 from datetime import date
 from functools import lru_cache
 from pathlib import Path
@@ -21,6 +23,20 @@ _CONFIG = Path(__file__).resolve().parent.parent / "config" / "search_domains.ya
 
 # Domain allowlist cap (Exa / OpenRouter web_search).
 _MAX_ALLOWED_DOMAINS = 5
+
+
+class OlympusWebSearchError(RuntimeError):
+    """Web grounding was required (``OLYMPUS_WEB_SEARCH=required``) but unavailable."""
+
+
+def olympus_web_search_required() -> bool:
+    """Return True when the run must fail if web grounding is unavailable."""
+    return os.environ.get("OLYMPUS_WEB_SEARCH", "").strip().lower() in (
+        "required",
+        "1",
+        "true",
+        "yes",
+    )
 
 
 @lru_cache(maxsize=1)
@@ -88,8 +104,16 @@ def fetch_web_grounding(
         max_results=max_results,
     )
     if result is None:
+        if olympus_web_search_required():
+            raise OlympusWebSearchError(
+                f"OLYMPUS_WEB_SEARCH=required but web search returned no results for {segment!r}"
+            )
         return None
     summary, sources = result
     if not summary.strip():
+        if olympus_web_search_required():
+            raise OlympusWebSearchError(
+                f"OLYMPUS_WEB_SEARCH=required but web search returned empty text for {segment!r}"
+            )
         return None
     return {"summary": summary, "sources": sources, "as_of": run_date.isoformat()}

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -223,13 +223,13 @@ def build_grounding(
         from digigraph.model_config import get_grounding_model
         from digiquant.olympus.atlas.data.ai_portfolios import fetch_ai_portfolio_grounding
 
-        grounding = get_grounding_model()
+        grounding = get_grounding_model(segment=segment or "ai-portfolios")
         if grounding:
             web_grounding = fetch_ai_portfolio_grounding(model=grounding, run_date=run_date)
     elif live_search:
         from digigraph.model_config import get_grounding_model
 
-        grounding = get_grounding_model() or model
+        grounding = get_grounding_model(segment=segment or "research")
         if live_search_is_fallback and not _ingested_macro_stale(run_date):
             logger.info(
                 "%s: ingested macro layer fresh — skipping paid fallback web_search",

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -219,8 +219,6 @@ def build_grounding(
                 execute_tool = _combined_execute
         except Exception as exc:  # noqa: BLE001 — degrade to tool-less rather than crash the phase
             logger.warning("research tools unavailable (%s); proceeding without them", exc)
-    if not _data_tools_enabled():
-        return tools, execute_tool, web_grounding
     if ai_portfolios:
         from digigraph.model_config import get_grounding_model
         from digiquant.olympus.atlas.data.ai_portfolios import fetch_ai_portfolio_grounding
@@ -244,6 +242,38 @@ def build_grounding(
                 model=grounding, segment=segment or "research", run_date=run_date, scope=scope
             )
     return tools, execute_tool, web_grounding
+
+
+def apply_web_grounding_to_inputs(
+    phase_inputs: dict[str, Any],
+    *,
+    web_grounding: dict[str, Any] | None,
+    segment: str,
+    live_search: bool,
+) -> dict[str, Any]:
+    """Merge web grounding into ``phase_inputs``; flag or fail when absent."""
+    from digiquant.olympus.atlas.data.web_grounding import (
+        OlympusWebSearchError,
+        olympus_web_search_required,
+    )
+
+    inputs = dict(phase_inputs)
+    if web_grounding:
+        inputs["web_grounding"] = web_grounding
+        return inputs
+    if not live_search:
+        return inputs
+    if olympus_web_search_required():
+        raise OlympusWebSearchError(
+            f"{segment}: OLYMPUS_WEB_SEARCH=required but web grounding unavailable"
+        )
+    inputs["grounding_absent"] = True
+    logger.warning(
+        "%s: grounding-dependent segment received no web_grounding; "
+        "flagging grounding_absent=True in phase_inputs",
+        segment,
+    )
+    return inputs
 
 
 @dataclass(frozen=True)
@@ -760,14 +790,11 @@ def build_segment_node(
         if web_grounding:
             inputs = {**inputs, "web_grounding": web_grounding}
         elif spec.live_search or spec.ai_portfolios:
-            # Grounding-dependent segment received no web_grounding (#946).
-            # Flag so downstream output is honestly labeled absent/low-confidence
-            # rather than fabricated from market-implied proxies.
-            inputs = {**inputs, "grounding_absent": True}
-            logger.warning(
-                "%s: grounding-dependent segment received no web_grounding; "
-                "flagging grounding_absent=True in phase_inputs",
-                spec.segment_slug,
+            inputs = apply_web_grounding_to_inputs(
+                inputs,
+                web_grounding=None,
+                segment=spec.segment_slug,
+                live_search=spec.live_search or spec.ai_portfolios,
             )
 
         edit_mode = _resolve_segment_edit_mode(state, spec.segment_slug)

--- a/digiquant/src/digiquant/olympus/hermes/phases/h6_deliberation.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h6_deliberation.py
@@ -10,7 +10,10 @@ from digigraph.graph.pipeline_builder import FanOutPhase, NodeSpec, PipelinePhas
 from digigraph.graph.research_agent import run_research_agent
 from digigraph.model_config import get_model_for_mode, get_model_for_phase
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.phases._node_factory import (
+    _shared_context,
+    apply_web_grounding_to_inputs,
+)
 from digiquant.olympus.atlas.state import PhaseError, PhaseHermesState
 from digiquant.olympus.hermes.candidates import holdings_from_prior_book
 from digiquant.olympus.hermes.focus_roster import (
@@ -117,7 +120,9 @@ def run_deliberation_loop(state: HermesState, ticker: str) -> DeliberationSummar
     """PM↔analyst loop until ``converged=true`` or ``ATLAS_DELIBERATION_MAX_ROUNDS`` cap."""
     pm_skill = load_skill_full("deliberation")
     analyst_skill = load_skill_full("asset-analyst")
-    tools, execute_tool, _ = _portfolio_grounding(state, phase="h6_deliberation")
+    tools, execute_tool, web_grounding = _portfolio_grounding(
+        state, phase="h6_deliberation", segment=f"{NODE_ID}-{ticker}"
+    )
     transcript: list[DeliberationTurn] = []
     round_number = 0
     prior_summary = _prior_deliberation_summary(state, ticker)
@@ -127,14 +132,19 @@ def run_deliberation_loop(state: HermesState, ticker: str) -> DeliberationSummar
 
     while True:
         round_number += 1
-        pm_inputs = {
-            **_portfolio_phase_inputs(state, ticker),
-            "segment": f"h6_pm_challenge-{ticker}",
-            "role": "pm",
-            "round_number": round_number,
-            "transcript": [t.model_dump(mode="json") for t in transcript],
-            "prior_deliberation": prior_summary,
-        }
+        pm_inputs = apply_web_grounding_to_inputs(
+            {
+                **_portfolio_phase_inputs(state, ticker),
+                "segment": f"h6_pm_challenge-{ticker}",
+                "role": "pm",
+                "round_number": round_number,
+                "transcript": [t.model_dump(mode="json") for t in transcript],
+                "prior_deliberation": prior_summary,
+            },
+            web_grounding=web_grounding,
+            segment=f"h6_pm_challenge-{ticker}",
+            live_search=True,
+        )
         pm_result = run_research_agent(
             skill_text=pm_skill,
             phase_inputs=pm_inputs,
@@ -190,14 +200,19 @@ def run_deliberation_loop(state: HermesState, ticker: str) -> DeliberationSummar
             )
         )
 
-        analyst_inputs = {
-            **_portfolio_phase_inputs(state, ticker),
-            "segment": f"h6_analyst_response-{ticker}",
-            "role": "analyst",
-            "round_number": round_number,
-            "pm_challenge": pm_turn.challenge,
-            "transcript": [t.model_dump(mode="json") for t in transcript],
-        }
+        analyst_inputs = apply_web_grounding_to_inputs(
+            {
+                **_portfolio_phase_inputs(state, ticker),
+                "segment": f"h6_analyst_response-{ticker}",
+                "role": "analyst",
+                "round_number": round_number,
+                "pm_challenge": pm_turn.challenge,
+                "transcript": [t.model_dump(mode="json") for t in transcript],
+            },
+            web_grounding=web_grounding,
+            segment=f"h6_analyst_response-{ticker}",
+            live_search=True,
+        )
         analyst_result = run_research_agent(
             skill_text=analyst_skill,
             phase_inputs=analyst_inputs,

--- a/digiquant/src/digiquant/olympus/hermes/phases/h7_pm_direction.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h7_pm_direction.py
@@ -6,7 +6,10 @@ from typing import Any  # noqa  # scored-lint suppression: heterogeneous graph /
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from digigraph.graph.research_agent import run_research_agent
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.phases._node_factory import (
+    _shared_context,
+    apply_web_grounding_to_inputs,
+)
 from digiquant.olympus.atlas.state import PhaseHermesState
 from digiquant.olympus.hermes.candidates import holdings_from_prior_book
 from digiquant.olympus.hermes.models.pm_direction import PMDirectionMemo
@@ -72,7 +75,13 @@ def _h7_node(state: HermesState) -> dict[str, Any]:
         "focus_roster": _focus_roster_tickers(state),
         "fed_odds": (state.phase6_bias_row or {}).get("fed_odds"),
     }
-    tools, execute_tool, _ = _portfolio_grounding(state, phase="h7_pm")
+    tools, execute_tool, web_grounding = _portfolio_grounding(state, phase="h7_pm", segment=NODE_ID)
+    phase_inputs = apply_web_grounding_to_inputs(
+        phase_inputs,
+        web_grounding=web_grounding,
+        segment=NODE_ID,
+        live_search=True,
+    )
     result = run_research_agent(
         skill_text=load_skill_full("pm-direction"),
         phase_inputs=phase_inputs,

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7d_pm.py
@@ -26,25 +26,35 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 from pydantic import BaseModel, Field
 
 from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
-from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
+from digiquant.olympus.atlas.phases._node_factory import (
+    _shared_context,
+    apply_web_grounding_to_inputs,
+    build_grounding,
+)
 from digiquant.olympus.hermes.candidates import holdings_from_prior_book
 from digiquant.olympus.hermes.payloads import analyst_payloads, deliberation_summaries
 from digiquant.olympus.hermes.state import HermesState
 
 
-def _pm_tools(state: HermesState):
+def _pm_tools(state: HermesState, *, segment: str = "pm-rebalance"):
     """Full-scope query_data + computed tools for the PM. As the decision-maker it MAY
     read the book (positions/nav_history/theses) for rebalance + sizing context — it is
     not blinded like the analysts/debaters."""
-    return build_grounding(use_data_tools=True, live_search=False, run_date=state.run_date)
+    return build_grounding(
+        use_data_tools=True,
+        live_search=True,
+        run_date=state.run_date,
+        segment=segment,
+    )
 
 
-def _risk_tools(state: HermesState):
+def _risk_tools(state: HermesState, *, segment: str):
     """Market-data-scoped tools for the risk debaters (blinded to the book)."""
     return build_grounding(
         use_data_tools=True,
-        live_search=False,
+        live_search=True,
         run_date=state.run_date,
+        segment=segment,
         data_tool_tables=MARKET_DATA_TABLES,
     )
 
@@ -116,10 +126,16 @@ def _risk_aggressive_node(state: HermesState) -> dict[str, Any]:
     from digiquant.olympus.hermes.skills import load_skill
 
     skill_text = load_skill("risk-aggressive")
-    tools, execute_tool, _ = _risk_tools(state)
+    tools, execute_tool, web_grounding = _risk_tools(state, segment="risk-aggressive")
+    phase_inputs = apply_web_grounding_to_inputs(
+        _build_risk_phase_inputs(state, role="aggressive"),
+        web_grounding=web_grounding,
+        segment="risk-aggressive",
+        live_search=True,
+    )
     result = run_research_agent(
         skill_text=skill_text,
-        phase_inputs=_build_risk_phase_inputs(state, role="aggressive"),
+        phase_inputs=phase_inputs,
         shared_context=_shared_context(
             state,
             context_keys=("pm-rebalance", "digest-delta", "digest-baseline"),
@@ -160,7 +176,13 @@ def _risk_conservative_node(state: HermesState) -> dict[str, Any]:
     inputs["aggressive_case"] = aggressive
 
     skill_text = load_skill("risk-conservative")
-    tools, execute_tool, _ = _risk_tools(state)
+    tools, execute_tool, web_grounding = _risk_tools(state, segment="risk-conservative")
+    inputs = apply_web_grounding_to_inputs(
+        inputs,
+        web_grounding=web_grounding,
+        segment="risk-conservative",
+        live_search=True,
+    )
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=inputs,
@@ -243,7 +265,13 @@ def _pm_node(state: HermesState) -> dict[str, Any]:
         # macro-policy awareness. Already fail-soft (None when unavailable).
         "fed_odds": (state.phase6_bias_row or {}).get("fed_odds"),
     }
-    tools, execute_tool, _ = _pm_tools(state)
+    tools, execute_tool, web_grounding = _pm_tools(state, segment="pm-rebalance")
+    phase_inputs = apply_web_grounding_to_inputs(
+        phase_inputs,
+        web_grounding=web_grounding,
+        segment="pm-rebalance",
+        live_search=True,
+    )
     result = run_research_agent(
         skill_text=skill_text,
         phase_inputs=phase_inputs,

--- a/digiquant/src/digiquant/olympus/hermes/phases/portfolio_common.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/portfolio_common.py
@@ -11,7 +11,11 @@ from digigraph.graph.research_agent import run_research_agent
 from digigraph.model_config import get_model_for_mode, get_model_for_phase
 
 from digiquant.olympus.atlas.data.queries import MARKET_DATA_TABLES
-from digiquant.olympus.atlas.phases._node_factory import _shared_context, build_grounding
+from digiquant.olympus.atlas.phases._node_factory import (
+    _shared_context,
+    apply_web_grounding_to_inputs,
+    build_grounding,
+)
 from digiquant.olympus.atlas.state import PhaseError, refresh_scope_forces_full
 from digiquant.olympus.edit_mode import (
     DocumentPatch,
@@ -151,11 +155,12 @@ def _stance_to_bias(stance: str) -> str:
     }.get(stance, "neutral")
 
 
-def _portfolio_grounding(state: HermesState, *, phase: RetrievalPhase):
+def _portfolio_grounding(state: HermesState, *, phase: RetrievalPhase, segment: str = ""):
     return build_grounding(
         use_data_tools=True,
-        live_search=False,
+        live_search=True,
         run_date=state.run_date,
+        segment=segment or f"hermes/{phase}",
         data_tool_tables=MARKET_DATA_TABLES,
         use_research_tools=True,
         research_phase=phase,
@@ -192,7 +197,9 @@ def run_asset_analyst_llm(
     skill_text = (
         load_skill_edit("asset-analyst") if mode == "edit" else load_skill_full("asset-analyst")
     )
-    tools, execute_tool, _ = _portfolio_grounding(state, phase="h5_analyst")
+    tools, execute_tool, web_grounding = _portfolio_grounding(
+        state, phase="h5_analyst", segment=phase_slug
+    )
     phase_inputs: dict[str, Any] = {
         "segment": phase_slug,
         "ticker": ticker,
@@ -204,6 +211,12 @@ def run_asset_analyst_llm(
         "held_in_prior_book": ticker
         in set(holdings_from_prior_book(state.prior_context.prior_book)),
     }
+    phase_inputs = apply_web_grounding_to_inputs(
+        phase_inputs,
+        web_grounding=web_grounding,
+        segment=phase_slug,
+        live_search=True,
+    )
     if prior is not None:
         phase_inputs["prior_analyst"] = dict(prior.payload)
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/thesis_common.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/thesis_common.py
@@ -10,7 +10,10 @@ from pydantic import BaseModel, ValidationError
 from digigraph.graph.research_agent import run_research_agent
 from digigraph.model_config import get_model_for_mode, get_model_for_phase
 
-from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.phases._node_factory import (
+    _shared_context,
+    apply_web_grounding_to_inputs,
+)
 from digiquant.olympus.atlas.state import PhaseError, refresh_scope_forces_full
 from digiquant.olympus.edit_mode import (
     DocumentPatch,
@@ -109,8 +112,12 @@ def run_thesis_phase_llm(
         state, phase=retrieval_phase, use_data_tools=False
     )
     inputs = dict(phase_inputs)
-    if web_grounding:
-        inputs["web_grounding"] = web_grounding
+    inputs = apply_web_grounding_to_inputs(
+        inputs,
+        web_grounding=web_grounding,
+        segment=phase_slug,
+        live_search=True,
+    )
 
     eff_model = get_model_for_phase(phase_slug) or get_model_for_mode()
     prior = _StatePriorLoader(state).load(artifact_key, state.run_date)

--- a/digiquant/src/digiquant/olympus/hermes/thesis_grounding.py
+++ b/digiquant/src/digiquant/olympus/hermes/thesis_grounding.py
@@ -17,7 +17,7 @@ def build_thesis_grounding(
     """Grounding bundle for thesis nodes — always includes ``RESEARCH_TOOLS``."""
     return build_grounding(
         use_data_tools=use_data_tools,
-        live_search=False,
+        live_search=True,
         run_date=state.run_date,
         use_research_tools=True,
         research_phase=phase,

--- a/digiquant/src/digiquant/olympus/learning/beliefs_distillation.py
+++ b/digiquant/src/digiquant/olympus/learning/beliefs_distillation.py
@@ -91,17 +91,35 @@ def _run_beliefs_llm(
     active_theses: list[dict[str, Any]],
 ) -> BeliefsBlob:
     from digigraph.graph.research_agent import run_research_agent
+    from digigraph.model_config import get_grounding_model
 
+    from digiquant.olympus.atlas.data.web_grounding import fetch_web_grounding
+    from digiquant.olympus.atlas.phases._node_factory import apply_web_grounding_to_inputs
     from digiquant.olympus.atlas.skills import load_skill
 
     skill_text = load_skill("beliefs-distillation")
-    result = run_research_agent(
-        skill_text=skill_text,
-        phase_inputs={
+    grounding_model = get_grounding_model()
+    web_grounding = None
+    if grounding_model:
+        web_grounding = fetch_web_grounding(
+            model=grounding_model,
+            segment="beliefs-distillation",
+            run_date=run_date,
+            scope="portfolio lessons and active theses",
+        )
+    phase_inputs = apply_web_grounding_to_inputs(
+        {
             "segment": "learning/beliefs-distillation",
             "resolved_lessons": lessons,
             "active_theses": active_theses,
         },
+        web_grounding=web_grounding,
+        segment="beliefs-distillation",
+        live_search=True,
+    )
+    result = run_research_agent(
+        skill_text=skill_text,
+        phase_inputs=phase_inputs,
         shared_context={"run_date": run_date.isoformat()},
         output_model=BeliefsBlob,
         phase_slug="beliefs-distillation",

--- a/tests/dg/test_llm_openrouter_web_search.py
+++ b/tests/dg/test_llm_openrouter_web_search.py
@@ -50,6 +50,21 @@ def test_openrouter_web_search_none_without_api_key(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.unit
+def test_openrouter_web_search_skips_require_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    captured: dict = {}
+
+    def _capture_create(_client, **kwargs):
+        captured.update(kwargs)
+        return _chat_resp("headline [[1]](https://example.com)")
+
+    with patch("digillm.client._create_with_retry", side_effect=_capture_create):
+        openrouter_web_search("openrouter/perplexity/sonar", "latest CPI")
+    extra = captured.get("extra_body") or {}
+    assert "require_parameters" not in (extra.get("provider") or {})
+
+
+@pytest.mark.unit
 def test_openrouter_web_search_fails_soft_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     with patch("digillm.client.completion", side_effect=RuntimeError("boom")):

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
+import yaml
 
 import digigraph.model_config as model_config
 from digigraph.model_config import (
@@ -15,22 +16,21 @@ from digigraph.model_config import (
     get_olympus_tier,
     is_flagship_allowed_models_entry,
     is_flagship_openrouter_model,
+    is_web_search_capable_model,
     sanitize_allowed_models,
 )
 
 _REPO_CONFIG = str(Path(__file__).parents[2] / "config")
 
-# OpenRouter slugs verified in CI (OPENROUTER_API_KEY only — no direct OpenAI).
-_KNOWN_GOOD_OPENROUTER_MODELS = frozenset(
+# OpenRouter slugs in tier pools (CI has OPENROUTER_API_KEY only).
+_WEB_SEARCH_POOL = frozenset(
     {
-        "openrouter/deepseek/deepseek-chat",
-        "openrouter/deepseek/deepseek-r1",
-        "openrouter/meta-llama/llama-4-maverick",
+        "openrouter/deepseek/deepseek-chat:online",
+        "openrouter/deepseek/deepseek-r1:online",
+        "openrouter/meta-llama/llama-4-maverick:online",
         "openrouter/perplexity/sonar",
     }
 )
-
-_GROUNDING_MODELS = frozenset({"openrouter/perplexity/sonar"})
 
 # Retired OpenRouter IDs — must not appear in olympus_models.yaml pins or pools.
 _BANNED_QWEN_MODEL_MARKERS = (
@@ -47,49 +47,74 @@ def _repo_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
 
 
+def _cheap_research_pool() -> list[str]:
+    cfg = model_config._load_olympus_models()
+    return list(cfg.tiers["cheap"].allowed_models["research"])
+
+
 @pytest.mark.unit
 def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Hermes H1–H7 slugs must resolve via olympus_models (CI has OPENROUTER_API_KEY only)."""
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    assert get_model_for_phase("hermes/thesis/market-review") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
-    assert get_model_for_phase("hermes/portfolio/asset-analyst-AAPL") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
-    assert get_model_for_phase("hermes/portfolio/pm-direction") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
-    assert get_model_for_phase("beliefs-distillation") == ("openrouter/deepseek/deepseek-chat")
+    pool = _cheap_research_pool()
+    for slug in (
+        "hermes/thesis/market-review",
+        "beliefs-distillation",
+    ):
+        model = get_model_for_phase(slug)
+        assert model is not None
+        assert model.startswith("openrouter/")
+        assert model in pool
+    extraction_pool = model_config._load_olympus_models().tiers["cheap"].allowed_models[
+        "extraction"
+    ]
+    assert get_model_for_phase("hermes/portfolio/asset-analyst-AAPL") in extraction_pool
+    reasoning_pool = model_config._load_olympus_models().tiers["cheap"].allowed_models[
+        "reasoning"
+    ]
+    assert get_model_for_phase("hermes/portfolio/pm-direction") in reasoning_pool
 
 
 @pytest.mark.unit
-def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
+def test_asset_analyst_slug_resolves_to_web_search_pool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """H5 asset-analyst must not pin stale/invalid OpenRouter slugs (CI run 27950332738)."""
+    """H5 asset-analyst must resolve from the extraction pool (all search-capable)."""
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     model = get_model_for_phase("hermes/portfolio/asset-analyst-AAPL")
     assert model is not None
     assert model.startswith("openrouter/")
-    assert model in _KNOWN_GOOD_OPENROUTER_MODELS
+    assert model in _WEB_SEARCH_POOL
+    assert is_web_search_capable_model(model)
 
 
 @pytest.mark.unit
-def test_cheap_tier_resolves_extraction_and_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cheap_tier_resolves_from_capability_pools(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    assert get_model_for_phase("alt-sentiment-news") == ("openrouter/deepseek/deepseek-chat")
-    assert get_model_for_phase("monthly-digest") == "openrouter/deepseek/deepseek-chat"
-    assert get_model_for_phase("technical-analyst-AAPL") == ("openrouter/deepseek/deepseek-chat")
+    cfg = model_config._load_olympus_models()
+    cheap = cfg.tiers["cheap"]
+    assert get_model_for_phase("alt-sentiment-news") in cheap.allowed_models["extraction"]
+    assert get_model_for_phase("monthly-digest") in cheap.allowed_models["reasoning"]
+    assert get_model_for_phase("technical-analyst-AAPL") in cheap.allowed_models["extraction"]
 
 
 @pytest.mark.unit
-def test_quality_tier_uses_deepseek_r1_for_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_quality_tier_picks_from_reasoning_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "quality")
-    assert get_model_for_phase("pm-rebalance") == "openrouter/deepseek/deepseek-r1"
-    assert get_model_for_phase("macro") == "openrouter/deepseek/deepseek-chat"
+    quality = model_config._load_olympus_models().tiers["quality"]
+    assert get_model_for_phase("pm-rebalance") in quality.allowed_models["reasoning"]
+    assert get_model_for_phase("macro") in quality.allowed_models["research"]
+
+
+@pytest.mark.unit
+def test_phase_slug_selection_is_stable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    first = get_model_for_phase("macro")
+    second = get_model_for_phase("macro")
+    assert first == second
+    assert get_model_for_phase("crypto") != first or len(_cheap_research_pool()) == 1
 
 
 @pytest.mark.unit
@@ -119,9 +144,13 @@ def test_apply_does_not_override_explicit_env(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.unit
-def test_grounding_model_is_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_grounding_model_from_web_search_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    assert get_grounding_model() == "openrouter/perplexity/sonar"
+    model = get_grounding_model(segment="macro")
+    assert model is not None
+    assert model.startswith("openrouter/")
+    assert model in model_config._load_olympus_models().tiers["cheap"].web_search_models
+    assert is_web_search_capable_model(model)
 
 
 @pytest.mark.unit
@@ -137,7 +166,7 @@ def test_phase_models_flagship_override_rejected(
     monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
-    assert get_model_for_phase("macro") == "openrouter/deepseek/deepseek-chat"
+    assert get_model_for_phase("macro") in _cheap_research_pool()
 
 
 @pytest.mark.unit
@@ -162,12 +191,26 @@ def test_phase_models_open_weight_override_wins(
     [
         ("openrouter/openai/gpt-5.5", True),
         ("openrouter/anthropic/claude-sonnet-4", True),
-        ("openrouter/deepseek/deepseek-chat", False),
-        ("openrouter/meta-llama/llama-4-maverick", False),
+        ("openrouter/deepseek/deepseek-chat:online", False),
+        ("openrouter/meta-llama/llama-4-maverick:online", False),
     ],
 )
 def test_flagship_detection(model: str, flagship: bool) -> None:
     assert is_flagship_openrouter_model(model) is flagship
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model", "search_capable"),
+    [
+        ("openrouter/deepseek/deepseek-chat:online", True),
+        ("openrouter/perplexity/sonar", True),
+        ("openrouter/deepseek/deepseek-chat", False),
+        ("openrouter/meta-llama/llama-4-maverick", False),
+    ],
+)
+def test_web_search_capability(model: str, search_capable: bool) -> None:
+    assert is_web_search_capable_model(model) is search_capable
 
 
 @pytest.mark.unit
@@ -187,12 +230,17 @@ def test_no_stale_qwen_model_ids_in_olympus_config() -> None:
 
     cfg = model_config._load_olympus_models()
     for tier_name, tier_cfg in cfg.tiers.items():
-        for capability, model in tier_cfg.models.items():
-            slug = model.lower()
-            assert slug in _KNOWN_GOOD_OPENROUTER_MODELS, (
-                f"tier {tier_name} {capability} pins unverified model {model!r}"
+        assert not tier_cfg.models, f"tier {tier_name} must use allowed_models pools, not models pins"
+        for capability, pool in tier_cfg.allowed_models.items():
+            for model in pool:
+                assert model.startswith("openrouter/"), f"{tier_name}.{capability}: {model}"
+                assert is_web_search_capable_model(model), (
+                    f"{tier_name}.{capability} pools non-search model {model!r}"
+                )
+        for model in tier_cfg.web_search_models:
+            assert is_web_search_capable_model(model), (
+                f"{tier_name}.web_search_models contains non-search model {model!r}"
             )
-        assert tier_cfg.grounding_model.lower() in {m.lower() for m in _GROUNDING_MODELS}
     assert "qwen" not in cfg.openrouter_defaults.allowed_models.lower()
 
 
@@ -217,24 +265,40 @@ def test_default_tier_is_cheap(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_edit_mode_segments_route_to_cheap_open_weight_models(
     monkeypatch: pytest.MonkeyPatch, phase_slug: str
 ) -> None:
-    """#926 gate: default cheap tier pins open-weight models for edit-mode segment schemas."""
+    """#926 gate: default cheap tier pools open-weight search-capable models."""
     monkeypatch.delenv("OLYMPUS_MODEL_TIER", raising=False)
     assert get_olympus_tier() == "cheap"
     model = get_model_for_phase(phase_slug)
     assert model is not None
     assert model.startswith("openrouter/")
     assert not is_flagship_openrouter_model(model)
+    assert is_web_search_capable_model(model)
 
 
 @pytest.mark.unit
 def test_repo_olympus_config_has_no_flagship_pins() -> None:
     cfg = model_config._load_olympus_models()
     for tier_name, tier_cfg in cfg.tiers.items():
-        for capability, model in tier_cfg.models.items():
-            assert not is_flagship_openrouter_model(model), (
-                f"tier {tier_name} {capability} pins flagship {model}"
-            )
-        assert not is_flagship_openrouter_model(tier_cfg.grounding_model)
+        for capability, pool in tier_cfg.allowed_models.items():
+            for model in pool:
+                assert not is_flagship_openrouter_model(model), (
+                    f"tier {tier_name} {capability} pools flagship {model}"
+                )
+        for model in tier_cfg.web_search_models:
+            assert not is_flagship_openrouter_model(model)
     assert cfg.openrouter_defaults.cost_quality_tradeoff == 10
     assert "openai" not in cfg.openrouter_defaults.allowed_models
     assert "anthropic" not in cfg.openrouter_defaults.allowed_models
+
+
+@pytest.mark.unit
+def test_yaml_uses_allowed_models_pools_not_single_pins() -> None:
+    raw = yaml.safe_load(Path(_REPO_CONFIG, "olympus_models.yaml").read_text())
+    for tier_name, tier_cfg in raw["tiers"].items():
+        assert "models" not in tier_cfg, f"tier {tier_name} must not use legacy models pins"
+        assert "grounding_model" not in tier_cfg, (
+            f"tier {tier_name} must use web_search_models, not grounding_model pin"
+        )
+        for capability, pool in tier_cfg["allowed_models"].items():
+            assert isinstance(pool, list), f"{tier_name}.{capability} must be a list pool"
+            assert len(pool) >= 1, f"{tier_name}.{capability} pool must not be empty"

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -26,8 +26,11 @@ _KNOWN_GOOD_OPENROUTER_MODELS = frozenset(
         "openrouter/deepseek/deepseek-chat",
         "openrouter/deepseek/deepseek-r1",
         "openrouter/meta-llama/llama-4-maverick",
+        "openrouter/perplexity/sonar",
     }
 )
+
+_GROUNDING_MODELS = frozenset({"openrouter/perplexity/sonar"})
 
 # Retired OpenRouter IDs — must not appear in olympus_models.yaml pins or pools.
 _BANNED_QWEN_MODEL_MARKERS = (
@@ -77,13 +80,9 @@ def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
 @pytest.mark.unit
 def test_cheap_tier_resolves_extraction_and_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    assert get_model_for_phase("alt-sentiment-news") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
+    assert get_model_for_phase("alt-sentiment-news") == ("openrouter/deepseek/deepseek-chat")
     assert get_model_for_phase("monthly-digest") == "openrouter/deepseek/deepseek-chat"
-    assert get_model_for_phase("technical-analyst-AAPL") == (
-        "openrouter/deepseek/deepseek-chat"
-    )
+    assert get_model_for_phase("technical-analyst-AAPL") == ("openrouter/deepseek/deepseek-chat")
 
 
 @pytest.mark.unit
@@ -122,7 +121,7 @@ def test_apply_does_not_override_explicit_env(monkeypatch: pytest.MonkeyPatch) -
 @pytest.mark.unit
 def test_grounding_model_is_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    assert get_grounding_model() == "openrouter/deepseek/deepseek-chat"
+    assert get_grounding_model() == "openrouter/perplexity/sonar"
 
 
 @pytest.mark.unit
@@ -193,9 +192,7 @@ def test_no_stale_qwen_model_ids_in_olympus_config() -> None:
             assert slug in _KNOWN_GOOD_OPENROUTER_MODELS, (
                 f"tier {tier_name} {capability} pins unverified model {model!r}"
             )
-        assert tier_cfg.grounding_model.lower() in {
-            m.lower() for m in _KNOWN_GOOD_OPENROUTER_MODELS
-        }
+        assert tier_cfg.grounding_model.lower() in {m.lower() for m in _GROUNDING_MODELS}
     assert "qwen" not in cfg.openrouter_defaults.allowed_models.lower()
 
 

--- a/tests/dq/atlas/data/test_web_grounding.py
+++ b/tests/dq/atlas/data/test_web_grounding.py
@@ -83,3 +83,35 @@ def test_fetch_web_grounding_none_on_empty_text():
             )
             is None
         )
+
+
+@pytest.mark.unit
+def test_fetch_web_grounding_raises_when_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLYMPUS_WEB_SEARCH", "required")
+    with patch.object(web_grounding, "_openrouter_web_search", return_value=None):
+        with pytest.raises(web_grounding.OlympusWebSearchError):
+            web_grounding.fetch_web_grounding(
+                model="openrouter/perplexity/sonar", segment="macro", run_date=date(2026, 6, 9)
+            )
+
+
+@pytest.mark.unit
+def test_build_grounding_live_search_without_data_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Web grounding must not be gated on ATLAS_DATA_TOOLS (#946)."""
+    from digiquant.olympus.atlas.phases import _node_factory as nf
+
+    monkeypatch.setenv("ATLAS_DATA_TOOLS", "0")
+    grounding = {"summary": "ok", "sources": [], "as_of": "2026-06-09"}
+    with patch(
+        "digiquant.olympus.atlas.data.web_grounding.fetch_web_grounding",
+        return_value=grounding,
+    ):
+        tools, execute_tool, web_grounding = nf.build_grounding(
+            use_data_tools=True,
+            live_search=True,
+            run_date=date(2026, 6, 9),
+            segment="alt-sentiment-news",
+        )
+    assert tools is None
+    assert execute_tool is None
+    assert web_grounding == grounding

--- a/tests/dq/atlas/test_phase_tool_flags.py
+++ b/tests/dq/atlas/test_phase_tool_flags.py
@@ -74,7 +74,9 @@ def test_build_grounding_respects_kill_switch(monkeypatch):
         run_date=date(2026, 6, 8),
         model="openrouter/openrouter/auto",
     )
-    assert tools is None and execute_tool is None and grounding is None
+    # ATLAS_DATA_TOOLS disables Supabase data tools only; live_search pre-pass is independent.
+    assert tools is None and execute_tool is None
+    assert grounding is not None
 
     monkeypatch.setenv("ATLAS_DATA_TOOLS", "1")
     tools, execute_tool, grounding = _node_factory.build_grounding(


### PR DESCRIPTION
## Summary
Promote develop to main after #968 — restores OpenRouter `web_search` grounding across Atlas/Hermes phases and tier web-search pools (#968 follow-up).

Fixes #959

## Test plan
- [x] CI on #968 (digigraph, digiquant, nautilus-smoke)
- [ ] Re-dispatch `olympus.yml` on main after merge

Made with [Cursor](https://cursor.com)