### PR TITLE
fix(olympus): drop mistral-small from cheap phase pools (no tool support)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -46,14 +46,14 @@ tiers:
     # Phase pools = bare slugs (function tools). ``:online`` is web-search-only and lives
     # in ``web_search_models``; grounding is a separate pre-pass injected into the prompt.
     allowed_models:
+      # NOTE: mistralai/mistral-small-3.1-24b-instruct removed — OpenRouter has no endpoint
+      # supporting function tools for it (validate-providers function-tool smoke test 404'd).
       extraction:
         - "openrouter/deepseek/deepseek-chat"
         - "openrouter/meta-llama/llama-4-maverick"
-        - "openrouter/mistralai/mistral-small-3.1-24b-instruct"
       research:
         - "openrouter/deepseek/deepseek-chat"
         - "openrouter/meta-llama/llama-4-maverick"
-        - "openrouter/mistralai/mistral-small-3.1-24b-instruct"
       reasoning:
         - "openrouter/deepseek/deepseek-chat"
         - "openrouter/deepseek/deepseek-r1"

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -32,7 +32,6 @@ _CHEAP_PHASE_MODELS = frozenset(
         "openrouter/deepseek/deepseek-chat",
         "openrouter/deepseek/deepseek-r1",
         "openrouter/meta-llama/llama-4-maverick",
-        "openrouter/mistralai/mistral-small-3.1-24b-instruct",
     }
 )
 
@@ -275,9 +274,10 @@ def test_phase_models_mid_tier_override_wins_on_balanced(
 def test_phase_models_open_weight_override_wins(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    # A bare open-weight slug is tool-capable, so the override is honored.
+    # A bare open-weight slug (not in the macro/research pool) is tool-capable, so the
+    # override is honored and wins over the tier pool.
     (tmp_path / "model_modes.yaml").write_text(
-        'phase_models:\n  macro: "openrouter/mistralai/mistral-small-3.1-24b-instruct"\n'
+        'phase_models:\n  macro: "openrouter/deepseek/deepseek-r1"\n'
     )
     (tmp_path / "olympus_models.yaml").write_text(
         Path(_REPO_CONFIG, "olympus_models.yaml").read_text()
@@ -285,7 +285,7 @@ def test_phase_models_open_weight_override_wins(
     monkeypatch.setenv("DIGI_CONFIG_PATH", str(tmp_path))
     monkeypatch.setattr(model_config, "_model_modes_cache", None)
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
-    assert get_model_for_phase("macro") == "openrouter/mistralai/mistral-small-3.1-24b-instruct"
+    assert get_model_for_phase("macro") == "openrouter/deepseek/deepseek-r1"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The function-tool smoke test added in #980 (in `validate-providers`) caught `openrouter/mistralai/mistral-small-3.1-24b-instruct` 404ing on the `query_data` function tool — OpenRouter has no endpoint supporting function tools for it. The other cheap-tier phase models (deepseek-chat, deepseek-r1, llama-4-maverick) all passed.

Remove mistral-small from the cheap extraction + research pools (its only pools). Tests updated; 53 routing tests pass. Confirmed against the live dry-run smoke test (run 27980841181).

Follow-up to #980. (No tracking issue per request; `Require Fixes` linkage non-blocking on develop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)