### PR TITLE
fix(olympus): coerce date/datetime at Supabase write boundary

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -191,6 +191,27 @@ def _audit(event_type: str, payload: dict[str, Any]) -> None:
     logger.info("atlas_io audit: %s %s", event_type, redact_mapping(payload))
 
 
+def _json_safe(value: Any) -> Any:
+    """Recursively coerce ``date``/``datetime`` to ISO strings.
+
+    The Supabase client serializes upsert bodies with the stdlib ``json``
+    encoder (via httpx), which cannot encode ``date``/``datetime``. Atlas/Hermes
+    payloads are heterogeneous dicts: e.g. a ``PMDirectionMemo`` rehydrated from
+    a LangGraph checkpoint as a plain dict — rather than the Pydantic model
+    whose ``model_dump(mode="json")`` would coerce it — carries a raw ``date``
+    in ``payload["date"]``. Coercing here, at the single write boundary,
+    protects every caller (analyst/deliberation/book/memo/delta/snapshot) at
+    once instead of relying on each one to pre-serialize its dates.
+    """
+    if isinstance(value, dict):
+        return {key: _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
 def publish_document(
     *,
     client: SupabaseClient,
@@ -231,7 +252,9 @@ def publish_document(
         "payload": payload,
         "content": content_markdown,
     }
-    resp = client.table("documents").upsert(row, on_conflict="date,document_key").execute()
+    resp = (
+        client.table("documents").upsert(_json_safe(row), on_conflict="date,document_key").execute()
+    )
     row_id = _extract_row_id(resp) or document_key
     _audit(
         "publish_document",
@@ -291,7 +314,7 @@ def publish_daily_snapshot(
         "snapshot": snapshot,
         "digest_markdown": digest_markdown,
     }
-    resp = client.table("daily_snapshots").upsert(row, on_conflict="date").execute()
+    resp = client.table("daily_snapshots").upsert(_json_safe(row), on_conflict="date").execute()
     row_id = _extract_row_id(resp) or date_str
     _audit(
         "publish_daily_snapshot",
@@ -320,7 +343,9 @@ def upsert_onchain_cohort_positioning(
     if not rows:
         return 0
     for row in rows:
-        client.table("onchain_cohort_positioning").upsert(row, on_conflict="date,market").execute()
+        client.table("onchain_cohort_positioning").upsert(
+            _json_safe(row), on_conflict="date,market"
+        ).execute()
     _audit(
         "upsert_onchain_cohort_positioning",
         {"date": rows[0].get("date"), "row_count": len(rows)},

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any  # noqa: F401 — used for fake-client payload dict shape
 
 import pytest
@@ -23,6 +24,7 @@ from digiquant.olympus.atlas.supabase_io import (
     query_pending_decisions,
     query_price_deltas,
     query_price_technicals_freshness,
+    upsert_onchain_cohort_positioning,
 )
 
 
@@ -174,7 +176,56 @@ class TestSupabaseConfig:
 
 
 @pytest.mark.unit
+class TestJsonSafe:
+    """`_json_safe` is the write-boundary coercion that keeps date/datetime
+    objects out of the JSON body the Supabase client hands to httpx."""
+
+    def test_coerces_date_and_datetime_recursively(self) -> None:
+        from digiquant.olympus.atlas.supabase_io import _json_safe
+
+        out = _json_safe(
+            {
+                "date": date(2026, 6, 22),
+                "roster": [{"as_of": datetime(2026, 6, 22, 13, 30)}, "flat"],
+                "label": "long-tech",
+                "rank": 3,
+                "weight": None,
+            }
+        )
+        assert out == {
+            "date": "2026-06-22",
+            "roster": [{"as_of": "2026-06-22T13:30:00"}, "flat"],
+            "label": "long-tech",
+            "rank": 3,
+            "weight": None,
+        }
+        json.dumps(out)  # the whole structure must be JSON-encodable
+
+
+@pytest.mark.unit
 class TestPublishDocument:
+    def test_serializes_date_objects_nested_in_payload(self) -> None:
+        """Regression (Olympus daily crash, 2026-06-22): a ``PMDirectionMemo``
+        rehydrated from a LangGraph checkpoint as a plain dict — rather than the
+        Pydantic model — carries a raw ``datetime.date`` in ``payload['date']``.
+        The Supabase client JSON-encodes the row via httpx, so the date must be
+        coerced to an ISO string before upsert or it raises
+        ``TypeError: Object of type date is not JSON serializable``."""
+        client = FakeSupabaseClient()
+        publish_document(
+            client=client,
+            document_key="pm-direction-memo",
+            payload={"schema_version": "1.0", "date": date(2026, 6, 22), "roster": []},
+            doc_type="PM Direction Memo",
+            run_type="baseline",
+            title="PM Direction 2026-06-22",
+            date_str="2026-06-22",
+            category="portfolio",
+        )
+        row = client.store["documents"][0]
+        json.dumps(row)  # mirrors the real client's encode step — must not raise
+        assert row["payload"]["date"] == "2026-06-22"
+
     def test_idempotent_on_date_plus_document_key(self) -> None:
         client = FakeSupabaseClient()
         out1 = publish_document(
@@ -250,6 +301,37 @@ class TestPublishDailySnapshot:
         assert out.table == "daily_snapshots"
         assert client.store["daily_snapshots"][0]["_on_conflict"] == "date"
         assert client.store["daily_snapshots"][0]["snapshot"] == {"regime": "slowing"}
+
+    def test_serializes_date_objects_in_snapshot(self) -> None:
+        """Same date-not-serializable class as documents — the snapshot JSONB
+        payload is written in the same H9 commit step."""
+        client = FakeSupabaseClient()
+        publish_daily_snapshot(
+            client=client,
+            date_str="2026-06-22",
+            snapshot={"regime": "slowing", "as_of": date(2026, 6, 22)},
+            run_type="baseline",
+            baseline_date=None,
+        )
+        row = client.store["daily_snapshots"][0]
+        json.dumps(row)  # must not raise
+        assert row["snapshot"]["as_of"] == "2026-06-22"
+
+
+@pytest.mark.unit
+class TestUpsertOnchainCohortPositioning:
+    def test_serializes_date_objects_in_rows(self) -> None:
+        """Every write through this adapter must survive JSON encoding — a
+        date-bearing on-chain row would otherwise crash the upsert too."""
+        client = FakeSupabaseClient()
+        written = upsert_onchain_cohort_positioning(
+            client=client,
+            rows=[{"date": date(2026, 6, 22), "market": "BTC", "net_taker": 0.3}],
+        )
+        assert written == 1
+        row = client.store["onchain_cohort_positioning"][0]
+        json.dumps(row)  # must not raise
+        assert row["date"] == "2026-06-22"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

The daily Olympus research pipeline hard-fails in H9 `commit_run` with:

```
TypeError: Object of type date is not JSON serializable
  h9_commit_run.py:113  commit_run -> publish_hermes_documents
  commit_io.py:438      -> publish_document (pm-direction-memo)
  atlas/supabase_io.py:234  -> client.table("documents").upsert(row, ...).execute()
```

The run reports `{"ok": false, ..., "book_materialized": false}` — the book never materializes.

## Root cause

`commit_io.py` builds the memo payload as:

```python
payload = memo.model_dump(mode="json") if hasattr(memo, "model_dump") else dict(memo)
```

`PMDirectionMemo.date` is a Pydantic `date` field, and `state.phase_hermes.pm_direction_memo` is typed `Any`. When the memo is the **model**, `model_dump(mode="json")` coerces the date to an ISO string. But when it arrives as a plain **dict** — e.g. after LangGraph rehydrates checkpointed state (`chain: hermes graph failed; continuing with last-good state`) or via a degraded fallback — the `dict(memo)` branch keeps the raw `datetime.date`, which the Supabase client's httpx `json.dumps` cannot encode.

The same latent bug exists at the other two upserts in `supabase_io.py` (`daily_snapshots`, `onchain_cohort_positioning`).

## Fix

Add a recursive `_json_safe()` coercion applied at **all three upserts** in `supabase_io.py`, fixing the whole class at the single Supabase write boundary regardless of which caller's payload (analyst / deliberation / book / memo / delta / snapshot) carries a date. This is preferred over re-validating a possibly-degraded dict through `PMDirectionMemo` (whose `extra="forbid"` could itself raise). Conflict keys and the audit line are unaffected — the top-level `date` column was already a string.

## Testing

- Reproduced the exact `TypeError` at the unit level (verified RED first), then GREEN.
- New: `_json_safe` helper unit test + regression tests on all three upserts.
- `tests/dq/atlas/test_supabase_io.py`: **32 passed**; write/commit-path suites (`publish_category`, `portfolio_materialize`, `phase7e_risk_sizing`): **112 passed**; ruff check + format clean.
- `make score`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10 — all thresholds met.

## Scope

This fixes the **hard crash** only. The same run also shows independent degradations (`DeliberationAnalystTurn` empty-response parse failures; `macro … grounding_absent=True`) tracked separately.

Fixes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)