### PR TITLE
Promote develop → main: Olympus routing fix (#975) + NAV chart empty-state (#723)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -3,91 +3,112 @@
 # Single source of truth for per-phase model selection and OpenRouter cost knobs.
 # Override the active tier at runtime: OLYMPUS_MODEL_TIER=cheap|balanced|quality
 #
-# ── OPENROUTER ROUTING (Jun 2026) ───────────────────────────────────────────
-# Per-tier ``allowed_models`` pools (NOT single-model pins). Phase routing picks
-# deterministically from the capability pool via hash(phase_slug). Every model in
-# every pool MUST support web search — use ``:online`` suffix or native search
-# providers (perplexity/sonar). Grounding uses ``web_search_models`` from the same
-# search-capable set.
+# ── ROUTING MODEL (Jun 2026) ────────────────────────────────────────────────
+# Two pool kinds — do not conflate them:
 #
-# Auto Router knobs (``openrouter_defaults``) apply when a call uses openrouter/auto
-# or OPENROUTER_FALLBACK_MODELS — digillm injects:
-#   plugins[{ id: auto-router, allowed_models, cost_quality_tradeoff }]
+#   allowed_models   — phase LLM calls (structured JSON, function tools, reasoning).
+#                      Every entry MUST support tool use + structured outputs.
+#                      Web search via the ``:online`` suffix (built-in plugin).
 #
-# Web grounding: openrouter:web_search (Exa, $0.005/search) via web_search_models.
-# Fail-hard when unavailable: OLYMPUS_WEB_SEARCH=required.
-# Structured JSON: response_format json_schema + strict:true on pool models.
+#   web_search_models — grounding pre-passes only (Atlas/Hermes live_search).
+#                      May include native-search models (perplexity/sonar) that
+#                      lack function tools — NEVER routed to run_tools phases.
 #
-# Env contract (unchanged): OPENROUTER_API_KEY only — apply_olympus_openrouter_env()
-# sets OPENROUTER_ALLOWED_MODELS + OPENROUTER_COST_QUALITY_TRADEOFF at chain startup.
+# Phase routing: stable hash(phase_slug) → capability pool (extraction / research /
+# reasoning). Grounding: hash(segment) → web_search_models pool.
 #
-# ── PRICING (OpenRouter pass-through, per 1M tokens, Jun 2026) ─────────────
-#   deepseek-chat:online              $0.20 in / $0.80 out  [structured_outputs ✓, web ✓]
-#   llama-4-maverick:online           $0.15 in / $0.60 out  [structured_outputs ✓, web ✓]
-#   deepseek-r1:online                $0.70 in / $2.50 out  [structured_outputs ✓, web ✓]
-#   perplexity/sonar                  $1.00 in / $1.00 out  [web search native ✓]
+# Tier philosophy:
+#   cheap     — open-weight OSS ``:online`` models; perplexity for grounding only
+#   balanced  — cheap pool + mid-tier (Gemini Flash, GPT-4o-mini, Grok) ``:online``
+#   quality   — unbounded frontier models; no auto-router sanitization
 #
-# Capability tiers (see docs/atlas/token-budget.md):
-#   extraction — short structured JSON fan-out (phases 1, 2, 7C)
-#   research   — multi-factor analysis (phases 3–5, debate, evolution)
-#   reasoning  — high-stakes synthesis (master-digest, pm-rebalance, monthly)
+# Fail-hard when grounding unavailable: OLYMPUS_WEB_SEARCH=required.
+#
+# Env contract: OPENROUTER_API_KEY only — apply_olympus_openrouter_env() sets
+# OPENROUTER_ALLOWED_MODELS + OPENROUTER_COST_QUALITY_TRADEOFF at chain startup.
 
 default_tier: cheap
 
-# Global OpenRouter Auto Router knobs — inherited by every tier unless overridden.
 openrouter_defaults:
   allowed_models: "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*,perplexity/*"
   cost_quality_tradeoff: 10
 
 tiers:
   cheap:
+    openrouter:
+      allowed_models: "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*,perplexity/*"
+      cost_quality_tradeoff: 10
     allowed_models:
       extraction:
         - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
       research:
         - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
       reasoning:
         - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/deepseek/deepseek-r1:online"
+        - "openrouter/meta-llama/llama-4-maverick:online"
     web_search_models:
       - "openrouter/perplexity/sonar"
       - "openrouter/deepseek/deepseek-chat:online"
+      - "openrouter/meta-llama/llama-4-maverick:online"
 
   balanced:
+    openrouter:
+      allowed_models: "deepseek/*,meta-llama/*,mistralai/*,google/*,x-ai/*,openai/gpt-4o-mini*,perplexity/*"
+      cost_quality_tradeoff: 7
     allowed_models:
       extraction:
         - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/google/gemini-2.0-flash-001:online"
+        - "openrouter/openai/gpt-4o-mini:online"
+        - "openrouter/meta-llama/llama-4-maverick:online"
       research:
         - "openrouter/deepseek/deepseek-chat:online"
         - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/google/gemini-2.0-flash-001:online"
+        - "openrouter/x-ai/grok-3-mini:online"
+        - "openrouter/openai/gpt-4o-mini:online"
       reasoning:
-        - "openrouter/meta-llama/llama-4-maverick:online"
         - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/x-ai/grok-3-mini:online"
+        - "openrouter/google/gemini-2.0-flash-001:online"
     web_search_models:
       - "openrouter/perplexity/sonar"
       - "openrouter/deepseek/deepseek-chat:online"
+      - "openrouter/google/gemini-2.0-flash-001:online"
+      - "openrouter/openai/gpt-4o-mini:online"
 
   quality:
+    openrouter:
+      allowed_models: "deepseek/*,meta-llama/*,mistralai/*,openai/*,google/*,anthropic/*,x-ai/*,perplexity/*"
+      cost_quality_tradeoff: 0
     allowed_models:
       extraction:
         - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/openai/gpt-4o-mini:online"
+        - "openrouter/google/gemini-2.5-flash:online"
+        - "openrouter/anthropic/claude-sonnet-4:online"
       research:
-        - "openrouter/deepseek/deepseek-chat:online"
         - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/openai/gpt-4o:online"
+        - "openrouter/anthropic/claude-sonnet-4:online"
+        - "openrouter/google/gemini-2.5-pro:online"
+        - "openrouter/x-ai/grok-3:online"
       reasoning:
         - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/perplexity/sonar"
+        - "openrouter/anthropic/claude-sonnet-4:online"
+        - "openrouter/openai/gpt-4o:online"
+        - "openrouter/x-ai/grok-3:online"
     web_search_models:
       - "openrouter/perplexity/sonar"
-      - "openrouter/deepseek/deepseek-chat:online"
+      - "openrouter/openai/gpt-4o:online"
+      - "openrouter/deepseek/deepseek-r1:online"
+      - "openrouter/anthropic/claude-sonnet-4:online"
 
 phase_capabilities:
   macro: research

--- a/digigraph/src/digigraph/model_config.py
+++ b/digigraph/src/digigraph/model_config.py
@@ -54,8 +54,25 @@ _FLAGSHIP_MODEL_ID_MARKERS = frozenset(
         "claude-4",
     }
 )
-_OPEN_WEIGHT_ALLOWED_MODELS = "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*"
+_OPEN_WEIGHT_ALLOWED_MODELS = (
+    "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*,perplexity/*"
+)
+_BALANCED_ALLOWED_MODELS = (
+    "deepseek/*,meta-llama/*,mistralai/*,google/*,x-ai/*,openai/gpt-4o-mini*,perplexity/*"
+)
 _DEFAULT_COST_QUALITY_TRADEOFF = 10
+# Mid-tier frontier slugs permitted on ``balanced`` (not ``cheap``).
+_BALANCED_FLAGSHIP_MARKERS = frozenset(
+    {
+        "gpt-4o-mini",
+        "gemini-2.0-flash",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "grok-3-mini",
+        "grok-3",
+    }
+)
+_NATIVE_SEARCH_ONLY_PREFIXES = frozenset({"perplexity/"})
 
 
 # test = minimal tokens (free tier); medium = balanced; best = largest.
@@ -236,18 +253,55 @@ def is_flagship_allowed_models_entry(entry: str) -> bool:
     return is_flagship_openrouter_model(normalized)
 
 
-def sanitize_allowed_models(allowed_models: str) -> str:
-    """Drop frontier entries from a comma-separated OpenRouter allowed_models string."""
-    kept = [
-        entry
-        for entry in (part.strip() for part in allowed_models.split(","))
-        if entry and not is_flagship_allowed_models_entry(entry)
-    ]
+def is_native_search_only_model(model: str) -> bool:
+    """True for providers that ground via native search but lack function tools."""
+    slug = _openrouter_slug(model).strip().lower()
+    return any(slug.startswith(prefix) for prefix in _NATIVE_SEARCH_ONLY_PREFIXES)
+
+
+def _balanced_allows_flagship_model(model: str) -> bool:
+    """Mid-tier frontier models allowed on ``balanced`` but not ``cheap``."""
+    slug = _openrouter_slug(model).strip().lower()
+    return any(marker in slug for marker in _BALANCED_FLAGSHIP_MARKERS)
+
+
+def tier_allows_phase_model(model: str, tier: str) -> bool:
+    """Whether *model* may run tool-calling / structured-output phase LLM calls."""
+    if is_native_search_only_model(model):
+        return False
+    if not is_tool_use_capable_model(model):
+        return False
+    if not is_flagship_openrouter_model(model):
+        return True
+    if tier == "quality":
+        return True
+    if tier == "balanced":
+        return _balanced_allows_flagship_model(model)
+    return False
+
+
+def sanitize_allowed_models(allowed_models: str, *, tier: str = "cheap") -> str:
+    """Drop disallowed entries from a comma-separated OpenRouter allowed_models string."""
+    if tier == "quality":
+        stripped = allowed_models.strip()
+        return stripped if stripped else _OPEN_WEIGHT_ALLOWED_MODELS
+    entries = [part.strip() for part in allowed_models.split(",") if part.strip()]
+    if tier == "balanced":
+        kept = [
+            entry
+            for entry in entries
+            if not is_flagship_allowed_models_entry(entry)
+            or entry.lower().startswith(("openai/gpt-4o-mini", "google/", "x-ai/"))
+        ]
+        return ",".join(kept) if kept else _BALANCED_ALLOWED_MODELS
+    kept = [entry for entry in entries if not is_flagship_allowed_models_entry(entry)]
     return ",".join(kept) if kept else _OPEN_WEIGHT_ALLOWED_MODELS
 
 
 def _effective_openrouter_config(
-    tier_cfg: OlympusTierConfig, olympus: OlympusModelsConfig
+    tier_name: str,
+    tier_cfg: OlympusTierConfig,
+    olympus: OlympusModelsConfig,
 ) -> OlympusOpenRouterTierConfig:
     """Merge tier overrides with ``openrouter_defaults`` (defaults win on empty tier fields)."""
     defaults = olympus.openrouter_defaults
@@ -259,35 +313,31 @@ def _effective_openrouter_config(
         else defaults.cost_quality_tradeoff
     )
     return OlympusOpenRouterTierConfig(
-        allowed_models=sanitize_allowed_models(allowed),
+        allowed_models=sanitize_allowed_models(allowed, tier=tier_name),
         cost_quality_tradeoff=tradeoff,
     )
 
 
 def _warn_flagship_models_in_olympus_config(cfg: OlympusModelsConfig) -> None:
-    """Log when olympus_models.yaml pins or pools a frontier model."""
+    """Log when olympus_models.yaml pools a frontier model on a restricted tier."""
     for tier_name, tier_cfg in cfg.tiers.items():
+        if tier_name == "quality":
+            continue
         for capability, pool in tier_cfg.allowed_models.items():
             for model in pool:
-                if is_flagship_openrouter_model(model):
+                if is_flagship_openrouter_model(model) and not tier_allows_phase_model(
+                    model, tier_name
+                ):
                     logger.warning(
-                        "olympus_models tier=%s capability=%s pools flagship model %r",
+                        "olympus_models tier=%s capability=%s pools disallowed model %r",
                         tier_name,
                         capability,
                         model,
                     )
-        for model in _tier_web_search_pool(tier_cfg):
-            if is_flagship_openrouter_model(model):
-                logger.warning(
-                    "olympus_models tier=%s web_search pool contains flagship %r",
-                    tier_name,
-                    model,
-                )
-    pool = sanitize_allowed_models(cfg.openrouter_defaults.allowed_models)
+    pool = sanitize_allowed_models(cfg.openrouter_defaults.allowed_models, tier="cheap")
     if pool != cfg.openrouter_defaults.allowed_models.strip():
-        logger.warning(
-            "olympus_models openrouter_defaults.allowed_models contained frontier entries; "
-            "sanitized to %r",
+        logger.debug(
+            "olympus_models openrouter_defaults sanitized for cheap tier to %r",
             pool,
         )
 
@@ -320,14 +370,29 @@ def _capability_for_phase(phase_slug: str, cfg: OlympusModelsConfig) -> str | No
     return None
 
 
-def is_web_search_capable_model(model: str) -> bool:
-    """True when *model* can run OpenRouter web search (``:online`` or native search providers)."""
+def is_tool_use_capable_model(model: str) -> bool:
+    """True when *model* supports OpenRouter function tools (query_data, query_research).
+
+    Native-search-only providers (perplexity/sonar) are excluded — route those via
+    ``web_search_models`` / grounding pre-passes only.
+    """
     slug = _openrouter_slug(model).strip().lower()
-    if not slug:
+    if not slug or is_native_search_only_model(model):
         return False
     if ":online" in slug:
         return True
-    return slug.startswith("perplexity/")
+    # Non-``:online`` slugs are not in phase pools; reject unless explicitly expanded.
+    return False
+
+
+def is_web_search_capable_model(model: str) -> bool:
+    """True when *model* can ground via ``:online`` or native search (perplexity/*)."""
+    slug = _openrouter_slug(model).strip().lower()
+    if not slug:
+        return False
+    if is_native_search_only_model(model):
+        return True
+    return ":online" in slug
 
 
 def _pick_from_pool(pool: list[str], key: str) -> str:
@@ -350,19 +415,22 @@ def _tier_capability_pool(tier_cfg: OlympusTierConfig, capability: str) -> list[
 
 def _tier_web_search_pool(tier_cfg: OlympusTierConfig) -> list[str]:
     if tier_cfg.web_search_models:
-        return list(tier_cfg.web_search_models)
-    seen: set[str] = set()
-    merged: list[str] = []
-    for capability in ("research", "extraction", "reasoning"):
-        for model in _tier_capability_pool(tier_cfg, capability):
-            if model not in seen:
-                seen.add(model)
-                merged.append(model)
-    if merged:
-        return merged
-    if tier_cfg.grounding_model:
-        return [tier_cfg.grounding_model]
-    return []
+        pool = list(tier_cfg.web_search_models)
+    else:
+        seen: set[str] = set()
+        merged: list[str] = []
+        for capability in ("research", "extraction", "reasoning"):
+            for model in _tier_capability_pool(tier_cfg, capability):
+                if model not in seen:
+                    seen.add(model)
+                    merged.append(model)
+        if merged:
+            pool = merged
+        elif tier_cfg.grounding_model:
+            pool = [tier_cfg.grounding_model]
+        else:
+            pool = []
+    return [m for m in pool if is_web_search_capable_model(m)]
 
 
 def _model_for_olympus_capability(capability: str, tier: str, phase_slug: str) -> str | None:
@@ -371,14 +439,16 @@ def _model_for_olympus_capability(capability: str, tier: str, phase_slug: str) -
     tier_cfg = _load_olympus_models().tiers.get(tier)
     if tier_cfg is None:
         return None
-    pool = _tier_capability_pool(tier_cfg, capability)
+    pool = [
+        m for m in _tier_capability_pool(tier_cfg, capability) if tier_allows_phase_model(m, tier)
+    ]
     if not pool:
         return None
     return _pick_from_pool(pool, phase_slug)
 
 
 def get_grounding_model(*, segment: str = "grounding") -> str | None:
-    """Return an OpenRouter model for ``openrouter:web_search`` grounding pre-passes."""
+    """Return an OpenRouter model for web-search grounding pre-passes."""
     tier_cfg = _load_olympus_models().tiers.get(get_olympus_tier())
     if tier_cfg is None:
         return None
@@ -401,7 +471,7 @@ def apply_olympus_openrouter_env(*, force: bool = False) -> str:
         logger.warning("olympus tier %r not found in olympus_models.yaml", tier)
         return tier
     olympus = _load_olympus_models()
-    or_cfg = _effective_openrouter_config(tier_cfg, olympus)
+    or_cfg = _effective_openrouter_config(tier, tier_cfg, olympus)
     if or_cfg.allowed_models and (
         force or not os.environ.get("OPENROUTER_ALLOWED_MODELS", "").strip()
     ):
@@ -452,22 +522,23 @@ def get_model_for_phase(phase_slug: str) -> str | None:
     """
     data = _load_model_modes()
     phase_models = data.phase_models
+    tier = get_olympus_tier()
     override = _phase_models_override(phase_slug, phase_models)
     if override is not None:
-        if is_flagship_openrouter_model(override):
-            logger.warning(
-                "Rejecting flagship phase_models override for %s (%r); "
-                "using olympus_models.yaml instead",
-                phase_slug,
-                override,
-            )
-        else:
+        if tier_allows_phase_model(override, tier):
             return override
+        logger.warning(
+            "Rejecting phase_models override for %s (%r) on tier %s; "
+            "using olympus_models.yaml instead",
+            phase_slug,
+            override,
+            tier,
+        )
 
     olympus = _load_olympus_models()
     capability = _capability_for_phase(phase_slug, olympus)
     if capability is not None:
-        return _model_for_olympus_capability(capability, get_olympus_tier(), phase_slug)
+        return _model_for_olympus_capability(capability, tier, phase_slug)
     return None
 
 

--- a/digillm/src/digillm/client.py
+++ b/digillm/src/digillm/client.py
@@ -943,12 +943,14 @@ def openrouter_web_search(
     max_results: int = 8,
     engine: str = "exa",
 ) -> tuple[str, list[str]] | None:
-    """Run OpenRouter's ``openrouter:web_search`` server tool and return grounding.
+    """Run OpenRouter web search grounding and return ``(summary_text, source_urls)``.
 
-    Uses a single chat completion with the server-side web search tool (Exa by
-    default for consistent ``allowed_domains`` support). Returns
-    ``(summary_text, source_urls)`` or ``None`` when the model isn't OpenRouter,
-    ``OPENROUTER_API_KEY`` is unset, or the call fails (fail-soft).
+    ``:online`` models and native-search providers (``perplexity/*``) use built-in web
+    search via a plain completion. Other models fall back to the server-side
+    ``openrouter:web_search`` tool (Exa by default).
+
+    Returns ``None`` when the model isn't OpenRouter, ``OPENROUTER_API_KEY`` is
+    unset, or the call fails (fail-soft).
     """
     provider, model_id = _parse_provider_prefix(model)
     if provider != "openrouter":
@@ -958,15 +960,6 @@ def openrouter_web_search(
         logger.debug("openrouter_web_search skipped: OPENROUTER_API_KEY not set")
         return None
 
-    tool_params: dict[str, Any] = {
-        "engine": engine,
-        "max_results": max(1, min(max_results, 25)),
-        "search_context_size": "medium",
-    }
-    if allowed_domains:
-        tool_params["allowed_domains"] = list(allowed_domains)
-
-    tools: list[dict[str, Any]] = [{"type": "openrouter:web_search", "parameters": tool_params}]
     messages: list[ChatCompletionMessage] = [
         {
             "role": "system",
@@ -979,14 +972,34 @@ def openrouter_web_search(
         {"role": "user", "content": query},
     ]
     try:
-        resp = completion(
-            model,
-            messages,
-            tools=tools,
-            tool_choice="auto",
-            temperature=0.2,
-            usage_kind="web_search",
-        )
+        # ``:online`` and native-search (perplexity) models use built-in web search —
+        # do NOT attach ``openrouter:web_search`` (404 on endpoints that lack the tool).
+        if ":online" in model_id or model_id.startswith("perplexity/"):
+            resp = completion(
+                model,
+                messages,
+                temperature=0.2,
+                usage_kind="web_search",
+            )
+        else:
+            tool_params: dict[str, Any] = {
+                "engine": engine,
+                "max_results": max(1, min(max_results, 25)),
+                "search_context_size": "medium",
+            }
+            if allowed_domains:
+                tool_params["allowed_domains"] = list(allowed_domains)
+            tools: list[dict[str, Any]] = [
+                {"type": "openrouter:web_search", "parameters": tool_params}
+            ]
+            resp = completion(
+                model,
+                messages,
+                tools=tools,
+                tool_choice="auto",
+                temperature=0.2,
+                usage_kind="web_search",
+            )
     except Exception as exc:  # noqa: BLE001 — grounding is best-effort; degrade gracefully
         logger.warning("openrouter_web_search failed (%s); continuing ungrounded", exc)
         _record_usage(kind="web_search", model=model_id, ok=False)

--- a/frontend/olympus/components/portfolio/performance-chart-workspace.tsx
+++ b/frontend/olympus/components/portfolio/performance-chart-workspace.tsx
@@ -74,6 +74,14 @@ function NavComparableChart({
   /** Pre-aggregated events per date for tooltip enrichment. */
   activityEventsByDate?: Record<string, { ticker: string; event: string }[]>;
 }) {
+  if (data.length < 2) {
+    return (
+      <div className="h-full min-h-[280px] flex items-center justify-center text-text-muted text-sm">
+        Need at least two NAV points in this range.
+      </div>
+    );
+  }
+
   const legendContent = (props: { payload?: LegendPayloadItem[] }) => {
     const { payload } = props;
     if (!payload?.length) return null;

--- a/tests/dg/test_llm_openrouter_web_search.py
+++ b/tests/dg/test_llm_openrouter_web_search.py
@@ -50,18 +50,17 @@ def test_openrouter_web_search_none_without_api_key(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.unit
-def test_openrouter_web_search_skips_require_parameters(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openrouter_web_search_perplexity_uses_native_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Perplexity uses plain completion (native search), not openrouter:web_search server tool."""
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    captured: dict = {}
-
-    def _capture_create(_client, **kwargs):
-        captured.update(kwargs)
-        return _chat_resp("headline [[1]](https://example.com)")
-
-    with patch("digillm.client._create_with_retry", side_effect=_capture_create):
+    with patch("digillm.client.completion") as completion:
+        completion.return_value = _chat_resp("headline [[1]](https://example.com)")
         openrouter_web_search("openrouter/perplexity/sonar", "latest CPI")
-    extra = captured.get("extra_body") or {}
-    assert "require_parameters" not in (extra.get("provider") or {})
+    kwargs = completion.call_args[1]
+    assert "tools" not in kwargs
+    assert kwargs["usage_kind"] == "web_search"
 
 
 @pytest.mark.unit

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -15,21 +15,58 @@ from digigraph.model_config import (
     get_olympus_tier,
     is_flagship_allowed_models_entry,
     is_flagship_openrouter_model,
+    is_native_search_only_model,
+    is_tool_use_capable_model,
     is_web_search_capable_model,
     sanitize_allowed_models,
+    tier_allows_phase_model,
 )
 
 _REPO_CONFIG = str(Path(__file__).parents[2] / "config")
 
 # OpenRouter slugs verified in CI (OPENROUTER_API_KEY only — no direct OpenAI).
-_KNOWN_GOOD_OPENROUTER_MODELS = frozenset(
+_CHEAP_PHASE_MODELS = frozenset(
     {
         "openrouter/deepseek/deepseek-chat:online",
         "openrouter/deepseek/deepseek-r1:online",
         "openrouter/meta-llama/llama-4-maverick:online",
-        "openrouter/perplexity/sonar",
+        "openrouter/mistralai/mistral-small-3.1-24b-instruct:online",
     }
 )
+
+_BALANCED_PHASE_MODELS = _CHEAP_PHASE_MODELS | frozenset(
+    {
+        "openrouter/google/gemini-2.0-flash-001:online",
+        "openrouter/openai/gpt-4o-mini:online",
+        "openrouter/x-ai/grok-3-mini:online",
+    }
+)
+
+_QUALITY_PHASE_MODELS = _BALANCED_PHASE_MODELS | frozenset(
+    {
+        "openrouter/openai/gpt-4o:online",
+        "openrouter/anthropic/claude-sonnet-4:online",
+        "openrouter/google/gemini-2.5-flash:online",
+        "openrouter/google/gemini-2.5-pro:online",
+        "openrouter/x-ai/grok-3:online",
+    }
+)
+
+_WEB_SEARCH_MODELS = _CHEAP_PHASE_MODELS | frozenset(
+    {
+        "openrouter/perplexity/sonar",
+        "openrouter/google/gemini-2.0-flash-001:online",
+        "openrouter/openai/gpt-4o-mini:online",
+        "openrouter/openai/gpt-4o:online",
+        "openrouter/anthropic/claude-sonnet-4:online",
+    }
+)
+
+_TIER_PHASE_MODELS = {
+    "cheap": _CHEAP_PHASE_MODELS,
+    "balanced": _BALANCED_PHASE_MODELS,
+    "quality": _QUALITY_PHASE_MODELS,
+}
 
 # Retired OpenRouter IDs — must not appear in olympus_models.yaml pins or pools.
 _BANNED_QWEN_MODEL_MARKERS = (
@@ -73,7 +110,8 @@ def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
     model = get_model_for_phase("hermes/portfolio/asset-analyst-AAPL")
     assert model is not None
     assert model.startswith("openrouter/")
-    assert model in _KNOWN_GOOD_OPENROUTER_MODELS
+    assert model in _CHEAP_PHASE_MODELS
+    assert is_tool_use_capable_model(model)
 
 
 @pytest.mark.unit
@@ -96,6 +134,29 @@ def test_quality_tier_uses_reasoning_pool(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.unit
+def test_balanced_tier_includes_mid_frontier_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "balanced")
+    cfg = model_config._load_olympus_models()
+    balanced = cfg.tiers["balanced"]
+    research = balanced.allowed_models["research"]
+    assert any("gpt-4o-mini" in m for m in research)
+    assert any("gemini" in m for m in research)
+    model = get_model_for_phase("macro")
+    assert model is not None
+    assert tier_allows_phase_model(model, "balanced")
+
+
+@pytest.mark.unit
+def test_quality_tier_allows_frontier_in_pools() -> None:
+    cfg = model_config._load_olympus_models()
+    quality = cfg.tiers["quality"]
+    frontier = [m for m in quality.allowed_models["reasoning"] if is_flagship_openrouter_model(m)]
+    assert frontier, "quality tier should include frontier reasoning models"
+    for model in frontier:
+        assert tier_allows_phase_model(model, "quality")
+
+
+@pytest.mark.unit
 def test_phase_slug_selection_is_stable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     first = get_model_for_phase("macro")
@@ -115,10 +176,23 @@ def test_apply_olympus_openrouter_env_sets_open_weight_pool(
     assert tier == "cheap"
     pool = os.environ["OPENROUTER_ALLOWED_MODELS"]
     assert "deepseek/*" in pool
+    assert "perplexity/*" in pool
     assert "qwen" not in pool.lower()
     assert "openai" not in pool
     assert "anthropic" not in pool
     assert os.environ["OPENROUTER_COST_QUALITY_TRADEOFF"] == "10"
+
+
+@pytest.mark.unit
+def test_apply_quality_tier_preserves_frontier_auto_router_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_ALLOWED_MODELS", raising=False)
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "quality")
+    apply_olympus_openrouter_env()
+    pool = os.environ["OPENROUTER_ALLOWED_MODELS"]
+    assert "openai/*" in pool
+    assert "anthropic/*" in pool
 
 
 @pytest.mark.unit
@@ -142,7 +216,22 @@ def test_grounding_model_from_web_search_pool(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.unit
-def test_phase_models_flagship_override_rejected(
+def test_grounding_model_may_be_perplexity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Perplexity is valid for grounding-only paths, not tool phases."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    cfg = model_config._load_olympus_models()
+    assert "openrouter/perplexity/sonar" in cfg.tiers["cheap"].web_search_models
+    # Deterministic pick for a segment that hashes to perplexity
+    for segment in ("macro", "bonds", "perplexity-grounding", "alt-sentiment-news"):
+        model = get_grounding_model(segment=segment)
+        assert model is not None
+        assert is_web_search_capable_model(model)
+        if is_native_search_only_model(model):
+            assert not is_tool_use_capable_model(model)
+
+
+@pytest.mark.unit
+def test_phase_models_flagship_override_rejected_on_cheap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     (tmp_path / "model_modes.yaml").write_text(
@@ -152,9 +241,27 @@ def test_phase_models_flagship_override_rejected(
         Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
     )
     monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
     assert get_model_for_phase("macro") in _cheap_research_pool()
+
+
+@pytest.mark.unit
+def test_phase_models_mid_tier_override_wins_on_balanced(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "model_modes.yaml").write_text(
+        'phase_models:\n  macro: "openrouter/openai/gpt-4o-mini:online"\n'
+    )
+    (tmp_path / "olympus_models.yaml").write_text(
+        Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
+    )
+    monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "balanced")
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
+    assert get_model_for_phase("macro") == "openrouter/openai/gpt-4o-mini:online"
 
 
 @pytest.mark.unit
@@ -162,7 +269,7 @@ def test_phase_models_open_weight_override_wins(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     (tmp_path / "model_modes.yaml").write_text(
-        'phase_models:\n  macro: "openrouter/mistralai/mistral-small"\n'
+        'phase_models:\n  macro: "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"\n'
     )
     (tmp_path / "olympus_models.yaml").write_text(
         Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
@@ -170,7 +277,9 @@ def test_phase_models_open_weight_override_wins(
     monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
-    assert get_model_for_phase("macro") == "openrouter/mistralai/mistral-small"
+    assert (
+        get_model_for_phase("macro") == "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
+    )
 
 
 @pytest.mark.unit
@@ -192,12 +301,36 @@ def test_flagship_detection(model: str, flagship: bool) -> None:
     "model",
     (
         "openrouter/deepseek/deepseek-chat:online",
-        "openrouter/perplexity/sonar",
         "openrouter/meta-llama/llama-4-maverick:online",
+        "openrouter/perplexity/sonar",
     ),
 )
 def test_web_search_capable_models(model: str) -> None:
     assert is_web_search_capable_model(model)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model", "capable"),
+    [
+        ("openrouter/deepseek/deepseek-chat:online", True),
+        ("openrouter/meta-llama/llama-4-maverick:online", True),
+        ("openrouter/deepseek/deepseek-r1:online", True),
+        ("openrouter/perplexity/sonar", False),
+        ("openrouter/deepseek/deepseek-chat", False),
+        ("openrouter/openai/gpt-4o-mini:online", True),
+    ],
+)
+def test_tool_use_capable_models(model: str, capable: bool) -> None:
+    assert is_tool_use_capable_model(model) is capable
+
+
+@pytest.mark.unit
+def test_perplexity_is_native_search_only() -> None:
+    assert is_native_search_only_model("openrouter/perplexity/sonar")
+    assert is_web_search_capable_model("openrouter/perplexity/sonar")
+    assert not is_tool_use_capable_model("openrouter/perplexity/sonar")
+    assert not tier_allows_phase_model("openrouter/perplexity/sonar", "quality")
 
 
 @pytest.mark.unit
@@ -206,11 +339,32 @@ def test_non_online_deepseek_not_web_search_capable() -> None:
 
 
 @pytest.mark.unit
-def test_sanitize_allowed_models_strips_frontier() -> None:
+def test_sanitize_allowed_models_strips_frontier_on_cheap() -> None:
     raw = "deepseek/*,openai/*,anthropic/*,meta-llama/*"
-    assert sanitize_allowed_models(raw) == "deepseek/*,meta-llama/*"
+    assert sanitize_allowed_models(raw, tier="cheap") == "deepseek/*,meta-llama/*"
     assert is_flagship_allowed_models_entry("openai/*")
     assert not is_flagship_allowed_models_entry("deepseek/*")
+
+
+@pytest.mark.unit
+def test_sanitize_allowed_models_preserves_frontier_on_quality() -> None:
+    raw = "deepseek/*,openai/*,anthropic/*"
+    assert sanitize_allowed_models(raw, tier="quality") == raw
+
+
+@pytest.mark.unit
+def test_perplexity_only_in_web_search_pools_not_phase_pools() -> None:
+    """Regression: perplexity/sonar in allowed_models caused tool-use 404s."""
+    cfg = model_config._load_olympus_models()
+    for tier_name, tier_cfg in cfg.tiers.items():
+        for capability, pool in tier_cfg.allowed_models.items():
+            for model in pool:
+                assert not is_native_search_only_model(model), (
+                    f"tier {tier_name} {capability} must not pool native-search-only {model}"
+                )
+        assert any(
+            is_native_search_only_model(m) for m in tier_cfg.web_search_models
+        ), f"tier {tier_name} should offer perplexity in web_search_models"
 
 
 @pytest.mark.unit
@@ -224,18 +378,23 @@ def test_no_stale_qwen_model_ids_in_olympus_config() -> None:
     for tier_name, tier_cfg in cfg.tiers.items():
         assert tier_cfg.allowed_models, f"tier {tier_name} must define allowed_models pools"
         assert not tier_cfg.models, f"tier {tier_name} must not use legacy models: pins"
+        allowed_phase = _TIER_PHASE_MODELS[tier_name]
         for capability, pool in tier_cfg.allowed_models.items():
             assert len(pool) >= 1, f"tier {tier_name} {capability} pool is empty"
             for model in pool:
                 slug = model.lower()
-                assert slug in {m.lower() for m in _KNOWN_GOOD_OPENROUTER_MODELS}, (
+                assert slug in {m.lower() for m in allowed_phase}, (
                     f"tier {tier_name} {capability} pools unverified model {model!r}"
                 )
-                assert is_web_search_capable_model(model), (
-                    f"tier {tier_name} {capability} model {model!r} lacks web search"
+                assert tier_allows_phase_model(model, tier_name), (
+                    f"tier {tier_name} {capability} model {model!r} not allowed for phase calls"
+                )
+                assert is_tool_use_capable_model(model), (
+                    f"tier {tier_name} {capability} model {model!r} lacks tool use"
                 )
         for model in tier_cfg.web_search_models:
             assert is_web_search_capable_model(model)
+            assert model.lower() in {m.lower() for m in _WEB_SEARCH_MODELS}
     assert "qwen" not in cfg.openrouter_defaults.allowed_models.lower()
 
 
@@ -268,19 +427,17 @@ def test_edit_mode_segments_route_to_cheap_open_weight_models(
     assert model.startswith("openrouter/")
     assert not is_flagship_openrouter_model(model)
     assert is_web_search_capable_model(model)
+    assert is_tool_use_capable_model(model)
 
 
 @pytest.mark.unit
-def test_repo_olympus_config_has_no_flagship_pins() -> None:
+def test_cheap_tier_has_no_flagship_pins() -> None:
     cfg = model_config._load_olympus_models()
-    for tier_name, tier_cfg in cfg.tiers.items():
-        for capability, pool in tier_cfg.allowed_models.items():
-            for model in pool:
-                assert not is_flagship_openrouter_model(model), (
-                    f"tier {tier_name} {capability} pools flagship {model}"
-                )
-        for model in tier_cfg.web_search_models:
-            assert not is_flagship_openrouter_model(model)
-    assert cfg.openrouter_defaults.cost_quality_tradeoff == 10
-    assert "openai" not in cfg.openrouter_defaults.allowed_models
-    assert "anthropic" not in cfg.openrouter_defaults.allowed_models
+    cheap = cfg.tiers["cheap"]
+    for capability, pool in cheap.allowed_models.items():
+        for model in pool:
+            assert not is_flagship_openrouter_model(model), (
+                f"cheap {capability} pools flagship {model}"
+            )
+    for model in cheap.web_search_models:
+        assert not is_flagship_openrouter_model(model)


### PR DESCRIPTION
Routine develop→main promotion to take the latest reviewed Olympus work live (the daily `olympus.yml` pipeline runs from `main`).

Brings exactly 2 commits:
- #975 — route tool phases to `:online` models only (OpenRouter tool-use pools)
- #723 — empty-state for NAV-vs-comparables chart when <2 NAV points

Both merged to develop green/CLEAN. develop is 2 ahead / 0 behind main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)