### PR TITLE
fix(olympus): route H6 deliberation to research pool (off deepseek-r1)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -149,6 +149,10 @@ phase_capability_prefixes:
   hermes/thesis/market-: research
   hermes/thesis/vehicle-: research
   hermes/portfolio/asset-analyst-: extraction
-  hermes/portfolio/deliberation-: reasoning
+  # Deliberation turns emit strict JSON (DeliberationPmTurn/AnalystTurn). The `reasoning` pool
+  # carries deepseek-r1, whose chain-of-thought content is prose, not JSON — json.loads failed
+  # at char 0 for ~1/3 of tickers (run 27984259662). `research` is JSON+tool capable and matches
+  # the per-turn h6_* mappings below.
+  hermes/portfolio/deliberation-: research
   h6_pm_challenge-: research
   h6_analyst_response-: research

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -108,6 +108,34 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
+def test_deliberation_routes_to_json_capable_research_pool_not_r1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression (Olympus daily, 2026-06-22, run 27984259662): H6 deliberation turns must
+    emit strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 mapped the phase to
+    the ``reasoning`` pool, which in the cheap tier contains ``deepseek-r1`` — a chain-of-thought
+    model that returns prose, so ``json.loads`` failed at char 0 ("Expecting value: line 1
+    column 1") for the ~1/3 of tickers that hashed onto it. Deliberation must route to the
+    JSON/tool-capable ``research`` pool — never the prose-only r1 — matching the (already
+    intended) h6_pm_challenge-/h6_analyst_response- mappings.
+    """
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    research = set(model_config._load_olympus_models().tiers["cheap"].allowed_models["research"])
+    # The live macro watchlist from the failing run.
+    watchlist = (
+        "SPY QQQ DIA IWB VTI MDY IJH IWM IJR XLK XLF XLE XLV XLI XLRE XLU XLY XLP XLB XLC "
+        "EFA VEA VGK EWJ EWG EWU EWA EEM VWO FXI ASHR EWZ EWT EWY INDA BITO IBIT FBTC ETHA "
+        "FETH GBTC GLD IAU SLV DBO USO BNO PDBC DJP CPER BIL SHV SHY IEF TLT AGG HYG LQD TIP "
+        "EMB DXY UUP VIX"
+    ).split()
+    for ticker in watchlist:
+        model = get_model_for_phase(f"hermes/portfolio/deliberation-{ticker}")
+        assert model in research, f"deliberation-{ticker} -> {model!r}, not a research-pool model"
+        assert "deepseek-r1" not in model, f"deliberation-{ticker} routes to prose-only r1"
+        assert is_tool_use_capable_model(model)
+
+
+@pytest.mark.unit
 def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -546,14 +574,16 @@ def test_pipeline_phase_slugs_resolve_to_openrouter(
 
 
 @pytest.mark.unit
-def test_deliberation_slug_routes_to_reasoning_pool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The deliberation worker slug routes to the tier reasoning pool (was the 401 bug)."""
+def test_deliberation_slug_routes_to_research_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deliberation worker slug routes to the tier research pool — OpenRouter (the #991
+    401 guard) and JSON/tool-capable. It must NOT use the reasoning pool, whose deepseek-r1
+    returns prose and broke json.loads for the H6 turns (#993)."""
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
     cfg = model_config._load_olympus_models()
     assert (
         get_model_for_phase("hermes/portfolio/deliberation-NVDA")
-        in cfg.tiers["cheap"].allowed_models["reasoning"]
+        in cfg.tiers["cheap"].allowed_models["research"]
     )
 
 


### PR DESCRIPTION
## Problem

H6 deliberation logs a burst of JSON-parse failures in the daily run:

```
research_agent attempt 1/2 failed for DeliberationAnalystTurn: Expecting value: line 1 column 1 (char 0)   (x13)
research_agent attempt 1/2 failed for DeliberationPmTurn: Expecting ':' delimiter: line 1 column 717
```

`Expecting value: line 1 column 1` is `json.loads()` on **non-JSON prose** — `research_agent`'s empty-body guard already catches truly-empty responses with a clear `ValueError`, so this is a non-empty, non-JSON body.

## Root cause

`h6_deliberation` resolves `eff_model = get_model_for_phase("hermes/portfolio/deliberation-{ticker}")`. Config mapped `hermes/portfolio/deliberation- → reasoning` (added by #991 to fix a prior `ollama`/401 fallback). The cheap `reasoning` pool is `[deepseek-chat, deepseek-r1, llama-4-maverick]`, picked by a stable hash of the slug. **~1/3 of tickers hash onto `deepseek-r1`** — a chain-of-thought model whose `content` is prose, not the strict JSON `DeliberationPmTurn`/`DeliberationAnalystTurn` require → `json.loads` fails at char 0. The `deepseek-chat`/`maverick` picks (and every other phase) succeed.

Verified deterministically: **17 of 63** live watchlist tickers route to `deepseek-r1` for deliberation; `pm-direction` (also `reasoning`) hashes to `deepseek-chat`, which is why the PM memo was produced.

## Fix

Route `hermes/portfolio/deliberation- → research` (JSON + tool capable; cheap/balanced research pools contain no r1), matching the already-present `h6_pm_challenge-/h6_analyst_response- → research` intent and preserving #991's OpenRouter/401 guarantee.

## Testing

- New regression test asserts deliberation routes to the research pool — never `deepseek-r1` — across the full live watchlist (RED before, GREEN after). Updated the #991 test (`…routes_to_research_pool`) to assert the corrected pool; the 401 guard is still covered by `test_pipeline_phase_slugs_resolve_to_openrouter`.
- `tests/dg/test_olympus_models.py`: **62 passed**; broader dg model/config suite: **100 passed**; ruff clean; `make score` 10/10 all dimensions.

## Scope / follow-ups

Separate from the H9 `date`-serialization crash (#993, PR #994). Not addressed here: the `macro … grounding_absent=True` warning (grounding availability), and that the **quality**-tier `research` pool also contains `deepseek-r1` (the live deploy is cheap tier; a structured-output capability guard for r1 across all tiers would be a broader change).

Fixes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)