### PR TITLE
fix(olympus): pin H6 deliberation to deepseek-chat (#1006)

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -19,4 +19,11 @@ defaults:
   best: ollama/qwen3:8b
 
 # Optional per-phase overrides — empty by default; olympus_models.yaml owns routing.
-phase_models: {}
+phase_models:
+  # #1006: pin H6 deliberation to deepseek-chat. The cheap ``research`` pool also holds
+  # llama-4-maverick, which returns empty completions under STRICT json_schema — so the
+  # ~40% of watchlist tickers that hashed onto it failed json.loads at char 0
+  # (DeliberationPmTurn / DeliberationAnalystTurn). deepseek-chat is the json/tool-reliable
+  # open-weight model already in the pool; the trailing '-' makes this a prefix match for
+  # every per-ticker slug (hermes/portfolio/deliberation-{ticker}) emitted by h6_deliberation.
+  hermes/portfolio/deliberation-: openrouter/deepseek/deepseek-chat

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -108,19 +108,21 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
-def test_deliberation_routes_to_json_capable_research_pool_not_r1(
+def test_deliberation_pinned_to_json_reliable_deepseek_chat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression (Olympus daily, 2026-06-22, run 27984259662): H6 deliberation turns must
-    emit strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 mapped the phase to
-    the ``reasoning`` pool, which in the cheap tier contains ``deepseek-r1`` — a chain-of-thought
-    model that returns prose, so ``json.loads`` failed at char 0 ("Expecting value: line 1
-    column 1") for the ~1/3 of tickers that hashed onto it. Deliberation must route to the
-    JSON/tool-capable ``research`` pool — never the prose-only r1 — matching the (already
-    intended) h6_pm_challenge-/h6_analyst_response- mappings.
+    """Regression (Olympus daily, run 28014812240, #1006): H6 deliberation turns must emit
+    strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 first mapped the phase to
+    the ``reasoning`` pool (prose-only deepseek-r1 → json.loads failed at char 0); #998 then
+    routed it to the cheap ``research`` pool — but that pool also contains ``llama-4-maverick``,
+    which returns *empty* completions under STRICT json_schema, so the ~half of tickers hashing
+    onto it still failed at char 0. Deliberation is now pinned (model_modes.yaml ``phase_models``)
+    to deepseek-chat — the json/tool-reliable open-weight model — for *every* ticker, bypassing
+    the pool hash. Never maverick, never r1.
     """
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    research = set(model_config._load_olympus_models().tiers["cheap"].allowed_models["research"])
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
     # The live macro watchlist from the failing run.
     watchlist = (
         "SPY QQQ DIA IWB VTI MDY IJH IWM IJR XLK XLF XLE XLV XLI XLRE XLU XLY XLP XLB XLC "
@@ -130,7 +132,10 @@ def test_deliberation_routes_to_json_capable_research_pool_not_r1(
     ).split()
     for ticker in watchlist:
         model = get_model_for_phase(f"hermes/portfolio/deliberation-{ticker}")
-        assert model in research, f"deliberation-{ticker} -> {model!r}, not a research-pool model"
+        assert model == "openrouter/deepseek/deepseek-chat", (
+            f"deliberation-{ticker} -> {model!r}, expected the pinned json-reliable deepseek-chat"
+        )
+        assert "maverick" not in model, f"deliberation-{ticker} routes to empty-prone maverick"
         assert "deepseek-r1" not in model, f"deliberation-{ticker} routes to prose-only r1"
         assert is_tool_use_capable_model(model)
 


### PR DESCRIPTION
## Problem
In run [28014812240](https://github.com/digithings-ai/digithings/actions/runs/28014812240):
\`\`\`
empty completion from meta-llama/llama-4-maverick (empty-retry 1/4); backing off 5.0s
research_agent attempt 1/2 failed for DeliberationAnalystTurn: Expecting value: line 1 column 1 (char 0)  (x4)
\`\`\`
Non-fatal (degrades gracefully, run continues) but deliberation quality drops for the tickers affected.

## Root cause
#998 routed H6 deliberation off prose-only \`deepseek-r1\` to the cheap \`research\` pool \`[deepseek-chat, llama-4-maverick]\`. The per-ticker stable hash sends **26 of 63** watchlist tickers to \`llama-4-maverick\`, which **persistently returns empty completions under STRICT \`response_format=json_schema\`**. \`digillm/client.py\` empty-retries 4× then (by design) falls through with the empty body, which then fails JSON parsing in \`run_research_agent\`.

## Fix
Pin \`hermes/portfolio/deliberation-*\` to \`deepseek-chat\` — the json/tool-reliable open-weight model already in the pool — via the documented \`model_modes.yaml\` \`phase_models\` override. This bypasses the maverick hash **without** touching the shared LLM client or other phases' pools. The \`eff_model\` resolved from this slug drives both deliberation turn types (PM challenge + analyst response), so the pin covers all deliberation LLM calls.

## Test (TDD)
\`test_deliberation_pinned_to_json_reliable_deepseek_chat\` asserts all 63 watchlist deliberation slugs resolve to \`deepseek-chat\` (never maverick, never r1). Verified RED (26/63 → maverick) → GREEN. Full \`test_olympus_models.py\` suite: 62 passed. \`make score\`: 10/10 all dimensions.

## Known residual (out of scope, tracked separately)
\`llama-4-maverick\` also produced malformed/empty output for \`OnchainCohortPositioningReport\` and \`SectorReport\` in the same run (non-fatal, retried). Broader maverick-reliability cleanup is a separate follow-up.

Fixes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)