### PR TITLE
feat(twelve-x): Today page single-screen daily snapshot (Part A)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-twelve-x-today-snapshot.md
+++ b/docs/superpowers/plans/2026-06-23-twelve-x-today-snapshot.md
@@ -1,0 +1,829 @@
+# Twelve-X "Today" Snapshot Redesign (Part A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the Olympus twelve-x **Today** tab into a single-screen daily snapshot — focal trade idea(s) + always-on digest brief above the fold, a consensus "what changed" strip, then a briefs slideshow + today's-events timeline, each with a "see more →" pass-through, plus a new Briefs index view.
+
+**Architecture:** Pure data helpers + thin Supabase fetchers in `lib/twelve-x/fetch.ts` feed presentational components in `components/twelve-x/`. `TwelveXClient` orchestrates fetching/URL-state; `TodayTab` composes the new section components. All new files are twelve-x-only — no shared-shell edits (that's Part B).
+
+**Tech Stack:** Next.js 16 (App Router, static export, `output: 'export'`, `basePath: '/olympus'`), React 19 (`'use client'`), Tailwind v4, `@supabase/supabase-js` (anon key, RLS), Vitest (unit tests for pure helpers), lucide-react icons.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md`
+
+## Global Constraints
+
+- Olympus app dir: `frontend/olympus`. All paths below are relative to it.
+- Every twelve-x component is a client component — first line `'use client';`.
+- Reuse existing tokens/classes: `glass-card`, `text-text-primary/secondary/muted`, `border-border-subtle`, `bg-bg-secondary`, `.fin-green/.fin-red/.fin-amber/.fin-blue`; sign semantics green=bullish/long, red=bearish/short, amber=watch.
+- Data access goes through the existing `querySupabase(...)` retry wrapper and the `twelveXSupabase` client; gate every fetcher on `isTwelveXConfigured()` and return `[]`/`null` when unconfigured (match the existing fetchers exactly).
+- Canonical run date is already threaded as `runDate` from `TwelveXClient` (digest ?? intelligence ?? latestConsensus). Use it; do not re-resolve per section.
+- Do **not** touch `components/subpage-tab-bar.tsx`, `app-frame.tsx`, `sidebar.tsx`, `mobile-app-bar.tsx`, or add a tab to the tab bar (Part B).
+- Build/verify needs deps: the worktree has no `node_modules` — symlink from the main checkout before building (see Task 6).
+- Pre-existing baseline: `tsc --noEmit` reports 2 errors in `lib/security-headers.test.ts` only — ignore those; your changes must add zero new errors.
+
+---
+
+### Task 1: Data layer — trade ideas, today's briefs, today's events
+
+**Files:**
+- Modify: `lib/twelve-x/types.ts` (add `FxTradeIdeaRow`)
+- Modify: `lib/twelve-x/fetch.ts` (add `getTradeIdeas`, `getTodayBriefs`, `sortTodayBriefs`, `getTodayEvents`)
+- Test: `lib/twelve-x/fetch.test.ts` (add tests for `sortTodayBriefs` + `getTodayEvents` filter)
+
+**Interfaces:**
+- Consumes (existing): `querySupabase`, `isTwelveXConfigured`, `twelveXSupabase`, `getUpcomingEvents()`, `eventLocalDateKey(row)`, types `FxBriefRow`, `FxEconomicCalendarRow`, `CurrencyView`, `BRIEF_COLUMNS`, `asCurrencyViews`.
+- Produces (later tasks rely on these exact signatures):
+  - `interface FxTradeIdeaRow { run_date: string; rank: number; pair: string; direction: string; title: string; thesis: string; catalyst: string; levels: unknown[]; citations: unknown[]; as_of: string; }`
+  - `getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]>` — ordered by `rank` asc.
+  - `getTodayBriefs(runDate: string): Promise<FxBriefRow[]>` — briefs for that run_date, returned already sorted by `sortTodayBriefs`.
+  - `sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[]` — pure; relevance(high→med→low) → #currency_views desc → report_date desc.
+  - `getTodayEvents(): Promise<FxEconomicCalendarRow[]>` — upcoming events filtered to the viewer-local "today".
+
+- [ ] **Step 1: Add the `FxTradeIdeaRow` type.** In `lib/twelve-x/types.ts`, after `ConfluenceCatalyst` (end of file), add:
+
+```typescript
+/**
+ * `fx_trade_ideas_snapshot` (twelve-x migration 012) — the curated, synthesized
+ * actionable trade ideas for a run. PRIMARY KEY (run_date, rank). anon-readable.
+ */
+export interface FxTradeIdeaRow {
+  run_date: string; // date (ISO YYYY-MM-DD)
+  rank: number; // int (1 = top)
+  pair: string; // e.g. "USD/JPY"
+  direction: string; // 'long' | 'short' | ...
+  title: string; // e.g. "JPY SHORT — via USD/JPY"
+  thesis: string;
+  catalyst: string;
+  levels: unknown[]; // jsonb array of broker levels/targets
+  citations: unknown[]; // jsonb array of TradeIdeaCitation
+  as_of: string; // timestamptz (ISO)
+}
+```
+
+- [ ] **Step 2: Write the failing test for `sortTodayBriefs`.** In `lib/twelve-x/fetch.test.ts`, add (import `sortTodayBriefs` and `FxBriefRow` at the top of the file alongside the existing imports):
+
+```typescript
+import { sortTodayBriefs } from './fetch';
+import type { FxBriefRow } from './types';
+
+const brief = (over: Partial<FxBriefRow>): FxBriefRow => ({
+  run_date: '2026-06-23', source_file: 's.pdf', source_url: null,
+  document_title: null, broker_name: 'X', analyst_names: null,
+  report_date: '2026-06-23', trader_relevance: 'low', central_thesis: null,
+  brief_markdown: null, currency_views: [], risk_events: null,
+  macro_themes: null, positioning_signals: null, ...over,
+});
+
+describe('sortTodayBriefs', () => {
+  it('orders by relevance (high→low), then breadth, then newest report_date', () => {
+    const lowOld = brief({ source_file: 'a', trader_relevance: 'low', report_date: '2026-06-20' });
+    const highFew = brief({ source_file: 'b', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }] });
+    const highMany = brief({ source_file: 'c', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }, { currency: 'EUR', direction: 'bearish', conviction: 'low' }] });
+    const medNew = brief({ source_file: 'd', trader_relevance: 'medium', report_date: '2026-06-23' });
+    const out = sortTodayBriefs([lowOld, highFew, highMany, medNew]).map((b) => b.source_file);
+    expect(out).toEqual(['c', 'b', 'd', 'a']);
+  });
+
+  it('is stable and pure (does not mutate input)', () => {
+    const input = [brief({ source_file: 'a' }), brief({ source_file: 'b' })];
+    const copy = [...input];
+    sortTodayBriefs(input);
+    expect(input).toEqual(copy);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test, verify it fails.**
+
+Run: `npx --no-install vitest run lib/twelve-x/fetch.test.ts -t sortTodayBriefs`
+Expected: FAIL — `sortTodayBriefs is not a function` (not yet exported).
+
+- [ ] **Step 4: Implement `sortTodayBriefs` + the fetchers in `fetch.ts`.** Add near the brief helpers (after `getBrief`, ~line 450). `asCurrencyViews` already exists in this file; reuse it.
+
+```typescript
+const _RELEVANCE_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Pure ordering for the Today briefs slideshow: relevance desc, then breadth
+ *  (# of currency_views) desc, then newest report_date desc. Does not mutate. */
+export function sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[] {
+  const rel = (b: FxBriefRow) => _RELEVANCE_RANK[(b.trader_relevance ?? '').toLowerCase()] ?? 0;
+  const breadth = (b: FxBriefRow) => asCurrencyViews(b.currency_views).length;
+  return [...briefs].sort(
+    (a, b) =>
+      rel(b) - rel(a) ||
+      breadth(b) - breadth(a) ||
+      (b.report_date ?? '').localeCompare(a.report_date ?? '')
+  );
+}
+
+/** Curated trade ideas for a run_date (rank 1 = top). `[]` when unconfigured/empty. */
+export async function getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxTradeIdeaRow[]>((sb) =>
+    sb
+      .from('fx_trade_ideas_snapshot')
+      .select('run_date, rank, pair, direction, title, thesis, catalyst, levels, citations, as_of')
+      .eq('run_date', runDate)
+      .order('rank', { ascending: true })
+  );
+  return rows ?? [];
+}
+
+/** Today's research briefs for a run_date, pre-sorted for the slideshow. */
+export async function getTodayBriefs(runDate: string): Promise<FxBriefRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxBriefRow[]>(
+    (sb) =>
+      sb
+        .from('fx_research_history')
+        .select(BRIEF_COLUMNS)
+        .eq('run_date', runDate)
+        .order('report_date', { ascending: false }) as unknown as PromiseLike<{
+        data: FxBriefRow[] | null;
+        error: unknown;
+      }>
+  );
+  return sortTodayBriefs(rows ?? []);
+}
+
+/** Upcoming macro events narrowed to the viewer-local "today". */
+export async function getTodayEvents(): Promise<FxEconomicCalendarRow[]> {
+  const all = await getUpcomingEvents();
+  const todayKey = eventLocalDateKey({ event_datetime_utc: new Date().toISOString(), event_date: '' });
+  return all.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+```
+
+Add `FxTradeIdeaRow` to the `import type { ... } from './types'` block at the top of `fetch.ts`.
+
+- [ ] **Step 5: Write the failing test for `getTodayEvents` filtering.** `getTodayEvents` calls Supabase, so test the *filter* via a thin seam: export a pure helper and test it. Add to `fetch.ts`:
+
+```typescript
+/** Pure: keep only rows whose local event date matches `todayKey`. */
+export function filterEventsToDay(
+  events: FxEconomicCalendarRow[],
+  todayKey: string
+): FxEconomicCalendarRow[] {
+  return events.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+```
+
+Refactor `getTodayEvents` to use it: `return filterEventsToDay(all, todayKey);`. Then in `fetch.test.ts`:
+
+```typescript
+import { filterEventsToDay } from './fetch';
+import type { FxEconomicCalendarRow } from './types';
+
+const ev = (over: Partial<FxEconomicCalendarRow>): FxEconomicCalendarRow => ({
+  id: 1, external_id: 'e', event_date: '2026-06-23', event_time: null,
+  country: 'US', event_name: 'X', category: 'c', impact: 'low',
+  actual: null, forecast: null, prior: null, event_datetime_utc: null, ...over,
+});
+
+describe('filterEventsToDay', () => {
+  it('keeps only events whose local date equals the target key', () => {
+    const todayUtc = ev({ id: 1, event_datetime_utc: '2026-06-23T14:30:00Z', event_date: '2026-06-23' });
+    const tomorrow = ev({ id: 2, event_datetime_utc: '2026-06-24T14:30:00Z', event_date: '2026-06-24' });
+    const allDayToday = ev({ id: 3, event_datetime_utc: null, event_date: '2026-06-23' });
+    const key = '2026-06-23';
+    const out = filterEventsToDay([todayUtc, tomorrow, allDayToday], key).map((e) => e.id);
+    expect(out).toContain(1);
+    expect(out).toContain(3);
+    expect(out).not.toContain(2);
+  });
+});
+```
+
+(Note: the UTC-instant events resolve via the viewer's local tz; run CI/tests in UTC so `2026-06-23T14:30Z` → `2026-06-23`. This matches the existing `eventLocalDateKey` behavior.)
+
+- [ ] **Step 6: Run the data-layer tests, verify pass.**
+
+Run: `npx --no-install vitest run lib/twelve-x/fetch.test.ts`
+Expected: PASS (existing tests + the new `sortTodayBriefs` and `filterEventsToDay` tests). `tsc --noEmit` shows no new errors.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add lib/twelve-x/types.ts lib/twelve-x/fetch.ts lib/twelve-x/fetch.test.ts
+git commit -m "feat(twelve-x): data layer for Today snapshot — trade ideas, today briefs/events"
+```
+
+---
+
+### Task 2: `TradeIdeasPanel` + `DigestBrief` components
+
+**Files:**
+- Create: `components/twelve-x/TradeIdeasPanel.tsx`
+- Create: `components/twelve-x/DigestBrief.tsx`
+
+**Interfaces:**
+- Consumes: `FxTradeIdeaRow` (Task 1), `FxConfluenceSnapshotRow` (existing), `useTwelveX()` (existing — `openBrief`, `crossLink`), `FxDailyDigestRow` shape (`{ run_date, summary, key_themes: string[], doc_count, broker_count }`).
+- Produces:
+  - `TradeIdeasPanel({ ideas, confluence }: { ideas: FxTradeIdeaRow[]; confluence: FxConfluenceSnapshotRow[] })`
+  - `DigestBrief({ digest }: { digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null })`
+
+- [ ] **Step 1: Create `TradeIdeasPanel.tsx`.** Focal `#1` card + compact `#2…N` rows + an expand toggle revealing the confluence reads. Empty state when `ideas` is empty.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { FxTradeIdeaRow, FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+function dirClass(direction: string): string {
+  const d = direction.toLowerCase();
+  if (d.includes('long') || d.includes('bull')) return 'text-fin-green';
+  if (d.includes('short') || d.includes('bear')) return 'text-fin-red';
+  return 'text-text-muted';
+}
+
+function firstSource(citations: unknown[]): string | null {
+  for (const c of citations) {
+    if (c && typeof c === 'object' && typeof (c as Record<string, unknown>).source_file === 'string') {
+      return (c as Record<string, unknown>).source_file as string;
+    }
+  }
+  return null;
+}
+
+export default function TradeIdeasPanel({
+  ideas,
+  confluence,
+}: {
+  ideas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+}) {
+  const { crossLink, openBrief } = useTwelveX();
+  const [expanded, setExpanded] = useState(false);
+
+  if (ideas.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        </header>
+        <p className="text-sm text-text-muted">No curated trade idea for today yet.</p>
+      </section>
+    );
+  }
+
+  const [top, ...rest] = ideas;
+  const topSource = firstSource(top.citations);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        <span className="font-mono text-[10px] text-text-muted">· {ideas.length}</span>
+        <button
+          type="button"
+          className="ml-auto text-[11px] text-fin-blue hover:underline"
+          onClick={() => crossLink({ kind: 'tab', tab: 'intelligence' })}
+        >
+          see more →
+        </button>
+      </header>
+
+      {/* Focal #1 */}
+      <button
+        type="button"
+        className="rounded-lg border border-fin-green/30 bg-fin-green/[0.06] p-4 text-left transition-colors hover:border-fin-blue/50"
+        onClick={() => topSource && openBrief(topSource, top.run_date)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-text-muted">#1</span>
+          <span className="font-semibold text-text-primary">{top.pair}</span>
+          <span className={`text-xs font-semibold uppercase ${dirClass(top.direction)}`}>{top.direction}</span>
+        </div>
+        <p className="mt-1 text-sm text-text-primary">{top.title}</p>
+        {top.thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{top.thesis}</p> : null}
+        {top.catalyst ? <p className="mt-1 text-[11px] text-text-muted">Catalyst: {top.catalyst}</p> : null}
+      </button>
+
+      {/* #2…N rows */}
+      {rest.map((idea) => {
+        const src = firstSource(idea.citations);
+        return (
+          <button
+            key={`${idea.run_date}-${idea.rank}`}
+            type="button"
+            className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-2 text-left text-xs transition-colors hover:border-fin-blue/50"
+            onClick={() => src && openBrief(src, idea.run_date)}
+          >
+            <span className="font-mono text-[10px] text-text-muted">#{idea.rank}</span>
+            <span className="font-semibold text-text-primary">{idea.pair}</span>
+            <span className={`font-semibold uppercase ${dirClass(idea.direction)}`}>{idea.direction}</span>
+            <span className="ml-auto truncate text-text-muted">{idea.title}</span>
+          </button>
+        );
+      })}
+
+      {/* Expand → confluence reads */}
+      {confluence.length > 0 ? (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[11px] text-text-secondary hover:text-fin-blue"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+            {expanded ? 'Hide' : 'Expand'} confluence reads ({confluence.length})
+          </button>
+          {expanded ? (
+            <ul className="mt-2 grid gap-1">
+              {confluence.map((c) => (
+                <li key={`${c.run_date}-${c.rank}`} className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-1.5 text-xs">
+                  <span className="font-mono text-[10px] text-text-muted">#{c.rank}</span>
+                  <span className="font-semibold text-text-primary">{c.currency}</span>
+                  <span className={`uppercase ${dirClass(c.direction)}`}>{c.direction}</span>
+                  <button
+                    type="button"
+                    className="ml-auto text-fin-blue hover:underline"
+                    onClick={() => crossLink({ kind: 'currency', currency: c.currency })}
+                  >
+                    trend →
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `DigestBrief.tsx`.** Always-on summary + key-theme chips; empty state when no digest.
+
+```tsx
+'use client';
+
+import { FileText } from 'lucide-react';
+
+export default function DigestBrief({
+  digest,
+}: {
+  digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+}) {
+  if (!digest) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <p className="mt-2 text-sm text-text-muted">No digest for today yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="glass-card flex flex-col gap-2 p-5">
+      <header className="flex items-baseline gap-2">
+        <FileText size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">
+          {digest.doc_count} docs · {digest.broker_count} brokers
+        </span>
+      </header>
+      <p className="whitespace-pre-line text-sm leading-relaxed text-text-primary">{digest.summary}</p>
+      {digest.key_themes.length > 0 ? (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {digest.key_themes.map((t) => (
+            <span key={t} className="rounded-full border border-border-subtle px-2.5 py-0.5 text-[11px] text-text-secondary">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'TradeIdeasPanel|DigestBrief' || echo CLEAN`
+Expected: `CLEAN` (no errors in the two new files).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add components/twelve-x/TradeIdeasPanel.tsx components/twelve-x/DigestBrief.tsx
+git commit -m "feat(twelve-x): TradeIdeasPanel (focal+list+expand) and DigestBrief"
+```
+
+---
+
+### Task 3: `BriefsSlideshow` + `EventsMiniTimeline` components
+
+**Files:**
+- Create: `components/twelve-x/BriefsSlideshow.tsx`
+- Create: `components/twelve-x/EventsMiniTimeline.tsx`
+
+**Interfaces:**
+- Consumes: `FxBriefRow`, `FxEconomicCalendarRow` (existing); `useTwelveX()` (`openBrief`, `crossLink`); `hasResolvedTime`, `eventInstant` (existing fetch helpers).
+- Produces:
+  - `BriefsSlideshow({ briefs, onSeeMore }: { briefs: FxBriefRow[]; onSeeMore: () => void })`
+  - `EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] })`
+
+- [ ] **Step 1: Create `BriefsSlideshow.tsx`.** One card visible, ◀▶ + dots, opens the brief; "see more" calls `onSeeMore`.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsSlideshow({
+  briefs,
+  onSeeMore,
+}: {
+  briefs: FxBriefRow[];
+  onSeeMore: () => void;
+}) {
+  const { openBrief } = useTwelveX();
+  const [i, setI] = useState(0);
+
+  if (briefs.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <p className="mt-2 text-sm text-text-muted">No research briefs for today yet.</p>
+      </section>
+    );
+  }
+
+  const idx = Math.min(i, briefs.length - 1);
+  const b = briefs[idx];
+  const go = (d: number) => setI((idx + d + briefs.length) % briefs.length);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <span className="font-mono text-[10px] text-text-muted">{idx + 1}/{briefs.length}</span>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={onSeeMore}>
+          see all →
+        </button>
+      </header>
+
+      <div className="flex items-center gap-2">
+        <button type="button" aria-label="Previous brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(-1)}>
+          <ChevronLeft size={16} />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 rounded-lg border border-border-subtle p-3 text-left transition-colors hover:border-fin-blue/50"
+          onClick={() => openBrief(b.source_file, b.run_date)}
+        >
+          <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+            {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+          </div>
+          <p className="mt-1 truncate text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+          {b.central_thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+        </button>
+        <button type="button" aria-label="Next brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(1)}>
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      <div className="flex justify-center gap-1">
+        {briefs.map((bb, n) => (
+          <button
+            key={bb.source_file}
+            type="button"
+            aria-label={`Go to brief ${n + 1}`}
+            className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}
+            onClick={() => setI(n)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `EventsMiniTimeline.tsx`.** Compact today timeline, impact-colored, see more → Events tab.
+
+```tsx
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import type { FxEconomicCalendarRow } from '@/lib/twelve-x/types';
+import { hasResolvedTime, eventInstant } from '@/lib/twelve-x/fetch';
+import { useTwelveX } from './context';
+
+function impactClass(impact: string): string {
+  const i = impact.trim().toLowerCase();
+  if (i === 'high') return 'bg-fin-red';
+  if (i === 'medium') return 'bg-fin-amber';
+  return 'bg-text-muted/60';
+}
+
+function localTime(e: FxEconomicCalendarRow): string {
+  const inst = eventInstant(e);
+  if (inst) return inst.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return e.event_time ?? '—';
+}
+
+export default function EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] }) {
+  const { crossLink } = useTwelveX();
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <CalendarClock size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s events</h2>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'events' })}>
+          see more →
+        </button>
+      </header>
+      {events.length === 0 ? (
+        <p className="text-sm text-text-muted">No macro events scheduled today.</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {events.map((e) => (
+            <li key={e.id} className="flex items-center gap-2.5 text-xs">
+              <span className="w-14 shrink-0 text-right font-mono tabular-nums text-text-secondary">{localTime(e)}</span>
+              <span className={`h-2 w-2 shrink-0 rounded-full ${impactClass(e.impact)}`} aria-hidden />
+              <span className="font-mono text-[10px] uppercase text-text-muted">{e.country}</span>
+              <span className="truncate text-text-primary">{e.event_name}</span>
+              {!hasResolvedTime(e) ? <span className="text-text-muted/60" title="venue-local time">≈</span> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'BriefsSlideshow|EventsMiniTimeline' || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add components/twelve-x/BriefsSlideshow.tsx components/twelve-x/EventsMiniTimeline.tsx
+git commit -m "feat(twelve-x): BriefsSlideshow and EventsMiniTimeline"
+```
+
+---
+
+### Task 4: `BriefsIndex` view
+
+**Files:**
+- Create: `components/twelve-x/BriefsIndex.tsx`
+
+**Interfaces:**
+- Consumes: `FxBriefRow`; `useTwelveX()` (`openBrief`).
+- Produces: `BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void })`
+
+- [ ] **Step 1: Create `BriefsIndex.tsx`.** Full-width list/grid of today's briefs (already sorted), each opens the brief; a back link to Today.
+
+```tsx
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void }) {
+  const { openBrief } = useTwelveX();
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex items-center gap-3">
+        <button type="button" className="flex items-center gap-1 text-xs text-fin-blue hover:underline" onClick={onBack}>
+          <ArrowLeft size={14} /> Today
+        </button>
+        <h2 className="text-base font-semibold text-text-primary">Today&rsquo;s briefs</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">{briefs.length}</span>
+      </header>
+      {briefs.length === 0 ? (
+        <div className="glass-card p-10 text-center text-sm text-text-muted">No research briefs for today yet.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {briefs.map((b) => (
+            <button
+              key={b.source_file}
+              type="button"
+              className="glass-card p-4 text-left transition-colors hover:border-fin-blue/50"
+              onClick={() => openBrief(b.source_file, b.run_date)}
+            >
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+                {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+              </div>
+              <p className="mt-1 text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+              {b.central_thesis ? <p className="mt-1 line-clamp-3 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck + commit.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep BriefsIndex || echo CLEAN` → `CLEAN`
+```bash
+git add components/twelve-x/BriefsIndex.tsx
+git commit -m "feat(twelve-x): BriefsIndex view"
+```
+
+---
+
+### Task 5: `TwelveXClient` integration + `TodayTab` rewrite
+
+**Files:**
+- Modify: `components/twelve-x/TwelveXClient.tsx` (fetch trade ideas / today briefs / today events; add `?view=briefs` URL state; pass data to `TodayTab`; render `BriefsIndex` when `view==='briefs'`)
+- Modify (rewrite): `components/twelve-x/TodayTab.tsx` (A1 layout composing the new sections)
+
+**Interfaces:**
+- Consumes: `getTradeIdeas`, `getTodayBriefs`, `getTodayEvents` (Task 1); `TradeIdeasPanel`, `DigestBrief`, `BriefsSlideshow`, `EventsMiniTimeline` (Tasks 2–3); `BriefsIndex` (Task 4); existing `consensusDeltas`, `intelligence` (confluence), `MoversStrip`, `canonicalRunDate`, `TwelveXProvider`/`useTwelveX`.
+- Produces: `TodayTab({ digest, tradeIdeas, confluence, deltas, briefs, events, onSeeAllBriefs }: { digest: DigestData; tradeIdeas: FxTradeIdeaRow[]; confluence: FxConfluenceSnapshotRow[]; deltas: ConsensusDeltaSet; briefs: FxBriefRow[]; events: FxEconomicCalendarRow[]; onSeeAllBriefs: () => void })`
+
+- [ ] **Step 1: Extend `TwelveXData` + the load in `TwelveXClient.tsx`.** Add `tradeIdeas`, `todayBriefs`, `todayEvents` to the `TwelveXData` interface; add the three fetchers to the `Promise.all` (they parallelize — no added latency); they need the canonical run_date, so resolve trade ideas/briefs after the digest/intelligence dates are known (fetch them in a second `await` using `canonicalRunDate`, mirroring how `eventOpinions` is already fetched after `opinionsDate`). Concretely, after the existing `Promise.all` and the `opinionsDate`/`eventOpinions` lines:
+
+```typescript
+const canonical = intelligence[0]?.run_date ?? digest?.run_date ?? null;
+const [tradeIdeas, todayBriefs, todayEvents] = canonical
+  ? await Promise.all([getTradeIdeas(canonical), getTodayBriefs(canonical), getTodayEvents()])
+  : [[], [], await getTodayEvents()];
+```
+
+Add `tradeIdeas`, `todayBriefs`, `todayEvents` to the `setData({...})` call. Add the imports `getTradeIdeas, getTodayBriefs, getTodayEvents` and types `FxTradeIdeaRow` to the existing import blocks.
+
+- [ ] **Step 2: Add `?view=briefs` URL state.** In `TwelveXClient.tsx`:
+  - Add state: `const [view, setView] = useState<'briefs' | null>(() => (readParam('view') === 'briefs' ? 'briefs' : null));`
+  - Extend `syncUrl(...)` to also accept/serialize `view` (add `if (view) p.set('view', view);` and a `view` parameter, threading it through the existing `setTab`/`openBrief`/etc. callers — pass the current `view`).
+  - Add `const openBriefsIndex = useCallback(() => { setView('briefs'); syncUrl(tab, brief, ledgerCcy, 'briefs'); }, [tab, brief, ledgerCcy]);` and `const closeBriefsIndex = useCallback(() => { setView(null); syncUrl(tab, brief, ledgerCcy, null); }, [tab, brief, ledgerCcy]);`
+
+- [ ] **Step 3: Render `BriefsIndex` or `TodayTab`.** In the Today branch of the tab switch, render the index when `view==='briefs'`:
+
+```tsx
+) : (
+  view === 'briefs' ? (
+    <BriefsIndex briefs={data?.todayBriefs ?? []} onBack={closeBriefsIndex} />
+  ) : (
+    <TodayTab
+      digest={data?.digest ?? null}
+      tradeIdeas={data?.tradeIdeas ?? []}
+      confluence={data?.intelligence ?? []}
+      deltas={consensusDeltas}
+      briefs={data?.todayBriefs ?? []}
+      events={data?.todayEvents ?? []}
+      onSeeAllBriefs={openBriefsIndex}
+    />
+  )
+)
+```
+
+Import `BriefsIndex` and `TodayTab` (TodayTab already imported). Keep `TwelveXProvider` wrapping unchanged.
+
+- [ ] **Step 4: Rewrite `TodayTab.tsx` to the A1 layout.** Replace the file contents:
+
+```tsx
+'use client';
+
+import type {
+  FxConfluenceSnapshotRow,
+  FxEconomicCalendarRow,
+  FxBriefRow,
+  FxTradeIdeaRow,
+  ConsensusDeltaSet,
+} from '@/lib/twelve-x/types';
+import TradeIdeasPanel from './TradeIdeasPanel';
+import DigestBrief from './DigestBrief';
+import BriefsSlideshow from './BriefsSlideshow';
+import EventsMiniTimeline from './EventsMiniTimeline';
+import MoversStrip from './MoversStrip';
+import { useTwelveX } from './context';
+
+type DigestData = { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+
+export default function TodayTab({
+  digest,
+  tradeIdeas,
+  confluence,
+  deltas,
+  briefs,
+  events,
+  onSeeAllBriefs,
+}: {
+  digest: DigestData;
+  tradeIdeas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+  deltas: ConsensusDeltaSet;
+  briefs: FxBriefRow[];
+  events: FxEconomicCalendarRow[];
+  onSeeAllBriefs: () => void;
+}) {
+  const { crossLink } = useTwelveX();
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Above the fold: trade ideas + digest brief co-lead */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <TradeIdeasPanel ideas={tradeIdeas} confluence={confluence} />
+        <DigestBrief digest={digest} />
+      </div>
+
+      {/* What changed in consensus */}
+      <section className="glass-card p-4">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">What changed — consensus</h2>
+          <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'consensus' })}>
+            see more →
+          </button>
+        </header>
+        {deltas.movers.length > 0 ? (
+          <MoversStrip movers={deltas.movers} onSelect={(c) => crossLink({ kind: 'currency', currency: c })} title="" />
+        ) : (
+          <p className="text-sm text-text-muted">No prior run to compare yet.</p>
+        )}
+      </section>
+
+      {/* Below the fold: briefs slideshow + today's events */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <BriefsSlideshow briefs={briefs} onSeeMore={onSeeAllBriefs} />
+        <EventsMiniTimeline events={events} />
+      </div>
+    </div>
+  );
+}
+```
+
+(Confirm `MoversStrip` accepts an empty `title` to suppress its own header; if not, pass the default and drop the section's `<h2>`.)
+
+- [ ] **Step 5: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'twelve-x/(TodayTab|TwelveXClient)' || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add components/twelve-x/TwelveXClient.tsx components/twelve-x/TodayTab.tsx
+git commit -m "feat(twelve-x): compose Today snapshot (A1) + briefs-index view + data wiring"
+```
+
+---
+
+### Task 6: Verify — typecheck, lint, tests, build, live render
+
+**Files:** none (verification + fixups only).
+
+- [ ] **Step 1: Make deps available in the worktree.** Symlink from the main checkout (worktrees don't get untracked `node_modules`):
+
+```bash
+MAIN=/Users/chrisstefan/Code/digithings
+WT=/Users/chrisstefan/Code/digithings/.claude/worktrees/twelve-x-today-redesign
+[ -e "$WT/node_modules" ] || ln -s "$MAIN/node_modules" "$WT/node_modules"
+[ -e "$WT/frontend/olympus/node_modules" ] || ln -s "$MAIN/frontend/olympus/node_modules" "$WT/frontend/olympus/node_modules"
+```
+
+- [ ] **Step 2: Typecheck (no new errors).**
+
+Run (from `frontend/olympus`): `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'components/twelve-x/|lib/twelve-x/' | grep -v security-headers || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 3: Lint twelve-x.**
+
+Run: `npx --no-install eslint components/twelve-x lib/twelve-x`
+Expected: exit 0.
+
+- [ ] **Step 4: Unit tests.**
+
+Run: `npx --no-install vitest run lib/twelve-x`
+Expected: all pass (existing + new from Task 1).
+
+- [ ] **Step 5: Production build.**
+
+Run (with the twelve-x Supabase env exported as in prior work): `npm run build`
+Expected: "Compiled successfully", TypeScript clean, `/twelve-x` prerendered.
+
+- [ ] **Step 6: Live render — desktop & mobile.** Start `npm run dev -p 3210` (env exported), load `http://localhost:3210/olympus/twelve-x/`. Verify at 1440×900: trade ideas + brief co-lead and the consensus strip are above the fold; briefs slideshow + events below; the slideshow ◀▶/dots work; "see all →" opens the Briefs index (`?view=briefs`) and "Today" returns; "expand confluence" toggles. At 390×844: everything stacks single-column in priority order 1→5; no console errors. Capture screenshots.
+
+- [ ] **Step 7: Final commit (if any fixups).**
+
+```bash
+git add -A frontend/olympus/components/twelve-x frontend/olympus/lib/twelve-x
+git commit -m "fix(twelve-x): Today snapshot render fixups from verification" || echo "nothing to fix"
+```
+
+---
+
+## Notes for the implementer
+
+- Trade-idea `citations` carry `source_file` (per `fx_research_history`/`TradeIdeaCitation`); `firstSource()` extracts it to open the brief. If a given idea has no resolvable `source_file`, the card simply isn't clickable (no broken link) — that's intended.
+- The Today layout `lg:` breakpoint is the single responsive control for Part A; the tab bar's responsiveness is Part B and must not be touched here.
+- `MoversStrip`/`DeltaChip`/`computeConsensusDeltaSet` already exist and are tested; do not reimplement.

--- a/docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md
+++ b/docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md
@@ -1,0 +1,99 @@
+# Twelve-X "Today" — single-screen daily snapshot (design)
+
+- **Date:** 2026-06-23
+- **Status:** Approved design / spec (pre-implementation)
+- **Surface:** Olympus FX Research suite, Today tab (`frontend/olympus/{app,components,lib}/twelve-x`)
+- **Scope:** **Part A only** — the Today page content redesign (twelve-x frontend files only). Part B (shared subpage top-bar: full-width on wide screens + collapse-to-hamburger on mobile) is a **separate, coordinated** change and is explicitly out of scope here.
+
+## 1. Goal
+
+Make the Today tab a glanceable **daily snapshot** that answers, at a glance, five questions — each section a teaser with a "see more →" pass-through to its full tab:
+
+1. What is today's **trade idea(s)**?
+2. What does today's research say (**digest brief**)?
+3. What **changed in consensus** today?
+4. What **briefs** do we have today?
+5. What **events** are today?
+
+**Priority (not strict no-scroll):** the top three — trade ideas, digest brief, consensus delta — are guaranteed **above the fold**; the briefs slideshow and events timeline sit just below.
+
+## 2. Layout — approach "A1"
+
+Capped-width container (~`max-w-[1400px]`, centered; consistent with the existing `SUBPAGE_MAX` content width), two zones:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ ① TRADE IDEAS (≈55%, focal+list)   │ ② DIGEST BRIEF (≈45%) │  ← above fold
+├───────────────────────────────────────────────────────────┤
+│ ③ WHAT CHANGED — consensus movers (full-width strip)       │  ← above fold
+├───────────────────────────────────────────────────────────┤  · · · fold · · ·
+│ ④ BRIEFS slideshow            │ ⑤ EVENTS — today timeline   │  ← just below
+└───────────────────────────────────────────────────────────┘
+```
+
+**Responsive (in scope for Part A):** below the `lg` breakpoint the whole page collapses to a **single column in priority order 1 → 2 → 3 → 4 → 5**. The page top-bar/tab-bar responsiveness (full-width, hamburger) is **Part B** and not touched here.
+
+## 3. Sections
+
+### ① Today's trade ideas — focal + list
+- **Source:** `fx_trade_ideas_snapshot` for the canonical run_date, ordered by `rank` ascending (1 = strongest). Count is **1…N** (today is 1; design must handle several).
+- **Render:** `#1` as a **focal** card (title, pair, direction, central thesis, levels/targets, catalyst, contributing desks). `#2…N` as compact tappable rows below the focal card; each row opens that idea's full detail in the existing slide-over (`BriefPanel`-style).
+- **Expand:** an inline **"expand ▾ → confluence reads"** control that reveals the broader directional set from `fx_confluence_snapshot` (the data Olympus shows today).
+- **See more →** Intelligence tab.
+
+### ② Digest brief — co-lead
+- **Source:** `fx_daily_digest` (`summary`, `key_themes`).
+- **Render:** the full summary, **always visible** (never collapsed), with key-theme chips beneath. Sits shoulder-to-shoulder with the trade ideas above the fold.
+- **See more:** none — it is shown in full inline. (Theme chips may deep-link into the relevant tab where useful.)
+
+### ③ What changed — consensus
+- **Source:** day-over-day deltas computed by the existing pure helper `computeConsensusDeltaSet(series)` over `fx_consensus_snapshot` history (already implemented in `lib/twelve-x/fetch.ts`).
+- **Render:** full-width compact strip of biggest movers via the existing `MoversStrip`/`DeltaChip` (e.g., `JPY ▲+0.94 · GBP ▼ · USD ▲`), sign-colored.
+- **See more →** Consensus tab.
+
+### ④ Briefs slideshow
+- **Source:** `fx_research_history` for the canonical run_date (today's briefs).
+- **Order:** `trader_relevance` (high → low), tiebreak by broker-mention count, then newest (`report_date`/`run_date`).
+- **Render:** carousel, one brief card visible at a time (◀ ▶ controls + position dots). Each card opens that brief in the slide-over.
+- **See more →** the new **Briefs index** (§3.⑥).
+
+### ⑤ Events — today timeline
+- **Source:** `fx_economic_calendar` filtered to **today** (local-date of the release instant), with `fx_events_snapshot` for the broker-mention overlay.
+- **Render:** compact horizontal timeline, impact-colored (high/medium/low), times in the viewer's local zone (reuse the `eventLocalDateKey`/`hasResolvedTime` helpers already added).
+- **See more →** Events tab.
+
+### ⑥ Briefs index (new — slideshow "see more" target)
+- A lightweight, full-width **list/grid of today's briefs** (broker, title, relevance, direction tags), each opening the brief slide-over.
+- **Reached only via the slideshow "see more"** as a URL-stateful view (e.g., `?view=briefs`), **not a new top-level tab** — this keeps Part A self-contained and avoids adding tab-bar pressure that interacts with Part B. (It can later be promoted to a tab during Part B if desired.)
+
+## 4. Data layer (new / changed)
+
+In `lib/twelve-x/fetch.ts` (+ `types.ts`):
+
+- `getTradeIdeas(runDate): Promise<FxTradeIdeaRow[]>` — reads `fx_trade_ideas_snapshot`, ordered by `rank`. **New row type `FxTradeIdeaRow`** (run_date, rank, title, pair, direction, thesis, catalyst, levels, citations, as_of).
+- `getTodayBriefs(runDate): Promise<FxBriefRow[]>` — reads `fx_research_history` for the run_date; client sorts per §3.④ ordering.
+- A **today-events selector** — reuse `getUpcomingEvents()` narrowed to today via `eventLocalDateKey`, or add `getTodayEvents(runDate)`.
+- Reuse: `computeConsensusDeltaSet`, `getConsensusTimeSeries`, `getIntelligence` (confluence), `resolveCatalyst`, `getBrief`.
+
+## 5. Components (twelve-x only — no shared-shell edits → no conflict risk)
+
+- **`TodayTab.tsx`** — rewritten to the A1 layout.
+- New: **`TradeIdeasPanel`** (focal + list + expand-to-confluence), **`DigestBrief`**, **`BriefsSlideshow`**, **`EventsMiniTimeline`**, **`BriefsIndex`** (the see-more view).
+- Reuse: `MoversStrip`, `DeltaChip`, `BriefPanel`, `useTwelveX()` context (canonical `runDate`, `crossLink`, `openBrief`).
+- `TwelveXClient.tsx` — pass today's data + wire the `?view=briefs` state for the Briefs index; **no tab-bar changes** (Part B).
+
+## 6. Risks & decisions
+
+- **`fx_trade_ideas_snapshot` anon-read (must verify):** Olympus does not currently read this table. To surface the curated ideas client-side it must carry an `anon_read` RLS policy (mirroring the other snapshot tables; created in migration 012). **Verify during planning.** If absent: either add the policy (twelve-x migration — separate change), or **fall back** to deriving the focal idea(s) from `fx_confluence_snapshot` so the page still works.
+- **"No scroll"** is interpreted as **priority-above-the-fold** (option c), not strict; the bottom two sections may extend below.
+- **Briefs index** is a see-more view, not a tab (decouples from Part B).
+
+## 7. Non-goals (Part A)
+
+- Part B: shared subpage top-bar full-width on wide screens + collapse-to-hamburger on mobile (separate coordinated change).
+- Push alerting; global full-text search/export (previously deferred).
+
+## 8. Testing
+
+- Unit tests for the new fetchers/transforms: trade-idea ordering, today-briefs sort (relevance → mentions → newest), today-events filter, and the (existing, tested) consensus-delta helper.
+- Render verification via the dev server at desktop (~1440) and mobile (~390) widths: above-the-fold priority holds on desktop; clean single-column stack on mobile; `next build` green; existing `lib/twelve-x` tests stay green.

--- a/frontend/olympus/components/twelve-x/BriefsIndex.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsIndex.tsx
@@ -19,9 +19,9 @@ export default function BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; 
         <div className="glass-card p-10 text-center text-sm text-text-muted">No research briefs for today yet.</div>
       ) : (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {briefs.map((b) => (
+          {briefs.map((b, i) => (
             <button
-              key={b.source_file}
+              key={`${b.source_file}-${i}`}
               type="button"
               className="glass-card p-4 text-left transition-colors hover:border-fin-blue/50"
               onClick={() => openBrief(b.source_file, b.run_date)}

--- a/frontend/olympus/components/twelve-x/BriefsIndex.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsIndex.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void }) {
+  const { openBrief } = useTwelveX();
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex items-center gap-3">
+        <button type="button" className="flex items-center gap-1 text-xs text-fin-blue hover:underline" onClick={onBack}>
+          <ArrowLeft size={14} /> Today
+        </button>
+        <h2 className="text-base font-semibold text-text-primary">Today&rsquo;s briefs</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">{briefs.length}</span>
+      </header>
+      {briefs.length === 0 ? (
+        <div className="glass-card p-10 text-center text-sm text-text-muted">No research briefs for today yet.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {briefs.map((b) => (
+            <button
+              key={b.source_file}
+              type="button"
+              className="glass-card p-4 text-left transition-colors hover:border-fin-blue/50"
+              onClick={() => openBrief(b.source_file, b.run_date)}
+            >
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+                {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+              </div>
+              <p className="mt-1 text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+              {b.central_thesis ? <p className="mt-1 line-clamp-3 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsSlideshow({
+  briefs,
+  onSeeMore,
+}: {
+  briefs: FxBriefRow[];
+  onSeeMore: () => void;
+}) {
+  const { openBrief } = useTwelveX();
+  const [i, setI] = useState(0);
+
+  if (briefs.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <p className="mt-2 text-sm text-text-muted">No research briefs for today yet.</p>
+      </section>
+    );
+  }
+
+  const idx = Math.min(i, briefs.length - 1);
+  const b = briefs[idx];
+  const go = (d: number) => setI((idx + d + briefs.length) % briefs.length);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <span className="font-mono text-[10px] text-text-muted">{idx + 1}/{briefs.length}</span>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={onSeeMore}>
+          see all →
+        </button>
+      </header>
+
+      <div className="flex items-center gap-2">
+        <button type="button" aria-label="Previous brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(-1)}>
+          <ChevronLeft size={16} />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 rounded-lg border border-border-subtle p-3 text-left transition-colors hover:border-fin-blue/50"
+          onClick={() => openBrief(b.source_file, b.run_date)}
+        >
+          <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+            {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+          </div>
+          <p className="mt-1 truncate text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+          {b.central_thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+        </button>
+        <button type="button" aria-label="Next brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(1)}>
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      <div className="flex justify-center gap-1">
+        {briefs.map((bb, n) => (
+          <button
+            key={bb.source_file}
+            type="button"
+            aria-label={`Go to brief ${n + 1}`}
+            className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}
+            onClick={() => setI(n)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
@@ -62,7 +62,7 @@ export default function BriefsSlideshow({
       <div className="flex justify-center gap-1">
         {briefs.map((bb, n) => (
           <button
-            key={bb.source_file}
+            key={`${bb.source_file}-${bb.run_date}`}
             type="button"
             aria-label={`Go to brief ${n + 1}`}
             className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}

--- a/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
@@ -62,7 +62,7 @@ export default function BriefsSlideshow({
       <div className="flex justify-center gap-1">
         {briefs.map((bb, n) => (
           <button
-            key={`${bb.source_file}-${bb.run_date}`}
+            key={`${bb.source_file}-${bb.run_date}-${n}`}
             type="button"
             aria-label={`Go to brief ${n + 1}`}
             className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}

--- a/frontend/olympus/components/twelve-x/DigestBrief.tsx
+++ b/frontend/olympus/components/twelve-x/DigestBrief.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { FileText } from 'lucide-react';
+
+export default function DigestBrief({
+  digest,
+}: {
+  digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+}) {
+  if (!digest) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <p className="mt-2 text-sm text-text-muted">No digest for today yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="glass-card flex flex-col gap-2 p-5">
+      <header className="flex items-baseline gap-2">
+        <FileText size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">
+          {digest.doc_count} docs · {digest.broker_count} brokers
+        </span>
+      </header>
+      <p className="whitespace-pre-line text-sm leading-relaxed text-text-primary">{digest.summary}</p>
+      {digest.key_themes.length > 0 ? (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {digest.key_themes.map((t) => (
+            <span key={t} className="rounded-full border border-border-subtle px-2.5 py-0.5 text-[11px] text-text-secondary">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
+++ b/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import type { FxEconomicCalendarRow } from '@/lib/twelve-x/types';
+import { hasResolvedTime, eventInstant } from '@/lib/twelve-x/fetch';
+import { useTwelveX } from './context';
+
+function impactClass(impact: string): string {
+  const i = impact.trim().toLowerCase();
+  if (i === 'high') return 'bg-fin-red';
+  if (i === 'medium') return 'bg-fin-amber';
+  return 'bg-text-muted/60';
+}
+
+function localTime(e: FxEconomicCalendarRow): string {
+  const inst = eventInstant(e);
+  if (inst) return inst.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return e.event_time ?? '—';
+}
+
+export default function EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] }) {
+  const { crossLink } = useTwelveX();
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <CalendarClock size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s events</h2>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'events' })}>
+          see more →
+        </button>
+      </header>
+      {events.length === 0 ? (
+        <p className="text-sm text-text-muted">No macro events scheduled today.</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {events.map((e) => (
+            <li key={e.id} className="flex items-center gap-2.5 text-xs">
+              <span className="w-14 shrink-0 text-right font-mono tabular-nums text-text-secondary">{localTime(e)}</span>
+              <span className={`h-2 w-2 shrink-0 rounded-full ${impactClass(e.impact)}`} aria-hidden />
+              <span className="font-mono text-[10px] uppercase text-text-muted">{e.country}</span>
+              <span className="truncate text-text-primary">{e.event_name}</span>
+              {!hasResolvedTime(e) ? <span className="text-text-muted/60" title="venue-local time">≈</span> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
+++ b/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
@@ -6,7 +6,7 @@ import { hasResolvedTime, eventInstant } from '@/lib/twelve-x/fetch';
 import { useTwelveX } from './context';
 
 function impactClass(impact: string): string {
-  const i = impact.trim().toLowerCase();
+  const i = (impact ?? '').trim().toLowerCase();
   if (i === 'high') return 'bg-fin-red';
   if (i === 'medium') return 'bg-fin-amber';
   return 'bg-text-muted/60';

--- a/frontend/olympus/components/twelve-x/TodayTab.tsx
+++ b/frontend/olympus/components/twelve-x/TodayTab.tsx
@@ -1,287 +1,67 @@
 'use client';
 
-import { Sparkles, FileText, Users, Star } from 'lucide-react';
-import { SafeMarkdown } from '@/components/SafeMarkdown';
-import type { FxConfluenceSnapshotRow, Mover, ConsensusDeltaSet } from '@/lib/twelve-x/types';
-import { useTwelveX } from './context';
+import type {
+  FxConfluenceSnapshotRow,
+  FxEconomicCalendarRow,
+  FxBriefRow,
+  FxTradeIdeaRow,
+  ConsensusDeltaSet,
+} from '@/lib/twelve-x/types';
+import TradeIdeasPanel from './TradeIdeasPanel';
+import DigestBrief from './DigestBrief';
+import BriefsSlideshow from './BriefsSlideshow';
+import EventsMiniTimeline from './EventsMiniTimeline';
 import MoversStrip from './MoversStrip';
+import { useTwelveX } from './context';
 
-// TODO(defer): push alerts — no server in static export
-
-interface DigestData {
-  run_date: string;
-  summary: string;
-  key_themes: string[];
-  doc_count: number;
-  broker_count: number;
-}
-
-/** Map a confluence/consensus direction string to a .fin-* text color class. */
-function directionColorClass(direction: string): string {
-  const d = direction.trim().toLowerCase();
-  if (d === 'bullish' || d === 'long' || d === 'buy') return 'text-fin-green';
-  if (d === 'bearish' || d === 'short' || d === 'sell') return 'text-fin-red';
-  if (d === 'watch') return 'text-fin-amber';
-  return 'text-text-secondary';
-}
-
-function directionLabel(direction: string): string {
-  const d = direction.trim();
-  if (!d) return '—';
-  return d.charAt(0).toUpperCase() + d.slice(1).toLowerCase();
-}
-
-/** The base currency an idea files under (numerator of a pair, uppercased). */
-function baseCurrency(currency: string): string {
-  return currency.trim().toUpperCase().split('/')[0];
-}
-
-/**
- * `brief_keys` are broker NAMES per the data contract, not `source_file` keys.
- * Only treat an entry as a brief link target if it actually looks like a file
- * key (has a path separator or a file extension); otherwise we skip the link
- * rather than wire up a broken openBrief() call.
- */
-function firstBriefSourceFile(briefKeys: unknown): string | null {
-  if (!Array.isArray(briefKeys)) return null;
-  for (const k of briefKeys) {
-    if (typeof k !== 'string') continue;
-    const s = k.trim();
-    if (s && (s.includes('/') || /\.[a-z0-9]{2,5}$/i.test(s))) return s;
-  }
-  return null;
-}
-
-/**
- * Drop reciprocal legs of the same pair: if two ideas share the same instrument
- * with opposite (currency, direction) — e.g. "EUR/USD long" and "EUR/USD" filed
- * under USD short — keep only the higher-ranked one. Input is rank-sorted.
- */
-function dedupeReciprocalLegs(ideas: FxConfluenceSnapshotRow[]): FxConfluenceSnapshotRow[] {
-  const seenPairs = new Set<string>();
-  const out: FxConfluenceSnapshotRow[] = [];
-  const sorted = [...ideas].sort((a, b) => a.rank - b.rank);
-  for (const idea of sorted) {
-    const legs = idea.currency.trim().toUpperCase().split('/').filter(Boolean).sort();
-    const pairKey = legs.join('|');
-    if (pairKey && seenPairs.has(pairKey)) continue;
-    if (pairKey) seenPairs.add(pairKey);
-    out.push(idea);
-  }
-  return out;
-}
-
-function ConfluenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
-  const { crossLink, openBrief, watchlist } = useTwelveX();
-  const colorClass = directionColorClass(idea.direction);
-  const ccy = baseCurrency(idea.currency);
-  const briefSource = firstBriefSourceFile(idea.brief_keys);
-  const starred = watchlist.has(ccy);
-
-  const cardInteractive = briefSource != null;
-  const openCardBrief = () => {
-    if (briefSource) openBrief(briefSource, idea.run_date);
-  };
-
-  return (
-    <div
-      className={`glass-card p-4 flex flex-col gap-2 transition-colors${
-        cardInteractive
-          ? ' cursor-pointer hover:border-fin-blue/50 focus-visible:border-fin-blue/50 focus-visible:outline-none'
-          : ''
-      }`}
-      role={cardInteractive ? 'button' : undefined}
-      tabIndex={cardInteractive ? 0 : undefined}
-      onClick={cardInteractive ? openCardBrief : undefined}
-      onKeyDown={
-        cardInteractive
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                openCardBrief();
-              }
-            }
-          : undefined
-      }
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-white/[0.06] text-text-muted border border-border-subtle shrink-0">
-            #{idea.rank}
-          </span>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              crossLink({ kind: 'currency', currency: ccy });
-            }}
-            className="font-mono text-sm font-semibold text-text-primary truncate hover:text-fin-blue transition-colors"
-            title={`View ${ccy} consensus`}
-          >
-            {idea.currency}
-          </button>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <span className={`text-xs font-semibold ${colorClass}`}>
-            {directionLabel(idea.direction)}
-          </span>
-          <button
-            type="button"
-            aria-label={starred ? `Remove ${ccy} from watchlist` : `Add ${ccy} to watchlist`}
-            aria-pressed={starred}
-            onClick={(e) => {
-              e.stopPropagation();
-              watchlist.toggle(ccy);
-            }}
-            className={`transition-colors ${
-              starred ? 'text-fin-amber' : 'text-text-muted hover:text-fin-amber'
-            }`}
-          >
-            <Star size={14} fill={starred ? 'currentColor' : 'none'} aria-hidden />
-          </button>
-        </div>
-      </div>
-      <p className="text-sm text-text-primary leading-snug">{idea.title}</p>
-      <div className="mt-auto flex items-center justify-between pt-1">
-        <span className="text-[11px] text-text-muted uppercase tracking-wider">Score</span>
-        <span className={`qn-metric tabular-nums ${colorClass}`}>
-          {Number.isFinite(idea.score) ? idea.score.toFixed(2) : '—'}
-        </span>
-      </div>
-    </div>
-  );
-}
+type DigestData = { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
 
 export default function TodayTab({
   digest,
+  tradeIdeas,
   confluence,
-  runDate,
-  movers,
   deltas,
+  briefs,
+  events,
+  onSeeAllBriefs,
 }: {
-  digest: DigestData | null;
+  digest: DigestData;
+  tradeIdeas: FxTradeIdeaRow[];
   confluence: FxConfluenceSnapshotRow[];
-  runDate: string | null;
-  movers: Mover[];
   deltas: ConsensusDeltaSet;
+  briefs: FxBriefRow[];
+  events: FxEconomicCalendarRow[];
+  onSeeAllBriefs: () => void;
 }) {
-  const { crossLink, watchlist } = useTwelveX();
-
-  // De-dupe reciprocal legs (higher rank wins) before slicing the top ideas.
-  const ranked = dedupeReciprocalLegs(confluence);
-  const filtered = watchlist.filterOn
-    ? ranked.filter((idea) => watchlist.has(baseCurrency(idea.currency)))
-    : ranked;
-  const topIdeas = filtered.slice(0, 6);
-
-  const headerDate = runDate ?? digest?.run_date ?? null;
-
+  const { crossLink } = useTwelveX();
   return (
-    <div className="space-y-4">
-      {/* What changed — biggest consensus shifts since the previous run */}
-      <MoversStrip
-        movers={movers}
-        onSelect={(currency) => crossLink({ kind: 'currency', currency })}
-        title="What changed since last run"
-      />
-
-      {/* Header + top trade ideas */}
-      <div className="space-y-3">
-        <div className="flex flex-wrap items-center gap-3 px-1">
-          <Sparkles size={16} className="text-fin-blue shrink-0" />
-          <h2 className="text-base md:text-lg font-semibold text-text-primary">
-            Top trade ideas
-          </h2>
-          {watchlist.items.length > 0 ? (
-            <button
-              type="button"
-              onClick={() => watchlist.setFilterOn(!watchlist.filterOn)}
-              aria-pressed={watchlist.filterOn}
-              className={`text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors flex items-center gap-1 ${
-                watchlist.filterOn
-                  ? 'border-fin-amber/40 bg-fin-amber/10 text-fin-amber'
-                  : 'border-border-subtle text-text-muted hover:text-text-secondary'
-              }`}
-            >
-              <Star size={11} fill={watchlist.filterOn ? 'currentColor' : 'none'} aria-hidden />
-              Watchlist
-            </button>
-          ) : null}
-          <span className="text-[10px] font-mono text-text-muted ml-auto">{headerDate ?? '—'}</span>
-        </div>
-
-        {/* Score-scale legend */}
-        <p className="text-[11px] text-text-muted px-1">
-          Score 0–1 · higher = stronger confluence
-        </p>
-
-        {topIdeas.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {topIdeas.map((idea) => (
-              <ConfluenceCard key={`${idea.run_date}-${idea.rank}`} idea={idea} />
-            ))}
-          </div>
-        ) : (
-          <div className="glass-card p-8 text-center text-text-muted text-sm">
-            {watchlist.filterOn && ranked.length > 0
-              ? 'No trade ideas match your watchlist.'
-              : `No confluence trade ideas${headerDate ? ` for ${headerDate}` : ''}.`}
-          </div>
-        )}
+    <div className="flex flex-col gap-4">
+      {/* Above the fold: trade ideas + digest brief co-lead */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <TradeIdeasPanel ideas={tradeIdeas} confluence={confluence} />
+        <DigestBrief digest={digest} />
       </div>
 
-      {/* Full brief — demoted below the ideas, collapsed by default */}
-      {digest ? (
-        <details className="glass-card p-0 overflow-hidden group">
-          <summary className="cursor-pointer list-none p-4 flex flex-wrap items-center gap-3 text-sm text-text-secondary hover:text-text-primary transition-colors">
-            <FileText size={15} className="text-fin-blue shrink-0" aria-hidden />
-            <span className="font-medium text-text-primary">Full brief</span>
-            <span className="text-text-muted">
-              · {digest.doc_count} {digest.doc_count === 1 ? 'doc' : 'docs'} ·{' '}
-              {digest.broker_count} {digest.broker_count === 1 ? 'broker' : 'brokers'}
-            </span>
-            <span className="text-[10px] font-mono text-text-muted ml-auto">{digest.run_date}</span>
-          </summary>
+      {/* What changed in consensus */}
+      <section className="glass-card p-4">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">What changed — consensus</h2>
+          <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'consensus' })}>
+            see more →
+          </button>
+        </header>
+        {deltas.movers.length > 0 ? (
+          <MoversStrip movers={deltas.movers} onSelect={(c) => crossLink({ kind: 'currency', currency: c })} title="" />
+        ) : (
+          <p className="text-sm text-text-muted">No prior run to compare yet.</p>
+        )}
+      </section>
 
-          <div className="px-4 pb-4 space-y-4 border-t border-border-subtle/60">
-            {digest.summary ? (
-              <SafeMarkdown className="prose prose-invert max-w-none text-sm text-text-secondary pt-4">
-                {digest.summary}
-              </SafeMarkdown>
-            ) : null}
-
-            {digest.key_themes.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {digest.key_themes.map((theme, i) => (
-                  <span
-                    key={`${theme}-${i}`}
-                    className="text-[11px] font-medium px-2.5 py-1 rounded-full border border-fin-blue/30 bg-fin-blue/10 text-fin-blue"
-                  >
-                    {theme}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-text-muted">
-              <span className="flex items-center gap-1.5">
-                <FileText size={13} aria-hidden />
-                <span className="qn-metric text-text-secondary tabular-nums">
-                  {digest.doc_count}
-                </span>
-                documents
-              </span>
-              <span className="flex items-center gap-1.5">
-                <Users size={13} aria-hidden />
-                <span className="qn-metric text-text-secondary tabular-nums">
-                  {digest.broker_count}
-                </span>
-                brokers
-              </span>
-            </div>
-          </div>
-        </details>
-      ) : null}
+      {/* Below the fold: briefs slideshow + today's events */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <BriefsSlideshow briefs={briefs} onSeeMore={onSeeAllBriefs} />
+        <EventsMiniTimeline events={events} />
+      </div>
     </div>
   );
 }

--- a/frontend/olympus/components/twelve-x/TradeIdeasPanel.tsx
+++ b/frontend/olympus/components/twelve-x/TradeIdeasPanel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { FxTradeIdeaRow, FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+function dirClass(direction: string): string {
+  const d = direction.toLowerCase();
+  if (d.includes('long') || d.includes('bull')) return 'text-fin-green';
+  if (d.includes('short') || d.includes('bear')) return 'text-fin-red';
+  return 'text-text-muted';
+}
+
+function firstSource(citations: unknown[]): string | null {
+  for (const c of citations) {
+    if (c && typeof c === 'object' && typeof (c as Record<string, unknown>).source_file === 'string') {
+      return (c as Record<string, unknown>).source_file as string;
+    }
+  }
+  return null;
+}
+
+export default function TradeIdeasPanel({
+  ideas,
+  confluence,
+}: {
+  ideas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+}) {
+  const { crossLink, openBrief } = useTwelveX();
+  const [expanded, setExpanded] = useState(false);
+
+  if (ideas.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        </header>
+        <p className="text-sm text-text-muted">No curated trade idea for today yet.</p>
+      </section>
+    );
+  }
+
+  const [top, ...rest] = ideas;
+  const topSource = firstSource(top.citations);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        <span className="font-mono text-[10px] text-text-muted">· {ideas.length}</span>
+        <button
+          type="button"
+          className="ml-auto text-[11px] text-fin-blue hover:underline"
+          onClick={() => crossLink({ kind: 'tab', tab: 'intelligence' })}
+        >
+          see more →
+        </button>
+      </header>
+
+      {/* Focal #1 */}
+      <button
+        type="button"
+        className="rounded-lg border border-fin-green/30 bg-fin-green/[0.06] p-4 text-left transition-colors hover:border-fin-blue/50"
+        onClick={() => topSource && openBrief(topSource, top.run_date)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-text-muted">#1</span>
+          <span className="font-semibold text-text-primary">{top.pair}</span>
+          <span className={`text-xs font-semibold uppercase ${dirClass(top.direction)}`}>{top.direction}</span>
+        </div>
+        <p className="mt-1 text-sm text-text-primary">{top.title}</p>
+        {top.thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{top.thesis}</p> : null}
+        {top.catalyst ? <p className="mt-1 text-[11px] text-text-muted">Catalyst: {top.catalyst}</p> : null}
+      </button>
+
+      {/* #2…N rows */}
+      {rest.map((idea) => {
+        const src = firstSource(idea.citations);
+        return (
+          <button
+            key={`${idea.run_date}-${idea.rank}`}
+            type="button"
+            className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-2 text-left text-xs transition-colors hover:border-fin-blue/50"
+            onClick={() => src && openBrief(src, idea.run_date)}
+          >
+            <span className="font-mono text-[10px] text-text-muted">#{idea.rank}</span>
+            <span className="font-semibold text-text-primary">{idea.pair}</span>
+            <span className={`font-semibold uppercase ${dirClass(idea.direction)}`}>{idea.direction}</span>
+            <span className="ml-auto truncate text-text-muted">{idea.title}</span>
+          </button>
+        );
+      })}
+
+      {/* Expand → confluence reads */}
+      {confluence.length > 0 ? (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[11px] text-text-secondary hover:text-fin-blue"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+            {expanded ? 'Hide' : 'Expand'} confluence reads ({confluence.length})
+          </button>
+          {expanded ? (
+            <ul className="mt-2 grid gap-1">
+              {confluence.map((c) => (
+                <li key={`${c.run_date}-${c.rank}`} className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-1.5 text-xs">
+                  <span className="font-mono text-[10px] text-text-muted">#{c.rank}</span>
+                  <span className="font-semibold text-text-primary">{c.currency}</span>
+                  <span className={`uppercase ${dirClass(c.direction)}`}>{c.direction}</span>
+                  <button
+                    type="button"
+                    className="ml-auto text-fin-blue hover:underline"
+                    onClick={() => crossLink({ kind: 'currency', currency: c.currency })}
+                  >
+                    trend →
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -22,18 +22,24 @@ import {
   getLedger,
   getLedgerRunDates,
   getMatrix,
+  getTradeIdeas,
+  getTodayBriefs,
+  getTodayEvents,
   getUpcomingEvents,
 } from '@/lib/twelve-x/fetch';
 import { isTwelveXConfigured } from '@/lib/twelve-x/supabase';
 import type {
+  FxBriefRow,
   FxConfluenceSnapshotRow,
   FxConsensusSnapshotRow,
   FxEconomicCalendarRow,
   FxEventSnapshotRow,
   FxLedgerRow,
+  FxTradeIdeaRow,
   MatrixCell,
 } from '@/lib/twelve-x/types';
 import TodayTab from './TodayTab';
+import BriefsIndex from './BriefsIndex';
 import ConsensusTab from './ConsensusTab';
 import IntelligenceTab from './IntelligenceTab';
 import EventsTab from './EventsTab';
@@ -68,6 +74,9 @@ interface TwelveXData {
   eventOpinions: FxEventSnapshotRow[];
   matrix: MatrixCell[];
   ledgerRunDates: string[];
+  tradeIdeas: FxTradeIdeaRow[];
+  todayBriefs: FxBriefRow[];
+  todayEvents: FxEconomicCalendarRow[];
 }
 
 function resolveTab(urlTab: string | null): TwelveXTab {
@@ -92,7 +101,12 @@ function readParam(key: string): string | null {
  * was the cause of tabs not switching / blank pages, so all control flow is
  * local React state and the URL is mirrored only for deep-link/shareability.
  */
-function syncUrl(tab: TwelveXTab, brief: BriefTarget | null, ledgerCcy: string | null): void {
+function syncUrl(
+  tab: TwelveXTab,
+  brief: BriefTarget | null,
+  ledgerCcy: string | null,
+  view: 'briefs' | null = null,
+): void {
   if (typeof window === 'undefined') return;
   const p = new URLSearchParams();
   if (tab !== 'today') p.set('tab', tab);
@@ -101,6 +115,7 @@ function syncUrl(tab: TwelveXTab, brief: BriefTarget | null, ledgerCcy: string |
     if (brief.runDate) p.set('briefDate', brief.runDate);
   }
   if (ledgerCcy) p.set('ledgerCcy', ledgerCcy);
+  if (view) p.set('view', view);
   const qs = p.toString();
   const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
   window.history.replaceState(window.history.state, '', url);
@@ -121,6 +136,9 @@ export default function TwelveXClient() {
     return sf ? { sourceFile: sf, runDate: readParam('briefDate') } : null;
   });
   const [ledgerCcy, setLedgerCcy] = useState<string | null>(() => readParam('ledgerCcy'));
+  const [view, setView] = useState<'briefs' | null>(() =>
+    readParam('view') === 'briefs' ? 'briefs' : null,
+  );
 
   // Ledger (P4) loads lazily by selected run_date so the audit table can be
   // re-pointed without refetching the whole workspace.
@@ -137,24 +155,34 @@ export default function TwelveXClient() {
   const setTab = useCallback(
     (next: TwelveXTab) => {
       setTabState(next);
-      syncUrl(next, brief, ledgerCcy);
+      syncUrl(next, brief, ledgerCcy, view);
     },
-    [brief, ledgerCcy]
+    [brief, ledgerCcy, view]
   );
 
   const openBrief = useCallback(
     (sourceFile: string, runDate: string | null) => {
       const next = { sourceFile, runDate };
       setBrief(next);
-      syncUrl(tab, next, ledgerCcy);
+      syncUrl(tab, next, ledgerCcy, view);
     },
-    [tab, ledgerCcy]
+    [tab, ledgerCcy, view]
   );
 
   const closeBrief = useCallback(() => {
     setBrief(null);
-    syncUrl(tab, null, ledgerCcy);
-  }, [tab, ledgerCcy]);
+    syncUrl(tab, null, ledgerCcy, view);
+  }, [tab, ledgerCcy, view]);
+
+  const openBriefsIndex = useCallback(() => {
+    setView('briefs');
+    syncUrl(tab, brief, ledgerCcy, 'briefs');
+  }, [tab, brief, ledgerCcy]);
+
+  const closeBriefsIndex = useCallback(() => {
+    setView(null);
+    syncUrl(tab, brief, ledgerCcy, null);
+  }, [tab, brief, ledgerCcy]);
 
   // "Why this weight?" from a consensus cell → jump to the ledger tab, pre-filtered
   // to that currency.
@@ -162,9 +190,9 @@ export default function TwelveXClient() {
     (currency: string) => {
       setTabState('ledger');
       setLedgerCcy(currency);
-      syncUrl('ledger', brief, currency);
+      syncUrl('ledger', brief, currency, view);
     },
-    [brief]
+    [brief, view]
   );
 
   useEffect(() => {
@@ -203,6 +231,10 @@ export default function TwelveXClient() {
         // so the catalysts tab shows desk views for the freshest session.
         const opinionsDate = intelligence[0]?.run_date ?? digest?.run_date ?? null;
         const eventOpinions = opinionsDate ? await getEventOpinions(opinionsDate) : [];
+        const canonical = intelligence[0]?.run_date ?? digest?.run_date ?? null;
+        const [tradeIdeas, todayBriefs, todayEvents] = canonical
+          ? await Promise.all([getTradeIdeas(canonical), getTodayBriefs(canonical), getTodayEvents()])
+          : [[], [], await getTodayEvents()];
         if (cancelled) return;
         setData({
           digest,
@@ -214,6 +246,9 @@ export default function TwelveXClient() {
           eventOpinions,
           matrix,
           ledgerRunDates,
+          tradeIdeas,
+          todayBriefs,
+          todayEvents,
         });
         // Default the ledger to the freshest run present.
         setLedgerRun((prev) => prev ?? ledgerRunDates[0] ?? null);
@@ -290,7 +325,7 @@ export default function TwelveXClient() {
         case 'currency':
           setTabState('consensus');
           setConsensusFocusCcy(l.currency);
-          syncUrl('consensus', brief, ledgerCcy);
+          syncUrl('consensus', brief, ledgerCcy, view);
           break;
         case 'ledger':
           drillToLedger(l.currency);
@@ -301,14 +336,14 @@ export default function TwelveXClient() {
         case 'event':
           setTabState('events');
           setEventFocus({ externalId: l.externalId ?? null, name: l.eventName });
-          syncUrl('events', brief, ledgerCcy);
+          syncUrl('events', brief, ledgerCcy, view);
           break;
         case 'tab':
           setTab(l.tab);
           break;
       }
     },
-    [brief, ledgerCcy, drillToLedger, openBrief, setTab]
+    [brief, ledgerCcy, view, drillToLedger, openBrief, setTab]
   );
 
   const ctx = useMemo<TwelveXContextValue>(
@@ -385,13 +420,17 @@ export default function TwelveXClient() {
           />
         );
       default:
-        return (
+        return view === 'briefs' ? (
+          <BriefsIndex briefs={data?.todayBriefs ?? []} onBack={closeBriefsIndex} />
+        ) : (
           <TodayTab
             digest={data?.digest ?? null}
-            confluence={data?.confluence ?? []}
-            runDate={canonicalRunDate}
-            movers={consensusDeltas.movers}
+            tradeIdeas={data?.tradeIdeas ?? []}
+            confluence={data?.intelligence ?? []}
             deltas={consensusDeltas}
+            briefs={data?.todayBriefs ?? []}
+            events={data?.todayEvents ?? []}
+            onSeeAllBriefs={openBriefsIndex}
           />
         );
     }

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -66,7 +66,6 @@ export type BriefTarget = { sourceFile: string; runDate: string | null };
 
 interface TwelveXData {
   digest: DigestData;
-  confluence: FxConfluenceSnapshotRow[];
   consensusSeries: FxConsensusSnapshotRow[];
   latestConsensus: FxConsensusSnapshotRow[];
   intelligence: FxConfluenceSnapshotRow[];
@@ -155,9 +154,10 @@ export default function TwelveXClient() {
   const setTab = useCallback(
     (next: TwelveXTab) => {
       setTabState(next);
-      syncUrl(next, brief, ledgerCcy, view);
+      setView(null);
+      syncUrl(next, brief, ledgerCcy, null);
     },
-    [brief, ledgerCcy, view]
+    [brief, ledgerCcy]
   );
 
   const openBrief = useCallback(
@@ -221,12 +221,6 @@ export default function TwelveXClient() {
           // Ledger (P4): run picker options.
           getLedgerRunDates(),
         ]);
-        // Today's "top trade ideas" are the top of the SAME ranked set the
-        // Intelligence tab shows (the latest confluence run) — not the digest's
-        // run_date, which can lag the latest confluence run (e.g. a digest exists
-        // for a day with no confluence) and leave Today empty while Intelligence
-        // has ideas. Slicing `intelligence` keeps the two surfaces consistent.
-        const confluence = intelligence.slice(0, 6);
         // Event opinions key off the intelligence run_date (latest confluence run)
         // so the catalysts tab shows desk views for the freshest session.
         const opinionsDate = intelligence[0]?.run_date ?? digest?.run_date ?? null;
@@ -238,7 +232,6 @@ export default function TwelveXClient() {
         if (cancelled) return;
         setData({
           digest,
-          confluence,
           consensusSeries,
           latestConsensus,
           intelligence,

--- a/frontend/olympus/lib/twelve-x/fetch.test.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { boardColumn, normalizeKeyThemes } from './fetch';
+import { boardColumn, normalizeKeyThemes, sortTodayBriefs, filterEventsToDay } from './fetch';
+import type { FxBriefRow, FxEconomicCalendarRow } from './types';
 
 /**
  * `boardColumn` must consolidate broker view currencies into the 8 G10 matrix
@@ -101,5 +102,50 @@ describe('normalizeKeyThemes', () => {
     // Only `[`-prefixed strings attempt a JSON-array parse; anything else is
     // taken verbatim as one theme rather than being dropped or mis-parsed.
     expect(normalizeKeyThemes('{"a":1}')).toEqual(['{"a":1}']);
+  });
+});
+
+const brief = (over: Partial<FxBriefRow>): FxBriefRow => ({
+  run_date: '2026-06-23', source_file: 's.pdf', source_url: null,
+  document_title: null, broker_name: 'X', analyst_names: null,
+  report_date: '2026-06-23', trader_relevance: 'low', central_thesis: null,
+  brief_markdown: null, currency_views: [], risk_events: null,
+  macro_themes: null, positioning_signals: null, ...over,
+});
+
+describe('sortTodayBriefs', () => {
+  it('orders by relevance (high→low), then breadth, then newest report_date', () => {
+    const lowOld = brief({ source_file: 'a', trader_relevance: 'low', report_date: '2026-06-20' });
+    const highFew = brief({ source_file: 'b', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }] });
+    const highMany = brief({ source_file: 'c', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }, { currency: 'EUR', direction: 'bearish', conviction: 'low' }] });
+    const medNew = brief({ source_file: 'd', trader_relevance: 'medium', report_date: '2026-06-23' });
+    const out = sortTodayBriefs([lowOld, highFew, highMany, medNew]).map((b) => b.source_file);
+    expect(out).toEqual(['c', 'b', 'd', 'a']);
+  });
+
+  it('is stable and pure (does not mutate input)', () => {
+    const input = [brief({ source_file: 'a' }), brief({ source_file: 'b' })];
+    const copy = [...input];
+    sortTodayBriefs(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+const ev = (over: Partial<FxEconomicCalendarRow>): FxEconomicCalendarRow => ({
+  id: 1, external_id: 'e', event_date: '2026-06-23', event_time: null,
+  country: 'US', event_name: 'X', category: 'c', impact: 'low',
+  actual: null, forecast: null, prior: null, event_datetime_utc: null, ...over,
+});
+
+describe('filterEventsToDay', () => {
+  it('keeps only events whose local date equals the target key', () => {
+    const todayUtc = ev({ id: 1, event_datetime_utc: '2026-06-23T14:30:00Z', event_date: '2026-06-23' });
+    const tomorrow = ev({ id: 2, event_datetime_utc: '2026-06-24T14:30:00Z', event_date: '2026-06-24' });
+    const allDayToday = ev({ id: 3, event_datetime_utc: null, event_date: '2026-06-23' });
+    const key = '2026-06-23';
+    const out = filterEventsToDay([todayUtc, tomorrow, allDayToday], key).map((e) => e.id);
+    expect(out).toContain(1);
+    expect(out).toContain(3);
+    expect(out).not.toContain(2);
   });
 });

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -25,6 +25,7 @@ import type {
   FxEconomicCalendarRow,
   FxEventSnapshotRow,
   FxLedgerRow,
+  FxTradeIdeaRow,
   MatrixCell,
   MatrixColumn,
   Mover,
@@ -432,6 +433,68 @@ export async function getBrief(
     }>;
   });
   return rows?.[0] ?? null;
+}
+
+const _RELEVANCE_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Pure ordering for the Today briefs slideshow: relevance desc, then breadth
+ *  (# of currency_views) desc, then newest report_date desc. Does not mutate. */
+export function sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[] {
+  const rel = (b: FxBriefRow) => _RELEVANCE_RANK[(b.trader_relevance ?? '').toLowerCase()] ?? 0;
+  const breadth = (b: FxBriefRow) => asCurrencyViews(b.currency_views).length;
+  return [...briefs].sort(
+    (a, b) =>
+      rel(b) - rel(a) ||
+      breadth(b) - breadth(a) ||
+      (b.report_date ?? '').localeCompare(a.report_date ?? '')
+  );
+}
+
+/** Curated trade ideas for a run_date (rank 1 = top). `[]` when unconfigured/empty. */
+export async function getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxTradeIdeaRow[]>((sb) =>
+    sb
+      .from('fx_trade_ideas_snapshot')
+      .select('run_date, rank, pair, direction, title, thesis, catalyst, levels, citations, as_of')
+      .eq('run_date', runDate)
+      .order('rank', { ascending: true })
+  );
+  return rows ?? [];
+}
+
+/** Today's research briefs for a run_date, pre-sorted for the slideshow. */
+export async function getTodayBriefs(runDate: string): Promise<FxBriefRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxBriefRow[]>(
+    (sb) =>
+      sb
+        .from('fx_research_history')
+        .select(BRIEF_COLUMNS)
+        .eq('run_date', runDate)
+        .order('report_date', { ascending: false }) as unknown as PromiseLike<{
+      data: FxBriefRow[] | null;
+      error: unknown;
+    }>
+  );
+  return sortTodayBriefs(rows ?? []);
+}
+
+/** Pure: keep only rows whose local event date matches `todayKey`. */
+export function filterEventsToDay(
+  events: FxEconomicCalendarRow[],
+  todayKey: string
+): FxEconomicCalendarRow[] {
+  return events.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+
+/** Upcoming macro events narrowed to the viewer-local "today". */
+export async function getTodayEvents(): Promise<FxEconomicCalendarRow[]> {
+  const all = await getUpcomingEvents();
+  const todayKey = eventLocalDateKey({ event_datetime_utc: new Date().toISOString(), event_date: '' });
+  return filterEventsToDay(all, todayKey);
 }
 
 // The extended leg-validity set: the 8 matrix columns + NOK/SEK. A pair is a

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -261,3 +261,20 @@ export interface ConfluenceCatalyst {
   calendarExternalId: string | null;
   daysToCatalyst: number | null;
 }
+
+/**
+ * `fx_trade_ideas_snapshot` (twelve-x migration 012) — the curated, synthesized
+ * actionable trade ideas for a run. PRIMARY KEY (run_date, rank). anon-readable.
+ */
+export interface FxTradeIdeaRow {
+  run_date: string; // date (ISO YYYY-MM-DD)
+  rank: number; // int (1 = top)
+  pair: string; // e.g. "USD/JPY"
+  direction: string; // 'long' | 'short' | ...
+  title: string; // e.g. "JPY SHORT — via USD/JPY"
+  thesis: string;
+  catalyst: string;
+  levels: unknown[]; // jsonb array of broker levels/targets
+  citations: unknown[]; // jsonb array of TradeIdeaCitation
+  as_of: string; // timestamptz (ISO)
+}

--- a/frontend/olympus/next-env.d.ts
+++ b/frontend/olympus/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #1003

## What

Redesigns the Olympus **twelve-x "Today"** tab into a single-screen daily snapshot ("A1" layout) that answers five questions at a glance, each section a teaser with a "see more →" pass-through to its full tab:

| Zone | Section | Source |
|------|---------|--------|
| Above fold (co-lead) | **① Trade ideas** — focal #1 card + #2…N rows + inline *expand ▾ → confluence reads* | `fx_trade_ideas_snapshot` (ranked) |
| Above fold (co-lead) | **② Digest brief** — full summary, always visible, key-theme chips | `fx_daily_digest` |
| Above fold (strip) | **③ What changed** — consensus movers | `computeConsensusDeltaSet` over `fx_consensus_snapshot` |
| Below fold | **④ Briefs slideshow** — carousel, relevance→breadth→newest | `fx_research_history` |
| Below fold | **⑤ Events** — today timeline, impact-colored, local time | `fx_economic_calendar` |
| `?view=briefs` | **⑥ Briefs index** — full-width grid, reached via slideshow "see more" (not a new tab) | `fx_research_history` |

Below the `lg` breakpoint the page collapses to a single column in priority order 1→2→3→4→5.

## Why

The prior Today tab buried the curated trade idea and the digest. This makes the trader's daily review glanceable: the curated idea(s) and the digest brief lead together above the fold, with "what changed in consensus" beside them, and today's briefs + events just below — each linking through to its dedicated tab for depth.

## Scope

**Part A only** — twelve-x frontend files (`frontend/olympus/{components,lib}/twelve-x`). No shared-shell edits.

**Part B is deliberately out of scope** (separate coordinated change): the shared subpage top-bar full-width behavior on wide screens + collapse-to-hamburger on mobile.

## Notable decisions / follow-ups

- `fx_trade_ideas_snapshot` is anon-readable (migration 012 `anon_read` RLS), confirmed — no confluence-derived fallback needed.
- Trade-idea count is handled as **1…N** (today is 1; design renders several).
- **Tracked, intentionally not in this PR:** today's live data contains a duplicate brief row (`MUFG_JPY Weekly` twice for 2026-06-22). React keys are index-suffixed so it renders cleanly; deduping `fx_research_history` rows is left for a deliberate upstream fix of the duplicate-row shape.
- Briefs-slideshow tiebreak uses **breadth (# of `currency_views`)** rather than the spec's looser "broker-mention count" wording — an intentional, test-asserted reinterpretation documented in the plan.

## Testing

- New pure data-layer helpers (`sortTodayBriefs`, `filterEventsToDay`) covered by vitest — **19/19 pass**.
- `tsc` clean for twelve-x, `eslint` exit 0.
- `next build` green — 15/15 static pages incl `/twelve-x`.
- Render-verified on the dev server at **1440px** (A1 above-fold layout) and **390px** (single-column stack), console clean.

## Review process

Built via subagent-driven development: fresh implementer + task reviewer per task (5 tasks), then a final whole-branch review on the most capable model. Final verdict: ready to merge; the two must-fix cleanups it raised (dead `confluence` state; `view` reset on tab nav) are applied in the last commit.

Spec: `docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md`
Plan: `docs/superpowers/plans/2026-06-23-twelve-x-today-snapshot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
