### PR TITLE
Promote develop → main: Olympus Today snapshot + responsive top-bar

### DIFF
--- a/config/model_modes.yaml
+++ b/config/model_modes.yaml
@@ -19,4 +19,11 @@ defaults:
   best: ollama/qwen3:8b
 
 # Optional per-phase overrides — empty by default; olympus_models.yaml owns routing.
-phase_models: {}
+phase_models:
+  # #1006: pin H6 deliberation to deepseek-chat. The cheap ``research`` pool also holds
+  # llama-4-maverick, which returns empty completions under STRICT json_schema — so the
+  # ~40% of watchlist tickers that hashed onto it failed json.loads at char 0
+  # (DeliberationPmTurn / DeliberationAnalystTurn). deepseek-chat is the json/tool-reliable
+  # open-weight model already in the pool; the trailing '-' makes this a prefix match for
+  # every per-ticker slug (hermes/portfolio/deliberation-{ticker}) emitted by h6_deliberation.
+  hermes/portfolio/deliberation-: openrouter/deepseek/deepseek-chat

--- a/digiquant/supabase/migrations/045_pm_direction_commit_run_doc_types.sql
+++ b/digiquant/supabase/migrations/045_pm_direction_commit_run_doc_types.sql
@@ -1,0 +1,52 @@
+-- 045_pm_direction_commit_run_doc_types.sql — register #930 thesis-first doc_types (#1005)
+--
+-- #930 (Olympus daily thesis-first graph) added two `documents` artifacts published
+-- in the H9 commit-run node whose doc_type was never registered in
+-- chk_documents_doc_type:
+--   - "PM Direction Memo"  (commit_io.publish_hermes_documents)
+--   - "Commit Run"         (commit_io.save_commit_manifest)
+-- The date-serialization crash (#993/#994) masked the violation by crashing before
+-- the row reached Postgres; once that was fixed the upsert was rejected with
+-- APIError 23514 (violates check constraint "chk_documents_doc_type").
+--
+-- Extends the migration-043 allow-list — every prior value is preserved, including
+-- the legacy "PM Allocation Memo" kept for historical rows.
+
+BEGIN;
+
+ALTER TABLE documents DROP CONSTRAINT IF EXISTS chk_documents_doc_type;
+
+ALTER TABLE documents ADD CONSTRAINT chk_documents_doc_type CHECK (
+  doc_type IS NULL OR doc_type IN (
+    'Daily Digest',
+    'Daily Delta',
+    'Weekly Rollup',
+    'Monthly Summary',
+    'Deep Dive',
+    'Research Delta',
+    'Research Baseline Manifest',
+    'Document Delta',
+    'Research Changelog',
+    'Rebalance Decision',
+    'Asset Recommendation',
+    'Deliberation Transcript',
+    'Deliberation Session Index',
+    'Market Thesis Exploration',
+    'Thesis Vehicle Map',
+    'PM Allocation Memo',
+    'PM Direction Memo',
+    'Commit Run',
+    'Sector Report',
+    'Evolution Sources',
+    'Evolution Quality Log',
+    'Evolution Proposals',
+    'Pipeline Review',
+    'Custom Research',
+    'Beliefs'
+  )
+);
+
+COMMENT ON CONSTRAINT chk_documents_doc_type ON documents IS
+  'Track A/B output + beliefs (#930) + thesis-first commit-run doc_types: PM Direction Memo, Commit Run (#1005).';
+
+COMMIT;

--- a/docs/superpowers/plans/2026-06-23-olympus-subpage-topbar-responsive.md
+++ b/docs/superpowers/plans/2026-06-23-olympus-subpage-topbar-responsive.md
@@ -1,0 +1,306 @@
+# Olympus subpage top-bar responsive — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the shared Olympus subpage top-bar full-bleed on wide screens and collapse its tabs into a `☰ Sections` menu on mobile, with zero callsite changes.
+
+**Architecture:** Self-contained refactor of `frontend/olympus/components/subpage-tab-bar.tsx`. Split the single sticky div into a full-width outer wrapper (chrome) + a `SUBPAGE_MAX`-capped inner wrapper (content). Add a `md:hidden` menu trigger with local `open` state; tabs render once in a container that is an inline wrapping row at `≥ md` and an absolute dropdown panel below `md`. The mobile-nav idiom (lucide `Menu`/`X`, `aria-expanded`/`aria-controls`, `md:hidden` backdrop, close-on-route-change) is reused but state stays local.
+
+**Tech Stack:** Next.js 16 App Router, React 19 client component, Tailwind v4 (stock breakpoints), lucide-react, Vitest 4 (`node` environment + `react-dom/server` `renderToStaticMarkup`).
+
+## Global Constraints
+
+- `SUBPAGE_MAX` keeps its exact value `'max-w-[1600px] mx-auto w-full px-4 md:px-6'` — do not change it; other components consume it.
+- Collapse breakpoint is **`md`** (768px) — matches `MobileAppBar` (`md:hidden`, 72px) and the existing `max-md:top-[72px]` offset.
+- New optional prop `menuLabel?: string` defaults to `"Sections"`. **No callsite passes it; no callsite changes at all.**
+- Do not touch `app-shell-context.tsx`, `sidebar.tsx`, `mobile-app-bar.tsx`, or any of the four callsites (`app/observability/page.tsx`, `app/research/ResearchClient.tsx`, `components/portfolio/PortfolioSectionNav.tsx`, `components/twelve-x/TwelveXClient.tsx`).
+- z-index ordering: dropdown panel `z-30`, trigger button `relative z-30`, backdrop `z-[19]` — all must stay below `MobileAppBar` (`z-[997]`) and the main drawer (`z-[999]`).
+- `subpageTabButtonClass` and `SUBPAGE_MAX` exports are unchanged; add a new exported pure helper `subpageTabsContainerClass(open: boolean): string`.
+- Tests use the repo's pattern: vitest `node` env, `renderToStaticMarkup`, `vi.mock('next/navigation', ...)` for `usePathname`. No jsdom/RTL.
+- ruff/pandas rules are backend-only; this is TS. Keep eslint clean (line length 100).
+
+## File Structure
+
+- `frontend/olympus/components/subpage-tab-bar.tsx` (modify) — the only source file. Exports: `SUBPAGE_MAX` (unchanged), `subpageTabButtonClass` (unchanged), **new** `subpageTabsContainerClass(open)`, `SubpageStickyTabBar` (refactored).
+- `frontend/olympus/components/subpage-tab-bar.test.tsx` (create) — helper unit tests + `renderToStaticMarkup` structural tests.
+
+All commands run from `frontend/olympus/` (the Next workspace). `node_modules` is symlinked there as in prior twelve-x work.
+
+---
+
+### Task 1: Pure helper `subpageTabsContainerClass(open)`
+
+**Files:**
+- Modify: `frontend/olympus/components/subpage-tab-bar.tsx` (add the exported helper after `subpageTabButtonClass`)
+- Test: `frontend/olympus/components/subpage-tab-bar.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `subpageTabsContainerClass(open: boolean): string` — the className for the tabs container. Visibility token is `flex` when `open`, `hidden` when closed; always includes `md:flex` (tabs visible at `≥ md` regardless of `open`); desktop layout (`flex-row flex-wrap`) is unprefixed base; the mobile dropdown panel chrome is entirely `max-md:`-gated.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/olympus/components/subpage-tab-bar.test.tsx`:
+
+```tsx
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/olympus/twelve-x',
+}));
+
+import { SubpageStickyTabBar, subpageTabsContainerClass } from './subpage-tab-bar';
+
+describe('subpageTabsContainerClass', () => {
+  it('is visible (flex, not hidden) when open', () => {
+    const cls = subpageTabsContainerClass(true);
+    expect(cls).toContain('flex');
+    expect(cls).not.toContain('hidden');
+  });
+
+  it('is hidden when closed', () => {
+    expect(subpageTabsContainerClass(false)).toContain('hidden');
+  });
+
+  it('always shows tabs at >= md regardless of open', () => {
+    expect(subpageTabsContainerClass(true)).toContain('md:flex');
+    expect(subpageTabsContainerClass(false)).toContain('md:flex');
+  });
+
+  it('gates the dropdown-panel chrome behind max-md so it stops at md', () => {
+    const cls = subpageTabsContainerClass(false);
+    expect(cls).toContain('max-md:absolute');
+    expect(cls).toContain('max-md:flex-col');
+    // panel chrome must not leak to desktop (no unprefixed absolute/border/shadow)
+    expect(cls).not.toMatch(/(^| )absolute( |$)/);
+  });
+});
+```
+
+> Note: the `SubpageStickyTabBar` import is used by Task 2's tests added to this same file; importing it now is harmless and keeps one test file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx`
+Expected: FAIL — `subpageTabsContainerClass` is not exported (`SyntaxError`/`undefined is not a function`).
+
+- [ ] **Step 3: Implement the helper**
+
+In `frontend/olympus/components/subpage-tab-bar.tsx`, add after the `subpageTabButtonClass` function (before `SubpageStickyTabBar`):
+
+```tsx
+/**
+ * Classes for the tabs container. Desktop layout is the unprefixed base; the
+ * mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops
+ * at the `md` breakpoint and needs no `md:` reset. `md:flex` keeps tabs visible
+ * at >= md regardless of `open`; below md they show only when `open`.
+ */
+export function subpageTabsContainerClass(open: boolean): string {
+  return `gap-2 flex-row flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:backdrop-blur-md max-md:p-2 max-md:shadow-lg max-md:z-30`;
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx -t subpageTabsContainerClass`
+Expected: PASS (4 tests). The `SubpageStickyTabBar` describe block does not exist yet, so only the helper tests run under the `-t` filter.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/olympus/components/subpage-tab-bar.tsx frontend/olympus/components/subpage-tab-bar.test.tsx
+git commit -m "feat(olympus): add subpageTabsContainerClass responsive helper"
+```
+
+---
+
+### Task 2: Refactor `SubpageStickyTabBar` (full-bleed + mobile menu)
+
+**Files:**
+- Modify: `frontend/olympus/components/subpage-tab-bar.tsx` (rewrite imports + `SubpageStickyTabBar`)
+- Test: `frontend/olympus/components/subpage-tab-bar.test.tsx` (append structural tests)
+
+**Interfaces:**
+- Consumes: `subpageTabsContainerClass(open)` and `SUBPAGE_MAX` from Task 1 / existing.
+- Produces: `SubpageStickyTabBar` with props `{ children, 'aria-label'?, topOffset?: 'app' | 'none', menuLabel?: string }`. Renders a full-width outer `<div role="navigation">` (chrome, no `max-w`) wrapping a `SUBPAGE_MAX relative py-3` inner `<div>` that holds a `md:hidden` trigger button, an optional backdrop, and the tabs container.
+
+- [ ] **Step 1: Write the failing structural tests**
+
+Append to `frontend/olympus/components/subpage-tab-bar.test.tsx`:
+
+```tsx
+function renderBar(): string {
+  return renderToStaticMarkup(
+    createElement(
+      SubpageStickyTabBar,
+      { 'aria-label': 'Test sections' },
+      createElement('a', { href: '/a', key: 'a' }, 'Alpha'),
+      createElement('a', { href: '/b', key: 'b' }, 'Bravo'),
+    ),
+  );
+}
+
+describe('SubpageStickyTabBar', () => {
+  it('renders its tab children', () => {
+    const html = renderBar();
+    expect(html).toContain('Alpha');
+    expect(html).toContain('Bravo');
+  });
+
+  it('renders a collapsed mobile menu trigger', () => {
+    const html = renderBar();
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="subpage-tabs"');
+    expect(html).toContain('Sections');
+  });
+
+  it('outer wrapper is full-bleed: has the border, sticky, but no width cap', () => {
+    const html = renderBar();
+    const firstClass = html.match(/class="([^"]*)"/)?.[1] ?? '';
+    expect(firstClass).toContain('sticky');
+    expect(firstClass).toContain('border-b');
+    expect(firstClass).not.toContain('max-w-[1600px]');
+  });
+
+  it('inner wrapper caps content at 1600px', () => {
+    expect(renderBar()).toContain('max-w-[1600px]');
+  });
+
+  it('respects a custom menuLabel', () => {
+    const html = renderToStaticMarkup(
+      createElement(SubpageStickyTabBar, { menuLabel: 'Views' }, createElement('a', { href: '/a' }, 'A')),
+    );
+    expect(html).toContain('Views');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx -t SubpageStickyTabBar`
+Expected: FAIL — current bar has no trigger (`aria-expanded` absent) and the outer wrapper still carries `max-w-[1600px]`.
+
+- [ ] **Step 3: Rewrite the component**
+
+In `frontend/olympus/components/subpage-tab-bar.tsx`, replace the top-of-file imports and the `SubpageStickyTabBar` function. The file's `'use client'`, `SUBPAGE_MAX`, `subpageTabButtonClass`, and `subpageTabsContainerClass` stay as they are.
+
+Replace the import line:
+
+```tsx
+import type { ReactNode } from 'react';
+```
+
+with:
+
+```tsx
+import { useEffect, useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { Menu, X } from 'lucide-react';
+```
+
+Replace the entire `SubpageStickyTabBar` function with:
+
+```tsx
+/** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
+export function SubpageStickyTabBar({
+  children,
+  'aria-label': ariaLabel = 'Section navigation',
+  topOffset = 'app',
+  menuLabel = 'Sections',
+}: {
+  children: ReactNode;
+  'aria-label'?: string;
+  topOffset?: 'app' | 'none';
+  menuLabel?: string;
+}) {
+  const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close the mobile menu on route change (covers <Link> tabs).
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Close on Escape while the menu is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  return (
+    <div
+      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass}`}
+      role="navigation"
+      aria-label={ariaLabel}
+    >
+      <div className={`${SUBPAGE_MAX} relative py-3`}>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
+          aria-expanded={open}
+          aria-controls="subpage-tabs"
+          aria-label={open ? 'Close sections menu' : 'Open sections menu'}
+        >
+          {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
+          <span>{menuLabel}</span>
+        </button>
+        {open ? (
+          <div
+            className="fixed inset-0 z-[19] md:hidden"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+        ) : null}
+        <div id="subpage-tabs" className={subpageTabsContainerClass(open)} onClick={() => setOpen(false)}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the full test file to verify it passes**
+
+Run: `cd frontend/olympus && npx vitest run components/subpage-tab-bar.test.tsx`
+Expected: PASS (all helper + structural tests, ~9 tests).
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `cd frontend/olympus && npx tsc --noEmit -p tsconfig.json && npx eslint components/subpage-tab-bar.tsx components/subpage-tab-bar.test.tsx`
+Expected: tsc reports no NEW errors in these files (a pre-existing `lib/security-headers.test.ts` TS7016/7006 pair is known and unrelated); eslint exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/olympus/components/subpage-tab-bar.tsx frontend/olympus/components/subpage-tab-bar.test.tsx
+git commit -m "feat(olympus): full-bleed subpage top-bar + mobile menu collapse"
+```
+
+---
+
+## Post-implementation verification (controller, not a task)
+
+After both tasks land, the controller verifies the whole branch:
+
+1. `cd frontend/olympus && npx vitest run` — full suite green (new + existing component tests).
+2. `cd frontend/olympus && npx next build` — green; `/twelve-x`, `/research`, `/observability`, `/portfolio` prerender without error.
+3. Dev-server render verification (browser) at three widths on a subpage with tabs (e.g. `/twelve-x`):
+   - **~2000px wide:** the bar's glass background + bottom border reach both viewport edges; tabs centered, aligned to the 1600px content column.
+   - **~1280px desktop:** tabs inline exactly as before; no trigger button.
+   - **~390px mobile:** only `☰ Sections` shows; tapping opens a dropdown listing the tabs; tapping a tab / outside / `Esc` closes it; the bar still sits below the 72px `MobileAppBar`.
+   - Console clean (0 errors).
+
+## Self-Review (writing-plans step)
+
+- **Spec coverage:** §4.1 full-bleed → Task 2 outer/inner split (tested). §4.2 mobile menu → Task 2 trigger + dropdown + close handlers; visibility logic → Task 1 helper (tested). §4.3 state/a11y → Task 2 `useState`/`usePathname`/`Escape`/`aria-*`. §5 files → both tasks. §6 testing → Task 1 helper tests + Task 2 structural tests + controller render verification. §7 non-goals → Global Constraints (no callsite/shell/SUBPAGE_MAX changes). §8 risks → Global Constraints (z-index ordering) + render verification (sticky/offset, class precedence).
+- **Placeholder scan:** none — every code step has complete code and exact commands.
+- **Type consistency:** `subpageTabsContainerClass(open: boolean): string` is defined in Task 1 and consumed in Task 2 with the same signature; `menuLabel` default `"Sections"` is consistent between the component and the test; `aria-controls="subpage-tabs"` matches the container `id="subpage-tabs"`.

--- a/docs/superpowers/plans/2026-06-23-twelve-x-today-snapshot.md
+++ b/docs/superpowers/plans/2026-06-23-twelve-x-today-snapshot.md
@@ -1,0 +1,829 @@
+# Twelve-X "Today" Snapshot Redesign (Part A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the Olympus twelve-x **Today** tab into a single-screen daily snapshot — focal trade idea(s) + always-on digest brief above the fold, a consensus "what changed" strip, then a briefs slideshow + today's-events timeline, each with a "see more →" pass-through, plus a new Briefs index view.
+
+**Architecture:** Pure data helpers + thin Supabase fetchers in `lib/twelve-x/fetch.ts` feed presentational components in `components/twelve-x/`. `TwelveXClient` orchestrates fetching/URL-state; `TodayTab` composes the new section components. All new files are twelve-x-only — no shared-shell edits (that's Part B).
+
+**Tech Stack:** Next.js 16 (App Router, static export, `output: 'export'`, `basePath: '/olympus'`), React 19 (`'use client'`), Tailwind v4, `@supabase/supabase-js` (anon key, RLS), Vitest (unit tests for pure helpers), lucide-react icons.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md`
+
+## Global Constraints
+
+- Olympus app dir: `frontend/olympus`. All paths below are relative to it.
+- Every twelve-x component is a client component — first line `'use client';`.
+- Reuse existing tokens/classes: `glass-card`, `text-text-primary/secondary/muted`, `border-border-subtle`, `bg-bg-secondary`, `.fin-green/.fin-red/.fin-amber/.fin-blue`; sign semantics green=bullish/long, red=bearish/short, amber=watch.
+- Data access goes through the existing `querySupabase(...)` retry wrapper and the `twelveXSupabase` client; gate every fetcher on `isTwelveXConfigured()` and return `[]`/`null` when unconfigured (match the existing fetchers exactly).
+- Canonical run date is already threaded as `runDate` from `TwelveXClient` (digest ?? intelligence ?? latestConsensus). Use it; do not re-resolve per section.
+- Do **not** touch `components/subpage-tab-bar.tsx`, `app-frame.tsx`, `sidebar.tsx`, `mobile-app-bar.tsx`, or add a tab to the tab bar (Part B).
+- Build/verify needs deps: the worktree has no `node_modules` — symlink from the main checkout before building (see Task 6).
+- Pre-existing baseline: `tsc --noEmit` reports 2 errors in `lib/security-headers.test.ts` only — ignore those; your changes must add zero new errors.
+
+---
+
+### Task 1: Data layer — trade ideas, today's briefs, today's events
+
+**Files:**
+- Modify: `lib/twelve-x/types.ts` (add `FxTradeIdeaRow`)
+- Modify: `lib/twelve-x/fetch.ts` (add `getTradeIdeas`, `getTodayBriefs`, `sortTodayBriefs`, `getTodayEvents`)
+- Test: `lib/twelve-x/fetch.test.ts` (add tests for `sortTodayBriefs` + `getTodayEvents` filter)
+
+**Interfaces:**
+- Consumes (existing): `querySupabase`, `isTwelveXConfigured`, `twelveXSupabase`, `getUpcomingEvents()`, `eventLocalDateKey(row)`, types `FxBriefRow`, `FxEconomicCalendarRow`, `CurrencyView`, `BRIEF_COLUMNS`, `asCurrencyViews`.
+- Produces (later tasks rely on these exact signatures):
+  - `interface FxTradeIdeaRow { run_date: string; rank: number; pair: string; direction: string; title: string; thesis: string; catalyst: string; levels: unknown[]; citations: unknown[]; as_of: string; }`
+  - `getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]>` — ordered by `rank` asc.
+  - `getTodayBriefs(runDate: string): Promise<FxBriefRow[]>` — briefs for that run_date, returned already sorted by `sortTodayBriefs`.
+  - `sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[]` — pure; relevance(high→med→low) → #currency_views desc → report_date desc.
+  - `getTodayEvents(): Promise<FxEconomicCalendarRow[]>` — upcoming events filtered to the viewer-local "today".
+
+- [ ] **Step 1: Add the `FxTradeIdeaRow` type.** In `lib/twelve-x/types.ts`, after `ConfluenceCatalyst` (end of file), add:
+
+```typescript
+/**
+ * `fx_trade_ideas_snapshot` (twelve-x migration 012) — the curated, synthesized
+ * actionable trade ideas for a run. PRIMARY KEY (run_date, rank). anon-readable.
+ */
+export interface FxTradeIdeaRow {
+  run_date: string; // date (ISO YYYY-MM-DD)
+  rank: number; // int (1 = top)
+  pair: string; // e.g. "USD/JPY"
+  direction: string; // 'long' | 'short' | ...
+  title: string; // e.g. "JPY SHORT — via USD/JPY"
+  thesis: string;
+  catalyst: string;
+  levels: unknown[]; // jsonb array of broker levels/targets
+  citations: unknown[]; // jsonb array of TradeIdeaCitation
+  as_of: string; // timestamptz (ISO)
+}
+```
+
+- [ ] **Step 2: Write the failing test for `sortTodayBriefs`.** In `lib/twelve-x/fetch.test.ts`, add (import `sortTodayBriefs` and `FxBriefRow` at the top of the file alongside the existing imports):
+
+```typescript
+import { sortTodayBriefs } from './fetch';
+import type { FxBriefRow } from './types';
+
+const brief = (over: Partial<FxBriefRow>): FxBriefRow => ({
+  run_date: '2026-06-23', source_file: 's.pdf', source_url: null,
+  document_title: null, broker_name: 'X', analyst_names: null,
+  report_date: '2026-06-23', trader_relevance: 'low', central_thesis: null,
+  brief_markdown: null, currency_views: [], risk_events: null,
+  macro_themes: null, positioning_signals: null, ...over,
+});
+
+describe('sortTodayBriefs', () => {
+  it('orders by relevance (high→low), then breadth, then newest report_date', () => {
+    const lowOld = brief({ source_file: 'a', trader_relevance: 'low', report_date: '2026-06-20' });
+    const highFew = brief({ source_file: 'b', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }] });
+    const highMany = brief({ source_file: 'c', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }, { currency: 'EUR', direction: 'bearish', conviction: 'low' }] });
+    const medNew = brief({ source_file: 'd', trader_relevance: 'medium', report_date: '2026-06-23' });
+    const out = sortTodayBriefs([lowOld, highFew, highMany, medNew]).map((b) => b.source_file);
+    expect(out).toEqual(['c', 'b', 'd', 'a']);
+  });
+
+  it('is stable and pure (does not mutate input)', () => {
+    const input = [brief({ source_file: 'a' }), brief({ source_file: 'b' })];
+    const copy = [...input];
+    sortTodayBriefs(input);
+    expect(input).toEqual(copy);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test, verify it fails.**
+
+Run: `npx --no-install vitest run lib/twelve-x/fetch.test.ts -t sortTodayBriefs`
+Expected: FAIL — `sortTodayBriefs is not a function` (not yet exported).
+
+- [ ] **Step 4: Implement `sortTodayBriefs` + the fetchers in `fetch.ts`.** Add near the brief helpers (after `getBrief`, ~line 450). `asCurrencyViews` already exists in this file; reuse it.
+
+```typescript
+const _RELEVANCE_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Pure ordering for the Today briefs slideshow: relevance desc, then breadth
+ *  (# of currency_views) desc, then newest report_date desc. Does not mutate. */
+export function sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[] {
+  const rel = (b: FxBriefRow) => _RELEVANCE_RANK[(b.trader_relevance ?? '').toLowerCase()] ?? 0;
+  const breadth = (b: FxBriefRow) => asCurrencyViews(b.currency_views).length;
+  return [...briefs].sort(
+    (a, b) =>
+      rel(b) - rel(a) ||
+      breadth(b) - breadth(a) ||
+      (b.report_date ?? '').localeCompare(a.report_date ?? '')
+  );
+}
+
+/** Curated trade ideas for a run_date (rank 1 = top). `[]` when unconfigured/empty. */
+export async function getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxTradeIdeaRow[]>((sb) =>
+    sb
+      .from('fx_trade_ideas_snapshot')
+      .select('run_date, rank, pair, direction, title, thesis, catalyst, levels, citations, as_of')
+      .eq('run_date', runDate)
+      .order('rank', { ascending: true })
+  );
+  return rows ?? [];
+}
+
+/** Today's research briefs for a run_date, pre-sorted for the slideshow. */
+export async function getTodayBriefs(runDate: string): Promise<FxBriefRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxBriefRow[]>(
+    (sb) =>
+      sb
+        .from('fx_research_history')
+        .select(BRIEF_COLUMNS)
+        .eq('run_date', runDate)
+        .order('report_date', { ascending: false }) as unknown as PromiseLike<{
+        data: FxBriefRow[] | null;
+        error: unknown;
+      }>
+  );
+  return sortTodayBriefs(rows ?? []);
+}
+
+/** Upcoming macro events narrowed to the viewer-local "today". */
+export async function getTodayEvents(): Promise<FxEconomicCalendarRow[]> {
+  const all = await getUpcomingEvents();
+  const todayKey = eventLocalDateKey({ event_datetime_utc: new Date().toISOString(), event_date: '' });
+  return all.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+```
+
+Add `FxTradeIdeaRow` to the `import type { ... } from './types'` block at the top of `fetch.ts`.
+
+- [ ] **Step 5: Write the failing test for `getTodayEvents` filtering.** `getTodayEvents` calls Supabase, so test the *filter* via a thin seam: export a pure helper and test it. Add to `fetch.ts`:
+
+```typescript
+/** Pure: keep only rows whose local event date matches `todayKey`. */
+export function filterEventsToDay(
+  events: FxEconomicCalendarRow[],
+  todayKey: string
+): FxEconomicCalendarRow[] {
+  return events.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+```
+
+Refactor `getTodayEvents` to use it: `return filterEventsToDay(all, todayKey);`. Then in `fetch.test.ts`:
+
+```typescript
+import { filterEventsToDay } from './fetch';
+import type { FxEconomicCalendarRow } from './types';
+
+const ev = (over: Partial<FxEconomicCalendarRow>): FxEconomicCalendarRow => ({
+  id: 1, external_id: 'e', event_date: '2026-06-23', event_time: null,
+  country: 'US', event_name: 'X', category: 'c', impact: 'low',
+  actual: null, forecast: null, prior: null, event_datetime_utc: null, ...over,
+});
+
+describe('filterEventsToDay', () => {
+  it('keeps only events whose local date equals the target key', () => {
+    const todayUtc = ev({ id: 1, event_datetime_utc: '2026-06-23T14:30:00Z', event_date: '2026-06-23' });
+    const tomorrow = ev({ id: 2, event_datetime_utc: '2026-06-24T14:30:00Z', event_date: '2026-06-24' });
+    const allDayToday = ev({ id: 3, event_datetime_utc: null, event_date: '2026-06-23' });
+    const key = '2026-06-23';
+    const out = filterEventsToDay([todayUtc, tomorrow, allDayToday], key).map((e) => e.id);
+    expect(out).toContain(1);
+    expect(out).toContain(3);
+    expect(out).not.toContain(2);
+  });
+});
+```
+
+(Note: the UTC-instant events resolve via the viewer's local tz; run CI/tests in UTC so `2026-06-23T14:30Z` → `2026-06-23`. This matches the existing `eventLocalDateKey` behavior.)
+
+- [ ] **Step 6: Run the data-layer tests, verify pass.**
+
+Run: `npx --no-install vitest run lib/twelve-x/fetch.test.ts`
+Expected: PASS (existing tests + the new `sortTodayBriefs` and `filterEventsToDay` tests). `tsc --noEmit` shows no new errors.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add lib/twelve-x/types.ts lib/twelve-x/fetch.ts lib/twelve-x/fetch.test.ts
+git commit -m "feat(twelve-x): data layer for Today snapshot — trade ideas, today briefs/events"
+```
+
+---
+
+### Task 2: `TradeIdeasPanel` + `DigestBrief` components
+
+**Files:**
+- Create: `components/twelve-x/TradeIdeasPanel.tsx`
+- Create: `components/twelve-x/DigestBrief.tsx`
+
+**Interfaces:**
+- Consumes: `FxTradeIdeaRow` (Task 1), `FxConfluenceSnapshotRow` (existing), `useTwelveX()` (existing — `openBrief`, `crossLink`), `FxDailyDigestRow` shape (`{ run_date, summary, key_themes: string[], doc_count, broker_count }`).
+- Produces:
+  - `TradeIdeasPanel({ ideas, confluence }: { ideas: FxTradeIdeaRow[]; confluence: FxConfluenceSnapshotRow[] })`
+  - `DigestBrief({ digest }: { digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null })`
+
+- [ ] **Step 1: Create `TradeIdeasPanel.tsx`.** Focal `#1` card + compact `#2…N` rows + an expand toggle revealing the confluence reads. Empty state when `ideas` is empty.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { FxTradeIdeaRow, FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+function dirClass(direction: string): string {
+  const d = direction.toLowerCase();
+  if (d.includes('long') || d.includes('bull')) return 'text-fin-green';
+  if (d.includes('short') || d.includes('bear')) return 'text-fin-red';
+  return 'text-text-muted';
+}
+
+function firstSource(citations: unknown[]): string | null {
+  for (const c of citations) {
+    if (c && typeof c === 'object' && typeof (c as Record<string, unknown>).source_file === 'string') {
+      return (c as Record<string, unknown>).source_file as string;
+    }
+  }
+  return null;
+}
+
+export default function TradeIdeasPanel({
+  ideas,
+  confluence,
+}: {
+  ideas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+}) {
+  const { crossLink, openBrief } = useTwelveX();
+  const [expanded, setExpanded] = useState(false);
+
+  if (ideas.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        </header>
+        <p className="text-sm text-text-muted">No curated trade idea for today yet.</p>
+      </section>
+    );
+  }
+
+  const [top, ...rest] = ideas;
+  const topSource = firstSource(top.citations);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        <span className="font-mono text-[10px] text-text-muted">· {ideas.length}</span>
+        <button
+          type="button"
+          className="ml-auto text-[11px] text-fin-blue hover:underline"
+          onClick={() => crossLink({ kind: 'tab', tab: 'intelligence' })}
+        >
+          see more →
+        </button>
+      </header>
+
+      {/* Focal #1 */}
+      <button
+        type="button"
+        className="rounded-lg border border-fin-green/30 bg-fin-green/[0.06] p-4 text-left transition-colors hover:border-fin-blue/50"
+        onClick={() => topSource && openBrief(topSource, top.run_date)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-text-muted">#1</span>
+          <span className="font-semibold text-text-primary">{top.pair}</span>
+          <span className={`text-xs font-semibold uppercase ${dirClass(top.direction)}`}>{top.direction}</span>
+        </div>
+        <p className="mt-1 text-sm text-text-primary">{top.title}</p>
+        {top.thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{top.thesis}</p> : null}
+        {top.catalyst ? <p className="mt-1 text-[11px] text-text-muted">Catalyst: {top.catalyst}</p> : null}
+      </button>
+
+      {/* #2…N rows */}
+      {rest.map((idea) => {
+        const src = firstSource(idea.citations);
+        return (
+          <button
+            key={`${idea.run_date}-${idea.rank}`}
+            type="button"
+            className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-2 text-left text-xs transition-colors hover:border-fin-blue/50"
+            onClick={() => src && openBrief(src, idea.run_date)}
+          >
+            <span className="font-mono text-[10px] text-text-muted">#{idea.rank}</span>
+            <span className="font-semibold text-text-primary">{idea.pair}</span>
+            <span className={`font-semibold uppercase ${dirClass(idea.direction)}`}>{idea.direction}</span>
+            <span className="ml-auto truncate text-text-muted">{idea.title}</span>
+          </button>
+        );
+      })}
+
+      {/* Expand → confluence reads */}
+      {confluence.length > 0 ? (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[11px] text-text-secondary hover:text-fin-blue"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+            {expanded ? 'Hide' : 'Expand'} confluence reads ({confluence.length})
+          </button>
+          {expanded ? (
+            <ul className="mt-2 grid gap-1">
+              {confluence.map((c) => (
+                <li key={`${c.run_date}-${c.rank}`} className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-1.5 text-xs">
+                  <span className="font-mono text-[10px] text-text-muted">#{c.rank}</span>
+                  <span className="font-semibold text-text-primary">{c.currency}</span>
+                  <span className={`uppercase ${dirClass(c.direction)}`}>{c.direction}</span>
+                  <button
+                    type="button"
+                    className="ml-auto text-fin-blue hover:underline"
+                    onClick={() => crossLink({ kind: 'currency', currency: c.currency })}
+                  >
+                    trend →
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `DigestBrief.tsx`.** Always-on summary + key-theme chips; empty state when no digest.
+
+```tsx
+'use client';
+
+import { FileText } from 'lucide-react';
+
+export default function DigestBrief({
+  digest,
+}: {
+  digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+}) {
+  if (!digest) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <p className="mt-2 text-sm text-text-muted">No digest for today yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="glass-card flex flex-col gap-2 p-5">
+      <header className="flex items-baseline gap-2">
+        <FileText size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">
+          {digest.doc_count} docs · {digest.broker_count} brokers
+        </span>
+      </header>
+      <p className="whitespace-pre-line text-sm leading-relaxed text-text-primary">{digest.summary}</p>
+      {digest.key_themes.length > 0 ? (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {digest.key_themes.map((t) => (
+            <span key={t} className="rounded-full border border-border-subtle px-2.5 py-0.5 text-[11px] text-text-secondary">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'TradeIdeasPanel|DigestBrief' || echo CLEAN`
+Expected: `CLEAN` (no errors in the two new files).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add components/twelve-x/TradeIdeasPanel.tsx components/twelve-x/DigestBrief.tsx
+git commit -m "feat(twelve-x): TradeIdeasPanel (focal+list+expand) and DigestBrief"
+```
+
+---
+
+### Task 3: `BriefsSlideshow` + `EventsMiniTimeline` components
+
+**Files:**
+- Create: `components/twelve-x/BriefsSlideshow.tsx`
+- Create: `components/twelve-x/EventsMiniTimeline.tsx`
+
+**Interfaces:**
+- Consumes: `FxBriefRow`, `FxEconomicCalendarRow` (existing); `useTwelveX()` (`openBrief`, `crossLink`); `hasResolvedTime`, `eventInstant` (existing fetch helpers).
+- Produces:
+  - `BriefsSlideshow({ briefs, onSeeMore }: { briefs: FxBriefRow[]; onSeeMore: () => void })`
+  - `EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] })`
+
+- [ ] **Step 1: Create `BriefsSlideshow.tsx`.** One card visible, ◀▶ + dots, opens the brief; "see more" calls `onSeeMore`.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsSlideshow({
+  briefs,
+  onSeeMore,
+}: {
+  briefs: FxBriefRow[];
+  onSeeMore: () => void;
+}) {
+  const { openBrief } = useTwelveX();
+  const [i, setI] = useState(0);
+
+  if (briefs.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <p className="mt-2 text-sm text-text-muted">No research briefs for today yet.</p>
+      </section>
+    );
+  }
+
+  const idx = Math.min(i, briefs.length - 1);
+  const b = briefs[idx];
+  const go = (d: number) => setI((idx + d + briefs.length) % briefs.length);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <span className="font-mono text-[10px] text-text-muted">{idx + 1}/{briefs.length}</span>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={onSeeMore}>
+          see all →
+        </button>
+      </header>
+
+      <div className="flex items-center gap-2">
+        <button type="button" aria-label="Previous brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(-1)}>
+          <ChevronLeft size={16} />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 rounded-lg border border-border-subtle p-3 text-left transition-colors hover:border-fin-blue/50"
+          onClick={() => openBrief(b.source_file, b.run_date)}
+        >
+          <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+            {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+          </div>
+          <p className="mt-1 truncate text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+          {b.central_thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+        </button>
+        <button type="button" aria-label="Next brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(1)}>
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      <div className="flex justify-center gap-1">
+        {briefs.map((bb, n) => (
+          <button
+            key={bb.source_file}
+            type="button"
+            aria-label={`Go to brief ${n + 1}`}
+            className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}
+            onClick={() => setI(n)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Create `EventsMiniTimeline.tsx`.** Compact today timeline, impact-colored, see more → Events tab.
+
+```tsx
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import type { FxEconomicCalendarRow } from '@/lib/twelve-x/types';
+import { hasResolvedTime, eventInstant } from '@/lib/twelve-x/fetch';
+import { useTwelveX } from './context';
+
+function impactClass(impact: string): string {
+  const i = impact.trim().toLowerCase();
+  if (i === 'high') return 'bg-fin-red';
+  if (i === 'medium') return 'bg-fin-amber';
+  return 'bg-text-muted/60';
+}
+
+function localTime(e: FxEconomicCalendarRow): string {
+  const inst = eventInstant(e);
+  if (inst) return inst.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return e.event_time ?? '—';
+}
+
+export default function EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] }) {
+  const { crossLink } = useTwelveX();
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <CalendarClock size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s events</h2>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'events' })}>
+          see more →
+        </button>
+      </header>
+      {events.length === 0 ? (
+        <p className="text-sm text-text-muted">No macro events scheduled today.</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {events.map((e) => (
+            <li key={e.id} className="flex items-center gap-2.5 text-xs">
+              <span className="w-14 shrink-0 text-right font-mono tabular-nums text-text-secondary">{localTime(e)}</span>
+              <span className={`h-2 w-2 shrink-0 rounded-full ${impactClass(e.impact)}`} aria-hidden />
+              <span className="font-mono text-[10px] uppercase text-text-muted">{e.country}</span>
+              <span className="truncate text-text-primary">{e.event_name}</span>
+              {!hasResolvedTime(e) ? <span className="text-text-muted/60" title="venue-local time">≈</span> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'BriefsSlideshow|EventsMiniTimeline' || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add components/twelve-x/BriefsSlideshow.tsx components/twelve-x/EventsMiniTimeline.tsx
+git commit -m "feat(twelve-x): BriefsSlideshow and EventsMiniTimeline"
+```
+
+---
+
+### Task 4: `BriefsIndex` view
+
+**Files:**
+- Create: `components/twelve-x/BriefsIndex.tsx`
+
+**Interfaces:**
+- Consumes: `FxBriefRow`; `useTwelveX()` (`openBrief`).
+- Produces: `BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void })`
+
+- [ ] **Step 1: Create `BriefsIndex.tsx`.** Full-width list/grid of today's briefs (already sorted), each opens the brief; a back link to Today.
+
+```tsx
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void }) {
+  const { openBrief } = useTwelveX();
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex items-center gap-3">
+        <button type="button" className="flex items-center gap-1 text-xs text-fin-blue hover:underline" onClick={onBack}>
+          <ArrowLeft size={14} /> Today
+        </button>
+        <h2 className="text-base font-semibold text-text-primary">Today&rsquo;s briefs</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">{briefs.length}</span>
+      </header>
+      {briefs.length === 0 ? (
+        <div className="glass-card p-10 text-center text-sm text-text-muted">No research briefs for today yet.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {briefs.map((b) => (
+            <button
+              key={b.source_file}
+              type="button"
+              className="glass-card p-4 text-left transition-colors hover:border-fin-blue/50"
+              onClick={() => openBrief(b.source_file, b.run_date)}
+            >
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+                {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+              </div>
+              <p className="mt-1 text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+              {b.central_thesis ? <p className="mt-1 line-clamp-3 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck + commit.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep BriefsIndex || echo CLEAN` → `CLEAN`
+```bash
+git add components/twelve-x/BriefsIndex.tsx
+git commit -m "feat(twelve-x): BriefsIndex view"
+```
+
+---
+
+### Task 5: `TwelveXClient` integration + `TodayTab` rewrite
+
+**Files:**
+- Modify: `components/twelve-x/TwelveXClient.tsx` (fetch trade ideas / today briefs / today events; add `?view=briefs` URL state; pass data to `TodayTab`; render `BriefsIndex` when `view==='briefs'`)
+- Modify (rewrite): `components/twelve-x/TodayTab.tsx` (A1 layout composing the new sections)
+
+**Interfaces:**
+- Consumes: `getTradeIdeas`, `getTodayBriefs`, `getTodayEvents` (Task 1); `TradeIdeasPanel`, `DigestBrief`, `BriefsSlideshow`, `EventsMiniTimeline` (Tasks 2–3); `BriefsIndex` (Task 4); existing `consensusDeltas`, `intelligence` (confluence), `MoversStrip`, `canonicalRunDate`, `TwelveXProvider`/`useTwelveX`.
+- Produces: `TodayTab({ digest, tradeIdeas, confluence, deltas, briefs, events, onSeeAllBriefs }: { digest: DigestData; tradeIdeas: FxTradeIdeaRow[]; confluence: FxConfluenceSnapshotRow[]; deltas: ConsensusDeltaSet; briefs: FxBriefRow[]; events: FxEconomicCalendarRow[]; onSeeAllBriefs: () => void })`
+
+- [ ] **Step 1: Extend `TwelveXData` + the load in `TwelveXClient.tsx`.** Add `tradeIdeas`, `todayBriefs`, `todayEvents` to the `TwelveXData` interface; add the three fetchers to the `Promise.all` (they parallelize — no added latency); they need the canonical run_date, so resolve trade ideas/briefs after the digest/intelligence dates are known (fetch them in a second `await` using `canonicalRunDate`, mirroring how `eventOpinions` is already fetched after `opinionsDate`). Concretely, after the existing `Promise.all` and the `opinionsDate`/`eventOpinions` lines:
+
+```typescript
+const canonical = intelligence[0]?.run_date ?? digest?.run_date ?? null;
+const [tradeIdeas, todayBriefs, todayEvents] = canonical
+  ? await Promise.all([getTradeIdeas(canonical), getTodayBriefs(canonical), getTodayEvents()])
+  : [[], [], await getTodayEvents()];
+```
+
+Add `tradeIdeas`, `todayBriefs`, `todayEvents` to the `setData({...})` call. Add the imports `getTradeIdeas, getTodayBriefs, getTodayEvents` and types `FxTradeIdeaRow` to the existing import blocks.
+
+- [ ] **Step 2: Add `?view=briefs` URL state.** In `TwelveXClient.tsx`:
+  - Add state: `const [view, setView] = useState<'briefs' | null>(() => (readParam('view') === 'briefs' ? 'briefs' : null));`
+  - Extend `syncUrl(...)` to also accept/serialize `view` (add `if (view) p.set('view', view);` and a `view` parameter, threading it through the existing `setTab`/`openBrief`/etc. callers — pass the current `view`).
+  - Add `const openBriefsIndex = useCallback(() => { setView('briefs'); syncUrl(tab, brief, ledgerCcy, 'briefs'); }, [tab, brief, ledgerCcy]);` and `const closeBriefsIndex = useCallback(() => { setView(null); syncUrl(tab, brief, ledgerCcy, null); }, [tab, brief, ledgerCcy]);`
+
+- [ ] **Step 3: Render `BriefsIndex` or `TodayTab`.** In the Today branch of the tab switch, render the index when `view==='briefs'`:
+
+```tsx
+) : (
+  view === 'briefs' ? (
+    <BriefsIndex briefs={data?.todayBriefs ?? []} onBack={closeBriefsIndex} />
+  ) : (
+    <TodayTab
+      digest={data?.digest ?? null}
+      tradeIdeas={data?.tradeIdeas ?? []}
+      confluence={data?.intelligence ?? []}
+      deltas={consensusDeltas}
+      briefs={data?.todayBriefs ?? []}
+      events={data?.todayEvents ?? []}
+      onSeeAllBriefs={openBriefsIndex}
+    />
+  )
+)
+```
+
+Import `BriefsIndex` and `TodayTab` (TodayTab already imported). Keep `TwelveXProvider` wrapping unchanged.
+
+- [ ] **Step 4: Rewrite `TodayTab.tsx` to the A1 layout.** Replace the file contents:
+
+```tsx
+'use client';
+
+import type {
+  FxConfluenceSnapshotRow,
+  FxEconomicCalendarRow,
+  FxBriefRow,
+  FxTradeIdeaRow,
+  ConsensusDeltaSet,
+} from '@/lib/twelve-x/types';
+import TradeIdeasPanel from './TradeIdeasPanel';
+import DigestBrief from './DigestBrief';
+import BriefsSlideshow from './BriefsSlideshow';
+import EventsMiniTimeline from './EventsMiniTimeline';
+import MoversStrip from './MoversStrip';
+import { useTwelveX } from './context';
+
+type DigestData = { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+
+export default function TodayTab({
+  digest,
+  tradeIdeas,
+  confluence,
+  deltas,
+  briefs,
+  events,
+  onSeeAllBriefs,
+}: {
+  digest: DigestData;
+  tradeIdeas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+  deltas: ConsensusDeltaSet;
+  briefs: FxBriefRow[];
+  events: FxEconomicCalendarRow[];
+  onSeeAllBriefs: () => void;
+}) {
+  const { crossLink } = useTwelveX();
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Above the fold: trade ideas + digest brief co-lead */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <TradeIdeasPanel ideas={tradeIdeas} confluence={confluence} />
+        <DigestBrief digest={digest} />
+      </div>
+
+      {/* What changed in consensus */}
+      <section className="glass-card p-4">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">What changed — consensus</h2>
+          <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'consensus' })}>
+            see more →
+          </button>
+        </header>
+        {deltas.movers.length > 0 ? (
+          <MoversStrip movers={deltas.movers} onSelect={(c) => crossLink({ kind: 'currency', currency: c })} title="" />
+        ) : (
+          <p className="text-sm text-text-muted">No prior run to compare yet.</p>
+        )}
+      </section>
+
+      {/* Below the fold: briefs slideshow + today's events */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <BriefsSlideshow briefs={briefs} onSeeMore={onSeeAllBriefs} />
+        <EventsMiniTimeline events={events} />
+      </div>
+    </div>
+  );
+}
+```
+
+(Confirm `MoversStrip` accepts an empty `title` to suppress its own header; if not, pass the default and drop the section's `<h2>`.)
+
+- [ ] **Step 5: Typecheck.**
+
+Run: `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'twelve-x/(TodayTab|TwelveXClient)' || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add components/twelve-x/TwelveXClient.tsx components/twelve-x/TodayTab.tsx
+git commit -m "feat(twelve-x): compose Today snapshot (A1) + briefs-index view + data wiring"
+```
+
+---
+
+### Task 6: Verify — typecheck, lint, tests, build, live render
+
+**Files:** none (verification + fixups only).
+
+- [ ] **Step 1: Make deps available in the worktree.** Symlink from the main checkout (worktrees don't get untracked `node_modules`):
+
+```bash
+MAIN=/Users/chrisstefan/Code/digithings
+WT=/Users/chrisstefan/Code/digithings/.claude/worktrees/twelve-x-today-redesign
+[ -e "$WT/node_modules" ] || ln -s "$MAIN/node_modules" "$WT/node_modules"
+[ -e "$WT/frontend/olympus/node_modules" ] || ln -s "$MAIN/frontend/olympus/node_modules" "$WT/frontend/olympus/node_modules"
+```
+
+- [ ] **Step 2: Typecheck (no new errors).**
+
+Run (from `frontend/olympus`): `npx --no-install tsc --noEmit -p tsconfig.json 2>&1 | grep -E 'components/twelve-x/|lib/twelve-x/' | grep -v security-headers || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 3: Lint twelve-x.**
+
+Run: `npx --no-install eslint components/twelve-x lib/twelve-x`
+Expected: exit 0.
+
+- [ ] **Step 4: Unit tests.**
+
+Run: `npx --no-install vitest run lib/twelve-x`
+Expected: all pass (existing + new from Task 1).
+
+- [ ] **Step 5: Production build.**
+
+Run (with the twelve-x Supabase env exported as in prior work): `npm run build`
+Expected: "Compiled successfully", TypeScript clean, `/twelve-x` prerendered.
+
+- [ ] **Step 6: Live render — desktop & mobile.** Start `npm run dev -p 3210` (env exported), load `http://localhost:3210/olympus/twelve-x/`. Verify at 1440×900: trade ideas + brief co-lead and the consensus strip are above the fold; briefs slideshow + events below; the slideshow ◀▶/dots work; "see all →" opens the Briefs index (`?view=briefs`) and "Today" returns; "expand confluence" toggles. At 390×844: everything stacks single-column in priority order 1→5; no console errors. Capture screenshots.
+
+- [ ] **Step 7: Final commit (if any fixups).**
+
+```bash
+git add -A frontend/olympus/components/twelve-x frontend/olympus/lib/twelve-x
+git commit -m "fix(twelve-x): Today snapshot render fixups from verification" || echo "nothing to fix"
+```
+
+---
+
+## Notes for the implementer
+
+- Trade-idea `citations` carry `source_file` (per `fx_research_history`/`TradeIdeaCitation`); `firstSource()` extracts it to open the brief. If a given idea has no resolvable `source_file`, the card simply isn't clickable (no broken link) — that's intended.
+- The Today layout `lg:` breakpoint is the single responsive control for Part A; the tab bar's responsiveness is Part B and must not be touched here.
+- `MoversStrip`/`DeltaChip`/`computeConsensusDeltaSet` already exist and are tested; do not reimplement.

--- a/docs/superpowers/specs/2026-06-23-olympus-subpage-topbar-responsive-design.md
+++ b/docs/superpowers/specs/2026-06-23-olympus-subpage-topbar-responsive-design.md
@@ -1,0 +1,98 @@
+# Olympus subpage top-bar — full-bleed + mobile menu (design)
+
+- **Date:** 2026-06-23
+- **Status:** Approved design / spec (pre-implementation)
+- **Surface:** Olympus shared subpage tab-bar (`frontend/olympus/components/subpage-tab-bar.tsx`)
+- **Relationship:** This is **Part B** of the twelve-x Today work. Part A (the Today snapshot redesign, PR #1002) is separate and already open. Part B is its own branch (`feat/olympus-subpage-topbar-responsive`) off `develop` and its own PR.
+
+## 1. Goal
+
+Fix two responsiveness defects in the shared subpage top-bar so it behaves consistently with the rest of Olympus:
+
+1. **Wide screens (> 1600px):** the bar's glass background and bottom border are capped at 1600px and centered, so on wide monitors the divider floats with empty gutters and reads as unfinished. The bar's *chrome* should span the full viewport while its *content* stays aligned to the 1600px page-content width.
+2. **Narrow / mobile screens:** the tab items use `flex flex-wrap` and wrap onto multiple lines. They should instead **collapse into a menu button** (a "☰ Sections" dropdown), consistent with the app's existing mobile-nav idiom.
+
+## 2. Context (what exists today)
+
+`components/subpage-tab-bar.tsx` is the single shared component, used by all subpages via `children`:
+
+- `app/observability/page.tsx`, `app/research/ResearchClient.tsx`, `components/portfolio/PortfolioSectionNav.tsx`, `components/twelve-x/TwelveXClient.tsx`.
+- The bar is rendered as a **sibling** of the capped content `<div className={SUBPAGE_MAX}>`, and applies `SUBPAGE_MAX` to *itself*. Its parent is the full-width main scroll container — so a full-width outer wrapper needs no negative-margin hack.
+- Tab children are heterogeneous: `<Link>` (research/observability/portfolio navigate by route) and stateful `<button>` (twelve-x calls `setTab`, changing `?tab=` not the pathname).
+- Current markup (lines 28–34):
+  ```tsx
+  <div className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass} ${SUBPAGE_MAX} py-3`} role="navigation" aria-label={ariaLabel}>
+    <div className="flex flex-wrap gap-2">{children}</div>
+  </div>
+  ```
+- `SUBPAGE_MAX = 'max-w-[1600px] mx-auto w-full px-4 md:px-6'` is consumed by other components too — its value **does not change**.
+- An established mobile-nav idiom exists in `components/mobile-app-bar.tsx` + `components/sidebar.tsx` + `components/app-shell-context.tsx`: lucide `Menu`/`X`, `aria-expanded`/`aria-controls`, a `md:hidden` backdrop (`fixed inset-0 … onClick=close`), and close-on-route-change. Part B **reuses the idiom** but keeps its own local state (it does not touch `app-shell-context`).
+- Tailwind v4, stock breakpoints (`md` = 768px). `MobileAppBar` is `md:hidden` (present < 768px) and 72px tall — the bar's existing `max-md:top-[72px]` offset already accounts for it. The mobile menu therefore collapses at the **`md`** breakpoint, matching where the main mobile nav appears.
+
+## 3. Approach
+
+**Self-contained refactor of `subpage-tab-bar.tsx` only. Zero callsite changes.** (Rejected alternatives: hoisting toggle state into `app-shell-context` — global state for a per-page dropdown is overkill; a data-driven `tabs` prop rewrite — would force converting all four callsites incl. twelve-x's stateful tabs, and the chosen static "Sections" trigger needs no tab data. YAGNI.)
+
+## 4. Design
+
+### 4.1 Full-bleed chrome, capped content
+
+Split the single sticky div into outer (full width) + inner (capped):
+
+- **Outer** `<div role="navigation" aria-label=…>`: `sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md` + `topClass`. **No `max-w`.** Spans the full-width parent → background + border reach the viewport edges.
+- **Inner** `<div>`: `SUBPAGE_MAX` + `relative py-3`. Holds the trigger + tabs. `relative` anchors the absolute mobile dropdown.
+
+`SUBPAGE_MAX` and its other consumers are untouched.
+
+### 4.2 Mobile menu (`< md`)
+
+Inside the inner container, tabs render **once** in a container whose layout is driven by breakpoint + open state; a trigger button toggles it below `md`.
+
+- **Trigger button** (`md:hidden`): `☰` + label (lucide `Menu` when closed, `X` when open), `aria-expanded={open}`, `aria-controls="subpage-tabs"`, `aria-label` toggling "Open/Close sections menu". Styled to match `mobile-app-bar.tsx`'s toggle (`rounded-lg border border-border-subtle … hover:bg-white/[0.06]`).
+- **Tabs container** (`id="subpage-tabs"`): one element, classes from a pure helper `subpageTabsContainerClass(open)`. Strategy: **desktop layout is the unprefixed base; the mobile dropdown panel is expressed entirely with `max-md:` so it auto-stops at `md` and needs no `md:` reset.**
+  - Visibility: `${open ? 'flex' : 'hidden'}` (base) + `md:flex` — at `≥ md` the tabs always show regardless of `open`; below `md` they show only when open.
+  - Desktop layout (base): `flex-row flex-wrap gap-2`.
+  - Mobile panel (`max-md:` only): `flex-col absolute left-0 right-0 top-full mt-1 rounded-lg border border-border-subtle bg-bg-glass/95 backdrop-blur-md p-2 shadow-lg z-30`. Because these are `max-md:`-gated, they vanish at `≥ md` automatically — no `md:bg-transparent`/`md:static`/etc. needed.
+- **Children** render unchanged inside that container (works for `<Link>` and `<button>` alike), stacked vertically in the panel, inline at `≥ md`. `subpageTabButtonClass` is unchanged (`sm:` sizing preserved).
+- **Close on:** tab click (panel `onClick={() => setOpen(false)}` — covers stateful buttons), route change (`usePathname()` effect — covers `<Link>`), `Escape` keydown (listener active only while open), and a `md:hidden` backdrop tap (`fixed inset-0 z-[19]`, the `sidebar.tsx` idiom).
+- New optional prop `menuLabel?: string`, default `"Sections"`. No callsite passes it.
+- `≥ md`: trigger hidden, backdrop never shown, tabs inline — visually identical to today.
+
+### 4.3 State & accessibility
+
+- Local `const [open, setOpen] = useState(false)` — no global context.
+- `'use client'` already present; add `useState`, `useEffect`, `usePathname` (next/navigation), lucide `Menu`/`X` imports.
+- Trigger ↔ panel wired via `aria-expanded` + `aria-controls`/`id`; `Escape` and backdrop give keyboard + pointer dismissal.
+
+## 5. Components / files
+
+- **Modify:** `components/subpage-tab-bar.tsx` — split outer/inner, add trigger + dropdown + state, export new pure helper `subpageTabsContainerClass(open: boolean): string`.
+- **Create:** `components/subpage-tab-bar.test.tsx` — unit tests (see §6).
+- **No other files change.** All four callsites are untouched.
+
+## 6. Testing
+
+Matches the repo's vitest `node` environment + `renderToStaticMarkup` pattern (e.g. `components/overview/as-of-badge.test.tsx`); no jsdom/RTL.
+
+- **Pure helper `subpageTabsContainerClass(open)`:** `open === true` → contains `flex` and not the closed `hidden`; `open === false` → contains `hidden`; both contain `md:flex` (always visible at `≥ md` regardless of `open`).
+- **`renderToStaticMarkup(<SubpageStickyTabBar>{tabs}</…>)`** (initial closed state):
+  - children render (tab labels present);
+  - a trigger button with `aria-expanded="false"` and `md:hidden`;
+  - **outer** wrapper has `border-b` but **not** `max-w-[1600px]`;
+  - an **inner** wrapper **has** `max-w-[1600px]`;
+  - tabs container carries the closed (`hidden`) + `md:flex` classes.
+- **Interactive behavior** (click-open, tab-click/Esc/backdrop/route close) is **render-verified** on the dev server at wide (~2000px), desktop (~1280px), and mobile (~390px) widths — `renderToStaticMarkup` cannot exercise effects/clicks.
+- Gate: `next build` green, twelve-x + shell `tsc`/`eslint` clean, full vitest suite green (new + existing component tests).
+
+## 7. Non-goals
+
+- No change to `SUBPAGE_MAX`'s value or to page-content max width.
+- No data-driven `tabs` prop; no active-section label in the trigger (the chosen design uses a static "Sections" trigger).
+- No change to the main sidebar / `MobileAppBar` / `app-shell-context`.
+- Part A (Today snapshot) is out of scope here.
+
+## 8. Risks
+
+- **Sticky + full-bleed outer:** the outer keeps `sticky` + `topClass`; only `max-w` moves to the inner. Verify stickiness and the `max-md:top-[72px]` offset still hold under the `MobileAppBar`.
+- **Dropdown overlay z-index:** panel `z-30` and backdrop `z-[19]` must sit above page content but below the main mobile drawer (`z-[999]`) and `MobileAppBar` (`z-[997]`) — confirmed lower, so the main nav still wins.
+- **Tailwind class precedence:** the closed-state `hidden` must be overridden by `md:flex`; ordering verified by the pure-helper test + render check.

--- a/docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md
+++ b/docs/superpowers/specs/2026-06-23-twelve-x-today-snapshot-design.md
@@ -1,0 +1,99 @@
+# Twelve-X "Today" — single-screen daily snapshot (design)
+
+- **Date:** 2026-06-23
+- **Status:** Approved design / spec (pre-implementation)
+- **Surface:** Olympus FX Research suite, Today tab (`frontend/olympus/{app,components,lib}/twelve-x`)
+- **Scope:** **Part A only** — the Today page content redesign (twelve-x frontend files only). Part B (shared subpage top-bar: full-width on wide screens + collapse-to-hamburger on mobile) is a **separate, coordinated** change and is explicitly out of scope here.
+
+## 1. Goal
+
+Make the Today tab a glanceable **daily snapshot** that answers, at a glance, five questions — each section a teaser with a "see more →" pass-through to its full tab:
+
+1. What is today's **trade idea(s)**?
+2. What does today's research say (**digest brief**)?
+3. What **changed in consensus** today?
+4. What **briefs** do we have today?
+5. What **events** are today?
+
+**Priority (not strict no-scroll):** the top three — trade ideas, digest brief, consensus delta — are guaranteed **above the fold**; the briefs slideshow and events timeline sit just below.
+
+## 2. Layout — approach "A1"
+
+Capped-width container (~`max-w-[1400px]`, centered; consistent with the existing `SUBPAGE_MAX` content width), two zones:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ ① TRADE IDEAS (≈55%, focal+list)   │ ② DIGEST BRIEF (≈45%) │  ← above fold
+├───────────────────────────────────────────────────────────┤
+│ ③ WHAT CHANGED — consensus movers (full-width strip)       │  ← above fold
+├───────────────────────────────────────────────────────────┤  · · · fold · · ·
+│ ④ BRIEFS slideshow            │ ⑤ EVENTS — today timeline   │  ← just below
+└───────────────────────────────────────────────────────────┘
+```
+
+**Responsive (in scope for Part A):** below the `lg` breakpoint the whole page collapses to a **single column in priority order 1 → 2 → 3 → 4 → 5**. The page top-bar/tab-bar responsiveness (full-width, hamburger) is **Part B** and not touched here.
+
+## 3. Sections
+
+### ① Today's trade ideas — focal + list
+- **Source:** `fx_trade_ideas_snapshot` for the canonical run_date, ordered by `rank` ascending (1 = strongest). Count is **1…N** (today is 1; design must handle several).
+- **Render:** `#1` as a **focal** card (title, pair, direction, central thesis, levels/targets, catalyst, contributing desks). `#2…N` as compact tappable rows below the focal card; each row opens that idea's full detail in the existing slide-over (`BriefPanel`-style).
+- **Expand:** an inline **"expand ▾ → confluence reads"** control that reveals the broader directional set from `fx_confluence_snapshot` (the data Olympus shows today).
+- **See more →** Intelligence tab.
+
+### ② Digest brief — co-lead
+- **Source:** `fx_daily_digest` (`summary`, `key_themes`).
+- **Render:** the full summary, **always visible** (never collapsed), with key-theme chips beneath. Sits shoulder-to-shoulder with the trade ideas above the fold.
+- **See more:** none — it is shown in full inline. (Theme chips may deep-link into the relevant tab where useful.)
+
+### ③ What changed — consensus
+- **Source:** day-over-day deltas computed by the existing pure helper `computeConsensusDeltaSet(series)` over `fx_consensus_snapshot` history (already implemented in `lib/twelve-x/fetch.ts`).
+- **Render:** full-width compact strip of biggest movers via the existing `MoversStrip`/`DeltaChip` (e.g., `JPY ▲+0.94 · GBP ▼ · USD ▲`), sign-colored.
+- **See more →** Consensus tab.
+
+### ④ Briefs slideshow
+- **Source:** `fx_research_history` for the canonical run_date (today's briefs).
+- **Order:** `trader_relevance` (high → low), tiebreak by broker-mention count, then newest (`report_date`/`run_date`).
+- **Render:** carousel, one brief card visible at a time (◀ ▶ controls + position dots). Each card opens that brief in the slide-over.
+- **See more →** the new **Briefs index** (§3.⑥).
+
+### ⑤ Events — today timeline
+- **Source:** `fx_economic_calendar` filtered to **today** (local-date of the release instant), with `fx_events_snapshot` for the broker-mention overlay.
+- **Render:** compact horizontal timeline, impact-colored (high/medium/low), times in the viewer's local zone (reuse the `eventLocalDateKey`/`hasResolvedTime` helpers already added).
+- **See more →** Events tab.
+
+### ⑥ Briefs index (new — slideshow "see more" target)
+- A lightweight, full-width **list/grid of today's briefs** (broker, title, relevance, direction tags), each opening the brief slide-over.
+- **Reached only via the slideshow "see more"** as a URL-stateful view (e.g., `?view=briefs`), **not a new top-level tab** — this keeps Part A self-contained and avoids adding tab-bar pressure that interacts with Part B. (It can later be promoted to a tab during Part B if desired.)
+
+## 4. Data layer (new / changed)
+
+In `lib/twelve-x/fetch.ts` (+ `types.ts`):
+
+- `getTradeIdeas(runDate): Promise<FxTradeIdeaRow[]>` — reads `fx_trade_ideas_snapshot`, ordered by `rank`. **New row type `FxTradeIdeaRow`** (run_date, rank, title, pair, direction, thesis, catalyst, levels, citations, as_of).
+- `getTodayBriefs(runDate): Promise<FxBriefRow[]>` — reads `fx_research_history` for the run_date; client sorts per §3.④ ordering.
+- A **today-events selector** — reuse `getUpcomingEvents()` narrowed to today via `eventLocalDateKey`, or add `getTodayEvents(runDate)`.
+- Reuse: `computeConsensusDeltaSet`, `getConsensusTimeSeries`, `getIntelligence` (confluence), `resolveCatalyst`, `getBrief`.
+
+## 5. Components (twelve-x only — no shared-shell edits → no conflict risk)
+
+- **`TodayTab.tsx`** — rewritten to the A1 layout.
+- New: **`TradeIdeasPanel`** (focal + list + expand-to-confluence), **`DigestBrief`**, **`BriefsSlideshow`**, **`EventsMiniTimeline`**, **`BriefsIndex`** (the see-more view).
+- Reuse: `MoversStrip`, `DeltaChip`, `BriefPanel`, `useTwelveX()` context (canonical `runDate`, `crossLink`, `openBrief`).
+- `TwelveXClient.tsx` — pass today's data + wire the `?view=briefs` state for the Briefs index; **no tab-bar changes** (Part B).
+
+## 6. Risks & decisions
+
+- **`fx_trade_ideas_snapshot` anon-read (must verify):** Olympus does not currently read this table. To surface the curated ideas client-side it must carry an `anon_read` RLS policy (mirroring the other snapshot tables; created in migration 012). **Verify during planning.** If absent: either add the policy (twelve-x migration — separate change), or **fall back** to deriving the focal idea(s) from `fx_confluence_snapshot` so the page still works.
+- **"No scroll"** is interpreted as **priority-above-the-fold** (option c), not strict; the bottom two sections may extend below.
+- **Briefs index** is a see-more view, not a tab (decouples from Part B).
+
+## 7. Non-goals (Part A)
+
+- Part B: shared subpage top-bar full-width on wide screens + collapse-to-hamburger on mobile (separate coordinated change).
+- Push alerting; global full-text search/export (previously deferred).
+
+## 8. Testing
+
+- Unit tests for the new fetchers/transforms: trade-idea ordering, today-briefs sort (relevance → mentions → newest), today-events filter, and the (existing, tested) consensus-delta helper.
+- Render verification via the dev server at desktop (~1440) and mobile (~390) widths: above-the-fold priority holds on desktop; clean single-column stack on mobile; `next build` green; existing `lib/twelve-x` tests stay green.

--- a/frontend/olympus/components/subpage-tab-bar.test.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.test.tsx
@@ -1,0 +1,87 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/olympus/twelve-x',
+}));
+
+import { SubpageStickyTabBar, subpageTabsContainerClass } from './subpage-tab-bar';
+
+describe('subpageTabsContainerClass', () => {
+  it('is visible (flex, not hidden) when open', () => {
+    const cls = subpageTabsContainerClass(true);
+    expect(cls.split(' ')).toContain('flex');
+    expect(cls).not.toContain('hidden');
+  });
+
+  it('is hidden when closed', () => {
+    expect(subpageTabsContainerClass(false)).toContain('hidden');
+  });
+
+  it('always shows tabs at >= md regardless of open', () => {
+    expect(subpageTabsContainerClass(true)).toContain('md:flex');
+    expect(subpageTabsContainerClass(false)).toContain('md:flex');
+  });
+
+  it('gates the dropdown-panel chrome behind max-md so it stops at md', () => {
+    const cls = subpageTabsContainerClass(false);
+    expect(cls).toContain('max-md:absolute');
+    expect(cls).toContain('max-md:flex-col');
+    // panel chrome must not leak to desktop (no unprefixed absolute/border/shadow)
+    expect(cls).not.toMatch(/(^| )absolute( |$)/);
+  });
+});
+
+function renderBar(): string {
+  return renderToStaticMarkup(
+    createElement(
+      SubpageStickyTabBar,
+      { 'aria-label': 'Test sections' },
+      createElement('a', { href: '/a', key: 'a' }, 'Alpha'),
+      createElement('a', { href: '/b', key: 'b' }, 'Bravo'),
+    ),
+  );
+}
+
+describe('SubpageStickyTabBar', () => {
+  it('renders its tab children', () => {
+    const html = renderBar();
+    expect(html).toContain('Alpha');
+    expect(html).toContain('Bravo');
+  });
+
+  it('renders a collapsed mobile menu trigger', () => {
+    const html = renderBar();
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="subpage-tabs"');
+    expect(html).toContain('Sections');
+    // Trigger must be hidden on desktop so the desktop layout is not broken.
+    expect(html).toContain('md:hidden');
+  });
+
+  it('outer wrapper is full-bleed: has the border, sticky, but no width cap', () => {
+    const html = renderBar();
+    const firstClass = html.match(/class="([^"]*)"/)?.[1] ?? '';
+    expect(firstClass).toContain('sticky');
+    expect(firstClass).toContain('border-b');
+    expect(firstClass).not.toContain('max-w-[1600px]');
+  });
+
+  it('inner wrapper caps content at 1600px', () => {
+    expect(renderBar()).toContain('max-w-[1600px]');
+  });
+
+  it('respects a custom menuLabel', () => {
+    const html = renderToStaticMarkup(
+      createElement(SubpageStickyTabBar, { menuLabel: 'Views' }, createElement('a', { href: '/a' }, 'A')),
+    );
+    expect(html).toContain('Views');
+  });
+
+  it('tabs container has hidden and md:flex classes in default (closed) state', () => {
+    const html = renderBar();
+    expect(html).toContain('hidden');
+    expect(html).toContain('md:flex');
+  });
+});

--- a/frontend/olympus/components/subpage-tab-bar.tsx
+++ b/frontend/olympus/components/subpage-tab-bar.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { Menu, X } from 'lucide-react';
 
 /** Max width and horizontal padding for portfolio, research, overview, and related pages. */
 export const SUBPAGE_MAX = 'max-w-[1600px] mx-auto w-full px-4 md:px-6';
@@ -13,24 +16,100 @@ export function subpageTabButtonClass(active: boolean): string {
   }`;
 }
 
+/**
+ * Classes for the tabs container. Desktop layout uses `md:flex-row md:flex-wrap`
+ * so direction and wrapping live on the same min-width range as `md:flex`,
+ * eliminating any generation-order reliance against `max-md:flex-col` and
+ * keeping the mobile dropdown a clean (non-wrapping) column. `md:flex` keeps
+ * tabs visible at >= md regardless of `open`; below md they show only when
+ * `open`. The panel's backdrop-blur is intentionally omitted here — the
+ * outer sticky bar already applies `backdrop-blur-md` to that region; a second
+ * layer would produce an additive double-blur artifact.
+ */
+export function subpageTabsContainerClass(open: boolean): string {
+  return `gap-2 md:flex-row md:flex-wrap md:flex ${open ? 'flex' : 'hidden'} max-md:flex-col max-md:absolute max-md:left-0 max-md:right-0 max-md:top-full max-md:mt-1 max-md:rounded-lg max-md:border max-md:border-border-subtle max-md:bg-bg-glass/95 max-md:p-2 max-md:shadow-lg max-md:z-30`;
+}
+
 /** Sticks under the main scroll so in-page tabs stay visible (Portfolio, Research). */
 export function SubpageStickyTabBar({
   children,
   'aria-label': ariaLabel = 'Section navigation',
   topOffset = 'app',
+  menuLabel = 'Sections',
 }: {
-  children: ReactNode;
+  children?: ReactNode;
   'aria-label'?: string;
   topOffset?: 'app' | 'none';
+  menuLabel?: string;
 }) {
   const topClass = topOffset === 'none' ? 'top-0' : 'max-md:top-[72px] md:top-0';
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close the mobile menu on route change (covers <Link> tabs).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- close menu on navigation
+    setOpen(false);
+  }, [pathname]);
+
+  // Close on Escape while the menu is open; restore focus to trigger on close.
+  useEffect(() => {
+    if (!open) return;
+    // Move focus to the first focusable item in the panel on open.
+    containerRef.current?.querySelector<HTMLElement>('button, a')?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
   return (
     <div
-      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass} ${SUBPAGE_MAX} py-3`}
+      className={`sticky z-20 shrink-0 border-b border-border-subtle bg-bg-glass/95 backdrop-blur-md ${topClass}`}
       role="navigation"
       aria-label={ariaLabel}
     >
-      <div className="flex flex-wrap gap-2">{children}</div>
+      <div className={`${SUBPAGE_MAX} relative py-3`}>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          className="relative z-30 flex items-center gap-2 rounded-lg border border-border-subtle px-3 py-1.5 text-sm font-medium text-text-primary hover:bg-white/[0.06] md:hidden"
+          aria-expanded={open}
+          aria-controls="subpage-tabs"
+          aria-label={`${open ? 'Close' : 'Open'} ${menuLabel} menu`}
+        >
+          {open ? <X size={18} strokeWidth={2} /> : <Menu size={18} strokeWidth={2} />}
+          <span>{menuLabel}</span>
+        </button>
+        {open
+          ? createPortal(
+              <div
+                className="fixed inset-0 z-[19] md:hidden"
+                onClick={() => setOpen(false)}
+                tabIndex={-1}
+                aria-hidden
+              />,
+              document.body,
+            )
+          : null}
+        <div
+          ref={containerRef}
+          id="subpage-tabs"
+          className={subpageTabsContainerClass(open)}
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('button, a')) setOpen(false);
+          }}
+        >
+          {children}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/olympus/components/twelve-x/BriefsIndex.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsIndex.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsIndex({ briefs, onBack }: { briefs: FxBriefRow[]; onBack: () => void }) {
+  const { openBrief } = useTwelveX();
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex items-center gap-3">
+        <button type="button" className="flex items-center gap-1 text-xs text-fin-blue hover:underline" onClick={onBack}>
+          <ArrowLeft size={14} /> Today
+        </button>
+        <h2 className="text-base font-semibold text-text-primary">Today&rsquo;s briefs</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">{briefs.length}</span>
+      </header>
+      {briefs.length === 0 ? (
+        <div className="glass-card p-10 text-center text-sm text-text-muted">No research briefs for today yet.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {briefs.map((b, i) => (
+            <button
+              key={`${b.source_file}-${i}`}
+              type="button"
+              className="glass-card p-4 text-left transition-colors hover:border-fin-blue/50"
+              onClick={() => openBrief(b.source_file, b.run_date)}
+            >
+              <div className="flex items-center gap-2 text-[11px] text-text-muted">
+                <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+                {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+              </div>
+              <p className="mt-1 text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+              {b.central_thesis ? <p className="mt-1 line-clamp-3 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
+++ b/frontend/olympus/components/twelve-x/BriefsSlideshow.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FxBriefRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+export default function BriefsSlideshow({
+  briefs,
+  onSeeMore,
+}: {
+  briefs: FxBriefRow[];
+  onSeeMore: () => void;
+}) {
+  const { openBrief } = useTwelveX();
+  const [i, setI] = useState(0);
+
+  if (briefs.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <p className="mt-2 text-sm text-text-muted">No research briefs for today yet.</p>
+      </section>
+    );
+  }
+
+  const idx = Math.min(i, briefs.length - 1);
+  const b = briefs[idx];
+  const go = (d: number) => setI((idx + d + briefs.length) % briefs.length);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s briefs</h2>
+        <span className="font-mono text-[10px] text-text-muted">{idx + 1}/{briefs.length}</span>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={onSeeMore}>
+          see all →
+        </button>
+      </header>
+
+      <div className="flex items-center gap-2">
+        <button type="button" aria-label="Previous brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(-1)}>
+          <ChevronLeft size={16} />
+        </button>
+        <button
+          type="button"
+          className="min-w-0 flex-1 rounded-lg border border-border-subtle p-3 text-left transition-colors hover:border-fin-blue/50"
+          onClick={() => openBrief(b.source_file, b.run_date)}
+        >
+          <div className="flex items-center gap-2 text-[11px] text-text-muted">
+            <span className="font-semibold text-text-secondary">{b.broker_name ?? 'Unknown desk'}</span>
+            {b.trader_relevance ? <span className="uppercase">· {b.trader_relevance}</span> : null}
+          </div>
+          <p className="mt-1 truncate text-sm font-medium text-text-primary">{b.document_title ?? b.source_file}</p>
+          {b.central_thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{b.central_thesis}</p> : null}
+        </button>
+        <button type="button" aria-label="Next brief" className="rounded-md border border-border-subtle p-1 text-text-muted hover:text-fin-blue" onClick={() => go(1)}>
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      <div className="flex justify-center gap-1">
+        {briefs.map((bb, n) => (
+          <button
+            key={`${bb.source_file}-${bb.run_date}-${n}`}
+            type="button"
+            aria-label={`Go to brief ${n + 1}`}
+            className={`h-1.5 w-1.5 rounded-full ${n === idx ? 'bg-fin-blue' : 'bg-white/20'}`}
+            onClick={() => setI(n)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/DigestBrief.tsx
+++ b/frontend/olympus/components/twelve-x/DigestBrief.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { FileText } from 'lucide-react';
+
+export default function DigestBrief({
+  digest,
+}: {
+  digest: { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
+}) {
+  if (!digest) {
+    return (
+      <section className="glass-card p-5">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <p className="mt-2 text-sm text-text-muted">No digest for today yet.</p>
+      </section>
+    );
+  }
+  return (
+    <section className="glass-card flex flex-col gap-2 p-5">
+      <header className="flex items-baseline gap-2">
+        <FileText size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Digest brief</h2>
+        <span className="ml-auto font-mono text-[10px] text-text-muted">
+          {digest.doc_count} docs · {digest.broker_count} brokers
+        </span>
+      </header>
+      <p className="whitespace-pre-line text-sm leading-relaxed text-text-primary">{digest.summary}</p>
+      {digest.key_themes.length > 0 ? (
+        <div className="mt-1 flex flex-wrap gap-1.5">
+          {digest.key_themes.map((t) => (
+            <span key={t} className="rounded-full border border-border-subtle px-2.5 py-0.5 text-[11px] text-text-secondary">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
+++ b/frontend/olympus/components/twelve-x/EventsMiniTimeline.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { CalendarClock } from 'lucide-react';
+import type { FxEconomicCalendarRow } from '@/lib/twelve-x/types';
+import { hasResolvedTime, eventInstant } from '@/lib/twelve-x/fetch';
+import { useTwelveX } from './context';
+
+function impactClass(impact: string): string {
+  const i = (impact ?? '').trim().toLowerCase();
+  if (i === 'high') return 'bg-fin-red';
+  if (i === 'medium') return 'bg-fin-amber';
+  return 'bg-text-muted/60';
+}
+
+function localTime(e: FxEconomicCalendarRow): string {
+  const inst = eventInstant(e);
+  if (inst) return inst.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return e.event_time ?? '—';
+}
+
+export default function EventsMiniTimeline({ events }: { events: FxEconomicCalendarRow[] }) {
+  const { crossLink } = useTwelveX();
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <CalendarClock size={15} className="shrink-0 text-fin-blue" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s events</h2>
+        <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'events' })}>
+          see more →
+        </button>
+      </header>
+      {events.length === 0 ? (
+        <p className="text-sm text-text-muted">No macro events scheduled today.</p>
+      ) : (
+        <ul className="grid gap-1.5">
+          {events.map((e) => (
+            <li key={e.id} className="flex items-center gap-2.5 text-xs">
+              <span className="w-14 shrink-0 text-right font-mono tabular-nums text-text-secondary">{localTime(e)}</span>
+              <span className={`h-2 w-2 shrink-0 rounded-full ${impactClass(e.impact)}`} aria-hidden />
+              <span className="font-mono text-[10px] uppercase text-text-muted">{e.country}</span>
+              <span className="truncate text-text-primary">{e.event_name}</span>
+              {!hasResolvedTime(e) ? <span className="text-text-muted/60" title="venue-local time">≈</span> : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/TodayTab.tsx
+++ b/frontend/olympus/components/twelve-x/TodayTab.tsx
@@ -1,287 +1,67 @@
 'use client';
 
-import { Sparkles, FileText, Users, Star } from 'lucide-react';
-import { SafeMarkdown } from '@/components/SafeMarkdown';
-import type { FxConfluenceSnapshotRow, Mover, ConsensusDeltaSet } from '@/lib/twelve-x/types';
-import { useTwelveX } from './context';
+import type {
+  FxConfluenceSnapshotRow,
+  FxEconomicCalendarRow,
+  FxBriefRow,
+  FxTradeIdeaRow,
+  ConsensusDeltaSet,
+} from '@/lib/twelve-x/types';
+import TradeIdeasPanel from './TradeIdeasPanel';
+import DigestBrief from './DigestBrief';
+import BriefsSlideshow from './BriefsSlideshow';
+import EventsMiniTimeline from './EventsMiniTimeline';
 import MoversStrip from './MoversStrip';
+import { useTwelveX } from './context';
 
-// TODO(defer): push alerts — no server in static export
-
-interface DigestData {
-  run_date: string;
-  summary: string;
-  key_themes: string[];
-  doc_count: number;
-  broker_count: number;
-}
-
-/** Map a confluence/consensus direction string to a .fin-* text color class. */
-function directionColorClass(direction: string): string {
-  const d = direction.trim().toLowerCase();
-  if (d === 'bullish' || d === 'long' || d === 'buy') return 'text-fin-green';
-  if (d === 'bearish' || d === 'short' || d === 'sell') return 'text-fin-red';
-  if (d === 'watch') return 'text-fin-amber';
-  return 'text-text-secondary';
-}
-
-function directionLabel(direction: string): string {
-  const d = direction.trim();
-  if (!d) return '—';
-  return d.charAt(0).toUpperCase() + d.slice(1).toLowerCase();
-}
-
-/** The base currency an idea files under (numerator of a pair, uppercased). */
-function baseCurrency(currency: string): string {
-  return currency.trim().toUpperCase().split('/')[0];
-}
-
-/**
- * `brief_keys` are broker NAMES per the data contract, not `source_file` keys.
- * Only treat an entry as a brief link target if it actually looks like a file
- * key (has a path separator or a file extension); otherwise we skip the link
- * rather than wire up a broken openBrief() call.
- */
-function firstBriefSourceFile(briefKeys: unknown): string | null {
-  if (!Array.isArray(briefKeys)) return null;
-  for (const k of briefKeys) {
-    if (typeof k !== 'string') continue;
-    const s = k.trim();
-    if (s && (s.includes('/') || /\.[a-z0-9]{2,5}$/i.test(s))) return s;
-  }
-  return null;
-}
-
-/**
- * Drop reciprocal legs of the same pair: if two ideas share the same instrument
- * with opposite (currency, direction) — e.g. "EUR/USD long" and "EUR/USD" filed
- * under USD short — keep only the higher-ranked one. Input is rank-sorted.
- */
-function dedupeReciprocalLegs(ideas: FxConfluenceSnapshotRow[]): FxConfluenceSnapshotRow[] {
-  const seenPairs = new Set<string>();
-  const out: FxConfluenceSnapshotRow[] = [];
-  const sorted = [...ideas].sort((a, b) => a.rank - b.rank);
-  for (const idea of sorted) {
-    const legs = idea.currency.trim().toUpperCase().split('/').filter(Boolean).sort();
-    const pairKey = legs.join('|');
-    if (pairKey && seenPairs.has(pairKey)) continue;
-    if (pairKey) seenPairs.add(pairKey);
-    out.push(idea);
-  }
-  return out;
-}
-
-function ConfluenceCard({ idea }: { idea: FxConfluenceSnapshotRow }) {
-  const { crossLink, openBrief, watchlist } = useTwelveX();
-  const colorClass = directionColorClass(idea.direction);
-  const ccy = baseCurrency(idea.currency);
-  const briefSource = firstBriefSourceFile(idea.brief_keys);
-  const starred = watchlist.has(ccy);
-
-  const cardInteractive = briefSource != null;
-  const openCardBrief = () => {
-    if (briefSource) openBrief(briefSource, idea.run_date);
-  };
-
-  return (
-    <div
-      className={`glass-card p-4 flex flex-col gap-2 transition-colors${
-        cardInteractive
-          ? ' cursor-pointer hover:border-fin-blue/50 focus-visible:border-fin-blue/50 focus-visible:outline-none'
-          : ''
-      }`}
-      role={cardInteractive ? 'button' : undefined}
-      tabIndex={cardInteractive ? 0 : undefined}
-      onClick={cardInteractive ? openCardBrief : undefined}
-      onKeyDown={
-        cardInteractive
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                openCardBrief();
-              }
-            }
-          : undefined
-      }
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
-          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-white/[0.06] text-text-muted border border-border-subtle shrink-0">
-            #{idea.rank}
-          </span>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              crossLink({ kind: 'currency', currency: ccy });
-            }}
-            className="font-mono text-sm font-semibold text-text-primary truncate hover:text-fin-blue transition-colors"
-            title={`View ${ccy} consensus`}
-          >
-            {idea.currency}
-          </button>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          <span className={`text-xs font-semibold ${colorClass}`}>
-            {directionLabel(idea.direction)}
-          </span>
-          <button
-            type="button"
-            aria-label={starred ? `Remove ${ccy} from watchlist` : `Add ${ccy} to watchlist`}
-            aria-pressed={starred}
-            onClick={(e) => {
-              e.stopPropagation();
-              watchlist.toggle(ccy);
-            }}
-            className={`transition-colors ${
-              starred ? 'text-fin-amber' : 'text-text-muted hover:text-fin-amber'
-            }`}
-          >
-            <Star size={14} fill={starred ? 'currentColor' : 'none'} aria-hidden />
-          </button>
-        </div>
-      </div>
-      <p className="text-sm text-text-primary leading-snug">{idea.title}</p>
-      <div className="mt-auto flex items-center justify-between pt-1">
-        <span className="text-[11px] text-text-muted uppercase tracking-wider">Score</span>
-        <span className={`qn-metric tabular-nums ${colorClass}`}>
-          {Number.isFinite(idea.score) ? idea.score.toFixed(2) : '—'}
-        </span>
-      </div>
-    </div>
-  );
-}
+type DigestData = { run_date: string; summary: string; key_themes: string[]; doc_count: number; broker_count: number } | null;
 
 export default function TodayTab({
   digest,
+  tradeIdeas,
   confluence,
-  runDate,
-  movers,
   deltas,
+  briefs,
+  events,
+  onSeeAllBriefs,
 }: {
-  digest: DigestData | null;
+  digest: DigestData;
+  tradeIdeas: FxTradeIdeaRow[];
   confluence: FxConfluenceSnapshotRow[];
-  runDate: string | null;
-  movers: Mover[];
   deltas: ConsensusDeltaSet;
+  briefs: FxBriefRow[];
+  events: FxEconomicCalendarRow[];
+  onSeeAllBriefs: () => void;
 }) {
-  const { crossLink, watchlist } = useTwelveX();
-
-  // De-dupe reciprocal legs (higher rank wins) before slicing the top ideas.
-  const ranked = dedupeReciprocalLegs(confluence);
-  const filtered = watchlist.filterOn
-    ? ranked.filter((idea) => watchlist.has(baseCurrency(idea.currency)))
-    : ranked;
-  const topIdeas = filtered.slice(0, 6);
-
-  const headerDate = runDate ?? digest?.run_date ?? null;
-
+  const { crossLink } = useTwelveX();
   return (
-    <div className="space-y-4">
-      {/* What changed — biggest consensus shifts since the previous run */}
-      <MoversStrip
-        movers={movers}
-        onSelect={(currency) => crossLink({ kind: 'currency', currency })}
-        title="What changed since last run"
-      />
-
-      {/* Header + top trade ideas */}
-      <div className="space-y-3">
-        <div className="flex flex-wrap items-center gap-3 px-1">
-          <Sparkles size={16} className="text-fin-blue shrink-0" />
-          <h2 className="text-base md:text-lg font-semibold text-text-primary">
-            Top trade ideas
-          </h2>
-          {watchlist.items.length > 0 ? (
-            <button
-              type="button"
-              onClick={() => watchlist.setFilterOn(!watchlist.filterOn)}
-              aria-pressed={watchlist.filterOn}
-              className={`text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors flex items-center gap-1 ${
-                watchlist.filterOn
-                  ? 'border-fin-amber/40 bg-fin-amber/10 text-fin-amber'
-                  : 'border-border-subtle text-text-muted hover:text-text-secondary'
-              }`}
-            >
-              <Star size={11} fill={watchlist.filterOn ? 'currentColor' : 'none'} aria-hidden />
-              Watchlist
-            </button>
-          ) : null}
-          <span className="text-[10px] font-mono text-text-muted ml-auto">{headerDate ?? '—'}</span>
-        </div>
-
-        {/* Score-scale legend */}
-        <p className="text-[11px] text-text-muted px-1">
-          Score 0–1 · higher = stronger confluence
-        </p>
-
-        {topIdeas.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {topIdeas.map((idea) => (
-              <ConfluenceCard key={`${idea.run_date}-${idea.rank}`} idea={idea} />
-            ))}
-          </div>
-        ) : (
-          <div className="glass-card p-8 text-center text-text-muted text-sm">
-            {watchlist.filterOn && ranked.length > 0
-              ? 'No trade ideas match your watchlist.'
-              : `No confluence trade ideas${headerDate ? ` for ${headerDate}` : ''}.`}
-          </div>
-        )}
+    <div className="flex flex-col gap-4">
+      {/* Above the fold: trade ideas + digest brief co-lead */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <TradeIdeasPanel ideas={tradeIdeas} confluence={confluence} />
+        <DigestBrief digest={digest} />
       </div>
 
-      {/* Full brief — demoted below the ideas, collapsed by default */}
-      {digest ? (
-        <details className="glass-card p-0 overflow-hidden group">
-          <summary className="cursor-pointer list-none p-4 flex flex-wrap items-center gap-3 text-sm text-text-secondary hover:text-text-primary transition-colors">
-            <FileText size={15} className="text-fin-blue shrink-0" aria-hidden />
-            <span className="font-medium text-text-primary">Full brief</span>
-            <span className="text-text-muted">
-              · {digest.doc_count} {digest.doc_count === 1 ? 'doc' : 'docs'} ·{' '}
-              {digest.broker_count} {digest.broker_count === 1 ? 'broker' : 'brokers'}
-            </span>
-            <span className="text-[10px] font-mono text-text-muted ml-auto">{digest.run_date}</span>
-          </summary>
+      {/* What changed in consensus */}
+      <section className="glass-card p-4">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">What changed — consensus</h2>
+          <button type="button" className="ml-auto text-[11px] text-fin-blue hover:underline" onClick={() => crossLink({ kind: 'tab', tab: 'consensus' })}>
+            see more →
+          </button>
+        </header>
+        {deltas.movers.length > 0 ? (
+          <MoversStrip movers={deltas.movers} onSelect={(c) => crossLink({ kind: 'currency', currency: c })} title="" />
+        ) : (
+          <p className="text-sm text-text-muted">No prior run to compare yet.</p>
+        )}
+      </section>
 
-          <div className="px-4 pb-4 space-y-4 border-t border-border-subtle/60">
-            {digest.summary ? (
-              <SafeMarkdown className="prose prose-invert max-w-none text-sm text-text-secondary pt-4">
-                {digest.summary}
-              </SafeMarkdown>
-            ) : null}
-
-            {digest.key_themes.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {digest.key_themes.map((theme, i) => (
-                  <span
-                    key={`${theme}-${i}`}
-                    className="text-[11px] font-medium px-2.5 py-1 rounded-full border border-fin-blue/30 bg-fin-blue/10 text-fin-blue"
-                  >
-                    {theme}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-text-muted">
-              <span className="flex items-center gap-1.5">
-                <FileText size={13} aria-hidden />
-                <span className="qn-metric text-text-secondary tabular-nums">
-                  {digest.doc_count}
-                </span>
-                documents
-              </span>
-              <span className="flex items-center gap-1.5">
-                <Users size={13} aria-hidden />
-                <span className="qn-metric text-text-secondary tabular-nums">
-                  {digest.broker_count}
-                </span>
-                brokers
-              </span>
-            </div>
-          </div>
-        </details>
-      ) : null}
+      {/* Below the fold: briefs slideshow + today's events */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <BriefsSlideshow briefs={briefs} onSeeMore={onSeeAllBriefs} />
+        <EventsMiniTimeline events={events} />
+      </div>
     </div>
   );
 }

--- a/frontend/olympus/components/twelve-x/TradeIdeasPanel.tsx
+++ b/frontend/olympus/components/twelve-x/TradeIdeasPanel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { FxTradeIdeaRow, FxConfluenceSnapshotRow } from '@/lib/twelve-x/types';
+import { useTwelveX } from './context';
+
+function dirClass(direction: string): string {
+  const d = direction.toLowerCase();
+  if (d.includes('long') || d.includes('bull')) return 'text-fin-green';
+  if (d.includes('short') || d.includes('bear')) return 'text-fin-red';
+  return 'text-text-muted';
+}
+
+function firstSource(citations: unknown[]): string | null {
+  for (const c of citations) {
+    if (c && typeof c === 'object' && typeof (c as Record<string, unknown>).source_file === 'string') {
+      return (c as Record<string, unknown>).source_file as string;
+    }
+  }
+  return null;
+}
+
+export default function TradeIdeasPanel({
+  ideas,
+  confluence,
+}: {
+  ideas: FxTradeIdeaRow[];
+  confluence: FxConfluenceSnapshotRow[];
+}) {
+  const { crossLink, openBrief } = useTwelveX();
+  const [expanded, setExpanded] = useState(false);
+
+  if (ideas.length === 0) {
+    return (
+      <section className="glass-card p-5">
+        <header className="mb-2 flex items-baseline gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        </header>
+        <p className="text-sm text-text-muted">No curated trade idea for today yet.</p>
+      </section>
+    );
+  }
+
+  const [top, ...rest] = ideas;
+  const topSource = firstSource(top.citations);
+
+  return (
+    <section className="glass-card flex flex-col gap-3 p-5">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">Today&rsquo;s trade ideas</h2>
+        <span className="font-mono text-[10px] text-text-muted">· {ideas.length}</span>
+        <button
+          type="button"
+          className="ml-auto text-[11px] text-fin-blue hover:underline"
+          onClick={() => crossLink({ kind: 'tab', tab: 'intelligence' })}
+        >
+          see more →
+        </button>
+      </header>
+
+      {/* Focal #1 */}
+      <button
+        type="button"
+        className="rounded-lg border border-fin-green/30 bg-fin-green/[0.06] p-4 text-left transition-colors hover:border-fin-blue/50"
+        onClick={() => topSource && openBrief(topSource, top.run_date)}
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] text-text-muted">#1</span>
+          <span className="font-semibold text-text-primary">{top.pair}</span>
+          <span className={`text-xs font-semibold uppercase ${dirClass(top.direction)}`}>{top.direction}</span>
+        </div>
+        <p className="mt-1 text-sm text-text-primary">{top.title}</p>
+        {top.thesis ? <p className="mt-1 line-clamp-2 text-xs text-text-secondary">{top.thesis}</p> : null}
+        {top.catalyst ? <p className="mt-1 text-[11px] text-text-muted">Catalyst: {top.catalyst}</p> : null}
+      </button>
+
+      {/* #2…N rows */}
+      {rest.map((idea) => {
+        const src = firstSource(idea.citations);
+        return (
+          <button
+            key={`${idea.run_date}-${idea.rank}`}
+            type="button"
+            className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-2 text-left text-xs transition-colors hover:border-fin-blue/50"
+            onClick={() => src && openBrief(src, idea.run_date)}
+          >
+            <span className="font-mono text-[10px] text-text-muted">#{idea.rank}</span>
+            <span className="font-semibold text-text-primary">{idea.pair}</span>
+            <span className={`font-semibold uppercase ${dirClass(idea.direction)}`}>{idea.direction}</span>
+            <span className="ml-auto truncate text-text-muted">{idea.title}</span>
+          </button>
+        );
+      })}
+
+      {/* Expand → confluence reads */}
+      {confluence.length > 0 ? (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[11px] text-text-secondary hover:text-fin-blue"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+            {expanded ? 'Hide' : 'Expand'} confluence reads ({confluence.length})
+          </button>
+          {expanded ? (
+            <ul className="mt-2 grid gap-1">
+              {confluence.map((c) => (
+                <li key={`${c.run_date}-${c.rank}`} className="flex items-center gap-2 rounded-md border border-border-subtle px-3 py-1.5 text-xs">
+                  <span className="font-mono text-[10px] text-text-muted">#{c.rank}</span>
+                  <span className="font-semibold text-text-primary">{c.currency}</span>
+                  <span className={`uppercase ${dirClass(c.direction)}`}>{c.direction}</span>
+                  <button
+                    type="button"
+                    className="ml-auto text-fin-blue hover:underline"
+                    onClick={() => crossLink({ kind: 'currency', currency: c.currency })}
+                  >
+                    trend →
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/olympus/components/twelve-x/TwelveXClient.tsx
+++ b/frontend/olympus/components/twelve-x/TwelveXClient.tsx
@@ -22,18 +22,24 @@ import {
   getLedger,
   getLedgerRunDates,
   getMatrix,
+  getTradeIdeas,
+  getTodayBriefs,
+  getTodayEvents,
   getUpcomingEvents,
 } from '@/lib/twelve-x/fetch';
 import { isTwelveXConfigured } from '@/lib/twelve-x/supabase';
 import type {
+  FxBriefRow,
   FxConfluenceSnapshotRow,
   FxConsensusSnapshotRow,
   FxEconomicCalendarRow,
   FxEventSnapshotRow,
   FxLedgerRow,
+  FxTradeIdeaRow,
   MatrixCell,
 } from '@/lib/twelve-x/types';
 import TodayTab from './TodayTab';
+import BriefsIndex from './BriefsIndex';
 import ConsensusTab from './ConsensusTab';
 import IntelligenceTab from './IntelligenceTab';
 import EventsTab from './EventsTab';
@@ -60,7 +66,6 @@ export type BriefTarget = { sourceFile: string; runDate: string | null };
 
 interface TwelveXData {
   digest: DigestData;
-  confluence: FxConfluenceSnapshotRow[];
   consensusSeries: FxConsensusSnapshotRow[];
   latestConsensus: FxConsensusSnapshotRow[];
   intelligence: FxConfluenceSnapshotRow[];
@@ -68,6 +73,9 @@ interface TwelveXData {
   eventOpinions: FxEventSnapshotRow[];
   matrix: MatrixCell[];
   ledgerRunDates: string[];
+  tradeIdeas: FxTradeIdeaRow[];
+  todayBriefs: FxBriefRow[];
+  todayEvents: FxEconomicCalendarRow[];
 }
 
 function resolveTab(urlTab: string | null): TwelveXTab {
@@ -92,7 +100,12 @@ function readParam(key: string): string | null {
  * was the cause of tabs not switching / blank pages, so all control flow is
  * local React state and the URL is mirrored only for deep-link/shareability.
  */
-function syncUrl(tab: TwelveXTab, brief: BriefTarget | null, ledgerCcy: string | null): void {
+function syncUrl(
+  tab: TwelveXTab,
+  brief: BriefTarget | null,
+  ledgerCcy: string | null,
+  view: 'briefs' | null = null,
+): void {
   if (typeof window === 'undefined') return;
   const p = new URLSearchParams();
   if (tab !== 'today') p.set('tab', tab);
@@ -101,6 +114,7 @@ function syncUrl(tab: TwelveXTab, brief: BriefTarget | null, ledgerCcy: string |
     if (brief.runDate) p.set('briefDate', brief.runDate);
   }
   if (ledgerCcy) p.set('ledgerCcy', ledgerCcy);
+  if (view) p.set('view', view);
   const qs = p.toString();
   const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
   window.history.replaceState(window.history.state, '', url);
@@ -121,6 +135,9 @@ export default function TwelveXClient() {
     return sf ? { sourceFile: sf, runDate: readParam('briefDate') } : null;
   });
   const [ledgerCcy, setLedgerCcy] = useState<string | null>(() => readParam('ledgerCcy'));
+  const [view, setView] = useState<'briefs' | null>(() =>
+    readParam('view') === 'briefs' ? 'briefs' : null,
+  );
 
   // Ledger (P4) loads lazily by selected run_date so the audit table can be
   // re-pointed without refetching the whole workspace.
@@ -137,7 +154,8 @@ export default function TwelveXClient() {
   const setTab = useCallback(
     (next: TwelveXTab) => {
       setTabState(next);
-      syncUrl(next, brief, ledgerCcy);
+      setView(null);
+      syncUrl(next, brief, ledgerCcy, null);
     },
     [brief, ledgerCcy]
   );
@@ -146,15 +164,25 @@ export default function TwelveXClient() {
     (sourceFile: string, runDate: string | null) => {
       const next = { sourceFile, runDate };
       setBrief(next);
-      syncUrl(tab, next, ledgerCcy);
+      syncUrl(tab, next, ledgerCcy, view);
     },
-    [tab, ledgerCcy]
+    [tab, ledgerCcy, view]
   );
 
   const closeBrief = useCallback(() => {
     setBrief(null);
-    syncUrl(tab, null, ledgerCcy);
-  }, [tab, ledgerCcy]);
+    syncUrl(tab, null, ledgerCcy, view);
+  }, [tab, ledgerCcy, view]);
+
+  const openBriefsIndex = useCallback(() => {
+    setView('briefs');
+    syncUrl(tab, brief, ledgerCcy, 'briefs');
+  }, [tab, brief, ledgerCcy]);
+
+  const closeBriefsIndex = useCallback(() => {
+    setView(null);
+    syncUrl(tab, brief, ledgerCcy, null);
+  }, [tab, brief, ledgerCcy]);
 
   // "Why this weight?" from a consensus cell → jump to the ledger tab, pre-filtered
   // to that currency.
@@ -162,9 +190,9 @@ export default function TwelveXClient() {
     (currency: string) => {
       setTabState('ledger');
       setLedgerCcy(currency);
-      syncUrl('ledger', brief, currency);
+      syncUrl('ledger', brief, currency, view);
     },
-    [brief]
+    [brief, view]
   );
 
   useEffect(() => {
@@ -193,20 +221,17 @@ export default function TwelveXClient() {
           // Ledger (P4): run picker options.
           getLedgerRunDates(),
         ]);
-        // Today's "top trade ideas" are the top of the SAME ranked set the
-        // Intelligence tab shows (the latest confluence run) — not the digest's
-        // run_date, which can lag the latest confluence run (e.g. a digest exists
-        // for a day with no confluence) and leave Today empty while Intelligence
-        // has ideas. Slicing `intelligence` keeps the two surfaces consistent.
-        const confluence = intelligence.slice(0, 6);
         // Event opinions key off the intelligence run_date (latest confluence run)
         // so the catalysts tab shows desk views for the freshest session.
         const opinionsDate = intelligence[0]?.run_date ?? digest?.run_date ?? null;
         const eventOpinions = opinionsDate ? await getEventOpinions(opinionsDate) : [];
+        const canonical = intelligence[0]?.run_date ?? digest?.run_date ?? null;
+        const [tradeIdeas, todayBriefs, todayEvents] = canonical
+          ? await Promise.all([getTradeIdeas(canonical), getTodayBriefs(canonical), getTodayEvents()])
+          : [[], [], await getTodayEvents()];
         if (cancelled) return;
         setData({
           digest,
-          confluence,
           consensusSeries,
           latestConsensus,
           intelligence,
@@ -214,6 +239,9 @@ export default function TwelveXClient() {
           eventOpinions,
           matrix,
           ledgerRunDates,
+          tradeIdeas,
+          todayBriefs,
+          todayEvents,
         });
         // Default the ledger to the freshest run present.
         setLedgerRun((prev) => prev ?? ledgerRunDates[0] ?? null);
@@ -290,7 +318,7 @@ export default function TwelveXClient() {
         case 'currency':
           setTabState('consensus');
           setConsensusFocusCcy(l.currency);
-          syncUrl('consensus', brief, ledgerCcy);
+          syncUrl('consensus', brief, ledgerCcy, view);
           break;
         case 'ledger':
           drillToLedger(l.currency);
@@ -301,14 +329,14 @@ export default function TwelveXClient() {
         case 'event':
           setTabState('events');
           setEventFocus({ externalId: l.externalId ?? null, name: l.eventName });
-          syncUrl('events', brief, ledgerCcy);
+          syncUrl('events', brief, ledgerCcy, view);
           break;
         case 'tab':
           setTab(l.tab);
           break;
       }
     },
-    [brief, ledgerCcy, drillToLedger, openBrief, setTab]
+    [brief, ledgerCcy, view, drillToLedger, openBrief, setTab]
   );
 
   const ctx = useMemo<TwelveXContextValue>(
@@ -385,13 +413,17 @@ export default function TwelveXClient() {
           />
         );
       default:
-        return (
+        return view === 'briefs' ? (
+          <BriefsIndex briefs={data?.todayBriefs ?? []} onBack={closeBriefsIndex} />
+        ) : (
           <TodayTab
             digest={data?.digest ?? null}
-            confluence={data?.confluence ?? []}
-            runDate={canonicalRunDate}
-            movers={consensusDeltas.movers}
+            tradeIdeas={data?.tradeIdeas ?? []}
+            confluence={data?.intelligence ?? []}
             deltas={consensusDeltas}
+            briefs={data?.todayBriefs ?? []}
+            events={data?.todayEvents ?? []}
+            onSeeAllBriefs={openBriefsIndex}
           />
         );
     }

--- a/frontend/olympus/lib/twelve-x/fetch.test.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { boardColumn, normalizeKeyThemes } from './fetch';
+import { boardColumn, normalizeKeyThemes, sortTodayBriefs, filterEventsToDay } from './fetch';
+import type { FxBriefRow, FxEconomicCalendarRow } from './types';
 
 /**
  * `boardColumn` must consolidate broker view currencies into the 8 G10 matrix
@@ -101,5 +102,50 @@ describe('normalizeKeyThemes', () => {
     // Only `[`-prefixed strings attempt a JSON-array parse; anything else is
     // taken verbatim as one theme rather than being dropped or mis-parsed.
     expect(normalizeKeyThemes('{"a":1}')).toEqual(['{"a":1}']);
+  });
+});
+
+const brief = (over: Partial<FxBriefRow>): FxBriefRow => ({
+  run_date: '2026-06-23', source_file: 's.pdf', source_url: null,
+  document_title: null, broker_name: 'X', analyst_names: null,
+  report_date: '2026-06-23', trader_relevance: 'low', central_thesis: null,
+  brief_markdown: null, currency_views: [], risk_events: null,
+  macro_themes: null, positioning_signals: null, ...over,
+});
+
+describe('sortTodayBriefs', () => {
+  it('orders by relevance (high→low), then breadth, then newest report_date', () => {
+    const lowOld = brief({ source_file: 'a', trader_relevance: 'low', report_date: '2026-06-20' });
+    const highFew = brief({ source_file: 'b', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }] });
+    const highMany = brief({ source_file: 'c', trader_relevance: 'high', currency_views: [{ currency: 'USD', direction: 'bullish', conviction: 'high' }, { currency: 'EUR', direction: 'bearish', conviction: 'low' }] });
+    const medNew = brief({ source_file: 'd', trader_relevance: 'medium', report_date: '2026-06-23' });
+    const out = sortTodayBriefs([lowOld, highFew, highMany, medNew]).map((b) => b.source_file);
+    expect(out).toEqual(['c', 'b', 'd', 'a']);
+  });
+
+  it('is stable and pure (does not mutate input)', () => {
+    const input = [brief({ source_file: 'a' }), brief({ source_file: 'b' })];
+    const copy = [...input];
+    sortTodayBriefs(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+const ev = (over: Partial<FxEconomicCalendarRow>): FxEconomicCalendarRow => ({
+  id: 1, external_id: 'e', event_date: '2026-06-23', event_time: null,
+  country: 'US', event_name: 'X', category: 'c', impact: 'low',
+  actual: null, forecast: null, prior: null, event_datetime_utc: null, ...over,
+});
+
+describe('filterEventsToDay', () => {
+  it('keeps only events whose local date equals the target key', () => {
+    const todayUtc = ev({ id: 1, event_datetime_utc: '2026-06-23T14:30:00Z', event_date: '2026-06-23' });
+    const tomorrow = ev({ id: 2, event_datetime_utc: '2026-06-24T14:30:00Z', event_date: '2026-06-24' });
+    const allDayToday = ev({ id: 3, event_datetime_utc: null, event_date: '2026-06-23' });
+    const key = '2026-06-23';
+    const out = filterEventsToDay([todayUtc, tomorrow, allDayToday], key).map((e) => e.id);
+    expect(out).toContain(1);
+    expect(out).toContain(3);
+    expect(out).not.toContain(2);
   });
 });

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -25,6 +25,7 @@ import type {
   FxEconomicCalendarRow,
   FxEventSnapshotRow,
   FxLedgerRow,
+  FxTradeIdeaRow,
   MatrixCell,
   MatrixColumn,
   Mover,
@@ -432,6 +433,68 @@ export async function getBrief(
     }>;
   });
   return rows?.[0] ?? null;
+}
+
+const _RELEVANCE_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 };
+
+/** Pure ordering for the Today briefs slideshow: relevance desc, then breadth
+ *  (# of currency_views) desc, then newest report_date desc. Does not mutate. */
+export function sortTodayBriefs(briefs: FxBriefRow[]): FxBriefRow[] {
+  const rel = (b: FxBriefRow) => _RELEVANCE_RANK[(b.trader_relevance ?? '').toLowerCase()] ?? 0;
+  const breadth = (b: FxBriefRow) => asCurrencyViews(b.currency_views).length;
+  return [...briefs].sort(
+    (a, b) =>
+      rel(b) - rel(a) ||
+      breadth(b) - breadth(a) ||
+      (b.report_date ?? '').localeCompare(a.report_date ?? '')
+  );
+}
+
+/** Curated trade ideas for a run_date (rank 1 = top). `[]` when unconfigured/empty. */
+export async function getTradeIdeas(runDate: string): Promise<FxTradeIdeaRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxTradeIdeaRow[]>((sb) =>
+    sb
+      .from('fx_trade_ideas_snapshot')
+      .select('run_date, rank, pair, direction, title, thesis, catalyst, levels, citations, as_of')
+      .eq('run_date', runDate)
+      .order('rank', { ascending: true })
+  );
+  return rows ?? [];
+}
+
+/** Today's research briefs for a run_date, pre-sorted for the slideshow. */
+export async function getTodayBriefs(runDate: string): Promise<FxBriefRow[]> {
+  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  if (!runDate) return [];
+  const rows = await querySupabase<FxBriefRow[]>(
+    (sb) =>
+      sb
+        .from('fx_research_history')
+        .select(BRIEF_COLUMNS)
+        .eq('run_date', runDate)
+        .order('report_date', { ascending: false }) as unknown as PromiseLike<{
+      data: FxBriefRow[] | null;
+      error: unknown;
+    }>
+  );
+  return sortTodayBriefs(rows ?? []);
+}
+
+/** Pure: keep only rows whose local event date matches `todayKey`. */
+export function filterEventsToDay(
+  events: FxEconomicCalendarRow[],
+  todayKey: string
+): FxEconomicCalendarRow[] {
+  return events.filter((e) => eventLocalDateKey(e) === todayKey);
+}
+
+/** Upcoming macro events narrowed to the viewer-local "today". */
+export async function getTodayEvents(): Promise<FxEconomicCalendarRow[]> {
+  const all = await getUpcomingEvents();
+  const todayKey = eventLocalDateKey({ event_datetime_utc: new Date().toISOString(), event_date: '' });
+  return filterEventsToDay(all, todayKey);
 }
 
 // The extended leg-validity set: the 8 matrix columns + NOK/SEK. A pair is a

--- a/frontend/olympus/lib/twelve-x/types.ts
+++ b/frontend/olympus/lib/twelve-x/types.ts
@@ -261,3 +261,20 @@ export interface ConfluenceCatalyst {
   calendarExternalId: string | null;
   daysToCatalyst: number | null;
 }
+
+/**
+ * `fx_trade_ideas_snapshot` (twelve-x migration 012) — the curated, synthesized
+ * actionable trade ideas for a run. PRIMARY KEY (run_date, rank). anon-readable.
+ */
+export interface FxTradeIdeaRow {
+  run_date: string; // date (ISO YYYY-MM-DD)
+  rank: number; // int (1 = top)
+  pair: string; // e.g. "USD/JPY"
+  direction: string; // 'long' | 'short' | ...
+  title: string; // e.g. "JPY SHORT — via USD/JPY"
+  thesis: string;
+  catalyst: string;
+  levels: unknown[]; // jsonb array of broker levels/targets
+  citations: unknown[]; // jsonb array of TradeIdeaCitation
+  as_of: string; // timestamptz (ISO)
+}

--- a/frontend/olympus/next-env.d.ts
+++ b/frontend/olympus/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/dg/test_olympus_models.py
+++ b/tests/dg/test_olympus_models.py
@@ -108,19 +108,21 @@ def test_hermes_thesis_and_portfolio_slugs_route_openrouter(
 
 
 @pytest.mark.unit
-def test_deliberation_routes_to_json_capable_research_pool_not_r1(
+def test_deliberation_pinned_to_json_reliable_deepseek_chat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression (Olympus daily, 2026-06-22, run 27984259662): H6 deliberation turns must
-    emit strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 mapped the phase to
-    the ``reasoning`` pool, which in the cheap tier contains ``deepseek-r1`` — a chain-of-thought
-    model that returns prose, so ``json.loads`` failed at char 0 ("Expecting value: line 1
-    column 1") for the ~1/3 of tickers that hashed onto it. Deliberation must route to the
-    JSON/tool-capable ``research`` pool — never the prose-only r1 — matching the (already
-    intended) h6_pm_challenge-/h6_analyst_response- mappings.
+    """Regression (Olympus daily, run 28014812240, #1006): H6 deliberation turns must emit
+    strict JSON (DeliberationPmTurn / DeliberationAnalystTurn). #991 first mapped the phase to
+    the ``reasoning`` pool (prose-only deepseek-r1 → json.loads failed at char 0); #998 then
+    routed it to the cheap ``research`` pool — but that pool also contains ``llama-4-maverick``,
+    which returns *empty* completions under STRICT json_schema, so the ~half of tickers hashing
+    onto it still failed at char 0. Deliberation is now pinned (model_modes.yaml ``phase_models``)
+    to deepseek-chat — the json/tool-reliable open-weight model — for *every* ticker, bypassing
+    the pool hash. Never maverick, never r1.
     """
     monkeypatch.setenv("OLYMPUS_MODEL_TIER", "cheap")
-    research = set(model_config._load_olympus_models().tiers["cheap"].allowed_models["research"])
+    monkeypatch.setattr(model_config, "_model_modes_cache", None)
+    monkeypatch.setattr(model_config, "_olympus_models_cache", None)
     # The live macro watchlist from the failing run.
     watchlist = (
         "SPY QQQ DIA IWB VTI MDY IJH IWM IJR XLK XLF XLE XLV XLI XLRE XLU XLY XLP XLB XLC "
@@ -130,7 +132,10 @@ def test_deliberation_routes_to_json_capable_research_pool_not_r1(
     ).split()
     for ticker in watchlist:
         model = get_model_for_phase(f"hermes/portfolio/deliberation-{ticker}")
-        assert model in research, f"deliberation-{ticker} -> {model!r}, not a research-pool model"
+        assert model == "openrouter/deepseek/deepseek-chat", (
+            f"deliberation-{ticker} -> {model!r}, expected the pinned json-reliable deepseek-chat"
+        )
+        assert "maverick" not in model, f"deliberation-{ticker} routes to empty-prone maverick"
         assert "deepseek-r1" not in model, f"deliberation-{ticker} routes to prose-only r1"
         assert is_tool_use_capable_model(model)
 

--- a/tests/dq/atlas/test_migration_045.py
+++ b/tests/dq/atlas/test_migration_045.py
@@ -1,0 +1,134 @@
+"""Unit tests for migration 045 (PM Direction Memo doc_type — #1005).
+
+#930 introduced a new ``documents`` artifact published with
+``doc_type="PM Direction Memo"`` (``commit_io.publish_hermes_documents``), but no
+migration ever added that value to the ``chk_documents_doc_type`` CHECK constraint
+(latest before 045 was 043, which only permits the legacy ``"PM Allocation Memo"``).
+The mismatch was masked by the date-serialization crash (#993/#994); once that was
+fixed the row reached Postgres and was rejected (APIError 23514).
+
+These tests assert the *latest* doc_type constraint permits every doc_type the
+publish code actually writes — the regression guard that would have caught #1005 —
+and that 045 extends rather than narrows the prior allow-list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[3] / "digiquant" / "supabase" / "migrations"
+)
+COMMIT_IO = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "src"
+    / "digiquant"
+    / "olympus"
+    / "hermes"
+    / "writers"
+    / "commit_io.py"
+)
+
+# Full allow-list as of migration 043 — 045 must preserve every entry (no regression),
+# including the legacy ``PM Allocation Memo`` retained for historical rows.
+DOC_TYPES_043 = frozenset(
+    {
+        "Daily Digest",
+        "Daily Delta",
+        "Weekly Rollup",
+        "Monthly Summary",
+        "Deep Dive",
+        "Research Delta",
+        "Research Baseline Manifest",
+        "Document Delta",
+        "Research Changelog",
+        "Rebalance Decision",
+        "Asset Recommendation",
+        "Deliberation Transcript",
+        "Deliberation Session Index",
+        "Market Thesis Exploration",
+        "Thesis Vehicle Map",
+        "PM Allocation Memo",
+        "Sector Report",
+        "Evolution Sources",
+        "Evolution Quality Log",
+        "Evolution Proposals",
+        "Pipeline Review",
+        "Custom Research",
+        "Beliefs",
+    }
+)
+
+_ADD_CONSTRAINT = "ADD CONSTRAINT chk_documents_doc_type"
+_MIGRATION_NUM_RE = re.compile(r"^(\d+)_")
+_QUOTED_RE = re.compile(r"'([^']+)'")
+
+
+def _migration_number(path: Path) -> int:
+    m = _MIGRATION_NUM_RE.match(path.name)
+    assert m, f"migration filename lacks numeric prefix: {path.name}"
+    return int(m.group(1))
+
+
+def _latest_doctype_constraint() -> tuple[Path, str]:
+    """The highest-numbered migration that (re)defines ``chk_documents_doc_type``."""
+    matches = [
+        (p, txt)
+        for p in MIGRATIONS_DIR.glob("*.sql")
+        if _ADD_CONSTRAINT in (txt := p.read_text(encoding="utf-8"))
+    ]
+    assert matches, "no migration defines chk_documents_doc_type"
+    return max(matches, key=lambda pair: _migration_number(pair[0]))
+
+
+def _allowed_doc_types(constraint_sql: str) -> frozenset[str]:
+    """Extract the quoted IN(...) members of the doc_type CHECK constraint."""
+    add_idx = constraint_sql.index(_ADD_CONSTRAINT)
+    # The IN(...) list lives between the constraint clause and its closing ');'.
+    in_clause = constraint_sql[add_idx:]
+    return frozenset(_QUOTED_RE.findall(in_clause))
+
+
+@pytest.fixture(scope="module")
+def latest() -> tuple[Path, frozenset[str]]:
+    path, sql = _latest_doctype_constraint()
+    return path, _allowed_doc_types(sql)
+
+
+@pytest.mark.unit
+class TestDocTypeConstraintPermitsPmDirectionMemo:
+    def test_latest_constraint_permits_pm_direction_memo(
+        self, latest: tuple[Path, frozenset[str]]
+    ) -> None:
+        """The new #930 doc_type must be in the latest constraint (RED until 045)."""
+        path, allowed = latest
+        assert "PM Direction Memo" in allowed, (
+            f"'PM Direction Memo' missing from {path.name}; commit_io writes it "
+            f"and Postgres rejects rows whose doc_type is not in the constraint"
+        )
+
+    def test_latest_constraint_preserves_043_doc_types(
+        self, latest: tuple[Path, frozenset[str]]
+    ) -> None:
+        """045 extends, never narrows: every 043 value still permitted."""
+        _path, allowed = latest
+        missing = DOC_TYPES_043 - allowed
+        assert not missing, f"latest doc_type constraint dropped: {sorted(missing)}"
+
+    def test_commit_io_pm_direction_doc_type_is_constraint_allowed(
+        self, latest: tuple[Path, frozenset[str]]
+    ) -> None:
+        """Every doc_type literal the publish code writes must be DB-allowed."""
+        _path, allowed = latest
+        src = COMMIT_IO.read_text(encoding="utf-8")
+        literals = set(re.findall(r'doc_type="([^"]+)"', src))
+        assert literals, "expected at least one doc_type= literal in commit_io.py"
+        disallowed = literals - allowed
+        assert not disallowed, (
+            f"commit_io.py writes doc_type(s) not in chk_documents_doc_type: "
+            f"{sorted(disallowed)}"
+        )


### PR DESCRIPTION
Promote `develop` → `main`.

Carries 4 commits:

- **feat(twelve-x): Today page single-screen daily snapshot (Part A)** — #1002 (closes #1003)
- **feat(olympus): full-bleed subpage top-bar + mobile menu collapse (Part B)** — #1013 (closes #1012)
- fix(olympus): pin H6 deliberation to deepseek-chat — #1009
- fix(olympus): register PM Direction Memo + Commit Run doc_types — #1007

Parts A and B were brainstormed → spec'd → planned → built and adversarially verified (Part B's review caught and fixed a critical `backdrop-filter`/portal bug), with browser render-verification at wide/desktop/mobile widths. The two olympus fixes (#1007, #1009) were already merged to develop by prior work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
