### PR TITLE
fix(ci): stop gh-aw Copilot workflows auto-filing a failure issue per run

### DIFF
--- a/.github/workflows/copilot-issue-dispatch.lock.yml
+++ b/.github/workflows/copilot-issue-dispatch.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"68d7c3a5d05c335be3f333874b5524d6694ea30a727fd5a41b89bcfc781fed84","body_hash":"98d04cc75ab83640c80bc27ae5a180378b3646ee95fb3afa7c424824e79babb3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9d47fb7d436bc4045991fc13a193400788177f005f7a9b4a757efeadd0eb52b5","body_hash":"98d04cc75ab83640c80bc27ae5a180378b3646ee95fb3afa7c424824e79babb3","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -201,20 +201,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_63d5f1b76dd68539_EOF'
+          cat << 'GH_AW_PROMPT_5202535ee3549f62_EOF'
           <system>
-          GH_AW_PROMPT_63d5f1b76dd68539_EOF
+          GH_AW_PROMPT_5202535ee3549f62_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_63d5f1b76dd68539_EOF'
+          cat << 'GH_AW_PROMPT_5202535ee3549f62_EOF'
           <safe-output-tools>
           Tools: add_comment, assign_to_agent, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_63d5f1b76dd68539_EOF
+          GH_AW_PROMPT_5202535ee3549f62_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_63d5f1b76dd68539_EOF'
+          cat << 'GH_AW_PROMPT_5202535ee3549f62_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -243,12 +243,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_63d5f1b76dd68539_EOF
+          GH_AW_PROMPT_5202535ee3549f62_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_63d5f1b76dd68539_EOF'
+          cat << 'GH_AW_PROMPT_5202535ee3549f62_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-issue-dispatch.md}}
-          GH_AW_PROMPT_63d5f1b76dd68539_EOF
+          GH_AW_PROMPT_5202535ee3549f62_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -457,9 +457,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_dcbaa40c2d679e6d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1809f72f18c8cc7e_EOF'
           {"add_comment":{"footer":false,"max":1},"assign_to_agent":{"base-branch":"develop","max":1,"name":"copilot","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_dcbaa40c2d679e6d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_1809f72f18c8cc7e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -679,7 +679,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_474c20a4bb143d4f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2417aaf835e91149_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -720,7 +720,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_474c20a4bb143d4f_EOF
+          GH_AW_MCP_CONFIG_2417aaf835e91149_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1103,7 +1103,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "20"

--- a/.github/workflows/copilot-issue-dispatch.md
+++ b/.github/workflows/copilot-issue-dispatch.md
@@ -5,6 +5,10 @@ on:
 permissions:
   contents: read
 safe-outputs:
+  # Transient Copilot/gh-aw failures self-heal; don't auto-file an
+  # un-deduplicated issue per failed run (see #982). Real failures still
+  # show as red runs in the Actions tab.
+  report-failure-as-issue: false
   assign-to-agent:
     name: copilot
     base-branch: develop

--- a/.github/workflows/copilot-pr-lifecycle.lock.yml
+++ b/.github/workflows/copilot-pr-lifecycle.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"69fc55097db4680a0e28654b9dc35117bc8e241525b8dd2191f3710975f5e6a2","body_hash":"22a769e3e05cd544679032751c6ae77e2f8f6bd6b10dcca2d943cefe26dcae45","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"727284ba64e0a5f4a6c5650f1507f5c333c184e154261238190a3fea1604bcd0","body_hash":"22a769e3e05cd544679032751c6ae77e2f8f6bd6b10dcca2d943cefe26dcae45","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -191,20 +191,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_cd6f060a2a07baf9_EOF'
+          cat << 'GH_AW_PROMPT_452a3faa119c079c_EOF'
           <system>
-          GH_AW_PROMPT_cd6f060a2a07baf9_EOF
+          GH_AW_PROMPT_452a3faa119c079c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cd6f060a2a07baf9_EOF'
+          cat << 'GH_AW_PROMPT_452a3faa119c079c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), update_pull_request(max:10), add_labels(max:10), add_reviewer(max:10), assign_to_agent(max:3), dispatch_workflow(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_cd6f060a2a07baf9_EOF
+          GH_AW_PROMPT_452a3faa119c079c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_cd6f060a2a07baf9_EOF'
+          cat << 'GH_AW_PROMPT_452a3faa119c079c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -233,12 +233,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_cd6f060a2a07baf9_EOF
+          GH_AW_PROMPT_452a3faa119c079c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cd6f060a2a07baf9_EOF'
+          cat << 'GH_AW_PROMPT_452a3faa119c079c_EOF'
           </system>
           {{#runtime-import .github/workflows/copilot-pr-lifecycle.md}}
-          GH_AW_PROMPT_cd6f060a2a07baf9_EOF
+          GH_AW_PROMPT_452a3faa119c079c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -449,9 +449,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f2ef38367cfdf9b8_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a60cb58ea9a089e0_EOF'
           {"add_comment":{"footer":false,"max":10,"target":"*"},"add_labels":{"allowed":["automerge-agent","needs-human-review"],"max":10,"target":"*"},"add_reviewer":{"max":10},"assign_to_agent":{"base-branch":"develop","max":3,"name":"copilot","target":"*"},"create_report_incomplete_issue":{},"dispatch_workflow":{"max":10,"workflow_files":{"copilot-pr-mark-ready":".yml","copilot-pr-targeted-ci":".yml"},"workflows":["copilot-pr-targeted-ci","copilot-pr-mark-ready"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_pull_request":{"allow_body":true,"allow_title":true,"max":10,"target":"*","update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f2ef38367cfdf9b8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a60cb58ea9a089e0_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -802,7 +802,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7bf58d42119cccbb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2ab457e6cf8e3239_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -843,7 +843,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7bf58d42119cccbb_EOF
+          GH_AW_MCP_CONFIG_2ab457e6cf8e3239_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1227,7 +1227,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "20"

--- a/.github/workflows/copilot-pr-lifecycle.md
+++ b/.github/workflows/copilot-pr-lifecycle.md
@@ -12,6 +12,10 @@ permissions:
   contents: read
   checks: read
 safe-outputs:
+  # Transient Copilot/gh-aw failures self-heal; don't auto-file an
+  # un-deduplicated issue per failed run (see #982). Real failures still
+  # show as red runs in the Actions tab.
+  report-failure-as-issue: false
   update-pull-request:
     max: 10
     target: "*"


### PR DESCRIPTION
Fixes #982. Part of the workflow-audit epic #321.

## Problem
`copilot-issue-dispatch` and `copilot-pr-lifecycle` (gh-aw workflows) fail **transiently** — Copilot CLI/API availability — and self-heal. But gh-aw's default `report-failure-as-issue` files a fresh, **un-deduplicated** GitHub issue on every failed run. 8 stale `[aw] … failed` issues piled up (#738, #939, #940, #954, #970, #971, #620, #622), and each orphan then tripped the daily `enforce-project-assignment` job.

Evidence the failures are transient, not a real bug:
- `copilot-pr-lifecycle`: red for ~6 runs on 2026-06-21, green on every run since.
- `copilot-issue-dispatch`: green on all recent runs.

## Change
Set `report-failure-as-issue: false` in the `safe-outputs:` frontmatter of both `.md` sources and recompiled the `.lock.yml` with `gh aw compile`.

- Local `gh aw` is **v0.77.5** — the exact version that compiled the committed locks — so the regenerated diff is minimal: the `GH_AW_FAILURE_REPORT_AS_ISSUE` `true`→`false` flip plus regenerated content-hash delimiters (14 lines per lock).
- Real failures still surface as **red runs in the Actions tab**; we only stop the per-failure issue spam.

## Verification
- `gh aw compile` — 0 errors, 0 warnings.
- `actionlint` clean on both regenerated locks (exit 0).
- Both locks confirmed emitting `GH_AW_FAILURE_REPORT_AS_ISSUE: "false"`.

The 8 stale `[aw]` issues are being closed separately (workflows are green; transient failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)