### PR TITLE
Promote develop → main: Olympus pipeline crash + degradation fixes (#994, #998, #1000)

### DIFF
--- a/config/olympus_models.yaml
+++ b/config/olympus_models.yaml
@@ -149,6 +149,10 @@ phase_capability_prefixes:
   hermes/thesis/market-: research
   hermes/thesis/vehicle-: research
   hermes/portfolio/asset-analyst-: extraction
-  hermes/portfolio/deliberation-: reasoning
+  # Deliberation turns emit strict JSON (DeliberationPmTurn/AnalystTurn). The `reasoning` pool
+  # carries deepseek-r1, whose chain-of-thought content is prose, not JSON — json.loads failed
+  # at char 0 for ~1/3 of tickers (run 27984259662). `research` is JSON+tool capable and matches
+  # the per-turn h6_* mappings below.
+  hermes/portfolio/deliberation-: research
   h6_pm_challenge-: research
   h6_analyst_response-: research

--- a/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/_node_factory.py
@@ -250,8 +250,17 @@ def apply_web_grounding_to_inputs(
     web_grounding: dict[str, Any] | None,
     segment: str,
     live_search: bool,
+    live_search_is_fallback: bool = False,
 ) -> dict[str, Any]:
-    """Merge web grounding into ``phase_inputs``; flag or fail when absent."""
+    """Merge web grounding into ``phase_inputs``; flag or fail when absent.
+
+    A ``live_search_is_fallback`` segment (e.g. macro, #711) is grounded by its primary
+    ingested-data layer; the paid web_search is a stale-only supplement that ``build_grounding``
+    skips on the fresh-data hot path. Its absence is the normal cost-cut, NOT an ungrounded
+    segment — so it is neither failed-hard (``OLYMPUS_WEB_SEARCH=required``) nor flagged
+    ``grounding_absent`` (which would wrongly tell the analyst to lower conviction; #946 is for
+    segments where web search is the *primary* grounding).
+    """
     from digiquant.olympus.atlas.data.web_grounding import (
         OlympusWebSearchError,
         olympus_web_search_required,
@@ -261,7 +270,7 @@ def apply_web_grounding_to_inputs(
     if web_grounding:
         inputs["web_grounding"] = web_grounding
         return inputs
-    if not live_search:
+    if not live_search or live_search_is_fallback:
         return inputs
     if olympus_web_search_required():
         raise OlympusWebSearchError(
@@ -795,6 +804,7 @@ def build_segment_node(
                 web_grounding=None,
                 segment=spec.segment_slug,
                 live_search=spec.live_search or spec.ai_portfolios,
+                live_search_is_fallback=spec.live_search_is_fallback,
             )
 
         edit_mode = _resolve_segment_edit_mode(state, spec.segment_slug)

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -191,6 +191,27 @@ def _audit(event_type: str, payload: dict[str, Any]) -> None:
     logger.info("atlas_io audit: %s %s", event_type, redact_mapping(payload))
 
 
+def _json_safe(value: Any) -> Any:
+    """Recursively coerce ``date``/``datetime`` to ISO strings.
+
+    The Supabase client serializes upsert bodies with the stdlib ``json``
+    encoder (via httpx), which cannot encode ``date``/``datetime``. Atlas/Hermes
+    payloads are heterogeneous dicts: e.g. a ``PMDirectionMemo`` rehydrated from
+    a LangGraph checkpoint as a plain dict — rather than the Pydantic model
+    whose ``model_dump(mode="json")`` would coerce it — carries a raw ``date``
+    in ``payload["date"]``. Coercing here, at the single write boundary,
+    protects every caller (analyst/deliberation/book/memo/delta/snapshot) at
+    once instead of relying on each one to pre-serialize its dates.
+    """
+    if isinstance(value, dict):
+        return {key: _json_safe(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
 def publish_document(
     *,
     client: SupabaseClient,
@@ -231,7 +252,9 @@ def publish_document(
         "payload": payload,
         "content": content_markdown,
     }
-    resp = client.table("documents").upsert(row, on_conflict="date,document_key").execute()
+    resp = (
+        client.table("documents").upsert(_json_safe(row), on_conflict="date,document_key").execute()
+    )
     row_id = _extract_row_id(resp) or document_key
     _audit(
         "publish_document",
@@ -291,7 +314,7 @@ def publish_daily_snapshot(
         "snapshot": snapshot,
         "digest_markdown": digest_markdown,
     }
-    resp = client.table("daily_snapshots").upsert(row, on_conflict="date").execute()
+    resp = client.table("daily_snapshots").upsert(_json_safe(row), on_conflict="date").execute()
     row_id = _extract_row_id(resp) or date_str
     _audit(
         "publish_daily_snapshot",
@@ -320,7 +343,9 @@ def upsert_onchain_cohort_positioning(
     if not rows:
         return 0
     for row in rows:
-        client.table("onchain_cohort_positioning").upsert(row, on_conflict="date,market").execute()
+        client.table("onchain_cohort_positioning").upsert(
+            _json_safe(row), on_conflict="date,market"
+        ).execute()
     _audit(
         "upsert_onchain_cohort_positioning",
         {"date": rows[0].get("date"), "row_count": len(rows)},

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -108,6 +108,34 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
+def test_deliberation_routes_to_json_capable_research_pool_not_r1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression (Olympus daily, 2026-06-22, run 27984259662): H6 deliberation turns must
+    emit strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 mapped the phase to
+    the ``reasoning`` pool, which in the cheap tier contains ``deepseek-r1`` — a chain-of-thought
+    model that returns prose, so ``json.loads`` failed at char 0 ("Expecting value: line 1
+    column 1") for the ~1/3 of tickers that hashed onto it. Deliberation must route to the
+    JSON/tool-capable ``research`` pool — never the prose-only r1 — matching the (already
+    intended) h6_pm_challenge-/h6_analyst_response- mappings.
+    """
+    monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
+    research = set(model_config._load_olympus_models().tiers["cheap"].allowed_models["research"])
+    # The live macro watchlist from the failing run.
+    watchlist = (
+        "SPY QQQ DIA IWB VTI MDY IJH IWM IJR XLK XLF XLE XLV XLI XLRE XLU XLY XLP XLB XLC "
+        "EFA VEA VGK EWJ EWG EWU EWA EEM VWO FXI ASHR EWZ EWT EWY INDA BITO IBIT FBTC ETHA "
+        "FETH GBTC GLD IAU SLV DBO USO BNO PDBC DJP CPER BIL SHV SHY IEF TLT AGG HYG LQD TIP "
+        "EMB DXY UUP VIX"
+    ).split()
+    for ticker in watchlist:
+        model = get_model_for_phase(f"hermes/portfolio/deliberation-{ticker}")
+        assert model in research, f"deliberation-{ticker} -> {model!r}, not a research-pool model"
+        assert "deepseek-r1" not in model, f"deliberation-{ticker} routes to prose-only r1"
+        assert is_tool_use_capable_model(model)
+
+
+@pytest.mark.unit
 def test_asset_analyst_slug_resolves_to_known_good_openrouter_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -546,14 +574,16 @@ def test_pipeline_phase_slugs_resolve_to_openrouter(
 
 
 @pytest.mark.unit
-def test_deliberation_slug_routes_to_reasoning_pool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The deliberation worker slug routes to the tier reasoning pool (was the 401 bug)."""
+def test_deliberation_slug_routes_to_research_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deliberation worker slug routes to the tier research pool — OpenRouter (the #991
+    401 guard) and JSON/tool-capable. It must NOT use the reasoning pool, whose deepseek-r1
+    returns prose and broke json.loads for the H6 turns (#993)."""
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
     monkeypatch.setattr(model_config, "_olympus_models_cache", None)
     cfg = model_config._load_olympus_models()
     assert (
         get_model_for_phase("hermes/portfolio/deliberation-NVDA")
-        in cfg.tiers["cheap"].allowed_models["reasoning"]
+        in cfg.tiers["cheap"].allowed_models["research"]
     )
 
 

--- a/tests/dq/atlas/test_grounding_absent.py
+++ b/tests/dq/atlas/test_grounding_absent.py
@@ -45,6 +45,16 @@ _SPEC_NO_SEARCH = SegmentNodeSpec(
     live_search=False,
 )
 
+_SPEC_FALLBACK = SegmentNodeSpec(
+    segment_slug="test-fallback",
+    skill_slug="macro",
+    output_model=_MinimalReport,
+    phase_outputs_field="phase1_outputs",
+    live_search=True,
+    live_search_is_fallback=True,
+    use_data_tools=True,
+)
+
 
 def _state() -> AtlasResearchState:
     return AtlasResearchState(run_type="baseline", run_date=date(2026, 6, 20))
@@ -124,4 +134,13 @@ class TestGroundingAbsentFlag:
         """A segment without live_search/ai_portfolios never gets the flag,
         even when web_grounding is None."""
         captured = self._run_capturing(_SPEC_NO_SEARCH, web_grounding=None)
+        assert "grounding_absent" not in captured
+
+    def test_fallback_segment_no_grounding_does_not_set_flag(self) -> None:
+        """A ``live_search_is_fallback`` segment (e.g. macro, #711) is grounded by its
+        primary ingested-data layer; the paid web_search is a stale-only supplement that is
+        skipped on the fresh-data hot path. Its absence is NOT an ungrounded segment, so
+        ``grounding_absent`` must not be flagged (it would wrongly tell the analyst to lower
+        conviction despite fresh FRED data)."""
+        captured = self._run_capturing(_SPEC_FALLBACK, web_grounding=None)
         assert "grounding_absent" not in captured

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any  # noqa: F401 — used for fake-client payload dict shape
 
 import pytest
@@ -23,6 +24,7 @@ from digiquant.olympus.atlas.supabase_io import (
     query_pending_decisions,
     query_price_deltas,
     query_price_technicals_freshness,
+    upsert_onchain_cohort_positioning,
 )
 
 
@@ -174,7 +176,56 @@ class TestSupabaseConfig:
 
 
 @pytest.mark.unit
+class TestJsonSafe:
+    """`_json_safe` is the write-boundary coercion that keeps date/datetime
+    objects out of the JSON body the Supabase client hands to httpx."""
+
+    def test_coerces_date_and_datetime_recursively(self) -> None:
+        from digiquant.olympus.atlas.supabase_io import _json_safe
+
+        out = _json_safe(
+            {
+                "date": date(2026, 6, 22),
+                "roster": [{"as_of": datetime(2026, 6, 22, 13, 30)}, "flat"],
+                "label": "long-tech",
+                "rank": 3,
+                "weight": None,
+            }
+        )
+        assert out == {
+            "date": "2026-06-22",
+            "roster": [{"as_of": "2026-06-22T13:30:00"}, "flat"],
+            "label": "long-tech",
+            "rank": 3,
+            "weight": None,
+        }
+        json.dumps(out)  # the whole structure must be JSON-encodable
+
+
+@pytest.mark.unit
 class TestPublishDocument:
+    def test_serializes_date_objects_nested_in_payload(self) -> None:
+        """Regression (Olympus daily crash, 2026-06-22): a ``PMDirectionMemo``
+        rehydrated from a LangGraph checkpoint as a plain dict — rather than the
+        Pydantic model — carries a raw ``datetime.date`` in ``payload['date']``.
+        The Supabase client JSON-encodes the row via httpx, so the date must be
+        coerced to an ISO string before upsert or it raises
+        ``TypeError: Object of type date is not JSON serializable``."""
+        client = FakeSupabaseClient()
+        publish_document(
+            client=client,
+            document_key="pm-direction-memo",
+            payload={"schema_version": "1.0", "date": date(2026, 6, 22), "roster": []},
+            doc_type="PM Direction Memo",
+            run_type="baseline",
+            title="PM Direction 2026-06-22",
+            date_str="2026-06-22",
+            category="portfolio",
+        )
+        row = client.store["documents"][0]
+        json.dumps(row)  # mirrors the real client's encode step — must not raise
+        assert row["payload"]["date"] == "2026-06-22"
+
     def test_idempotent_on_date_plus_document_key(self) -> None:
         client = FakeSupabaseClient()
         out1 = publish_document(
@@ -250,6 +301,37 @@ class TestPublishDailySnapshot:
         assert out.table == "daily_snapshots"
         assert client.store["daily_snapshots"][0]["_on_conflict"] == "date"
         assert client.store["daily_snapshots"][0]["snapshot"] == {"regime": "slowing"}
+
+    def test_serializes_date_objects_in_snapshot(self) -> None:
+        """Same date-not-serializable class as documents — the snapshot JSONB
+        payload is written in the same H9 commit step."""
+        client = FakeSupabaseClient()
+        publish_daily_snapshot(
+            client=client,
+            date_str="2026-06-22",
+            snapshot={"regime": "slowing", "as_of": date(2026, 6, 22)},
+            run_type="baseline",
+            baseline_date=None,
+        )
+        row = client.store["daily_snapshots"][0]
+        json.dumps(row)  # must not raise
+        assert row["snapshot"]["as_of"] == "2026-06-22"
+
+
+@pytest.mark.unit
+class TestUpsertOnchainCohortPositioning:
+    def test_serializes_date_objects_in_rows(self) -> None:
+        """Every write through this adapter must survive JSON encoding — a
+        date-bearing on-chain row would otherwise crash the upsert too."""
+        client = FakeSupabaseClient()
+        written = upsert_onchain_cohort_positioning(
+            client=client,
+            rows=[{"date": date(2026, 6, 22), "market": "BTC", "net_taker": 0.3}],
+        )
+        assert written == 1
+        row = client.store["onchain_cohort_positioning"][0]
+        json.dumps(row)  # must not raise
+        assert row["date"] == "2026-06-22"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Promotes the three Olympus fixes from the diagnosis of cancelled run `27984259662` so the daily pipeline (which checks out `main`) runs on fixed code.

| PR | Issue | Fix |
|----|-------|-----|
| #994 | #993 | H9 `commit_run` crash — coerce `date`/`datetime` to ISO at the Supabase write boundary |
| #998 | #997 | H6 deliberation routed off `deepseek-r1` (prose) to the JSON-capable `research` pool |
| #1000 | #999 | macro `live_search_is_fallback` segment no longer false-flagged `grounding_absent` |

All three merged to `develop` with full CI green (`digiquant / test`, `atlas-graph / tests`, `ruff-and-scripts`, `score` 10/10, CodeQL). No file overlap; disjoint, low-risk changes.

After this merges, a fresh `workflow_dispatch` of *Pipeline: Olympus research* (`refresh_scope=all`) will re-run the cancelled run's work end-to-end on the fixed code.