### PR TITLE
fix(olympus): decouple function-tool routing from :online web search

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -7,19 +7,24 @@
 # Two pool kinds — do not conflate them:
 #
 #   allowed_models   — phase LLM calls (structured JSON, function tools, reasoning).
-#                      Every entry MUST support tool use + structured outputs.
-#                      Web search via the ``:online`` suffix (built-in plugin).
+#                      BARE slugs only (no ``:online``). Every entry MUST support
+#                      OpenRouter function tools. ``:online`` is a web-search variant and
+#                      does NOT imply tool support — for open-weight models the ``:online``
+#                      endpoints 404 on function tools, so it is banned from phase pools.
+#                      Web grounding is NOT done here; it is a separate pre-pass (below).
 #
-#   web_search_models — grounding pre-passes only (Atlas/Hermes live_search).
-#                      May include native-search models (perplexity/sonar) that
-#                      lack function tools — NEVER routed to run_tools phases.
+#   web_search_models — grounding pre-passes only (Atlas/Hermes live_search). Carries the
+#                      ``:online``/native-search models (perplexity/sonar). The pre-pass
+#                      injects a ``web_grounding`` block into the prompt before the phase
+#                      runs, so phase models never need ``:online`` themselves. These models
+#                      may lack function tools — NEVER routed to run_tools phases.
 #
 # Phase routing: stable hash(phase_slug) → capability pool (extraction / research /
 # reasoning). Grounding: hash(segment) → web_search_models pool.
 #
 # Tier philosophy:
-#   cheap     — open-weight OSS ``:online`` models; perplexity for grounding only
-#   balanced  — cheap pool + mid-tier (Gemini Flash, GPT-4o-mini, Grok) ``:online``
+#   cheap     — open-weight OSS models (bare) for phases; ``:online``/perplexity grounding
+#   balanced  — cheap pool + mid-tier (Gemini Flash, GPT-4o-mini, Grok), all bare
 #   quality   — unbounded frontier models; no auto-router sanitization
 #
 # Fail-hard when grounding unavailable: OLYMPUS_WEB_SEARCH=required.
@@ -38,19 +43,21 @@ tiers:
     openrouter:
       allowed_models: "deepseek/*,meta-llama/*,mistralai/*,nvidia/*,google/gemma*,perplexity/*"
       cost_quality_tradeoff: 10
+    # Phase pools = bare slugs (function tools). ``:online`` is web-search-only and lives
+    # in ``web_search_models``; grounding is a separate pre-pass injected into the prompt.
     allowed_models:
       extraction:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/meta-llama/llama-4-maverick"
+        - "openrouter/mistralai/mistral-small-3.1-24b-instruct"
       research:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/meta-llama/llama-4-maverick"
+        - "openrouter/mistralai/mistral-small-3.1-24b-instruct"
       reasoning:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/deepseek/deepseek-r1"
+        - "openrouter/meta-llama/llama-4-maverick"
     web_search_models:
       - "openrouter/perplexity/sonar"
       - "openrouter/deepseek/deepseek-chat:online"
@@ -62,21 +69,21 @@ tiers:
       cost_quality_tradeoff: 7
     allowed_models:
       extraction:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/google/gemini-2.0-flash-001:online"
-        - "openrouter/openai/gpt-4o-mini:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/google/gemini-2.0-flash-001"
+        - "openrouter/openai/gpt-4o-mini"
+        - "openrouter/meta-llama/llama-4-maverick"
       research:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/google/gemini-2.0-flash-001:online"
-        - "openrouter/x-ai/grok-3-mini:online"
-        - "openrouter/openai/gpt-4o-mini:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/meta-llama/llama-4-maverick"
+        - "openrouter/google/gemini-2.0-flash-001"
+        - "openrouter/x-ai/grok-3-mini"
+        - "openrouter/openai/gpt-4o-mini"
       reasoning:
-        - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/meta-llama/llama-4-maverick:online"
-        - "openrouter/x-ai/grok-3-mini:online"
-        - "openrouter/google/gemini-2.0-flash-001:online"
+        - "openrouter/deepseek/deepseek-r1"
+        - "openrouter/meta-llama/llama-4-maverick"
+        - "openrouter/x-ai/grok-3-mini"
+        - "openrouter/google/gemini-2.0-flash-001"
     web_search_models:
       - "openrouter/perplexity/sonar"
       - "openrouter/deepseek/deepseek-chat:online"
@@ -89,21 +96,21 @@ tiers:
       cost_quality_tradeoff: 0
     allowed_models:
       extraction:
-        - "openrouter/deepseek/deepseek-chat:online"
-        - "openrouter/openai/gpt-4o-mini:online"
-        - "openrouter/google/gemini-2.5-flash:online"
-        - "openrouter/anthropic/claude-sonnet-4:online"
+        - "openrouter/deepseek/deepseek-chat"
+        - "openrouter/openai/gpt-4o-mini"
+        - "openrouter/google/gemini-2.5-flash"
+        - "openrouter/anthropic/claude-sonnet-4"
       research:
-        - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/openai/gpt-4o:online"
-        - "openrouter/anthropic/claude-sonnet-4:online"
-        - "openrouter/google/gemini-2.5-pro:online"
-        - "openrouter/x-ai/grok-3:online"
+        - "openrouter/deepseek/deepseek-r1"
+        - "openrouter/openai/gpt-4o"
+        - "openrouter/anthropic/claude-sonnet-4"
+        - "openrouter/google/gemini-2.5-pro"
+        - "openrouter/x-ai/grok-3"
       reasoning:
-        - "openrouter/deepseek/deepseek-r1:online"
-        - "openrouter/anthropic/claude-sonnet-4:online"
-        - "openrouter/openai/gpt-4o:online"
-        - "openrouter/x-ai/grok-3:online"
+        - "openrouter/deepseek/deepseek-r1"
+        - "openrouter/anthropic/claude-sonnet-4"
+        - "openrouter/openai/gpt-4o"
+        - "openrouter/x-ai/grok-3"
     web_search_models:
       - "openrouter/perplexity/sonar"
       - "openrouter/openai/gpt-4o:online"

--- a/digigraph/src/digigraph/model_config.py
+++ b/digigraph/src/digigraph/model_config.py
@@ -371,18 +371,27 @@ def _capability_for_phase(phase_slug: str, cfg: OlympusModelsConfig) -> str | No
 
 
 def is_tool_use_capable_model(model: str) -> bool:
-    """True when *model* supports OpenRouter function tools (query_data, query_research).
+    """True when *model* may run OpenRouter function-tool phases (query_data, query_research).
 
-    Native-search-only providers (perplexity/sonar) are excluded — route those via
-    ``web_search_models`` / grounding pre-passes only.
+    Tool capability is decoupled from web search. The ``:online`` suffix only activates
+    OpenRouter's built-in web plugin — it does **not** imply function-tool support. For
+    open-weight models the ``:online`` endpoints reject function tools outright (404
+    "No endpoints found that support tool use"), which is why pinning ``:online`` slugs in
+    phase pools broke the pipeline. Grounding is supplied by a separate web-search pre-pass
+    (:func:`get_grounding_model` over ``web_search_models``) that injects a ``web_grounding``
+    block into the prompt, so phase models never need ``:online`` themselves.
+
+    Therefore a model is tool-capable iff it is a plain (bare) OpenRouter slug that is not a
+    native-search-only provider (perplexity/*) and does not carry the ``:online`` suffix.
     """
     slug = _openrouter_slug(model).strip().lower()
     if not slug or is_native_search_only_model(model):
         return False
+    # ``:online`` is a web-search variant, not a function-tool signal — route it via
+    # ``web_search_models`` grounding only, never phase/tool calls.
     if ":online" in slug:
-        return True
-    # Non-``:online`` slugs are not in phase pools; reject unless explicitly expanded.
-    return False
+        return False
+    return True
 
 
 def is_web_search_capable_model(model: str) -> bool:

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -6,9 +6,13 @@ Checks (in order):
   1. Required env vars are present
   2. OpenRouter connectivity (1-token ping via openrouter/auto)
      Note: all phases route through OpenRouter Auto Router (config/model_modes.yaml).
-  4. Supabase is reachable and daily_snapshots has a prior baseline row
+  3. OpenRouter structured-output routing (real digillm json_schema call)
+  3b. OpenRouter function tools — each active-tier phase model accepts the query_data
+     tool (guards the ``:online`` "No endpoints found that support tool use" regression)
+  4. OpenRouter web search (grounding pre-pass)
+  5. Supabase is reachable and daily_snapshots has a prior baseline row
      (required for --auto-baseline on delta runs)
-  5. Graph compiles cleanly — dry-run for both baseline and delta
+  6. Graph compiles cleanly — dry-run for both baseline and delta
 
 Usage:
   python scripts/validate-providers.py          # from repo root or atlas dir
@@ -195,6 +199,65 @@ def check_openrouter_structured() -> bool:
         )
 
 
+def check_openrouter_function_tools() -> bool:
+    """Validate that the active tier's phase models accept FUNCTION TOOLS (``query_data``).
+
+    This is the check that would have caught the ``:online`` regression: structured-output and
+    web-search pings both succeed even when the pinned phase model can't do function tools, so the
+    pipeline 404'd at runtime with ``No endpoints found that support tool use``. ``:online`` is a
+    web-search variant and does NOT imply tool support for open-weight models. Here we send the
+    real ``query_data`` tool definitions to EACH distinct model in the active tier's phase pools
+    (a stub executor — we only care that OpenRouter accepts the tool request, not the DB read), so
+    any non-tool-capable pool member fails the preflight FAST instead of mid-run."""
+    print(_bold("\n3b. OpenRouter function tools (phase-model tool capability)"))
+    if not os.environ.get("OPENROUTER_API_KEY", "").strip():
+        return check("Function-tool smoke test", False, "OPENROUTER_API_KEY not set")
+    try:
+        _ensure_importable()
+        from digigraph.model_config import _load_olympus_models, get_olympus_tier
+        from digillm.client import completion
+        from digiquant.olympus.atlas.data.tools import DATA_TOOLS
+
+        tier = get_olympus_tier()
+        tier_cfg = _load_olympus_models().tiers.get(tier)
+        if tier_cfg is None:
+            return check("Function-tool smoke test", False, f"unknown tier {tier!r}")
+        # Distinct models across all phase (function-tool) pools, order preserved.
+        seen: set[str] = set()
+        models: list[str] = []
+        for pool in tier_cfg.allowed_models.values():
+            for m in pool:
+                if m not in seen:
+                    seen.add(m)
+                    models.append(m)
+        if not models:
+            return check("Function-tool smoke test", False, f"tier {tier!r} has no phase models")
+
+        all_ok = True
+        for model in models:
+            try:
+                t0 = time.monotonic()
+                resp = completion(
+                    model,
+                    [{"role": "user", "content": "Reply with the single word: ok"}],
+                    tools=DATA_TOOLS,
+                    tool_choice="auto",
+                    max_tokens=5,
+                    temperature=0,
+                )
+                elapsed = time.monotonic() - t0
+                ok = resp is not None
+                check(f"tools accepted: {model}", ok, f"{elapsed:.1f}s" if ok else "no response")
+                all_ok = all_ok and ok
+            except Exception as exc:  # noqa: BLE001 — a 404 "No endpoints …support tool use" here
+                # is exactly the regression we are guarding; report a clean FAIL per-model.
+                check(f"tools accepted: {model}", False, f"{type(exc).__name__}: {exc}")
+                all_ok = False
+        return all_ok
+    except Exception as exc:  # noqa: BLE001 — diagnostic probe must not crash preflight
+        return check("Function-tool smoke test", False, f"{type(exc).__name__}: {exc}")
+
+
 def check_openrouter_web_search() -> bool:
     """Validate the OpenRouter ``openrouter:web_search`` server-tool path (Olympus grounding).
 
@@ -335,6 +398,7 @@ def main() -> int:
     if not args.skip_llm:
         check_openrouter("openrouter/auto")
         check_openrouter_structured()
+        check_openrouter_function_tools()
         check_openrouter_web_search()
 
     if not args.skip_db:

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -24,37 +24,43 @@ from digigraph.model_config import (
 
 _REPO_CONFIG = str(Path(__file__).parents[2] / "config")
 
-# OpenRouter slugs verified in CI (OPENROUTER_API_KEY only — no direct OpenAI).
+# Phase pools = bare OpenRouter slugs (function tools). The ``:online`` suffix is a
+# web-search variant only and must never appear in a phase pool — it 404s on tool use
+# for open-weight models. Web-search/grounding slugs keep ``:online``/perplexity below.
 _CHEAP_PHASE_MODELS = frozenset(
     {
-        "openrouter/deepseek/deepseek-chat:online",
-        "openrouter/deepseek/deepseek-r1:online",
-        "openrouter/meta-llama/llama-4-maverick:online",
-        "openrouter/mistralai/mistral-small-3.1-24b-instruct:online",
+        "openrouter/deepseek/deepseek-chat",
+        "openrouter/deepseek/deepseek-r1",
+        "openrouter/meta-llama/llama-4-maverick",
+        "openrouter/mistralai/mistral-small-3.1-24b-instruct",
     }
 )
 
 _BALANCED_PHASE_MODELS = _CHEAP_PHASE_MODELS | frozenset(
     {
-        "openrouter/google/gemini-2.0-flash-001:online",
-        "openrouter/openai/gpt-4o-mini:online",
-        "openrouter/x-ai/grok-3-mini:online",
+        "openrouter/google/gemini-2.0-flash-001",
+        "openrouter/openai/gpt-4o-mini",
+        "openrouter/x-ai/grok-3-mini",
     }
 )
 
 _QUALITY_PHASE_MODELS = _BALANCED_PHASE_MODELS | frozenset(
     {
-        "openrouter/openai/gpt-4o:online",
-        "openrouter/anthropic/claude-sonnet-4:online",
-        "openrouter/google/gemini-2.5-flash:online",
-        "openrouter/google/gemini-2.5-pro:online",
-        "openrouter/x-ai/grok-3:online",
+        "openrouter/openai/gpt-4o",
+        "openrouter/anthropic/claude-sonnet-4",
+        "openrouter/google/gemini-2.5-flash",
+        "openrouter/google/gemini-2.5-pro",
+        "openrouter/x-ai/grok-3",
     }
 )
 
-_WEB_SEARCH_MODELS = _CHEAP_PHASE_MODELS | frozenset(
+# Web-search/grounding pools keep ``:online`` (built-in plugin) and perplexity (native).
+_WEB_SEARCH_MODELS = frozenset(
     {
         "openrouter/perplexity/sonar",
+        "openrouter/deepseek/deepseek-chat:online",
+        "openrouter/deepseek/deepseek-r1:online",
+        "openrouter/meta-llama/llama-4-maverick:online",
         "openrouter/google/gemini-2.0-flash-001:online",
         "openrouter/openai/gpt-4o-mini:online",
         "openrouter/openai/gpt-4o:online",
@@ -251,8 +257,9 @@ def test_phase_models_flagship_override_rejected_on_cheap(
 def test_phase_models_mid_tier_override_wins_on_balanced(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    # A bare (tool-capable) mid-tier slug is accepted as an override on balanced.
     (tmp_path / "model_modes.yaml").write_text(
-        'phase_models:\n  macro: "openrouter/openai/gpt-4o-mini:online"\n'
+        'phase_models:\n  macro: "openrouter/openai/gpt-4o-mini"\n'
     )
     (tmp_path / "olympus_models.yaml").write_text(
         Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
@@ -261,15 +268,16 @@ def test_phase_models_mid_tier_override_wins_on_balanced(
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "balanced")
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
-    assert get_model_for_phase("macro") == "openrouter/openai/gpt-4o-mini:online"
+    assert get_model_for_phase("macro") == "openrouter/openai/gpt-4o-mini"
 
 
 @pytest.mark.unit
 def test_phase_models_open_weight_override_wins(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    # A bare open-weight slug is tool-capable, so the override is honored.
     (tmp_path / "model_modes.yaml").write_text(
-        'phase_models:\n  macro: "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"\n'
+        'phase_models:\n  macro: "openrouter/mistralai/mistral-small-3.1-24b-instruct"\n'
     )
     (tmp_path / "olympus_models.yaml").write_text(
         Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
@@ -277,9 +285,32 @@ def test_phase_models_open_weight_override_wins(
     monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
-    assert (
-        get_model_for_phase("macro") == "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"
+    assert get_model_for_phase("macro") == "openrouter/mistralai/mistral-small-3.1-24b-instruct"
+
+
+@pytest.mark.unit
+def test_phase_models_online_override_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression: a ``:online`` override is web-search-only and must NOT route a phase.
+
+    The override is rejected (not tool-capable) and routing falls back to the tier's
+    bare phase pool from olympus_models.yaml.
+    """
+    (tmp_path / "model_modes.yaml").write_text(
+        'phase_models:\n  macro: "openrouter/mistralai/mistral-small-3.1-24b-instruct:online"\n'
     )
+    (tmp_path / "olympus_models.yaml").write_text(
+        Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
+    )
+    monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
+    model = get_model_for_phase("macro")
+    assert model in _cheap_research_pool()
+    assert ":online" not in model
+    assert is_tool_use_capable_model(model)
 
 
 @pytest.mark.unit
@@ -313,12 +344,17 @@ def test_web_search_capable_models(model: str) -> None:
 @pytest.mark.parametrize(
     ("model", "capable"),
     [
-        ("openrouter/deepseek/deepseek-chat:online", True),
-        ("openrouter/meta-llama/llama-4-maverick:online", True),
-        ("openrouter/deepseek/deepseek-r1:online", True),
+        # Bare slugs are tool-capable; ``:online`` is web-search-only and rejected.
+        ("openrouter/deepseek/deepseek-chat", True),
+        ("openrouter/meta-llama/llama-4-maverick", True),
+        ("openrouter/deepseek/deepseek-r1", True),
+        ("openrouter/mistralai/mistral-small-3.1-24b-instruct", True),
+        ("openrouter/openai/gpt-4o-mini", True),
+        ("openrouter/deepseek/deepseek-chat:online", False),
+        ("openrouter/meta-llama/llama-4-maverick:online", False),
+        ("openrouter/deepseek/deepseek-r1:online", False),
+        ("openrouter/openai/gpt-4o-mini:online", False),
         ("openrouter/perplexity/sonar", False),
-        ("openrouter/deepseek/deepseek-chat", False),
-        ("openrouter/openai/gpt-4o-mini:online", True),
     ],
 )
 def test_tool_use_capable_models(model: str, capable: bool) -> None:
@@ -362,9 +398,9 @@ def test_perplexity_only_in_web_search_pools_not_phase_pools() -> None:
                 assert not is_native_search_only_model(model), (
                     f"tier {tier_name} {capability} must not pool native-search-only {model}"
                 )
-        assert any(
-            is_native_search_only_model(m) for m in tier_cfg.web_search_models
-        ), f"tier {tier_name} should offer perplexity in web_search_models"
+        assert any(is_native_search_only_model(m) for m in tier_cfg.web_search_models), (
+            f"tier {tier_name} should offer perplexity in web_search_models"
+        )
 
 
 @pytest.mark.unit
@@ -426,8 +462,10 @@ def test_edit_mode_segments_route_to_cheap_open_weight_models(
     assert model is not None
     assert model.startswith("openrouter/")
     assert not is_flagship_openrouter_model(model)
-    assert is_web_search_capable_model(model)
+    # Phase models are bare (tool-capable); grounding is a separate web-search pre-pass.
+    assert ":online" not in model
     assert is_tool_use_capable_model(model)
+    assert not is_web_search_capable_model(model)
 
 
 @pytest.mark.unit
@@ -441,3 +479,29 @@ def test_cheap_tier_has_no_flagship_pins() -> None:
             )
     for model in cheap.web_search_models:
         assert not is_flagship_openrouter_model(model)
+
+
+@pytest.mark.unit
+def test_no_online_slug_in_any_phase_pool() -> None:
+    """Core regression guard for the production tool-use 404.
+
+    For every tier and every capability pool in ``allowed_models``, no model may carry
+    the ``:online`` suffix AND ``tier_allows_phase_model`` must hold. ``:online`` endpoints
+    reject function tools for open-weight models, so routing a tool phase to one 404s
+    ("No endpoints found that support tool use"). Grounding is a separate web-search
+    pre-pass over ``web_search_models``; phase pools stay bare.
+    """
+    cfg = model_config._load_olympus_models()
+    for tier_name, tier_cfg in cfg.tiers.items():
+        for capability, pool in tier_cfg.allowed_models.items():
+            for model in pool:
+                assert ":online" not in model, (
+                    f"tier {tier_name} {capability} pools web-search-only slug {model!r}; "
+                    "phase pools must be bare (:online 404s on function tools)"
+                )
+                assert tier_allows_phase_model(model, tier_name), (
+                    f"tier {tier_name} {capability} model {model!r} not allowed for phase calls"
+                )
+                assert is_tool_use_capable_model(model), (
+                    f"tier {tier_name} {capability} model {model!r} lacks tool use"
+                )


### PR DESCRIPTION
## Problem

The live baseline run 404'd across research nodes (`alt-options-derivatives`, `CryptoReport`, `CtaPositioningReport`, …) with `No endpoints found that support tool use. Try disabling "query_data"`. Root cause: the function-tool phases (extraction/research/reasoning, which call `run_tools` with the `query_data` tool) were routed to open-weight **`:online`** models. OpenRouter's `:online` endpoints for open-weight models don't support function tools. PR #975 wrongly treated `":online" in slug` as proof of tool capability — so the dry-run passed but the real run failed.

## Fix

Web grounding is already a **separate pre-pass** (`get_grounding_model` over `web_search_models`, injected as a `web_grounding` prompt block), so phase models never need `:online`.

- `model_config.is_tool_use_capable_model`: `:online` (and perplexity) are **not** tool-capable; bare OpenRouter slugs are. Invariant: **phase pools = bare slugs**.
- `config/olympus_models.yaml`: drop `:online` from `allowed_models` phase pools in all three tiers; `web_search_models` keep `:online`/perplexity for grounding.
- `validate-providers.py`: new **function-tool smoke test** — sends the real `query_data` tools to each active-tier phase model so preflight fails fast on the 404 (the structured-output/web-search pings never exercised function tools, which is why this regressed silently).
- Tests: assert bare=tool-capable / `:online`=web-search-only, `:online` override rejection, and a regression guard that no phase pool contains a `:online` slug.

## Validation

`pytest tests/dg/test_olympus_models.py tests/dg/test_llm_openrouter_web_search.py` → **53 passed**. ruff clean.

Follow-up to the routing work in #975. (No separate tracking issue per request; `Require Fixes` linkage is non-blocking on develop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)