### PR TITLE
feat(twelve-x): trader-workflow UI, mobile responsiveness, and consensus-timeframe fix

### DIFF
--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -17,13 +17,16 @@ export function subpageTabButtonClass(active: boolean): string {
 export function SubpageStickyTabBar({
   children,
   'aria-label': ariaLabel = 'Section navigation',
+  topOffset = 'app',
 }: {
   children: ReactNode;
   'aria-label'?: string;
+  topOffset?: 'app' | 'none';
 }) {
+  const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
   return (
     <div
-      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md max-md:top-[72px] md:top-0 ${SUBPAGE_MAX} py-3`}
+      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass} ${SUBPAGE_MAX} py-3`}
       role="navigation"
       aria-label={ariaLabel}
     >

--- a/frontend/olympus/components/twelve-x/BriefPanel.tsx
+++ b/frontend/olympus/components/twelve-x/BriefPanel.tsx
@@ -82,6 +82,17 @@ export default function BriefPanel({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, handleClose]);
 
+  // Lock body scroll while the panel is open (mirrors the app nav drawer), so
+  // the page behind the full-bleed mobile sheet doesn't scroll under it.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   const analysts = useMemo(() => asStringList(brief?.analyst_names), [brief?.analyst_names]);
 
   if (!open || !sourceFile) return null;
@@ -98,6 +109,10 @@ export default function BriefPanel({
 
       {/* Panel */}
       <div className="absolute inset-y-0 right-0 flex w-full max-w-xl flex-col border-l border-border-subtle bg-bg-secondary shadow-2xl">
+        {/* Grab bar — phone-only affordance hinting the sheet is dismissable. */}
+        <div className="flex shrink-0 justify-center pt-2 sm:hidden" aria-hidden>
+          <span className="h-1 w-9 rounded-full bg-white/20" />
+        </div>
         <div className="flex items-start gap-3 border-b border-border-subtle px-5 py-4">
           <FileText size={18} className="mt-0.5 shrink-0 text-fin-blue" aria-hidden />
           <div className="min-w-0 flex-1">
@@ -110,13 +125,13 @@ export default function BriefPanel({
             type="button"
             onClick={handleClose}
             aria-label="Close"
-            className="shrink-0 rounded-lg p-1.5 text-text-muted transition-colors hover:bg-white/[0.06] hover:text-text-primary"
+            className="-mr-1.5 -mt-1.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-white/[0.06] hover:text-text-primary sm:h-9 sm:w-9"
           >
             <X size={18} aria-hidden />
           </button>
         </div>
 
-        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
           {loading ? (
             <p className="text-sm text-text-muted">Loading brief…</p>
           ) : error ? (

--- a/frontend/olympus/components/twelve-x/ConsensusTab.tsx
+++ b/frontend/olympus/components/twelve-x/ConsensusTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Area,
   AreaChart,
@@ -16,7 +16,8 @@ import {
   YAxis,
 } from 'recharts';
 import { G10_CURRENCIES } from '@/lib/twelve-x/types';
-import type { FxConsensusSnapshotRow } from '@/lib/twelve-x/types';
+import type { ConsensusDeltaSet, FxConsensusSnapshotRow } from '@/lib/twelve-x/types';
+import DeltaChip from './DeltaChip';
 
 /** Score thresholds (shared with twelve-x): |score| ≥ 1.25 = strong, ≥ 0.35 = lean. */
 const STRONG_BAND = 1.25;
@@ -67,12 +68,18 @@ export default function ConsensusTab({
   latest,
   latestDate,
   onDrillToLedger,
+  deltas,
+  focusCcy,
 }: {
   series: FxConsensusSnapshotRow[];
   latest: FxConsensusSnapshotRow[];
   latestDate: string | null;
   /** "Why this weight?" cross-link: open the ledger filtered to a currency. */
   onDrillToLedger?: (currency: string) => void;
+  /** Run-over-run deltas + top movers (timeframe-pinned upstream). */
+  deltas: ConsensusDeltaSet;
+  /** Cross-link focus: when set, pre-select/highlight this currency. */
+  focusCcy?: string | null;
 }) {
   // Currencies actually present, in canonical G10 order (fall back to any extras).
   const currencies = useMemo<string[]>(() => {
@@ -84,6 +91,19 @@ export default function ConsensusTab({
   }, [series]);
 
   const [selectedCcy, setSelectedCcy] = useState<string | null>(null);
+
+  // Honor a cross-link focus: pre-select/highlight the focused currency. We track
+  // the last-applied focus so the user can still override the selection afterward
+  // without it snapping back on every re-render.
+  const lastFocusRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (focusCcy && focusCcy !== lastFocusRef.current) {
+      setSelectedCcy(focusCcy);
+    }
+    lastFocusRef.current = focusCcy ?? null;
+  }, [focusCcy]);
+
+  const topMover = deltas.movers[0] ?? null;
 
   // Pivot the score time series → one row per run_date, one key per currency.
   const scoreSeries = useMemo<ScoreSeriesRow[]>(() => {
@@ -177,13 +197,26 @@ export default function ConsensusTab({
 
       {/* Score-over-time multi-line chart */}
       <div className="glass-card p-4 md:p-5 space-y-3">
-        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
-          Consensus score over time
-        </h3>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Consensus score over time
+          </h3>
+          {/* Band legend: shaded = strong conviction (±1.25); dashed = directional lean (±0.35). */}
+          <span className="text-[10px] text-text-muted flex items-center gap-2 ml-auto">
+            <span className="flex items-center gap-1">
+              <span className="inline-block h-2.5 w-3 rounded-sm bg-fin-green/15" />
+              Strong ±{STRONG_BAND}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="inline-block w-3 border-t border-dashed border-fin-green/60" />
+              Lean ±{LEAN_BAND}
+            </span>
+          </span>
+        </div>
         {hasSeries ? (
           <div className="h-[min(420px,55vh)] min-h-[300px] w-full">
             <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={scoreSeries} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+              <LineChart data={scoreSeries} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
                 <CartesianGrid stroke="rgba(255,255,255,0.05)" />
                 {/* Strong-conviction bands */}
                 <ReferenceArea y1={STRONG_BAND} y2={SCORE_MAX} fill="#3fb984" fillOpacity={0.06} />
@@ -197,6 +230,7 @@ export default function ConsensusTab({
                   dataKey="run_date"
                   tick={{ fill: '#71717a', fontSize: 11 }}
                   tickFormatter={(d: string) => d?.slice(5)}
+                  label={{ value: 'Run date', position: 'insideBottom', offset: -4, fill: '#71717a', fontSize: 10 }}
                 />
                 <YAxis
                   domain={[SCORE_MIN, SCORE_MAX]}
@@ -308,6 +342,34 @@ export default function ConsensusTab({
         )}
       </div>
 
+      {/* Biggest shift since the prior run — one-line banner. */}
+      {topMover ? (
+        <button
+          type="button"
+          onClick={() => (onDrillToLedger ? onDrillToLedger(topMover.currency) : setSelectedCcy(topMover.currency))}
+          className="w-full glass-card px-4 py-2.5 flex items-center gap-2 text-left hover:bg-white/[0.03] transition-colors"
+          title={
+            onDrillToLedger
+              ? `Why this weight? Open the relevance ledger filtered to ${topMover.currency}`
+              : `Focus ${topMover.currency}`
+          }
+        >
+          <span className="text-[10px] font-medium uppercase tracking-wide text-text-muted shrink-0">
+            Biggest shift
+          </span>
+          <span className="font-mono font-semibold shrink-0" style={{ color: currencyColor(topMover.currency) }}>
+            {topMover.currency}
+          </span>
+          <span className="tabular-nums text-xs font-mono text-text-secondary shrink-0">
+            {topMover.scoreNow.toFixed(2)}
+          </span>
+          <DeltaChip delta={topMover.scoreDelta} />
+          <span className="text-[11px] text-text-muted ml-auto shrink-0">
+            {topMover.direction === 'up' ? 'turned more bullish' : 'turned more bearish'} since last run
+          </span>
+        </button>
+      ) : null}
+
       {/* Latest-snapshot table */}
       <div className="glass-card p-0 overflow-hidden">
         <div className="px-5 py-3 bg-bg-secondary border-b border-border-subtle flex items-center gap-3">
@@ -317,7 +379,7 @@ export default function ConsensusTab({
           ) : null}
         </div>
         {latestSorted.length > 0 ? (
-          <ConsensusTable rows={latestSorted} onDrillToLedger={onDrillToLedger} />
+          <ConsensusTable rows={latestSorted} onDrillToLedger={onDrillToLedger} byCurrency={deltas.byCurrency} />
         ) : (
           <div className="p-8 text-center text-text-muted text-sm">No latest consensus snapshot available.</div>
         )}
@@ -329,14 +391,16 @@ export default function ConsensusTab({
 function ConsensusTable({
   rows,
   onDrillToLedger,
+  byCurrency,
 }: {
   rows: FxConsensusSnapshotRow[];
   onDrillToLedger?: (currency: string) => void;
+  byCurrency: ConsensusDeltaSet['byCurrency'];
 }) {
   const cols = onDrillToLedger
-    ? '64px 1fr 96px 88px 88px 64px 64px 96px'
-    : '64px 1fr 96px 88px 88px 64px 64px';
-  const minW = onDrillToLedger ? 'min-w-[776px]' : 'min-w-[680px]';
+    ? '64px 1fr 80px 96px 88px 88px 64px 64px 96px'
+    : '64px 1fr 80px 96px 88px 88px 64px 64px';
+  const minW = onDrillToLedger ? 'min-w-[856px]' : 'min-w-[760px]';
   return (
     <div className="overflow-x-auto">
       {/* Header */}
@@ -346,6 +410,7 @@ function ConsensusTable({
       >
         <span>Ccy</span>
         <span>Score</span>
+        <span className="text-right">Δ vs prior</span>
         <span className="text-right">Signal</span>
         <span className="text-right">Confidence</span>
         <span className="text-right">Agreement</span>
@@ -363,9 +428,10 @@ function ConsensusTable({
           // Normalize score [-2,2] → bar width fraction of the half-track.
           const frac = Math.min(1, Math.abs(safeScore) / SCORE_MAX);
           const bullish = safeScore >= 0;
+          const cDelta = byCurrency[r.currency];
           return (
             <div
-              key={`${r.run_date}-${r.currency}`}
+              key={`${r.run_date}-${r.currency}-${r.timeframe}-${r.weighted}`}
               className={`grid items-center gap-2 px-5 py-3 text-sm ${minW} hover:bg-white/[0.02] transition-colors`}
               style={{ gridTemplateColumns: cols }}
             >
@@ -387,6 +453,13 @@ function ConsensusTable({
                   {Number.isFinite(r.score) ? r.score.toFixed(2) : '—'}
                 </span>
               </div>
+              {/* Δ vs prior run (timeframe-pinned upstream). "NEW" when there's no prior. */}
+              <span className="text-right">
+                <DeltaChip
+                  delta={cDelta?.scoreDelta ?? null}
+                  isNew={cDelta != null && cDelta.scoreDelta == null && cDelta.prevRunDate == null}
+                />
+              </span>
               <span className={`text-right text-xs font-medium ${colorClass}`}>{scoreLabel(safeScore)}</span>
               <span className="text-right tabular-nums text-text-secondary">
                 {Number.isFinite(r.confidence) ? `${(r.confidence * 100).toFixed(0)}%` : '—'}

--- a/frontend/olympus/components/twelve-x/DeltaChip.tsx
+++ b/frontend/olympus/components/twelve-x/DeltaChip.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+/** A compact run-over-run delta glyph (or a "NEW" badge when there's no prior). */
+export interface DeltaChipProps {
+  delta: number | null;
+  decimals?: number;
+  isNew?: boolean;
+  className?: string;
+}
+
+export default function DeltaChip({ delta, decimals = 2, isNew, className }: DeltaChipProps) {
+  if (delta == null && !isNew) return null;
+
+  if (isNew) {
+    return (
+      <span
+        className={`text-[10px] rounded bg-fin-blue/15 text-fin-blue px-1${
+          className ? ` ${className}` : ''
+        }`}
+      >
+        NEW
+      </span>
+    );
+  }
+
+  const value = delta ?? 0;
+  const isUp = value > 0.005;
+  const isDown = value < -0.005;
+  const glyph = isUp ? '▲' : isDown ? '▼' : '■';
+  const tone = isUp ? 'text-fin-green' : isDown ? 'text-fin-red' : 'text-text-muted';
+  const sign = isUp ? '+' : '';
+  const label = `${glyph}${sign}${value.toFixed(decimals)}`;
+
+  return (
+    <span
+      className={`tabular-nums text-[10px] font-mono ${tone}${className ? ` ${className}` : ''}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/olympus/components/twelve-x/EventsTab.tsx
+++ b/frontend/olympus/components/twelve-x/EventsTab.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { CalendarClock, ChevronRight, FileText, Globe, Users } from 'lucide-react';
+import { eventLocalDateKey, hasResolvedTime } from '@/lib/twelve-x/fetch';
 import type {
   FxEconomicCalendarRow,
   FxEventCitation,
@@ -155,19 +156,38 @@ function EventRow({
   opinions,
   runDate,
   onOpenBrief,
+  highlight = false,
 }: {
   event: FxEconomicCalendarRow;
   opinions: MatchedOpinions | null;
   runDate: string | null;
   onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+  highlight?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
   const { text: impactText, dot: impactDot } = impactClass(event.impact);
+  // `resolvedTime` is true only when we have a real UTC instant to localize; a
+  // falsy fallback to `event_time` is a raw venue/wall-clock string we mark with ≈.
+  const resolvedTime = hasResolvedTime(event);
   const time = formatLocalTime(event.event_datetime_utc) ?? event.event_time ?? null;
   const hasOpinions = Boolean(opinions && opinions.mentions > 0);
 
+  // When this row is the cross-link target (catalyst → Events), scroll it into
+  // view so the trader lands on the right catalyst.
+  useEffect(() => {
+    if (highlight && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlight]);
+
   return (
-    <div className="overflow-hidden">
+    <div
+      ref={rowRef}
+      className={`overflow-hidden transition-colors ${
+        highlight ? 'bg-fin-blue/10 ring-1 ring-inset ring-fin-blue/40' : ''
+      }`}
+    >
       <button
         type="button"
         // A row with no broker opinions has nothing to expand: disable it so it is
@@ -183,6 +203,14 @@ function EventRow({
         {/* Time column */}
         <div className="w-14 shrink-0 text-right">
           <span className="qn-metric block tabular-nums text-sm text-text-primary">
+            {!resolvedTime && time ? (
+              <span
+                className="mr-0.5 text-text-muted/70"
+                title="Venue-local time — could not convert to your timezone"
+              >
+                ≈
+              </span>
+            ) : null}
             {time ?? '—'}
           </span>
         </div>
@@ -206,12 +234,12 @@ function EventRow({
 
         {/* Forecast / actual */}
         <div className="hidden w-40 shrink-0 items-center justify-end gap-3 text-right sm:flex">
-          {event.forecast ? (
+          {event.forecast != null && event.forecast !== '' ? (
             <span className="text-[11px] text-text-muted">
               Fcst <span className="tabular-nums text-text-secondary">{event.forecast}</span>
             </span>
           ) : null}
-          {event.actual ? (
+          {event.actual != null && event.actual !== '' ? (
             <span className="text-[11px] text-text-muted">
               Act <span className="tabular-nums text-text-primary">{event.actual}</span>
             </span>
@@ -248,11 +276,14 @@ export default function EventsTab({
   opinions,
   runDate,
   onOpenBrief,
+  focus,
 }: {
   events: FxEconomicCalendarRow[];
   opinions: FxEventSnapshotRow[];
   runDate: string | null;
   onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+  /** Cross-link target from another tab (catalyst → Events): scroll/highlight it. */
+  focus?: { externalId?: string | null; name: string | null } | null;
 }) {
   // Index broker opinions so each upcoming calendar row can pick up the aggregated
   // desk views. Two lookups, mirroring how twelve-x groups risk events:
@@ -319,16 +350,37 @@ export default function EventsTab({
     return null;
   };
 
-  // Group the upcoming window by day for a timeline layout.
+  // Group the upcoming window by day. Bucket by the LOCAL date of each event's
+  // release instant (when known) so the day header agrees with the locale-
+  // converted times shown in each row; fall back to the wall-clock feed date
+  // only when there is no resolved instant.
   const grouped = useMemo(() => {
     const byDate = new Map<string, FxEconomicCalendarRow[]>();
     for (const e of events) {
-      const list = byDate.get(e.event_date) ?? [];
+      const key = eventLocalDateKey(e);
+      const list = byDate.get(key) ?? [];
       list.push(e);
-      byDate.set(e.event_date, list);
+      byDate.set(key, list);
     }
     return [...byDate.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   }, [events]);
+
+  // Resolve the cross-link focus target to a concrete event id (by external_id,
+  // then by normalized name) so the matching row can scroll/highlight itself.
+  const focusedId = useMemo(() => {
+    if (!focus) return null;
+    const wantId = (focus.externalId ?? '').trim();
+    if (wantId) {
+      const byId = events.find((e) => (e.external_id ?? '').trim() === wantId);
+      if (byId) return byId.id;
+    }
+    const wantName = normalizeName(focus.name ?? '');
+    if (wantName) {
+      const byName = events.find((e) => normalizeName(e.event_name) === wantName);
+      if (byName) return byName.id;
+    }
+    return null;
+  }, [focus, events]);
 
   return (
     <div className="space-y-4">
@@ -343,9 +395,10 @@ export default function EventsTab({
       </div>
 
       <p className="max-w-2xl px-1 text-xs text-text-muted">
-        The next 14 days of macro events (times in your local timezone). Rows with aggregated broker
-        expectations are expandable — open to see which desks weighed in, what they expect, and the
-        FX impact they flag.
+        The next 14 days of macro events — times in your local timezone where a precise release
+        instant is known; <span className="text-text-muted/70">≈</span> marks venue-local times we
+        could not convert. Rows with aggregated broker expectations are expandable — open to see
+        which desks weighed in, what they expect, and the FX impact they flag.
       </p>
 
       {grouped.length > 0 ? (
@@ -366,6 +419,7 @@ export default function EventsTab({
                     opinions={matchOpinions(event)}
                     runDate={runDate}
                     onOpenBrief={onOpenBrief}
+                    highlight={event.id === focusedId}
                   />
                 ))}
               </div>

--- a/frontend/olympus/components/twelve-x/IntelligenceTab.tsx
+++ b/frontend/olympus/components/twelve-x/IntelligenceTab.tsx
@@ -2,7 +2,9 @@
 
 import { useMemo } from 'react';
 import { Layers, Users, CalendarClock } from 'lucide-react';
-import type { FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import type { FxConfluenceSnapshotRow, FxEventSnapshotRow } from '@/lib/twelve-x/types';
+import { resolveCatalyst } from '@/lib/twelve-x/fetch';
+import { useTwelveX } from './context';
 
 /** Map a confluence direction/lean string to a .fin-* text color class. */
 function directionColorClass(direction: string): string {
@@ -21,8 +23,8 @@ function directionLabel(direction: string): string {
 
 /**
  * The three [0,1] score-contributing components from `build_confluence`, in
- * stacked-bar order. `recency`, `n_brokers`, `days_to_catalyst` are metadata,
- * surfaced as labels rather than bar segments.
+ * legend order. `recency`, `n_brokers`, `days_to_catalyst` are metadata,
+ * surfaced as labels rather than score legs.
  */
 const COMPONENT_SEGMENTS = [
   { key: 'consensus_strength', label: 'Consensus', color: '#3B82F6' },
@@ -50,28 +52,38 @@ function asStringList(raw: unknown): string[] {
   return [];
 }
 
-/** Small horizontal stacked bar of the [0,1] score components (CSS, no recharts). */
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, Number.isFinite(v) ? v : 0));
+}
+
+/**
+ * The three [0,1] score legs, each shown as its OWN magnitude fill against full
+ * weight (1.0) — NOT normalized to their sum. So a leg of 0.8 reads as a track
+ * that is 80% full regardless of the other legs, making each contribution's
+ * absolute strength legible (matching LedgerTab's WeightBar). Legs at ≈0 still
+ * render their (empty) track so a weak leg reads as weak, not missing.
+ */
 function ComponentBar({ components }: { components: Record<string, number> }) {
   const segments = COMPONENT_SEGMENTS.map((s) => ({
     ...s,
-    value: Math.max(0, components[s.key] ?? 0),
+    value: clamp01(components[s.key] ?? 0),
   }));
-  const total = segments.reduce((sum, s) => sum + s.value, 0);
-  if (total <= 0) return null;
 
   return (
     <div className="space-y-1.5">
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-white/[0.05]">
-        {segments.map((s) =>
-          s.value > 0 ? (
+      <div className="flex h-2 w-full gap-1">
+        {segments.map((s) => (
+          <div
+            key={s.key}
+            className="relative h-full flex-1 overflow-hidden rounded-full bg-white/[0.06]"
+            title={`${s.label}: ${s.value.toFixed(2)}`}
+          >
             <div
-              key={s.key}
-              className="h-full first:rounded-l-full last:rounded-r-full"
-              style={{ width: `${(s.value / total) * 100}%`, backgroundColor: s.color }}
-              title={`${s.label}: ${s.value.toFixed(2)}`}
+              className="absolute inset-y-0 left-0 rounded-full"
+              style={{ width: `${s.value * 100}%`, backgroundColor: s.color }}
             />
-          ) : null
-        )}
+          </div>
+        ))}
       </div>
       <div className="flex flex-wrap gap-x-3 gap-y-0.5">
         {segments.map((s) => (
@@ -86,14 +98,25 @@ function ComponentBar({ components }: { components: Record<string, number> }) {
   );
 }
 
-function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
+function IntelligenceCard({
+  idea,
+  events,
+}: {
+  idea: FxConfluenceSnapshotRow;
+  events: FxEventSnapshotRow[];
+}) {
+  const { crossLink } = useTwelveX();
   const colorClass = directionColorClass(idea.direction);
   const components = useMemo(() => asComponents(idea.components), [idea.components]);
   // brief_keys holds the SUPPORTING DESK names behind this idea (broker names,
   // not source_file document keys), so we list them rather than link to a brief.
   const supportingDesks = useMemo(() => asStringList(idea.brief_keys), [idea.brief_keys]);
   const nBrokers = asNumber(components.n_brokers);
-  const daysToCatalyst = asNumber(components.days_to_catalyst);
+  const catalyst = useMemo(() => resolveCatalyst(idea, events), [idea, events]);
+  const daysToCatalyst = catalyst.daysToCatalyst;
+  // A heuristic (non-explicit) catalyst match leaves eventKey null — hedge the
+  // wording so we don't overstate the link.
+  const hedged = catalyst.eventName != null && catalyst.eventKey == null;
 
   return (
     <div className="glass-card flex flex-col gap-3 p-4">
@@ -102,9 +125,14 @@ function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
           <span className="shrink-0 rounded border border-border-subtle bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-text-muted">
             #{idea.rank}
           </span>
-          <span className="truncate font-mono text-sm font-semibold text-text-primary">
+          <button
+            type="button"
+            onClick={() => crossLink({ kind: 'currency', currency: idea.currency })}
+            className="truncate font-mono text-sm font-semibold text-text-primary hover:text-fin-blue hover:underline transition-colors"
+            title={`See ${idea.currency} consensus`}
+          >
             {idea.currency}
-          </span>
+          </button>
         </div>
         <span className={`shrink-0 text-xs font-semibold ${colorClass}`}>
           {directionLabel(idea.direction)}
@@ -122,7 +150,7 @@ function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
 
       {Object.keys(components).length > 0 ? <ComponentBar components={components} /> : null}
 
-      {(nBrokers != null || daysToCatalyst != null || supportingDesks.length > 0) ? (
+      {(nBrokers != null || daysToCatalyst != null || catalyst.eventName != null || supportingDesks.length > 0) ? (
         <div className="mt-auto flex flex-col gap-1.5 border-t border-border-subtle/60 pt-2 text-[11px] text-text-muted">
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
             {nBrokers != null ? (
@@ -135,9 +163,34 @@ function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
             {daysToCatalyst != null ? (
               <span className="flex items-center gap-1.5">
                 <CalendarClock size={12} aria-hidden />
-                <span className="qn-metric tabular-nums text-text-secondary">{daysToCatalyst}</span>
+                <span className="qn-metric tabular-nums text-text-secondary">
+                  {hedged ? '~' : ''}
+                  {daysToCatalyst}
+                </span>
                 {daysToCatalyst === 1 ? 'day to catalyst' : 'days to catalyst'}
               </span>
+            ) : catalyst.eventName != null ? (
+              <span className="flex items-center gap-1.5">
+                <CalendarClock size={12} aria-hidden />
+                {hedged ? 'likely catalyst' : 'catalyst'}
+              </span>
+            ) : null}
+            {catalyst.eventName != null ? (
+              <button
+                type="button"
+                onClick={() =>
+                  crossLink({
+                    kind: 'event',
+                    eventName: catalyst.eventName,
+                    externalId: catalyst.calendarExternalId,
+                  })
+                }
+                className="max-w-full truncate font-medium text-fin-blue hover:underline"
+                title={`${hedged ? 'Likely catalyst: ' : 'Catalyst: '}${catalyst.eventName}`}
+              >
+                {hedged ? '~' : ''}
+                {catalyst.eventName}
+              </button>
             ) : null}
           </div>
           {supportingDesks.length > 0 ? (
@@ -154,9 +207,11 @@ function IntelligenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
 export default function IntelligenceTab({
   confluence,
   runDate,
+  events,
 }: {
   confluence: FxConfluenceSnapshotRow[];
   runDate: string | null;
+  events: FxEventSnapshotRow[];
 }) {
   return (
     <div className="space-y-4">
@@ -170,15 +225,18 @@ export default function IntelligenceTab({
         ) : null}
       </div>
 
-      <p className="max-w-2xl px-1 text-xs text-text-muted">
-        A directional cross-desk read meeting a near-term catalyst. Each idea&apos;s score blends
-        consensus strength, event alignment and broker breadth — shown as the stacked bar.
-      </p>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1">
+        <p className="max-w-2xl text-xs text-text-muted">
+          A directional cross-desk read meeting a near-term catalyst. Each idea&apos;s score blends
+          consensus strength, event alignment and broker breadth — each shown as its own [0,1] leg.
+        </p>
+        <span className="font-mono text-[10px] text-text-muted">score 0–1 · higher = stronger</span>
+      </div>
 
       {confluence.length > 0 ? (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {confluence.map((idea) => (
-            <IntelligenceCard key={`${idea.run_date}-${idea.rank}`} idea={idea} />
+            <IntelligenceCard key={`${idea.run_date}-${idea.rank}`} idea={idea} events={events} />
           ))}
         </div>
       ) : (

--- a/frontend/olympus/components/twelve-x/LedgerTab.tsx
+++ b/frontend/olympus/components/twelve-x/LedgerTab.tsx
@@ -51,6 +51,9 @@ function clamp01(v: number): number {
  * factor visible instead of leaving active rows looking empty. */
 function WeightBar({ row }: { row: FxLedgerRow }) {
   const segments = WEIGHT_SEGMENTS.map((s) => ({ ...s, value: clamp01(row[s.key]) }));
+  // All three legs ≈0 → the bar renders empty; flag it so a zero-weight row doesn't
+  // read as a missing value.
+  const collapsed = segments.every((s) => s.value < 0.01);
   return (
     <div className="space-y-1">
       <div className="flex h-1.5 w-full gap-1">
@@ -75,6 +78,9 @@ function WeightBar({ row }: { row: FxLedgerRow }) {
             <span className="tabular-nums text-text-secondary">{s.value.toFixed(2)}</span>
           </span>
         ))}
+        {collapsed ? (
+          <span className="text-[10px] italic text-text-muted">weight collapsed</span>
+        ) : null}
       </div>
     </div>
   );
@@ -87,6 +93,7 @@ export default function LedgerTab({
   onSelectRun,
   ccy,
   onOpenBrief,
+  error,
 }: {
   rows: FxLedgerRow[];
   runDate: string | null;
@@ -96,6 +103,9 @@ export default function LedgerTab({
   // currency (owned by the parent so it survives tab switches; no URL coupling).
   ccy: string | null;
   onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+  // A genuine ledger fetch failure surfaced by the client (querySupabase rethrows;
+  // the client never swallows). Takes precedence over the table / empty state.
+  error: string | null;
 }) {
   const [classFilter, setClassFilter] = useState<string>('all');
   const [ccyFilter, setCcyFilter] = useState<string>(ccy ?? 'all');
@@ -177,7 +187,7 @@ export default function LedgerTab({
       </p>
 
       {/* Filters */}
-      {rows.length > 0 ? (
+      {!error && rows.length > 0 ? (
         <div className="flex flex-col gap-2 px-1">
           {classifications.length > 0 ? (
             <div className="flex flex-wrap items-center gap-2">
@@ -208,7 +218,12 @@ export default function LedgerTab({
         </div>
       ) : null}
 
-      {filtered.length > 0 ? (
+      {error ? (
+        <div className="glass-card p-6 text-sm text-fin-red">
+          <p className="font-semibold">Couldn’t load the relevance ledger.</p>
+          <p className="mt-1 font-mono text-[11px] text-fin-red/80">{error}</p>
+        </div>
+      ) : filtered.length > 0 ? (
         <div className="glass-card overflow-hidden p-0">
           <div className="overflow-x-auto">
             {/* Header */}

--- a/frontend/olympus/components/twelve-x/MatrixTab.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.tsx
@@ -18,6 +18,32 @@ function directionStyle(direction: string): { text: string; bg: string; border: 
   return { text: 'text-text-secondary', bg: 'bg-white/[0.03]', border: 'border-border-subtle', glyph: '•' };
 }
 
+/** Flatten a cell's broker targets (unknown[]) into a short, human-readable string. */
+function formatTargets(targets: unknown[] | undefined): string | null {
+  if (!targets || targets.length === 0) return null;
+  const parts = targets
+    .map((t) => {
+      if (typeof t === 'string' || typeof t === 'number') return String(t);
+      if (t && typeof t === 'object') {
+        const o = t as Record<string, unknown>;
+        const label = typeof o.label === 'string' ? o.label : typeof o.type === 'string' ? o.type : null;
+        const level =
+          typeof o.level === 'number' || typeof o.level === 'string'
+            ? String(o.level)
+            : typeof o.value === 'number' || typeof o.value === 'string'
+              ? String(o.value)
+              : typeof o.price === 'number' || typeof o.price === 'string'
+                ? String(o.price)
+                : null;
+        if (label && level) return `${label} ${level}`;
+        return level ?? label;
+      }
+      return null;
+    })
+    .filter((p): p is string => !!p);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
 /** Conviction → opacity weight so high-conviction cells read louder. */
 function convictionOpacity(conviction: string): number {
   const c = conviction.trim().toLowerCase();
@@ -58,13 +84,16 @@ export default function MatrixTab({
       <div className="flex flex-wrap items-center gap-3 px-1">
         <Grid3x3 size={18} className="shrink-0 text-fin-blue" aria-hidden />
         <h2 className="text-base font-semibold text-text-primary md:text-lg">Desk view matrix</h2>
+        <span className="rounded bg-bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-text-muted">
+          8 of 10 G10 · NOK/SEK omitted
+        </span>
       </div>
 
       <p className="max-w-2xl px-1 text-xs text-text-muted">
-        Each desk&apos;s latest standing view per G10 currency over a recent window — consolidated the
-        same way as the Notion board: a pair files under its base currency (EUR/USD → EUR), shown as
-        stated. Cells are colored by direction and shaded by conviction; click any cell to open the
-        source brief.
+        Each desk&apos;s latest standing view per board currency (8 of G10 — NOK/SEK desk views appear
+        in Consensus &amp; Ledger, not here) over a recent window — consolidated the same way as the
+        Notion board: a pair files under its base currency (EUR/USD → EUR), shown as stated. Cells are
+        colored by direction and shaded by conviction; click any cell to open the source brief.
       </p>
 
       {hasData ? (
@@ -128,6 +157,13 @@ export default function MatrixTab({
                       // A pair (e.g. EUR/USD filed under EUR) shows the instrument so it's
                       // never misread as an outright single-currency call.
                       const isPair = cell.currency.includes('/');
+                      // Surface broker levels/thesis in the tooltip when the desk view carries them.
+                      const levels = formatTargets(cell.targets);
+                      const title = `${broker} · ${cell.currency} · ${cell.direction}${
+                        cell.conviction ? ` (${cell.conviction})` : ''
+                      }${cell.signal ? ` — ${cell.signal}` : ''} · ${cell.report_date ?? cell.run_date}${
+                        levels ? `\nLevels: ${levels}` : ''
+                      }${cell.rationale ? `\n${cell.rationale}` : ''} — open brief`;
                       return (
                         <div key={ccy} role="cell" className="p-1">
                           <button
@@ -135,9 +171,7 @@ export default function MatrixTab({
                             onClick={() => onOpenBrief(cell.source_file, cell.run_date)}
                             className={`flex h-full w-full flex-col items-center justify-center gap-0.5 rounded-md border ${s.bg} ${s.border} px-1 py-1.5 text-center transition-colors hover:border-fin-blue/50 hover:bg-white/[0.05]`}
                             style={{ opacity: convictionOpacity(cell.conviction) }}
-                            title={`${broker} · ${cell.currency} · ${cell.direction}${
-                              cell.conviction ? ` (${cell.conviction})` : ''
-                            }${cell.signal ? ` — ${cell.signal}` : ''} · ${cell.report_date ?? cell.run_date} — open brief`}
+                            title={title}
                           >
                             <span className={`text-sm leading-none ${s.text}`} aria-hidden>
                               {s.glyph}

--- a/frontend/olympus/components/twelve-x/MoversStrip.tsx
+++ b/frontend/olympus/components/twelve-x/MoversStrip.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { Mover } from '@/lib/twelve-x/types';
+import DeltaChip from './DeltaChip';
+
+/** A horizontally-scrollable strip of the biggest consensus shifts since the last run. */
+export interface MoversStripProps {
+  movers: Mover[];
+  onSelect?: (currency: string) => void;
+  title?: string;
+  className?: string;
+}
+
+export default function MoversStrip({
+  movers,
+  onSelect,
+  title = 'Biggest shifts since last run',
+  className,
+}: MoversStripProps) {
+  if (movers.length === 0) return null;
+
+  return (
+    <div className={className}>
+      <div className="text-[10px] font-medium uppercase tracking-wide text-text-muted mb-1.5">
+        {title}
+      </div>
+      <div className="flex gap-2 overflow-x-auto -mx-1 px-1 snap-x">
+        {movers.map((m) => (
+          <button
+            key={m.currency}
+            type="button"
+            onClick={() => onSelect?.(m.currency)}
+            className="snap-start shrink-0 glass-card px-2.5 py-1.5 flex items-center gap-1.5 hover:bg-white/[0.04] transition-colors"
+          >
+            <span className="font-mono font-semibold text-text-primary">{m.currency}</span>
+            <span className="tabular-nums text-[11px] font-mono text-text-secondary">
+              {m.scoreNow.toFixed(2)}
+            </span>
+            <DeltaChip delta={m.scoreDelta} />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/olympus/components/twelve-x/TodayTab.tsx
+++ b/frontend/olympus/components/twelve-x/TodayTab.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { Sparkles, FileText, Users } from 'lucide-react';
+import { Sparkles, FileText, Users, Star } from 'lucide-react';
 import { SafeMarkdown } from '@/components/SafeMarkdown';
-import type { FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import type { FxConfluenceSnapshotRow, Mover, ConsensusDeltaSet } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+import MoversStrip from './MoversStrip';
+
+// TODO(defer): push alerts — no server in static export
 
 interface DigestData {
   run_date: string;
@@ -27,18 +31,115 @@ function directionLabel(direction: string): string {
   return d.charAt(0).toUpperCase() + d.slice(1).toLowerCase();
 }
 
+/** The base currency an idea files under (numerator of a pair, uppercased). */
+function baseCurrency(currency: string): string {
+  return currency.trim().toUpperCase().split('/')[0];
+}
+
+/**
+ * `brief_keys` are broker NAMES per the data contract, not `source_file` keys.
+ * Only treat an entry as a brief link target if it actually looks like a file
+ * key (has a path separator or a file extension); otherwise we skip the link
+ * rather than wire up a broken openBrief() call.
+ */
+function firstBriefSourceFile(briefKeys: unknown): string | null {
+  if (!Array.isArray(briefKeys)) return null;
+  for (const k of briefKeys) {
+    if (typeof k !== 'string') continue;
+    const s = k.trim();
+    if (s && (s.includes('/') || /\.[a-z0-9]{2,5}$/i.test(s))) return s;
+  }
+  return null;
+}
+
+/**
+ * Drop reciprocal legs of the same pair: if two ideas share the same instrument
+ * with opposite (currency, direction) — e.g. "EUR/USD long" and "EUR/USD" filed
+ * under USD short — keep only the higher-ranked one. Input is rank-sorted.
+ */
+function dedupeReciprocalLegs(ideas: FxConfluenceSnapshotRow[]): FxConfluenceSnapshotRow[] {
+  const seenPairs = new Set<string>();
+  const out: FxConfluenceSnapshotRow[] = [];
+  const sorted = [...ideas].sort((a, b) => a.rank - b.rank);
+  for (const idea of sorted) {
+    const legs = idea.currency.trim().toUpperCase().split('/').filter(Boolean).sort();
+    const pairKey = legs.join('|');
+    if (pairKey && seenPairs.has(pairKey)) continue;
+    if (pairKey) seenPairs.add(pairKey);
+    out.push(idea);
+  }
+  return out;
+}
+
 function ConfluenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
+  const { crossLink, openBrief, watchlist } = useTwelveX();
   const colorClass = directionColorClass(idea.direction);
+  const ccy = baseCurrency(idea.currency);
+  const briefSource = firstBriefSourceFile(idea.brief_keys);
+  const starred = watchlist.has(ccy);
+
+  const cardInteractive = briefSource != null;
+  const openCardBrief = () => {
+    if (briefSource) openBrief(briefSource, idea.run_date);
+  };
+
   return (
-    <div className="glass-card p-4 flex flex-col gap-2">
+    <div
+      className={`glass-card p-4 flex flex-col gap-2 transition-colors${
+        cardInteractive
+          ? ' cursor-pointer hover:border-fin-blue/50 focus-visible:border-fin-blue/50 focus-visible:outline-none'
+          : ''
+      }`}
+      role={cardInteractive ? 'button' : undefined}
+      tabIndex={cardInteractive ? 0 : undefined}
+      onClick={cardInteractive ? openCardBrief : undefined}
+      onKeyDown={
+        cardInteractive
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openCardBrief();
+              }
+            }
+          : undefined
+      }
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-white/[0.06] text-text-muted border border-border-subtle shrink-0">
             #{idea.rank}
           </span>
-          <span className="font-mono text-sm font-semibold text-text-primary truncate">{idea.currency}</span>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              crossLink({ kind: 'currency', currency: ccy });
+            }}
+            className="font-mono text-sm font-semibold text-text-primary truncate hover:text-fin-blue transition-colors"
+            title={`View ${ccy} consensus`}
+          >
+            {idea.currency}
+          </button>
         </div>
-        <span className={`text-xs font-semibold shrink-0 ${colorClass}`}>{directionLabel(idea.direction)}</span>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className={`text-xs font-semibold ${colorClass}`}>
+            {directionLabel(idea.direction)}
+          </span>
+          <button
+            type="button"
+            aria-label={starred ? `Remove ${ccy} from watchlist` : `Add ${ccy} to watchlist`}
+            aria-pressed={starred}
+            onClick={(e) => {
+              e.stopPropagation();
+              watchlist.toggle(ccy);
+            }}
+            className={`transition-colors ${
+              starred ? 'text-fin-amber' : 'text-text-muted hover:text-fin-amber'
+            }`}
+          >
+            <Star size={14} fill={starred ? 'currentColor' : 'none'} aria-hidden />
+          </button>
+        </div>
       </div>
       <p className="text-sm text-text-primary leading-snug">{idea.title}</p>
       <div className="mt-auto flex items-center justify-between pt-1">
@@ -54,78 +155,133 @@ function ConfluenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
 export default function TodayTab({
   digest,
   confluence,
+  runDate,
+  movers,
+  deltas,
 }: {
   digest: DigestData | null;
   confluence: FxConfluenceSnapshotRow[];
+  runDate: string | null;
+  movers: Mover[];
+  deltas: ConsensusDeltaSet;
 }) {
-  if (!digest) {
-    return (
-      <div className="glass-card p-10 text-center text-text-muted text-sm">
-        No FX daily digest is available yet.
-      </div>
-    );
-  }
+  const { crossLink, watchlist } = useTwelveX();
+
+  // De-dupe reciprocal legs (higher rank wins) before slicing the top ideas.
+  const ranked = dedupeReciprocalLegs(confluence);
+  const filtered = watchlist.filterOn
+    ? ranked.filter((idea) => watchlist.has(baseCurrency(idea.currency)))
+    : ranked;
+  const topIdeas = filtered.slice(0, 6);
+
+  const headerDate = runDate ?? digest?.run_date ?? null;
 
   return (
     <div className="space-y-4">
-      {/* Greeting / digest header */}
-      <div className="glass-card p-5 md:p-6 space-y-4">
-        <div className="flex flex-wrap items-center gap-3">
-          <Sparkles size={18} className="text-fin-blue shrink-0" />
-          <h2 className="text-lg md:text-xl font-semibold text-text-primary">Daily FX brief</h2>
-          <span className="text-[10px] font-mono text-text-muted ml-auto">{digest.run_date}</span>
-        </div>
+      {/* What changed — biggest consensus shifts since the previous run */}
+      <MoversStrip
+        movers={movers}
+        onSelect={(currency) => crossLink({ kind: 'currency', currency })}
+        title="What changed since last run"
+      />
 
-        {digest.summary ? (
-          <SafeMarkdown className="prose prose-invert max-w-none text-sm text-text-secondary">
-            {digest.summary}
-          </SafeMarkdown>
-        ) : null}
-
-        {digest.key_themes.length > 0 ? (
-          <div className="flex flex-wrap gap-2 pt-1">
-            {digest.key_themes.map((theme, i) => (
-              <span
-                key={`${theme}-${i}`}
-                className="text-[11px] font-medium px-2.5 py-1 rounded-full border border-fin-blue/30 bg-fin-blue/10 text-fin-blue"
-              >
-                {theme}
-              </span>
-            ))}
-          </div>
-        ) : null}
-
-        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-text-muted pt-1 border-t border-border-subtle/60 mt-1">
-          <span className="flex items-center gap-1.5">
-            <FileText size={13} aria-hidden />
-            <span className="qn-metric text-text-secondary tabular-nums">{digest.doc_count}</span>
-            documents
-          </span>
-          <span className="flex items-center gap-1.5">
-            <Users size={13} aria-hidden />
-            <span className="qn-metric text-text-secondary tabular-nums">{digest.broker_count}</span>
-            brokers
-          </span>
-        </div>
-      </div>
-
-      {/* Top trade ideas */}
+      {/* Header + top trade ideas */}
       <div className="space-y-3">
-        <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider px-1">
-          Top trade ideas
-        </h3>
-        {confluence.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-3 px-1">
+          <Sparkles size={16} className="text-fin-blue shrink-0" />
+          <h2 className="text-base md:text-lg font-semibold text-text-primary">
+            Top trade ideas
+          </h2>
+          {watchlist.items.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => watchlist.setFilterOn(!watchlist.filterOn)}
+              aria-pressed={watchlist.filterOn}
+              className={`text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors flex items-center gap-1 ${
+                watchlist.filterOn
+                  ? 'border-fin-amber/40 bg-fin-amber/10 text-fin-amber'
+                  : 'border-border-subtle text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              <Star size={11} fill={watchlist.filterOn ? 'currentColor' : 'none'} aria-hidden />
+              Watchlist
+            </button>
+          ) : null}
+          <span className="text-[10px] font-mono text-text-muted ml-auto">{headerDate ?? '—'}</span>
+        </div>
+
+        {/* Score-scale legend */}
+        <p className="text-[11px] text-text-muted px-1">
+          Score 0–1 · higher = stronger confluence
+        </p>
+
+        {topIdeas.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {confluence.map((idea) => (
+            {topIdeas.map((idea) => (
               <ConfluenceCard key={`${idea.run_date}-${idea.rank}`} idea={idea} />
             ))}
           </div>
         ) : (
           <div className="glass-card p-8 text-center text-text-muted text-sm">
-            No confluence trade ideas for {digest.run_date}.
+            {watchlist.filterOn && ranked.length > 0
+              ? 'No trade ideas match your watchlist.'
+              : `No confluence trade ideas${headerDate ? ` for ${headerDate}` : ''}.`}
           </div>
         )}
       </div>
+
+      {/* Full brief — demoted below the ideas, collapsed by default */}
+      {digest ? (
+        <details className="glass-card p-0 overflow-hidden group">
+          <summary className="cursor-pointer list-none p-4 flex flex-wrap items-center gap-3 text-sm text-text-secondary hover:text-text-primary transition-colors">
+            <FileText size={15} className="text-fin-blue shrink-0" aria-hidden />
+            <span className="font-medium text-text-primary">Full brief</span>
+            <span className="text-text-muted">
+              · {digest.doc_count} {digest.doc_count === 1 ? 'doc' : 'docs'} ·{' '}
+              {digest.broker_count} {digest.broker_count === 1 ? 'broker' : 'brokers'}
+            </span>
+            <span className="text-[10px] font-mono text-text-muted ml-auto">{digest.run_date}</span>
+          </summary>
+
+          <div className="px-4 pb-4 space-y-4 border-t border-border-subtle/60">
+            {digest.summary ? (
+              <SafeMarkdown className="prose prose-invert max-w-none text-sm text-text-secondary pt-4">
+                {digest.summary}
+              </SafeMarkdown>
+            ) : null}
+
+            {digest.key_themes.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {digest.key_themes.map((theme, i) => (
+                  <span
+                    key={`${theme}-${i}`}
+                    className="text-[11px] font-medium px-2.5 py-1 rounded-full border border-fin-blue/30 bg-fin-blue/10 text-fin-blue"
+                  >
+                    {theme}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-text-muted">
+              <span className="flex items-center gap-1.5">
+                <FileText size={13} aria-hidden />
+                <span className="qn-metric text-text-secondary tabular-nums">
+                  {digest.doc_count}
+                </span>
+                documents
+              </span>
+              <span className="flex items-center gap-1.5">
+                <Users size={13} aria-hidden />
+                <span className="qn-metric text-text-secondary tabular-nums">
+                  {digest.broker_count}
+                </span>
+                brokers
+              </span>
+            </div>
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -13,6 +13,7 @@ import {
 import { SubpageStickyTabBar, SUBPAGE_MAX, subpageTabButtonClass } from '@/components/subpage-tab-bar';
 import AtlasLoader from '@/components/AtlasLoader';
 import {
+  computeConsensusDeltaSet,
   getConsensusTimeSeries,
   getEventOpinions,
   getIntelligence,
@@ -39,8 +40,8 @@ import EventsTab from './EventsTab';
 import MatrixTab from './MatrixTab';
 import LedgerTab from './LedgerTab';
 import BriefPanel from './BriefPanel';
-
-type TwelveXTab = 'today' | 'consensus' | 'intelligence' | 'events' | 'matrix' | 'ledger';
+import { TwelveXProvider, type TwelveXContextValue, type CrossLink, type TwelveXTab } from './context';
+import { useWatchlist } from './useWatchlist';
 
 type DigestData = Awaited<ReturnType<typeof getLatestDigest>>;
 
@@ -115,6 +116,13 @@ export default function TwelveXClient() {
   // re-pointed without refetching the whole workspace.
   const [ledgerRun, setLedgerRun] = useState<string | null>(null);
   const [ledgerRows, setLedgerRows] = useState<FxLedgerRow[]>([]);
+  const [ledgerError, setLedgerError] = useState<string | null>(null);
+
+  // Cross-link focus targets handed to the destination tabs.
+  const [consensusFocusCcy, setConsensusFocusCcy] = useState<string | null>(null);
+  const [eventFocus, setEventFocus] = useState<{ externalId?: string | null; name: string | null } | null>(
+    null
+  );
 
   const setTab = useCallback(
     (next: TwelveXTab) => {
@@ -226,6 +234,19 @@ export default function TwelveXClient() {
     [data?.eventOpinions, intelligenceDate]
   );
 
+  // Run-over-run consensus deltas (pure, derived from the fetched series).
+  const consensusDeltas = useMemo(
+    () => computeConsensusDeltaSet(data?.consensusSeries ?? []),
+    [data?.consensusSeries]
+  );
+
+  // The single canonical "as-of" run the workspace reports, preferring the
+  // digest's run, then intelligence, then the latest consensus run.
+  const canonicalRunDate = useMemo(
+    () => data?.digest?.run_date ?? intelligenceDate ?? latestConsensusDate,
+    [data?.digest?.run_date, intelligenceDate, latestConsensusDate]
+  );
+
   // Load the ledger audit rows for the selected run (P4). Re-runs whenever the
   // picker changes; independent of the main workspace load.
   useEffect(() => {
@@ -234,9 +255,15 @@ export default function TwelveXClient() {
     (async () => {
       try {
         const rows = await getLedger(ledgerRun);
-        if (!cancelled) setLedgerRows(rows);
-      } catch {
-        if (!cancelled) setLedgerRows([]);
+        if (!cancelled) {
+          setLedgerRows(rows);
+          setLedgerError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLedgerRows([]);
+          setLedgerError(err instanceof Error ? err.message : 'Failed to load the relevance ledger');
+        }
       }
     })();
     return () => {
@@ -245,6 +272,41 @@ export default function TwelveXClient() {
   }, [configured, ledgerRun]);
 
   const selectLedgerRun = useCallback((next: string) => setLedgerRun(next), []);
+
+  const watchlist = useWatchlist();
+
+  // The shared cross-surface navigator handed to every tab via context.
+  const crossLink = useCallback(
+    (l: CrossLink) => {
+      switch (l.kind) {
+        case 'currency':
+          setTabState('consensus');
+          setConsensusFocusCcy(l.currency);
+          syncUrl('consensus', brief, ledgerCcy);
+          break;
+        case 'ledger':
+          drillToLedger(l.currency);
+          break;
+        case 'brief':
+          openBrief(l.sourceFile, l.runDate);
+          break;
+        case 'event':
+          setTabState('events');
+          setEventFocus({ externalId: l.externalId ?? null, name: l.eventName });
+          syncUrl('events', brief, ledgerCcy);
+          break;
+        case 'tab':
+          setTab(l.tab);
+          break;
+      }
+    },
+    [brief, ledgerCcy, drillToLedger, openBrief, setTab]
+  );
+
+  const ctx = useMemo<TwelveXContextValue>(
+    () => ({ runDate: canonicalRunDate, crossLink, openBrief, watchlist }),
+    [canonicalRunDate, crossLink, openBrief, watchlist]
+  );
 
   if (loading) return <AtlasLoader />;
 
@@ -271,7 +333,7 @@ export default function TwelveXClient() {
 
   return (
     <div className="flex min-h-full flex-col">
-      <SubpageStickyTabBar aria-label="FX research workspace">
+      <SubpageStickyTabBar aria-label="FX research workspace" topOffset="none">
         <button type="button" onClick={() => setTab('today')} className={subpageTabButtonClass(tab === 'today')}>
           <CalendarClock size={16} aria-hidden />
           Today
@@ -318,46 +380,62 @@ export default function TwelveXClient() {
         </button>
       </SubpageStickyTabBar>
 
-      <div className={`${SUBPAGE_MAX} flex-1 space-y-4 py-4 md:py-5`}>
-        {tab === 'consensus' ? (
-          <ConsensusTab
-            series={data?.consensusSeries ?? []}
-            latest={data?.latestConsensus ?? []}
-            latestDate={latestConsensusDate}
-            onDrillToLedger={drillToLedger}
-          />
-        ) : tab === 'intelligence' ? (
-          <IntelligenceTab confluence={data?.intelligence ?? []} runDate={intelligenceDate} />
-        ) : tab === 'events' ? (
-          <EventsTab
-            events={data?.upcomingEvents ?? []}
-            opinions={data?.eventOpinions ?? []}
-            runDate={eventOpinionsDate}
-            onOpenBrief={openBrief}
-          />
-        ) : tab === 'matrix' ? (
-          <MatrixTab cells={data?.matrix ?? []} onOpenBrief={openBrief} />
-        ) : tab === 'ledger' ? (
-          <LedgerTab
-            rows={ledgerRows}
-            runDate={ledgerRun}
-            runDates={data?.ledgerRunDates ?? []}
-            onSelectRun={selectLedgerRun}
-            ccy={ledgerCcy}
-            onOpenBrief={openBrief}
-          />
-        ) : (
-          <TodayTab digest={data?.digest ?? null} confluence={data?.confluence ?? []} />
-        )}
-      </div>
+      <TwelveXProvider value={ctx}>
+        <div className={`${SUBPAGE_MAX} flex-1 space-y-4 py-4 md:py-5`}>
+          {tab === 'consensus' ? (
+            <ConsensusTab
+              series={data?.consensusSeries ?? []}
+              latest={data?.latestConsensus ?? []}
+              latestDate={latestConsensusDate}
+              onDrillToLedger={drillToLedger}
+              deltas={consensusDeltas}
+              focusCcy={consensusFocusCcy}
+            />
+          ) : tab === 'intelligence' ? (
+            <IntelligenceTab
+              confluence={data?.intelligence ?? []}
+              runDate={intelligenceDate}
+              events={data?.eventOpinions ?? []}
+            />
+          ) : tab === 'events' ? (
+            <EventsTab
+              events={data?.upcomingEvents ?? []}
+              opinions={data?.eventOpinions ?? []}
+              runDate={eventOpinionsDate}
+              onOpenBrief={openBrief}
+              focus={eventFocus}
+            />
+          ) : tab === 'matrix' ? (
+            <MatrixTab cells={data?.matrix ?? []} onOpenBrief={openBrief} />
+          ) : tab === 'ledger' ? (
+            <LedgerTab
+              rows={ledgerRows}
+              runDate={ledgerRun}
+              runDates={data?.ledgerRunDates ?? []}
+              onSelectRun={selectLedgerRun}
+              ccy={ledgerCcy}
+              onOpenBrief={openBrief}
+              error={ledgerError}
+            />
+          ) : (
+            <TodayTab
+              digest={data?.digest ?? null}
+              confluence={data?.confluence ?? []}
+              runDate={canonicalRunDate}
+              movers={consensusDeltas.movers}
+              deltas={consensusDeltas}
+            />
+          )}
+        </div>
 
-      {/* Slide-over brief panel — local state, no router. */}
-      <BriefPanel
-        open={!!brief}
-        sourceFile={brief?.sourceFile ?? null}
-        runDate={brief?.runDate ?? null}
-        onClose={closeBrief}
-      />
+        {/* Slide-over brief panel — local state, no router. */}
+        <BriefPanel
+          open={!!brief}
+          sourceFile={brief?.sourceFile ?? null}
+          runDate={brief?.runDate ?? null}
+          onClose={closeBrief}
+        />
+      </TwelveXProvider>
     </div>
   );
 }

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -45,6 +45,16 @@ import { useWatchlist } from './useWatchlist';
 
 type DigestData = Awaited<ReturnType<typeof getLatestDigest>>;
 
+/** The workspace tab bar, in display order: id, icon, and label. */
+const TABS: ReadonlyArray<{ id: TwelveXTab; Icon: typeof CalendarClock; label: string }> = [
+  { id: 'today', Icon: CalendarClock, label: 'Today' },
+  { id: 'consensus', Icon: LineChartIcon, label: 'Consensus' },
+  { id: 'intelligence', Icon: Layers, label: 'Intelligence' },
+  { id: 'events', Icon: CalendarDays, label: 'Events' },
+  { id: 'matrix', Icon: Grid3x3, label: 'Matrix' },
+  { id: 'ledger', Icon: ScrollText, label: 'Ledger' },
+];
+
 /** A brief drill-down target: the source_file key plus the run that owns it. */
 export type BriefTarget = { sourceFile: string; runDate: string | null };
 
@@ -271,8 +281,6 @@ export default function TwelveXClient() {
     };
   }, [configured, ledgerRun]);
 
-  const selectLedgerRun = useCallback((next: string) => setLedgerRun(next), []);
-
   const watchlist = useWatchlist();
 
   // The shared cross-surface navigator handed to every tab via context.
@@ -331,102 +339,82 @@ export default function TwelveXClient() {
     );
   }
 
+  const renderActiveTab = () => {
+    switch (tab) {
+      case 'consensus':
+        return (
+          <ConsensusTab
+            series={data?.consensusSeries ?? []}
+            latest={data?.latestConsensus ?? []}
+            latestDate={latestConsensusDate}
+            onDrillToLedger={drillToLedger}
+            deltas={consensusDeltas}
+            focusCcy={consensusFocusCcy}
+          />
+        );
+      case 'intelligence':
+        return (
+          <IntelligenceTab
+            confluence={data?.intelligence ?? []}
+            runDate={intelligenceDate}
+            events={data?.eventOpinions ?? []}
+          />
+        );
+      case 'events':
+        return (
+          <EventsTab
+            events={data?.upcomingEvents ?? []}
+            opinions={data?.eventOpinions ?? []}
+            runDate={eventOpinionsDate}
+            onOpenBrief={openBrief}
+            focus={eventFocus}
+          />
+        );
+      case 'matrix':
+        return <MatrixTab cells={data?.matrix ?? []} onOpenBrief={openBrief} />;
+      case 'ledger':
+        return (
+          <LedgerTab
+            rows={ledgerRows}
+            runDate={ledgerRun}
+            runDates={data?.ledgerRunDates ?? []}
+            onSelectRun={setLedgerRun}
+            ccy={ledgerCcy}
+            onOpenBrief={openBrief}
+            error={ledgerError}
+          />
+        );
+      default:
+        return (
+          <TodayTab
+            digest={data?.digest ?? null}
+            confluence={data?.confluence ?? []}
+            runDate={canonicalRunDate}
+            movers={consensusDeltas.movers}
+            deltas={consensusDeltas}
+          />
+        );
+    }
+  };
+
   return (
     <div className="flex min-h-full flex-col">
       <SubpageStickyTabBar aria-label="FX research workspace" topOffset="none">
-        <button type="button" onClick={() => setTab('today')} className={subpageTabButtonClass(tab === 'today')}>
-          <CalendarClock size={16} aria-hidden />
-          Today
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab('consensus')}
-          className={subpageTabButtonClass(tab === 'consensus')}
-        >
-          <LineChartIcon size={16} aria-hidden />
-          Consensus
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab('intelligence')}
-          className={subpageTabButtonClass(tab === 'intelligence')}
-        >
-          <Layers size={16} aria-hidden />
-          Intelligence
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab('events')}
-          className={subpageTabButtonClass(tab === 'events')}
-        >
-          <CalendarDays size={16} aria-hidden />
-          Events
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab('matrix')}
-          className={subpageTabButtonClass(tab === 'matrix')}
-        >
-          <Grid3x3 size={16} aria-hidden />
-          Matrix
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab('ledger')}
-          className={subpageTabButtonClass(tab === 'ledger')}
-        >
-          <ScrollText size={16} aria-hidden />
-          Ledger
-        </button>
+        {TABS.map(({ id, Icon, label }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTab(id)}
+            className={subpageTabButtonClass(tab === id)}
+          >
+            <Icon size={16} aria-hidden />
+            {label}
+          </button>
+        ))}
       </SubpageStickyTabBar>
 
       <TwelveXProvider value={ctx}>
-        <div className={`${SUBPAGE_MAX} flex-1 space-y-4 py-4 md:py-5`}>
-          {tab === 'consensus' ? (
-            <ConsensusTab
-              series={data?.consensusSeries ?? []}
-              latest={data?.latestConsensus ?? []}
-              latestDate={latestConsensusDate}
-              onDrillToLedger={drillToLedger}
-              deltas={consensusDeltas}
-              focusCcy={consensusFocusCcy}
-            />
-          ) : tab === 'intelligence' ? (
-            <IntelligenceTab
-              confluence={data?.intelligence ?? []}
-              runDate={intelligenceDate}
-              events={data?.eventOpinions ?? []}
-            />
-          ) : tab === 'events' ? (
-            <EventsTab
-              events={data?.upcomingEvents ?? []}
-              opinions={data?.eventOpinions ?? []}
-              runDate={eventOpinionsDate}
-              onOpenBrief={openBrief}
-              focus={eventFocus}
-            />
-          ) : tab === 'matrix' ? (
-            <MatrixTab cells={data?.matrix ?? []} onOpenBrief={openBrief} />
-          ) : tab === 'ledger' ? (
-            <LedgerTab
-              rows={ledgerRows}
-              runDate={ledgerRun}
-              runDates={data?.ledgerRunDates ?? []}
-              onSelectRun={selectLedgerRun}
-              ccy={ledgerCcy}
-              onOpenBrief={openBrief}
-              error={ledgerError}
-            />
-          ) : (
-            <TodayTab
-              digest={data?.digest ?? null}
-              confluence={data?.confluence ?? []}
-              runDate={canonicalRunDate}
-              movers={consensusDeltas.movers}
-              deltas={consensusDeltas}
-            />
-          )}
-        </div>
+        <div className={`${SUBPAGE_MAX} flex-1 space-y-4 py-4 md:py-5`}>{renderActiveTab()}</div>
 
         {/* Slide-over brief panel — local state, no router. */}
         <BriefPanel

--- a/frontend/olympus/components/twelve-x/context.tsx
+++ b/frontend/olympus/components/twelve-x/context.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+import type { WatchlistApi } from './useWatchlist';
+
+/** The six twelve-x workspace tabs. */
+export type TwelveXTab = 'today' | 'consensus' | 'intelligence' | 'events' | 'matrix' | 'ledger';
+
+/** A cross-surface navigation intent fired from any tab. */
+export type CrossLink =
+  | { kind: 'currency'; currency: string }
+  | { kind: 'ledger'; currency: string }
+  | { kind: 'brief'; sourceFile: string; runDate: string | null }
+  | { kind: 'event'; eventName: string | null; externalId?: string | null }
+  | { kind: 'tab'; tab: TwelveXTab };
+
+/** Shared workspace plumbing every tab can reach via `useTwelveX()`. */
+export interface TwelveXContextValue {
+  runDate: string | null;
+  crossLink: (l: CrossLink) => void;
+  openBrief: (sourceFile: string, runDate: string | null) => void;
+  watchlist: WatchlistApi;
+}
+
+export const TwelveXContext = createContext<TwelveXContextValue | null>(null);
+
+export function useTwelveX(): TwelveXContextValue {
+  const v = useContext(TwelveXContext);
+  if (!v) throw new Error('useTwelveX must be used within TwelveXProvider');
+  return v;
+}
+
+export function TwelveXProvider({
+  value,
+  children,
+}: {
+  value: TwelveXContextValue;
+  children: ReactNode;
+}) {
+  return <TwelveXContext.Provider value={value}>{children}</TwelveXContext.Provider>;
+}

--- a/frontend/olympus/components/twelve-x/useWatchlist.ts
+++ b/frontend/olympus/components/twelve-x/useWatchlist.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/** A localStorage-backed currency watchlist with an optional "filter on" toggle. */
+export interface WatchlistApi {
+  items: string[];
+  has: (c: string) => boolean;
+  toggle: (c: string) => void;
+  clear: () => void;
+  filterOn: boolean;
+  setFilterOn: (b: boolean) => void;
+}
+
+/**
+ * A small, SSR-safe watchlist hook. State lazy-inits to `[]` (never touches
+ * localStorage during render/init); the stored value is hydrated in a mount
+ * effect and persisted on change. All storage access is wrapped in try/catch.
+ */
+export function useWatchlist(storageKey = 'twelvex-watchlist'): WatchlistApi {
+  const [items, setItems] = useState<string[]>([]);
+  const [filterOn, setFilterOn] = useState(false);
+
+  // Hydrate from storage on mount (client only).
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        // Hydrate-after-mount is intentional: lazy-initializing from localStorage
+        // during render would cause an SSR/prerender hydration mismatch (server has
+        // no storage). Setting state in this mount-only effect is the safe pattern.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setItems(parsed.map((x) => String(x)));
+      }
+    } catch {
+      /* ignore unavailable / malformed storage */
+    }
+  }, [storageKey]);
+
+  // Persist on change.
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(items));
+    } catch {
+      /* ignore unavailable storage */
+    }
+  }, [storageKey, items]);
+
+  const has = useCallback((c: string) => items.includes(c), [items]);
+
+  const toggle = useCallback((c: string) => {
+    setItems((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  }, []);
+
+  const clear = useCallback(() => setItems([]), []);
+
+  return { items, has, toggle, clear, filterOn, setFilterOn };
+}

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -14,6 +14,9 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { isTwelveXConfigured, twelveXSupabase } from './supabase';
 import { MATRIX_COLUMNS } from './types';
 import type {
+  ConfluenceCatalyst,
+  ConsensusDelta,
+  ConsensusDeltaSet,
   CurrencyView,
   FxBriefRow,
   FxConfluenceSnapshotRow,
@@ -24,6 +27,8 @@ import type {
   FxLedgerRow,
   MatrixCell,
   MatrixColumn,
+  Mover,
+  Timeframe,
 } from './types';
 
 /**
@@ -97,15 +102,18 @@ export function normalizeKeyThemes(raw: FxDailyDigestRow['key_themes']): string[
  * ordered oldest→newest by date then currency — ready for per-currency time
  * series. Returns `[]` when twelve-x is unconfigured.
  */
-export async function getConsensusTimeSeries(): Promise<FxConsensusSnapshotRow[]> {
+export async function getConsensusTimeSeries(
+  timeframe: Timeframe = 'medium'
+): Promise<FxConsensusSnapshotRow[]> {
   if (!isTwelveXConfigured() || !twelveXSupabase) return [];
   const rows = await querySupabase<FxConsensusSnapshotRow[]>((sb) =>
     sb
       .from('fx_consensus_snapshot')
       .select(
-        'run_date, currency, weighted, score, confidence, agreement, tilt, n_eff, n_brokers, n_views, bullish_pct, bearish_pct, neutral_pct, watch_pct, as_of'
+        'run_date, currency, weighted, score, confidence, agreement, tilt, n_eff, n_brokers, n_views, bullish_pct, bearish_pct, neutral_pct, watch_pct, as_of, timeframe, horizon_weeks'
       )
       .eq('weighted', true)
+      .eq('timeframe', timeframe)
       .order('run_date', { ascending: true })
       .order('currency', { ascending: true })
   );
@@ -117,7 +125,9 @@ export async function getConsensusTimeSeries(): Promise<FxConsensusSnapshotRow[]
  * (one row per G10 currency). Returns `[]` when twelve-x is unconfigured or the
  * table is empty.
  */
-export async function getLatestConsensus(): Promise<FxConsensusSnapshotRow[]> {
+export async function getLatestConsensus(
+  timeframe: Timeframe = 'medium'
+): Promise<FxConsensusSnapshotRow[]> {
   if (!isTwelveXConfigured() || !twelveXSupabase) return [];
 
   // Resolve the latest run_date first (cheap), then pull that day's full set.
@@ -126,6 +136,7 @@ export async function getLatestConsensus(): Promise<FxConsensusSnapshotRow[]> {
       .from('fx_consensus_snapshot')
       .select('run_date')
       .eq('weighted', true)
+      .eq('timeframe', timeframe)
       .order('run_date', { ascending: false })
       .limit(1)
   );
@@ -137,13 +148,84 @@ export async function getLatestConsensus(): Promise<FxConsensusSnapshotRow[]> {
     sb
       .from('fx_consensus_snapshot')
       .select(
-        'run_date, currency, weighted, score, confidence, agreement, tilt, n_eff, n_brokers, n_views, bullish_pct, bearish_pct, neutral_pct, watch_pct, as_of'
+        'run_date, currency, weighted, score, confidence, agreement, tilt, n_eff, n_brokers, n_views, bullish_pct, bearish_pct, neutral_pct, watch_pct, as_of, timeframe, horizon_weeks'
       )
       .eq('weighted', true)
+      .eq('timeframe', timeframe)
       .eq('run_date', latestDate)
       .order('currency', { ascending: true })
   );
   return rows ?? [];
+}
+
+/**
+ * PURE — no fetch. Compute the run-over-run consensus delta picture from a
+ * timeframe-pinned series (sorted oldest→newest, one row per currency per run).
+ * Takes the two newest distinct run_dates; per currency in the newest run it
+ * derives the score/confidence deltas and a direction-flip flag, then ranks the
+ * biggest absolute score shifts as the top-6 movers.
+ */
+export function computeConsensusDeltaSet(series: FxConsensusSnapshotRow[]): ConsensusDeltaSet {
+  if (series.length === 0) {
+    return { runDate: null, prevRunDate: null, byCurrency: {}, movers: [] };
+  }
+
+  // Distinct run_dates present, newest-first (series is oldest→newest).
+  const dates: string[] = [];
+  for (let i = series.length - 1; i >= 0; i--) {
+    const d = series[i].run_date;
+    if (!dates.includes(d)) {
+      dates.push(d);
+      if (dates.length >= 2) break;
+    }
+  }
+  const runDate = dates[0] ?? null;
+  const prevRunDate = dates[1] ?? null;
+
+  const nowRows = series.filter((r) => r.run_date === runDate);
+  const prevByCcy = new Map<string, FxConsensusSnapshotRow>();
+  if (prevRunDate) {
+    for (const r of series) {
+      if (r.run_date === prevRunDate) prevByCcy.set(r.currency, r);
+    }
+  }
+
+  const byCurrency: Record<string, ConsensusDelta> = {};
+  const movers: Mover[] = [];
+  for (const row of nowRows) {
+    const prev = prevByCcy.get(row.currency) ?? null;
+    const scoreNow = row.score;
+    const scorePrev = prev ? prev.score : null;
+    const scoreDelta = prev ? scoreNow - prev.score : null;
+    const confidenceDelta = prev ? row.confidence - prev.confidence : null;
+    const flippedDirection =
+      !!prev &&
+      Math.sign(scoreNow) !== Math.sign(prev.score) &&
+      Math.abs(scoreNow - prev.score) > 0.05;
+    const delta: ConsensusDelta = {
+      currency: row.currency,
+      scoreNow,
+      scorePrev,
+      scoreDelta,
+      confidenceDelta,
+      flippedDirection,
+      prevRunDate,
+    };
+    byCurrency[row.currency] = delta;
+    if (scoreDelta != null) {
+      movers.push({
+        currency: row.currency,
+        scoreNow,
+        scoreDelta,
+        absDelta: Math.abs(scoreDelta),
+        direction: scoreDelta >= 0 ? 'up' : 'down',
+      });
+    }
+  }
+
+  movers.sort((a, b) => b.absDelta - a.absDelta);
+
+  return { runDate, prevRunDate, byCurrency, movers: movers.slice(0, 6) };
 }
 
 /**
@@ -412,6 +494,9 @@ export async function getMatrix(windowDays = 14): Promise<MatrixCell[]> {
         run_date: b.run_date,
         report_date: b.report_date,
         source_file: b.source_file,
+        rationale: v.rationale,
+        key_facts: v.key_facts,
+        targets: v.targets,
       };
       const existing = byCell.get(key);
       if (!existing || isNewer(candidate, existing)) {
@@ -468,6 +553,10 @@ export async function getLedgerRunDates(limit = 30): Promise<string[]> {
  * The relevance-ledger rows for a run_date (the deliberation audit), ordered by
  * relevance descending. Defaults to the latest run in the table when `runDate`
  * is omitted. Returns `[]` when unconfigured or none exist.
+ *
+ * NOTE: genuine errors propagate (querySupabase rethrows once the retry budget
+ * is exhausted) — they are NOT swallowed here. The CLIENT owns surfacing a
+ * `ledgerError` to the user; do not catch-and-empty in this layer.
  */
 export async function getLedger(runDate?: string | null): Promise<FxLedgerRow[]> {
   if (!isTwelveXConfigured() || !twelveXSupabase) return [];
@@ -486,4 +575,84 @@ export async function getLedger(runDate?: string | null): Promise<FxLedgerRow[]>
       }>
   );
   return rows ?? [];
+}
+
+/* ------------------------------------------------------------------ *
+ * Catalyst resolution + event-time helpers (PURE)
+ * ------------------------------------------------------------------ */
+
+/**
+ * PURE — resolve the catalyst a confluence idea hangs on against the events
+ * feed. Honors an explicit `event_key` in the idea's components; otherwise
+ * heuristically matches the earliest upcoming event touching the idea's base
+ * currency (in which case `eventKey` stays null so the UI can hedge wording).
+ */
+export function resolveCatalyst(
+  idea: FxConfluenceSnapshotRow,
+  events: FxEventSnapshotRow[]
+): ConfluenceCatalyst {
+  const comp = (idea.components ?? {}) as Record<string, unknown>;
+  const dtc = typeof comp.days_to_catalyst === 'number' ? comp.days_to_catalyst : null;
+  const explicitKey = typeof comp.event_key === 'string' ? comp.event_key : null;
+  const ccy = idea.currency.toUpperCase().split('/')[0];
+
+  let match: FxEventSnapshotRow | undefined;
+  if (explicitKey) {
+    match = events.find((e) => e.event_key === explicitKey);
+  } else {
+    const candidates = events
+      .filter((e) => {
+        const currencies = Array.isArray(e.currencies) ? (e.currencies as unknown[]) : [];
+        return currencies.some((c) => String(c).toUpperCase() === ccy);
+      })
+      .sort((a, b) => (a.event_date ?? '').localeCompare(b.event_date ?? ''));
+    match = candidates[0];
+  }
+
+  if (!match) {
+    return {
+      eventKey: null,
+      eventName: null,
+      eventDate: null,
+      calendarExternalId: null,
+      daysToCatalyst: dtc,
+    };
+  }
+
+  return {
+    eventKey: explicitKey ? match.event_key : null,
+    eventName: match.event_name,
+    eventDate: match.event_date,
+    calendarExternalId: match.calendar_external_id,
+    daysToCatalyst: dtc,
+  };
+}
+
+/** PURE — the absolute release instant of an event, or null when unparseable. */
+export function eventInstant(row: { event_datetime_utc: string | null }): Date | null {
+  if (!row.event_datetime_utc) return null;
+  const d = new Date(row.event_datetime_utc);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** PURE — whether an event has a resolved absolute release time. */
+export function hasResolvedTime(row: { event_datetime_utc: string | null }): boolean {
+  return eventInstant(row) != null;
+}
+
+/**
+ * PURE — the LOCAL calendar day an event falls on. When an absolute instant is
+ * present, its local YYYY-MM-DD; otherwise the feed's wall-clock `event_date`.
+ */
+export function eventLocalDateKey(row: {
+  event_datetime_utc: string | null;
+  event_date: string;
+}): string {
+  const inst = eventInstant(row);
+  if (!inst) return row.event_date;
+  return new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(inst);
 }

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -32,14 +32,20 @@ export type G10Currency = (typeof G10_CURRENCIES)[number];
 export const MATRIX_COLUMNS = ['USD', 'EUR', 'GBP', 'AUD', 'CAD', 'CHF', 'JPY', 'NZD'] as const;
 export type MatrixColumn = (typeof MATRIX_COLUMNS)[number];
 
+/** Consensus horizon bucket — the medium- vs long-term view of a currency. */
+export type Timeframe = 'medium' | 'long';
+
 /**
  * `fx_consensus_snapshot` — one row per G10 currency per run_date, for the
  * weighted (relevance-weighted live) view AND the unweighted (frozen) view.
- * PRIMARY KEY (run_date, currency, weighted).
+ * PRIMARY KEY (run_date, currency, timeframe, weighted) — MULTIPLE rows per
+ * currency per run (one per timeframe); callers MUST pin a timeframe.
  */
 export interface FxConsensusSnapshotRow {
   run_date: string; // date (ISO YYYY-MM-DD)
   currency: string;
+  timeframe: Timeframe;
+  horizon_weeks: number | null;
   weighted: boolean;
   score: number; // float8, expected range [-2, +2]
   confidence: number; // float8
@@ -211,4 +217,47 @@ export interface MatrixCell {
   run_date: string; // the brief's run_date (as-of)
   report_date: string | null;
   source_file: string; // drill-to-brief key
+  rationale?: string;
+  key_facts?: string[];
+  targets?: unknown[];
+}
+
+/**
+ * Per-currency consensus movement between the two newest distinct runs for a
+ * pinned timeframe. Computed in TS (see `computeConsensusDeltaSet`).
+ */
+export interface ConsensusDelta {
+  currency: string;
+  scoreNow: number;
+  scorePrev: number | null;
+  scoreDelta: number | null;
+  confidenceDelta: number | null;
+  flippedDirection: boolean;
+  prevRunDate: string | null;
+}
+
+/** A notable consensus shift since the previous run (for the movers strip). */
+export interface Mover {
+  currency: string;
+  scoreNow: number;
+  scoreDelta: number;
+  absDelta: number;
+  direction: 'up' | 'down';
+}
+
+/** The full run-over-run delta picture: per-currency deltas plus top movers. */
+export interface ConsensusDeltaSet {
+  runDate: string | null;
+  prevRunDate: string | null;
+  byCurrency: Record<string, ConsensusDelta>;
+  movers: Mover[];
+}
+
+/** The catalyst a confluence idea hangs on, resolved against the events feed. */
+export interface ConfluenceCatalyst {
+  eventKey: string | null;
+  eventName: string | null;
+  eventDate: string | null;
+  calendarExternalId: string | null;
+  daysToCatalyst: number | null;
 }


### PR DESCRIPTION
## Summary

End-to-end improvements to the Olympus **twelve-x** FX Research suite, addressing the findings from a full review of the deployed page plus a UI/mobile pass. The suite worked but was strong-on-observability / weak-on-daily-optimization, carried one silent data bug, and had a mobile shell defect.

Full review (context): https://claude.ai/code/artifact/43acefae-4532-49c0-b0f3-7b6040ba56a0

## What's in here

**Critical fix**
- **Consensus blended timeframes.** The fetchers filtered `weighted=true` but never pinned `timeframe`; the `(run_date,currency,timeframe,weighted)` PK returned two rows per currency per run that silently overwrote each other and collided React keys. Now pinned (default `medium`) — the score-over-time chart is visibly de-blended.

**Trader workflow (the "optimize" gap)**
- **Day-over-day deltas everywhere** — a "what changed since last run" movers strip on Today + Δ-vs-prior column/banner on Consensus (computed client-side from already-fetched history, no extra round-trips).
- **Trade-idea cards now drill** — currency → Consensus, catalyst → Events; lead Today with ranked ideas (brief demoted to a collapsible section); per-currency **watchlist** (localStorage) filter; score-scale legends.

**Correctness / clarity**
- Intelligence component bar renders each leg on its own `[0,1]` track (was normalized to the per-idea sum, so every card looked alike); **named + linked catalysts** (`~` hedges heuristic matches).
- Events: group by the **local date of the release instant** and mark venue-local (unconverted) times with `≈`; show literal `0` forecasts.
- Matrix surfaces the NOK/SEK coverage gap (8-of-10 board) instead of hiding it; Ledger renders its lazy-load **error state** (was swallowed to empty); one canonical `run_date` threaded to all tabs.

**Mobile** (your main report)
- The standalone `/twelve-x` `AppFrame` branch renders no `MobileAppBar`, but the shared `SubpageStickyTabBar` hard-coded `max-md:top-[72px]` → a 72px dead gap on phones. Added an additive `topOffset` prop; twelve-x passes `'none'` so the tab bar pins flush to the top. Portfolio/Research unaffected. Plus BriefPanel full-bleed drawer + body-scroll-lock + safe-area padding.

**Deferred** (flagged in-code, not built): push alerting (no server under static export) and global search/export.

## Verification
- `next build` ✅ — TypeScript clean, all 15 static pages prerendered incl. `/twelve-x`
- **16/16** unit tests · eslint clean on twelve-x files
- Live-rendered against real Supabase data at **390px mobile** and **1440px desktop**, zero console errors, every tab clicked through

## Commits
1. `fix(twelve-x)` — data layer: timeframe pin + delta/catalyst/timezone helpers
2. `feat(twelve-x)` — cross-link context, delta primitives, watchlist, canonical run_date, mobile offset
3. `feat(twelve-x)` — trader-workflow UI + mobile responsiveness across all tabs
4. `refactor(twelve-x)` — collapse tab bar to a config map + switch render

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #990
