### PR TITLE
feat(olympus): full-bleed subpage top-bar + mobile menu collapse (Part B)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-olympus-subpage-topbar-responsive.md
+++ b/docs/superpowers/plans/2026-06-23-olympus-subpage-topbar-responsive.md
@@ -1,0 +1,306 @@
+# Olympus subpage top-bar responsive — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the shared Olympus subpage top-bar full-bleed on wide screens and collapse its tabs into a `☰ Sections` menu on mobile, with zero callsite changes.
+
+**Architecture:** Self-contained refactor of `frontend/olympus/components/subpage-tab-bar.tsx`. Split the single sticky div into a full-width outer wrapper (chrome) + a `SUBPAGE_MAX`-capped inner wrapper (content). Add a `md:hidden` menu trigger with local `open` state; tabs render once in a container that is an inline wrapping row at `≥ md` and an absolute dropdown panel below `md`. The mobile-nav idiom (lucide `Menu`/`X`, `aria-expanded`/`aria-controls`, `md:hidden` backdrop, close-on-route-change) is reused but state stays local.
+
+**Tech Stack:** Next.js 16 App Router, React 19 client component, Tailwind v4 (stock breakpoints), lucide-react, Vitest 4 (`node` environment + `react-dom/server` `renderToStaticMarkup`).
+
+## Global Constraints
+
+- `SUBPAGE_MAX` keeps its exact value `'max-w-[1600px] mx-auto w-full px-4 md:px-6'` — do not change it; other components consume it.
+- Collapse breakpoint is **`md`** (768px) — matches `MobileAppBar` (`md:hidden`, 72px) and the existing `max-md:top-[72px]` offset.
+- New optional prop `menuLabel?: string` defaults to `"Sections"`. **No callsite passes it; no callsite changes at all.**
+- Do not touch `app-shell-context.tsx`, `sidebar.tsx`, `mobile-app-bar.tsx`, or any of the four callsites (`app/observability/page.tsx`, `app/research/ResearchClient.tsx`, `components/portfolio/PortfolioSectionNav.tsx`, `components/twelve-x/TwelveXClient.tsx`).
+- z-index ordering: dropdown panel `z-30`, trigger button `relative z-30`, backdrop `z-[19]` — all must stay below `MobileAppBar` (`z-[997]`) and the main drawer (`z-[999]`).
+- `subpageTabButtonClass` and `SUBPAGE_MAX` exports are unchanged; add a new exported pure helper `subpageTabsContainerClass(open: boolean): string`.
+- Tests use the repo's pattern: vitest `node` env, `renderToStaticMarkup`, `vi.mock('next/navigation', ...)` for `usePathname`. No jsdom/RTL.
+- ruff/pandas rules are backend-only; this is TS. Keep eslint clean (line length 100).
+
+## File Structure
+
+- `frontend/olympus/components/subpage-tab-bar.tsx` (modify) — the only source file. Exports: `SUBPAGE_MAX` (unchanged), `subpageTabButtonClass` (unchanged), **new** `subpageTabsContainerClass(open)`, `SubpageStickyTabBar` (refactored).
+- `frontend/olympus/components/subpage-tab-bar.test.tsx` (create) — helper unit tests + `renderToStaticMarkup` structural tests.
+
+All commands run from `frontend/olympus/` (the Next workspace). `node_modules` is symlinked there as in prior twelve-x work.
+
+---
+
+### Task 1: Pure helper `subpageTabsContainerClass(open)`
+
+**Files:**
+- Modify: `frontend/olympus/components/subpage-tab-bar.tsx` (add the exported helper after `subpageTabButtonClass`)
+- Test: `frontend/olympus/components/subpage-tab-bar.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `subpageTabsContainerClass(open: boolean): string` — the className for the tabs container. Visibility token is `flex` when `open`, `hidden` when closed; always includes `md:flex` (tabs visible at `≥ md` regardless of `open`); desktop layout (`flex-row flex-wrap`) is unprefixed base; the mobile dropdown panel chrome is entirely `max-md:`-gated.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/olympus/components/subpage-tab-bar.test.tsx`:
+
+```tsx
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/olympus/twelve-x',
+}));
+
+import { SubpageStickyTabBar, subpageTabsContainerClass } from './subpage-tab-bar';
+
+describe('subpageTabsContainerClass', () => {
+  it('is visible (flex, not hidden) when open', () => {
+    const cls = subpageTabsContainerClass(true);
+    expect(cls).toContain('flex');
+    expect(cls).not.toContain('hidden');
+  });
+
+  it('is hidden when closed', () => {
+    expect(subpageTabsContainerClass(false)).toContain('hidden');
+  });
+
+  it('always shows tabs at >= md regardless of open', () => {
+    expect(subpageTabsContainerClass(true)).toContain('md:flex');
+    expect(subpageTabsContainerClass(false)).toContain('md:flex');
+  });
+
+  it('gates the dropdown-panel chrome behind max-md so it stops at md', () => {
+    const cls = subpageTabsContainerClass(false);
+    expect(cls).toContain('max-md:absolute');
+    expect(cls).toContain('max-md:flex-col');
+    // panel chrome must not leak to desktop (no unprefixed absolute/border/shadow)
+    expect(cls).not.toMatch(/(^| )absolute( |$)/);
+  });
+});
+```
+
+> Note: the `SubpageStickyTabBar` import is used by Task 2's tests added to this same file; importing it now is harmless and keeps one test file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx`
+Expected: FAIL — `subpageTabsContainerClass` is not exported (`SyntaxError`/`undefined is not a function`).
+
+- [ ] **Step 3: Implement the helper**
+
+In `frontend/olympus/components/subpage-tab-bar.tsx`, add after the `subpageTabButtonClass` function (before `SubpageStickyTabBar`):
+
+```tsx
+/**
+ * Classes for the tabs container. Desktop layout is the unprefixed base; the
+ * mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops
+ * at the `md` breakpoint and needs no `md:` reset. `md:flex` keeps tabs visible
+ * at >= md regardless of `open`; below md they show only when `open`.
+ */
+export function subpageTabsContainerClass(open: boolean): string {
+  return `gap-2 flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:backdrop-blur-md max-md:p-2 max-md:shadow-lg max-md:z-30`;
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx -t subpageTabsContainerClass`
+Expected: PASS (4 tests). The `SubpageStickyTabBar` describe block does not exist yet, so only the helper tests run under the `-t` filter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/olympus/components/subpage-tab-bar.tsx frontend/olympus/components/subpage-tab-bar.test.tsx
+git commit -m "feat(olympus): add subpageTabsContainerClass responsive helper"
+```
+
+---
+
+### Task 2: Refactor `SubpageStickyTabBar` (full-bleed + mobile menu)
+
+**Files:**
+- Modify: `frontend/olympus/components/subpage-tab-bar.tsx` (rewrite imports + `SubpageStickyTabBar`)
+- Test: `frontend/olympus/components/subpage-tab-bar.test.tsx` (append structural tests)
+
+**Interfaces:**
+- Consumes: `subpageTabsContainerClass(open)` and `SUBPAGE_MAX` from Task 1 / existing.
+- Produces: `SubpageStickyTabBar` with props `{ children, 'aria-label'?, topOffset?: 'app' | 'none', menuLabel?: string }`. Renders a full-width outer `<div role="navigation">` (chrome, no `max-w`) wrapping a `SUBPAGE_MAX relative py-3` inner `<div>` that holds a `md:hidden` trigger button, an optional backdrop, and the tabs container.
+
+- [ ] **Step 1: Write the failing structural tests**
+
+Append to `frontend/olympus/components/subpage-tab-bar.test.tsx`:
+
+```tsx
+function renderBar(): string {
+  return renderToStaticMarkup(
+    createElement(
+      SubpageStickyTabBar,
+      { 'aria-label': 'Test sections' },
+      createElement('a', { href: '/a', key: 'a' }, 'Alpha'),
+      createElement('a', { href: '/b', key: 'b' }, 'Bravo'),
+    ),
+  );
+}
+
+describe('SubpageStickyTabBar', () => {
+  it('renders its tab children', () => {
+    const html = renderBar();
+    expect(html).toContain('Alpha');
+    expect(html).toContain('Bravo');
+  });
+
+  it('renders a collapsed mobile menu trigger', () => {
+    const html = renderBar();
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="subpage-tabs"');
+    expect(html).toContain('Sections');
+  });
+
+  it('outer wrapper is full-bleed: has the border, sticky, but no width cap', () => {
+    const html = renderBar();
+    const firstClass = html.match(/class="([^"]*)"/)?.[1] ?? '';
+    expect(firstClass).toContain('sticky');
+    expect(firstClass).toContain('border-b');
+    expect(firstClass).not.toContain('max-w-[1600px]');
+  });
+
+  it('inner wrapper caps content at 1600px', () => {
+    expect(renderBar()).toContain('max-w-[1600px]');
+  });
+
+  it('respects a custom menuLabel', () => {
+    const html = renderToStaticMarkup(
+      createElement(SubpageStickyTabBar, { menuLabel: 'Views' }, createElement('a', { href: '/a' }, 'A')),
+    );
+    expect(html).toContain('Views');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx -t SubpageStickyTabBar`
+Expected: FAIL — current bar has no trigger (`aria-expanded` absent) and the outer wrapper still carries `max-w-[1600px]`.
+
+- [ ] **Step 3: Rewrite the component**
+
+In `frontend/olympus/components/subpage-tab-bar.tsx`, replace the top-of-file imports and the `SubpageStickyTabBar` function. The file's `'use client'`, `SUBPAGE_MAX`, `subpageTabButtonClass`, and `subpageTabsContainerClass` stay as they are.
+
+Replace the import line:
+
+```tsx
+import type { ReactNode } from 'react';
+```
+
+with:
+
+```tsx
+import { useEffect, useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { Menu, X } from 'lucide-react';
+```
+
+Replace the entire `SubpageStickyTabBar` function with:
+
+```tsx
+/** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
+export function SubpageStickyTabBar({
+  children,
+  'aria-label': ariaLabel = 'Section navigation',
+  topOffset = 'app',
+  menuLabel = 'Sections',
+}: {
+  children: ReactNode;
+  'aria-label'?: string;
+  topOffset?: 'app' | 'none';
+  menuLabel?: string;
+}) {
+  const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close the mobile menu on route change (covers <Link> tabs).
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Close on Escape while the menu is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <div
+      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass}`}
+      role="navigation"
+      aria-label={ariaLabel}
+    >
+      <div className={`${SUBPAGE_MAX} relative py-3`}>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
+          aria-expanded={open}
+          aria-controls="subpage-tabs"
+          aria-label={open ? 'Close sections menu' : 'Open sections menu'}
+        >
+          {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
+          <span>{menuLabel}</span>
+        </button>
+        {open ? (
+          <div
+            className="fixed inset-0 z-[19] md:hidden"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+        ) : null}
+        <div id="subpage-tabs" className={subpageTabsContainerClass(open)} onClick={() => setOpen(false)}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the full test file to verify it passes**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx`
+Expected: PASS (all helper + structural tests, ~9 tests).
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `cd frontend/olympus && npx tsc --noEmit -p tsconfig.json && npx eslint components/subpage-tab-bar.tsx components/subpage-tab-bar.test.tsx`
+Expected: tsc reports no NEW errors in these files (a pre-existing `lib/security-headers.test.ts` TS7016/7006 pair is known and unrelated); eslint exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/olympus/components/subpage-tab-bar.tsx frontend/olympus/components/subpage-tab-bar.test.tsx
+git commit -m "feat(olympus): full-bleed subpage top-bar + mobile menu collapse"
+```
+
+---
+
+## Post-implementation verification (controller, not a task)
+
+After both tasks land, the controller verifies the whole branch:
+
+1. `cd frontend/olympus && npx vitest run` — full suite green (new + existing component tests).
+2. `cd frontend/olympus && npx next build` — green; `/twelve-x`, `/research`, `/observability`, `/portfolio` prerender without error.
+3. Dev-server render verification (browser) at three widths on a subpage with tabs (e.g. `/twelve-x`):
+   - **~2000px wide:** the bar's glass background + bottom border reach both viewport edges; tabs centered, aligned to the 1600px content column.
+   - **~1280px desktop:** tabs inline exactly as before; no trigger button.
+   - **~390px mobile:** only `☰ Sections` shows; tapping opens a dropdown listing the tabs; tapping a tab / outside / `Esc` closes it; the bar still sits below the 72px `MobileAppBar`.
+   - Console clean (0 errors).
+
+## Self-Review (writing-plans step)
+
+- **Spec coverage:** §4.1 full-bleed → Task 2 outer/inner split (tested). §4.2 mobile menu → Task 2 trigger + dropdown + close handlers; visibility logic → Task 1 helper (tested). §4.3 state/a11y → Task 2 `useState`/`usePathname`/`Escape`/`aria-*`. §5 files → both tasks. §6 testing → Task 1 helper tests + Task 2 structural tests + controller render verification. §7 non-goals → Global Constraints (no callsite/shell/SUBPAGE_MAX changes). §8 risks → Global Constraints (z-index ordering) + render verification (sticky/offset, class precedence).
+- **Placeholder scan:** none — every code step has complete code and exact commands.
+- **Type consistency:** `subpageTabsContainerClass(open: boolean): string` is defined in Task 1 and consumed in Task 2 with the same signature; `menuLabel` default `"Sections"` is consistent between the component and the test; `aria-controls="subpage-tabs"` matches the container `id="subpage-tabs"`.

--- a/docs/superpowers/specs/2026-06-23-olympus-subpage-topbar-responsive-design.md
+++ b/docs/superpowers/specs/2026-06-23-olympus-subpage-topbar-responsive-design.md
@@ -1,0 +1,98 @@
+# Olympus subpage top-bar — full-bleed + mobile menu (design)
+
+- **Date:** 2026-06-23
+- **Status:** Approved design / spec (pre-implementation)
+- **Surface:** Olympus shared subpage tab-bar (`frontend/olympus/components/subpage-tab-bar.tsx`)
+- **Relationship:** This is **Part B** of the twelve-x Today work. Part A (the Today snapshot redesign, PR #1002) is separate and already open. Part B is its own branch (`feat/olympus-subpage-topbar-responsive`) off `develop` and its own PR.
+
+## 1. Goal
+
+Fix two responsiveness defects in the shared subpage top-bar so it behaves consistently with the rest of Olympus:
+
+1. **Wide screens (> 1600px):** the bar's glass background and bottom border are capped at 1600px and centered, so on wide monitors the divider floats with empty gutters and reads as unfinished. The bar's *chrome* should span the full viewport while its *content* stays aligned to the 1600px page-content width.
+2. **Narrow / mobile screens:** the tab items use `flex flex-wrap` and wrap onto multiple lines. They should instead **collapse into a menu button** (a "☰ Sections" dropdown), consistent with the app's existing mobile-nav idiom.
+
+## 2. Context (what exists today)
+
+`components/subpage-tab-bar.tsx` is the single shared component, used by all subpages via `children`:
+
+- `app/observability/page.tsx`, `app/research/ResearchClient.tsx`, `components/portfolio/PortfolioSectionNav.tsx`, `components/twelve-x/TwelveXClient.tsx`.
+- The bar is rendered as a **sibling** of the capped content `<div className={SUBPAGE_MAX}>`, and applies `SUBPAGE_MAX` to *itself*. Its parent is the full-width main scroll container — so a full-width outer wrapper needs no negative-margin hack.
+- Tab children are heterogeneous: `<Link>` (research/observability/portfolio navigate by route) and stateful `<button>` (twelve-x calls `setTab`, changing `?tab=` not the pathname).
+- Current markup (lines 28–34):
+  ```tsx
+  <div className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass} ${SUBPAGE_MAX} py-3`} role="navigation" aria-label={ariaLabel}>
+    <div className="flex flex-wrap gap-2">{children}</div>
+  </div>
+  ```
+- `SUBPAGE_MAX = 'max-w-[1600px] mx-auto w-full px-4 md:px-6'` is consumed by other components too — its value **does not change**.
+- An established mobile-nav idiom exists in `components/mobile-app-bar.tsx` + `components/sidebar.tsx` + `components/app-shell-context.tsx`: lucide `Menu`/`X`, `aria-expanded`/`aria-controls`, a `md:hidden` backdrop (`fixed inset-0 … onClick=close`), and close-on-route-change. Part B **reuses the idiom** but keeps its own local state (it does not touch `app-shell-context`).
+- Tailwind v4, stock breakpoints (`md` = 768px). `MobileAppBar` is `md:hidden` (present < 768px) and 72px tall — the bar's existing `max-md:top-[72px]` offset already accounts for it. The mobile menu therefore collapses at the **`md`** breakpoint, matching where the main mobile nav appears.
+
+## 3. Approach
+
+**Self-contained refactor of `subpage-tab-bar.tsx` only. Zero callsite changes.** (Rejected alternatives: hoisting toggle state into `app-shell-context` — global state for a per-page dropdown is overkill; a data-driven `tabs` prop rewrite — would force converting all four callsites incl. twelve-x's stateful tabs, and the chosen static "Sections" trigger needs no tab data. YAGNI.)
+
+## 4. Design
+
+### 4.1 Full-bleed chrome, capped content
+
+Split the single sticky div into outer (full width) + inner (capped):
+
+- **Outer** `<div role="navigation" aria-label=…>`: `sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md` + `topClass`. **No `max-w`.** Spans the full-width parent → background + border reach the viewport edges.
+- **Inner** `<div>`: `SUBPAGE_MAX` + `relative py-3`. Holds the trigger + tabs. `relative` anchors the absolute mobile dropdown.
+
+`SUBPAGE_MAX` and its other consumers are untouched.
+
+### 4.2 Mobile menu (`< md`)
+
+Inside the inner container, tabs render **once** in a container whose layout is driven by breakpoint + open state; a trigger button toggles it below `md`.
+
+- **Trigger button** (`md:hidden`): `☰` + label (lucide `Menu` when closed, `X` when open), `aria-expanded={open}`, `aria-controls="subpage-tabs"`, `aria-label` toggling "Open/Close sections menu". Styled to match `mobile-app-bar.tsx`'s toggle (`rounded-lg border border-border-subtle … hover:bg-white/[0.06]`).
+- **Tabs container** (`id="subpage-tabs"`): one element, classes from a pure helper `subpageTabsContainerClass(open)`. Strategy: **desktop layout is the unprefixed base; the mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops at `md` and needs no `md:` reset.**
+  - Visibility: `${open ? 'flex' : 'hidden'}` (base) + `md:flex` — at `≥ md` the tabs always show regardless of `open`; below `md` they show only when open.
+  - Desktop layout (base): `flex-row flex-wrap gap-2`.
+  - Mobile panel (`max-md:` only): `flex-col absolute left-0 right-0 top-full mt-1 rounded-lg border border-border-subtle bg-bg-glass/95 backdrop-blur-md p-2 shadow-lg z-30`. Because these are `max-md:`-gated, they vanish at `≥ md` automatically — no `md:bg-transparent`/`md:static`/etc. needed.
+- **Children** render unchanged inside that container (works for `<Link>` and `<button>` alike), stacked vertically in the panel, inline at `≥ md`. `subpageTabButtonClass` is unchanged (`sm:` sizing preserved).
+- **Close on:** tab click (panel `onClick={() => setOpen(false)}` — covers stateful buttons), route change (`usePathname()` effect — covers `<Link>`), `Escape` keydown (listener active only while open), and a `md:hidden` backdrop tap (`fixed inset-0 z-[19]`, the `sidebar.tsx` idiom).
+- New optional prop `menuLabel?: string`, default `"Sections"`. No callsite passes it.
+- `≥ md`: trigger hidden, backdrop never shown, tabs inline — visually identical to today.
+
+### 4.3 State & accessibility
+
+- Local `const [open, setOpen] = useState(false)` — no global context.
+- `'use client'` already present; add `useState`, `useEffect`, `usePathname` (next/navigation), lucide `Menu`/`X` imports.
+- Trigger ↔ panel wired via `aria-expanded` + `aria-controls`/`id`; `Escape` and backdrop give keyboard + pointer dismissal.
+
+## 5. Components / files
+
+- **Modify:** `components/subpage-tab-bar.tsx` — split outer/inner, add trigger + dropdown + state, export new pure helper `subpageTabsContainerClass(open: boolean): string`.
+- **Create:** `components/subpage-tab-bar.test.tsx` — unit tests (see §6).
+- **No other files change.** All four callsites are untouched.
+
+## 6. Testing
+
+Matches the repo's vitest `node` environment + `renderToStaticMarkup` pattern (e.g. `components/overview/as-of-badge.test.tsx`); no jsdom/RTL.
+
+- **Pure helper `subpageTabsContainerClass(open)`:** `open === true` → contains `flex` and not the closed `hidden`; `open === false` → contains `hidden`; both contain `md:flex` (always visible at `≥ md` regardless of `open`).
+- **`renderToStaticMarkup(<SubpageStickyTabBar>{tabs}</…>)`** (initial closed state):
+  - children render (tab labels present);
+  - a trigger button with `aria-expanded="false"` and `md:hidden`;
+  - **outer** wrapper has `border-b` but **not** `max-w-[1600px]`;
+  - an **inner** wrapper **has** `max-w-[1600px]`;
+  - tabs container carries the closed (`hidden`) + `md:flex` classes.
+- **Interactive behavior** (click-open, tab-click/Esc/backdrop/route close) is **render-verified** on the dev server at wide (~2000px), desktop (~1280px), and mobile (~390px) widths — `renderToStaticMarkup` cannot exercise effects/clicks.
+- Gate: `next build` green, twelve-x + shell `tsc`/`eslint` clean, full vitest suite green (new + existing component tests).
+
+## 7. Non-goals
+
+- No change to `SUBPAGE_MAX`'s value or to page-content max width.
+- No data-driven `tabs` prop; no active-section label in the trigger (the chosen design uses a static "Sections" trigger).
+- No change to the main sidebar / `MobileAppBar` / `app-shell-context`.
+- Part A (Today snapshot) is out of scope here.
+
+## 8. Risks
+
+- **Sticky + full-bleed outer:** the outer keeps `sticky` + `topClass`; only `max-w` moves to the inner. Verify stickiness and the `max-md:top-[72px]` offset still hold under the `MobileAppBar`.
+- **Dropdown overlay z-index:** panel `z-30` and backdrop `z-[19]` must sit above page content but below the main mobile drawer (`z-[999]`) and `MobileAppBar` (`z-[997]`) — confirmed lower, so the main nav still wins.
+- **Tailwind class precedence:** the closed-state `hidden` must be overridden by `md:flex`; ordering verified by the pure-helper test + render check.

--- a/frontend/olympus/components/subpage-tab-bar.test.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.test.tsx
@@ -32,3 +32,48 @@ describe('subpageTabsContainerClass', () => {
     expect(cls).not.toMatch(/(^| )absolute( |$)/);
   });
 });
+
+function renderBar(): string {
+  return renderToStaticMarkup(
+    createElement(
+      SubpageStickyTabBar,
+      { 'aria-label': 'Test sections' },
+      createElement('a', { href: '/a', key: 'a' }, 'Alpha'),
+      createElement('a', { href: '/b', key: 'b' }, 'Bravo'),
+    ),
+  );
+}
+
+describe('SubpageStickyTabBar', () => {
+  it('renders its tab children', () => {
+    const html = renderBar();
+    expect(html).toContain('Alpha');
+    expect(html).toContain('Bravo');
+  });
+
+  it('renders a collapsed mobile menu trigger', () => {
+    const html = renderBar();
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="subpage-tabs"');
+    expect(html).toContain('Sections');
+  });
+
+  it('outer wrapper is full-bleed: has the border, sticky, but no width cap', () => {
+    const html = renderBar();
+    const firstClass = html.match(/class="([^"]*)"/)?.[1] ?? '';
+    expect(firstClass).toContain('sticky');
+    expect(firstClass).toContain('border-b');
+    expect(firstClass).not.toContain('max-w-[1600px]');
+  });
+
+  it('inner wrapper caps content at 1600px', () => {
+    expect(renderBar()).toContain('max-w-[1600px]');
+  });
+
+  it('respects a custom menuLabel', () => {
+    const html = renderToStaticMarkup(
+      createElement(SubpageStickyTabBar, { menuLabel: 'Views' }, createElement('a', { href: '/a' }, 'A')),
+    );
+    expect(html).toContain('Views');
+  });
+});

--- a/frontend/olympus/components/subpage-tab-bar.test.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.test.tsx
@@ -1,0 +1,34 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/olympus/twelve-x',
+}));
+
+import { SubpageStickyTabBar, subpageTabsContainerClass } from './subpage-tab-bar';
+
+describe('subpageTabsContainerClass', () => {
+  it('is visible (flex, not hidden) when open', () => {
+    const cls = subpageTabsContainerClass(true);
+    expect(cls).toContain('flex');
+    expect(cls).not.toContain('hidden');
+  });
+
+  it('is hidden when closed', () => {
+    expect(subpageTabsContainerClass(false)).toContain('hidden');
+  });
+
+  it('always shows tabs at >= md regardless of open', () => {
+    expect(subpageTabsContainerClass(true)).toContain('md:flex');
+    expect(subpageTabsContainerClass(false)).toContain('md:flex');
+  });
+
+  it('gates the dropdown-panel chrome behind max-md so it stops at md', () => {
+    const cls = subpageTabsContainerClass(false);
+    expect(cls).toContain('max-md:absolute');
+    expect(cls).toContain('max-md:flex-col');
+    // panel chrome must not leak to desktop (no unprefixed absolute/border/shadow)
+    expect(cls).not.toMatch(/(^| )absolute( |$)/);
+  });
+});

--- a/frontend/olympus/components/subpage-tab-bar.test.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.test.tsx
@@ -11,7 +11,7 @@ import { SubpageStickyTabBar, subpageTabsContainerClass } from './subpage-tab-ba
 describe('subpageTabsContainerClass', () => {
   it('is visible (flex, not hidden) when open', () => {
     const cls = subpageTabsContainerClass(true);
-    expect(cls).toContain('flex');
+    expect(cls.split(' ')).toContain('flex');
     expect(cls).not.toContain('hidden');
   });
 
@@ -56,6 +56,8 @@ describe('SubpageStickyTabBar', () => {
     expect(html).toContain('aria-expanded="false"');
     expect(html).toContain('aria-controls="subpage-tabs"');
     expect(html).toContain('Sections');
+    // Trigger must be hidden on desktop so the desktop layout is not broken.
+    expect(html).toContain('md:hidden');
   });
 
   it('outer wrapper is full-bleed: has the border, sticky, but no width cap', () => {
@@ -75,5 +77,11 @@ describe('SubpageStickyTabBar', () => {
       createElement(SubpageStickyTabBar, { menuLabel: 'Views' }, createElement('a', { href: '/a' }, 'A')),
     );
     expect(html).toContain('Views');
+  });
+
+  it('tabs container has hidden and md:flex classes in default (closed) state', () => {
+    const html = renderBar();
+    expect(html).toContain('hidden');
+    expect(html).toContain('md:flex');
   });
 });

--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { Menu, X } from 'lucide-react';
 
@@ -16,13 +17,16 @@ export function subpageTabButtonClass(active: boolean): string {
 }
 
 /**
- * Classes for the tabs container. Desktop layout is the unprefixed base; the
- * mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops
- * at the `md` breakpoint and needs no `md:` reset. `md:flex` keeps tabs visible
- * at >= md regardless of `open`; below md they show only when `open`.
+ * Classes for the tabs container. Desktop layout uses `md:flex-row` so the
+ * direction is on the same min-width range as `md:flex`, eliminating any
+ * generation-order reliance between `flex-row` and `max-md:flex-col`. `md:flex`
+ * keeps tabs visible at >= md regardless of `open`; below md they show only
+ * when `open`. The panel's backdrop-blur is intentionally omitted here — the
+ * outer sticky bar already applies `backdrop-blur-md` to that region; a second
+ * layer would produce an additive double-blur artifact.
  */
 export function subpageTabsContainerClass(open: boolean): string {
-  return `gap-2 flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:backdrop-blur-md max-md:p-2 max-md:shadow-lg max-md:z-30`;
+  return `gap-2 md:flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:p-2 max-md:shadow-lg max-md:z-30`;
 }
 
 /** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
@@ -40,6 +44,8 @@ export function SubpageStickyTabBar({
   const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Close the mobile menu on route change (covers <Link> tabs).
   useEffect(() => {
@@ -47,11 +53,16 @@ export function SubpageStickyTabBar({
     setOpen(false);
   }, [pathname]);
 
-  // Close on Escape while the menu is open.
+  // Close on Escape while the menu is open; restore focus to trigger on close.
   useEffect(() => {
     if (!open) return;
+    // Move focus to the first focusable item in the panel on open.
+    containerRef.current?.querySelector<HTMLElement>('button, a')?.focus();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -65,6 +76,7 @@ export function SubpageStickyTabBar({
     >
       <div className={`${SUBPAGE_MAX} relative py-3`}>
         <button
+          ref={triggerRef}
           type="button"
           onClick={() => setOpen((o) => !o)}
           className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
@@ -75,14 +87,25 @@ export function SubpageStickyTabBar({
           {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
           <span>{menuLabel}</span>
         </button>
-        {open ? (
-          <div
-            className="fixed inset-0 z-[19] md:hidden"
-            onClick={() => setOpen(false)}
-            aria-hidden
-          />
-        ) : null}
-        <div id="subpage-tabs" className={subpageTabsContainerClass(open)} onClick={() => setOpen(false)}>
+        {open
+          ? createPortal(
+              <div
+                className="fixed inset-0 z-[19] md:hidden"
+                onClick={() => setOpen(false)}
+                tabIndex={-1}
+                aria-hidden
+              />,
+              document.body,
+            )
+          : null}
+        <div
+          ref={containerRef}
+          id="subpage-tabs"
+          className={subpageTabsContainerClass(open)}
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('button, a')) setOpen(false);
+          }}
+        >
           {children}
         </div>
       </div>

--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -13,6 +13,16 @@ export function subpageTabButtonClass(active: boolean): string {
   }`;
 }
 
+/**
+ * Classes for the tabs container. Desktop layout is the unprefixed base; the
+ * mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops
+ * at the `md` breakpoint and needs no `md:` reset. `md:flex` keeps tabs visible
+ * at >= md regardless of `open`; below md they show only when `open`.
+ */
+export function subpageTabsContainerClass(open: boolean): string {
+  return `gap-2 flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:backdrop-blur-md max-md:p-2 max-md:shadow-lg max-md:z-30`;
+}
+
 /** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
 export function SubpageStickyTabBar({
   children,

--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -17,16 +17,17 @@ export function subpageTabButtonClass(active: boolean): string {
 }
 
 /**
- * Classes for the tabs container. Desktop layout uses `md:flex-row` so the
- * direction is on the same min-width range as `md:flex`, eliminating any
- * generation-order reliance between `flex-row` and `max-md:flex-col`. `md:flex`
- * keeps tabs visible at >= md regardless of `open`; below md they show only
- * when `open`. The panel's backdrop-blur is intentionally omitted here — the
+ * Classes for the tabs container. Desktop layout uses `md:flex-row md:flex-wrap`
+ * so direction and wrapping live on the same min-width range as `md:flex`,
+ * eliminating any generation-order reliance against `max-md:flex-col` and
+ * keeping the mobile dropdown a clean (non-wrapping) column. `md:flex` keeps
+ * tabs visible at >= md regardless of `open`; below md they show only when
+ * `open`. The panel's backdrop-blur is intentionally omitted here — the
  * outer sticky bar already applies `backdrop-blur-md` to that region; a second
  * layer would produce an additive double-blur artifact.
  */
 export function subpageTabsContainerClass(open: boolean): string {
-  return `gap-2 md:flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:p-2 max-md:shadow-lg max-md:z-30`;
+  return `gap-2 md:flex-row md:flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:p-2 max-md:shadow-lg max-md:z-30`;
 }
 
 /** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
@@ -82,7 +83,7 @@ export function SubpageStickyTabBar({
           className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
           aria-expanded={open}
           aria-controls="subpage-tabs"
-          aria-label={open ? 'Close sections menu' : 'Open sections menu'}
+          aria-label={`${open ? 'Close' : 'Open'} ${menuLabel} menu`}
         >
           {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
           <span>{menuLabel}</span>

--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { Menu, X } from 'lucide-react';
 
 /** Max width and horizontal padding for portfolio, research, overview, and related pages. */
 export const SUBPAGE_MAX = 'max-w-[1600px] mx-auto w-full px-4 md:px-6';
@@ -28,19 +30,62 @@ export function SubpageStickyTabBar({
   children,
   'aria-label': ariaLabel = 'Section navigation',
   topOffset = 'app',
+  menuLabel = 'Sections',
 }: {
-  children: ReactNode;
+  children?: ReactNode;
   'aria-label'?: string;
   topOffset?: 'app' | 'none';
+  menuLabel?: string;
 }) {
   const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close the mobile menu on route change (covers <Link> tabs).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- close menu on navigation
+    setOpen(false);
+  }, [pathname]);
+
+  // Close on Escape while the menu is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
   return (
     <div
-      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass} ${SUBPAGE_MAX} py-3`}
+      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass}`}
       role="navigation"
       aria-label={ariaLabel}
     >
-      <div className="flex flex-wrap gap-2">{children}</div>
+      <div className={`${SUBPAGE_MAX} relative py-3`}>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
+          aria-expanded={open}
+          aria-controls="subpage-tabs"
+          aria-label={open ? 'Close sections menu' : 'Open sections menu'}
+        >
+          {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
+          <span>{menuLabel}</span>
+        </button>
+        {open ? (
+          <div
+            className="fixed inset-0 z-[19] md:hidden"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+        ) : null}
+        <div id="subpage-tabs" className={subpageTabsContainerClass(open)} onClick={() => setOpen(false)}>
+          {children}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #1012

## What

Fixes the shared Olympus subpage top-bar (`components/subpage-tab-bar.tsx`) so it behaves consistently with the rest of Olympus. **Self-contained refactor — zero callsite changes**; all four subpages (observability, research, portfolio, twelve-x) inherit it.

- **Full-bleed chrome on wide screens:** split into a full-width outer wrapper (sticky glass background + bottom border now span the viewport) and a `SUBPAGE_MAX`-capped inner wrapper (tabs stay centered at 1600px, aligned with page content). `SUBPAGE_MAX`'s value is unchanged.
- **Mobile menu (`< md`):** the tabs collapse into a `☰ Sections` button that opens a dropdown, instead of wrapping onto multiple lines. Reuses the app's mobile-nav idiom (lucide `Menu`/`X`, `aria-expanded`/`aria-controls`, backdrop), with close on tab-tap, route change, `Escape`, and outside-tap, plus focus management (focus moves into the panel on open, back to the trigger on close).
- New optional `menuLabel` prop (default `"Sections"`); `≥ md` is visually identical to before.

This is **Part B** — the follow-up to the twelve-x "Today" redesign (PR #1002 / issue #1003), which deferred the shared top-bar here.

## How it was built

Brainstorm → spec → plan → a Workflow that implemented the change then **adversarially reviewed it across 4 lenses** (Tailwind class precedence, z-index/stacking, a11y/interaction, test adequacy). The panel caught a **critical** bug the plan would have shipped: `backdrop-filter` on the bar creates a fixed-positioning containing block, so the `fixed inset-0` backdrop was trapped to the ~52px bar box and outside-tap-to-close was silently broken. Fixed by rendering the backdrop through a `createPortal(document.body)` (SSR-safe — only mounts client-side when open).

## Testing

- Unit: pure `subpageTabsContainerClass(open)` helper + `renderToStaticMarkup` structural assertions (repo's `node`-env pattern). Full suite **164/164 green**; `tsc`/`eslint` clean; `next build` green (15/15 static pages).
- Browser render-verified (Playwright) on `/observability`:
  - **wide (2000px):** bar spans the full content area (1740px to the viewport edge); inner content capped at 1600px, centered; tabs inline; trigger hidden.
  - **mobile (390px):** trigger-only when closed; open → column dropdown + a **full-viewport** portal backdrop (0,0 → 390×844, confirming the portal fix); outside-tap closes; `Esc` closes and returns focus to the trigger. Console clean.

Screenshots in the linked issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
