### PR TITLE
fix(olympus): map deliberation phase + harden model fallback off non-OpenRouter

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -149,5 +149,6 @@ phase_capability_prefixes:
   hermes/thesis/market-: research
   hermes/thesis/vehicle-: research
   hermes/portfolio/asset-analyst-: extraction
+  hermes/portfolio/deliberation-: reasoning
   h6_pm_challenge-: research
   h6_analyst_response-: research

--- a/digigraph/src/digigraph/model_config.py
+++ b/digigraph/src/digigraph/model_config.py
@@ -501,21 +501,37 @@ def apply_olympus_openrouter_env(*, force: bool = False) -> str:
 def get_model_for_mode() -> str:
     """Return the fallback model for phases without a phase_models entry.
 
-    Atlas/Hermes phases all have explicit phase_models entries, so this is
-    reached only by non-Atlas digigraph agent runners that don't supply a
-    phase_slug. Resolution order:
+    Resolution order:
     1. ``default_model`` in model_modes.yaml — optional explicit fallback.
     2. ``defaults[DIGI_LLM_MODE]`` — legacy mode-keyed fallback.
     3. ``"gpt-4o-mini"`` — hard last resort.
+
+    Defense-in-depth (Olympus / OpenRouter-only deploy): the legacy defaults are
+    dev-oriented (``ollama/*``, bare ``gpt-4o-mini``). digillm routes any model whose
+    prefix is not a registered provider to the default OpenAI client, so a dev fallback
+    leaking into the pipeline 401s ("Incorrect API key provided: not-set"). When
+    ``OPENROUTER_API_KEY`` is set and the resolved fallback is not OpenRouter-routable,
+    use the active tier's reasoning model instead, so an unmapped phase slug still routes
+    through OpenRouter rather than an unauthenticated provider.
     """
     data = _load_model_modes()
     if data.default_model:
-        return str(data.default_model)
-    mode = _get_llm_mode()
-    model = data.defaults.get(mode) or data.defaults.get("test")
-    if model:
-        return model
-    return "gpt-4o-mini"
+        resolved = str(data.default_model)
+    else:
+        mode = _get_llm_mode()
+        resolved = data.defaults.get(mode) or data.defaults.get("test") or "gpt-4o-mini"
+
+    if os.environ.get("OPENROUTER_API_KEY", "").strip() and not resolved.startswith("openrouter/"):
+        tier_fallback = _model_for_olympus_capability("reasoning", get_olympus_tier(), "fallback")
+        if tier_fallback:
+            logger.warning(
+                "get_model_for_mode: fallback %r is not OpenRouter-routable in an OpenRouter "
+                "deploy; using tier reasoning model %r instead",
+                resolved,
+                tier_fallback,
+            )
+            return tier_fallback
+    return resolved
 
 
 def get_model_for_phase(phase_slug: str) -> str | None:

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -11,6 +11,7 @@ import digigraph.model_config as model_config
 from digigraph.model_config import (
     apply_olympus_openrouter_env,
     get_grounding_model,
+    get_model_for_mode,
     get_model_for_phase,
     get_olympus_tier,
     is_flagship_allowed_models_entry,
@@ -505,3 +506,80 @@ def test_no_online_slug_in_any_phase_pool() -> None:
                 assert is_tool_use_capable_model(model), (
                     f"tier {tier_name} {capability} model {model!r} lacks tool use"
                 )
+
+
+# ── Phase-slug routing must never fall through to the dev fallback (401 guard) ──
+# Regression: the Hermes deliberation worker built slug
+# ``hermes/portfolio/deliberation-{ticker}`` which matched no phase_capabilities entry
+# nor prefix, so get_model_for_phase returned None and the caller fell back to
+# get_model_for_mode() -> a dev model (ollama/*) that digillm routed to the default
+# OpenAI client -> 401 "Incorrect API key provided: not-set", failing the live baseline.
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "slug",
+    [
+        "hermes/portfolio/deliberation-AAPL",  # the regression: was unmapped
+        "h6_pm_challenge-AAPL",
+        "h6_analyst_response-AAPL",
+        "hermes/portfolio/asset-analyst-AAPL",
+        "hermes/portfolio/pm-direction",
+        "sector-technology",
+        "macro",
+        "alt-options-derivatives",
+        "pm-rebalance",
+        "beliefs-distillation",
+    ],
+)
+def test_pipeline_phase_slugs_resolve_to_openrouter(
+    monkeypatch: pytest.MonkeyPatch, slug: str
+) -> None:
+    """Every live-pipeline phase slug must resolve to an OpenRouter model (never None)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
+    resolved = get_model_for_phase(slug)
+    assert resolved is not None, f"phase slug {slug!r} is unmapped — falls back to dev model (401)"
+    assert resolved.startswith("openrouter/"), (
+        f"phase slug {slug!r} resolved to non-OpenRouter model {resolved!r}"
+    )
+
+
+@pytest.mark.unit
+def test_deliberation_slug_routes_to_reasoning_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deliberation worker slug routes to the tier reasoning pool (was the 401 bug)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
+    cfg = model_config._load_olympus_models()
+    assert (
+        get_model_for_phase("hermes/portfolio/deliberation-NVDA")
+        in cfg.tiers["cheap"].allowed_models["reasoning"]
+    )
+
+
+@pytest.mark.unit
+def test_get_model_for_mode_uses_tier_reasoning_in_openrouter_deploy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: with OPENROUTER_API_KEY set, a dev fallback (ollama/*) must be
+    replaced by an OpenRouter-routable tier reasoning model, never leak to the default
+    OpenAI client (which 401s)."""
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
+    resolved = get_model_for_mode()
+    assert resolved.startswith("openrouter/"), (
+        f"get_model_for_mode leaked non-OpenRouter fallback {resolved!r} in OpenRouter deploy"
+    )
+
+
+@pytest.mark.unit
+def test_get_model_for_mode_keeps_dev_default_without_openrouter_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside an OpenRouter deploy the legacy dev fallback is preserved (no behavior change)."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    resolved = get_model_for_mode()
+    # model_modes.yaml defaults are dev models (ollama/*); not forced to OpenRouter here.
+    assert not resolved.startswith("openrouter/")


### PR DESCRIPTION
## Problem

The live baseline failed in Hermes deliberation with `401 Incorrect API key provided: not-set` (OpenAI), `book_materialized: false`. Root cause: the deliberation worker's phase slug `hermes/portfolio/deliberation-{ticker}` was **unmapped** → `get_model_for_phase` returned None → `get_model_for_mode()` returned the **dev default** (`ollama/qwen3:8b`). digillm routes any unregistered-prefix model to the **default OpenAI client**, which 401s in our OpenRouter-only deploy.

## Fix

- **config**: add prefix `hermes/portfolio/deliberation-: reasoning`. (Audited all H1–H9 + Atlas phase slugs; `sector-` etc. are already mapped — deliberation- was the only real gap.)
- **defense-in-depth** (`get_model_for_mode`): when `OPENROUTER_API_KEY` is set and the resolved fallback isn't OpenRouter-routable, return the active tier's reasoning model — so no future unmapped slug can ever leak to the unauthenticated OpenAI client again.
- **tests**: every live-pipeline phase slug resolves to an `openrouter/` model (incl. the deliberation regression); `get_model_for_mode` never leaks a non-OpenRouter fallback in an OpenRouter deploy.

## Validation

`pytest tests/dg/test_olympus_models.py tests/dg/test_llm_openrouter_web_search.py` → **66 passed**. ruff clean.

Follow-up to #980/#987. (No tracking issue per request; `Require Fixes` non-blocking on develop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)