### PR TITLE
fix(olympus): don't flag grounding_absent for the fallback macro segment

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -250,8 +250,17 @@ def apply_web_grounding_to_inputs(
     web_grounding: dict[str, Any] | None,
     segment: str,
     live_search: bool,
+    live_search_is_fallback: bool = False,
 ) -> dict[str, Any]:
-    """Merge web grounding into ``phase_inputs``; flag or fail when absent."""
+    """Merge web grounding into ``phase_inputs``; flag or fail when absent.
+
+    A ``live_search_is_fallback`` segment (e.g. macro, #711) is grounded by its primary
+    ingested-data layer; the paid web_search is a stale-only supplement that ``build_grounding``
+    skips on the fresh-data hot path. Its absence is the normal cost-cut, NOT an ungrounded
+    segment — so it is neither failed-hard (``OLYMPUS_WEB_SEARCH=required``) nor flagged
+    ``grounding_absent`` (which would wrongly tell the analyst to lower conviction; #946 is for
+    segments where web search is the *primary* grounding).
+    """
     from digiquant.olympus.atlas.data.web_grounding import (
         OlympusWebSearchError,
         olympus_web_search_required,
@@ -261,7 +270,7 @@ def apply_web_grounding_to_inputs(
     if web_grounding:
         inputs["web_grounding"] = web_grounding
         return inputs
-    if not live_search:
+    if not live_search or live_search_is_fallback:
         return inputs
     if olympus_web_search_required():
         raise OlympusWebSearchError(
@@ -795,6 +804,7 @@ def build_segment_node(
                 web_grounding=None,
                 segment=spec.segment_slug,
                 live_search=spec.live_search or spec.ai_portfolios,
+                live_search_is_fallback=spec.live_search_is_fallback,
             )
 
         edit_mode = _resolve_segment_edit_mode(state, spec.segment_slug)

--- a/tests/dq/atlas/test_grounding_absent.py
+++ b/tests/dq/atlas/test_grounding_absent.py
@@ -45,6 +45,16 @@ _SPEC_NO_SEARCH = SegmentNodeSpec(
     live_search=False,
 )
 
+_SPEC_FALLBACK = SegmentNodeSpec(
+    segment_slug="test-fallback",
+    skill_slug="macro",
+    output_model=_MinimalReport,
+    phase_outputs_field="phase1_outputs",
+    live_search=True,
+    live_search_is_fallback=True,
+    use_data_tools=True,
+)
+
 
 def _state() -> AtlasResearchState:
     return AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 20))
@@ -124,4 +134,13 @@ class TestGroundingAbsentFlag:
         """A segment without live_search/ai_portfolios never gets the flag,
         even when web_grounding is None."""
         captured = self._run_capturing(_SPEC_NO_SEARCH, web_grounding=None)
+        assert "grounding_absent" not in captured
+
+    def test_fallback_segment_no_grounding_does_not_set_flag(self) -> None:
+        """A ``live_search_is_fallback`` segment (e.g. macro, #711) is grounded by its
+        primary ingested-data layer; the paid web_search is a stale-only supplement that is
+        skipped on the fresh-data hot path. Its absence is NOT an ungrounded segment, so
+        ``grounding_absent`` must not be flagged (it would wrongly tell the analyst to lower
+        conviction despite fresh FRED data)."""
+        captured = self._run_capturing(_SPEC_FALLBACK, web_grounding=None)
         assert "grounding_absent" not in captured


### PR DESCRIPTION
## Problem

Every daily Olympus run logs at the macro phase:

```
macro: grounding-dependent segment received no web_grounding; flagging grounding_absent=True in phase_inputs
```

`grounding_absent=True` is injected into the macro analyst's `phase_inputs`, which (per `ANALYST_SYSTEM`) tells the model to lower conviction — despite the macro segment having fresh FRED data.

## Root cause — two features collide

- **#946** flags `grounding_absent=True` for any `live_search=True` segment that gets no `web_grounding` (so web-search-dependent output is honestly labeled low-confidence).
- **#711** made macro `live_search_is_fallback=True`: its **primary** grounding is the ingested FRED layer (`use_data_tools`), and the paid web_search fires **only when FRED is stale**. On the normal hot path (fresh FRED), `build_grounding` deliberately skips the paid search → `web_grounding=None`.

`build_segment_node` can't distinguish "intentionally skipped, FRED fresh" from "genuinely ungrounded" — both are `web_grounding=None` — so it applies #946's logic and flags `grounding_absent` + warns on **every** run. (`grounding_absent` has no code consumer; its only effect is in the prompt.)

## Fix

A `live_search_is_fallback` segment is grounded by its primary ingested-data layer, so a missing paid web_search is the expected cost-cut — not an ungrounded segment. Thread `live_search_is_fallback` into `apply_web_grounding_to_inputs` and short-circuit for fallback segments: neither fail-hard (`OLYMPUS_WEB_SEARCH=required`) nor flag `grounding_absent`. The new param defaults `False`, so the other 10 callers and the #946 primary-web-search semantics are unchanged. Scoped to macro — the only `live_search_is_fallback` segment.

## Testing

- New test: a `live_search_is_fallback` segment with `web_grounding=None` must NOT set `grounding_absent` (RED before, GREEN after, reproducing the live WARNING). The 3 existing #946 tests (non-fallback `live_search` still flags; grounding present doesn't; no-search never flags) still pass.
- `tests/dq/atlas/{test_grounding_absent, test_build_grounding_research_tools, test_phase_tool_flags, data/test_web_grounding}.py`: **29 passed**; ruff clean; `make score` 10/10.

## Scope

Third and last of the issues from run 27984259662 — after the H9 `date`-serialization crash (#993 / PR #994) and the deliberation r1 routing (#997 / PR #998).

Fixes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)