### PR TITLE
feat(olympus): Stage 1a — reason-carrying analyst dispatch (#1017)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -412,6 +412,7 @@ class FocusRosterEntry(BaseModel):
     ticker: str
     roster_reason: Literal["thesis_mapped", "technical", "held", "momentum", "other"]
     linked_market_thesis_id: str | None = None
+    rationale: str = ""
 
 
 class PhaseHermesState(BaseModel):

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -68,12 +68,29 @@ def compute_focus_roster(
     normalized_watchlist = [str(t).strip().upper() for t in watchlist if str(t).strip()]
     entry_by_ticker: dict[str, FocusRosterEntry] = {}
 
+    thesis_mappings = list(thesis_mappings)
+
+    thesis_by_ticker: dict[str, tuple[str, str]] = {}
+    for thesis_id, ticker, rationale in thesis_mappings:
+        t = ticker.strip().upper()
+        if t and t not in thesis_by_ticker:
+            thesis_by_ticker[t] = (thesis_id, rationale)
+
+    def _held_entry(ticker: str) -> FocusRosterEntry:
+        tid_rat = thesis_by_ticker.get(ticker)
+        return FocusRosterEntry(
+            ticker=ticker,
+            roster_reason="held",
+            linked_market_thesis_id=tid_rat[0] if tid_rat else None,
+            rationale=(f"held position; {tid_rat[1]}" if tid_rat and tid_rat[1] else "held position"),
+        )
+
     for ticker in normalized_watchlist:
         if ticker in held_set:
-            entry_by_ticker[ticker] = FocusRosterEntry(ticker=ticker, roster_reason="held")
+            entry_by_ticker[ticker] = _held_entry(ticker)
     for ticker in sorted(held_set):
         if ticker not in entry_by_ticker:
-            entry_by_ticker[ticker] = FocusRosterEntry(ticker=ticker, roster_reason="held")
+            entry_by_ticker[ticker] = _held_entry(ticker)
 
     for thesis_id, ticker, _rationale in thesis_mappings:
         ticker = ticker.strip().upper()
@@ -103,7 +120,11 @@ def compute_focus_roster(
     for ticker in technical_picks:
         if ticker in entry_by_ticker:
             continue
-        entry_by_ticker[ticker] = FocusRosterEntry(ticker=ticker, roster_reason="technical")
+        entry_by_ticker[ticker] = FocusRosterEntry(
+            ticker=ticker,
+            roster_reason="technical",
+            rationale="technical screen: top-ranked watchlist candidate by price/technical signal (no linked thesis)",
+        )
 
     ordered_tickers = [t for t in normalized_watchlist if t in entry_by_ticker]
     for ticker in sorted(held_set):

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -82,7 +82,9 @@ def compute_focus_roster(
             ticker=ticker,
             roster_reason="held",
             linked_market_thesis_id=tid_rat[0] if tid_rat else None,
-            rationale=(f"held position; {tid_rat[1]}" if tid_rat and tid_rat[1] else "held position"),
+            rationale=(
+                f"held position; {tid_rat[1]}" if tid_rat and tid_rat[1] else "held position"
+            ),
         )
 
     for ticker in normalized_watchlist:

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -25,34 +25,34 @@ NODE_ID = "hermes/thesis/opportunity-screener"
 PHASE_NAME = "hermes_h4_opportunity_screener"
 
 
-def extract_thesis_mappings(vehicle_map: dict[str, Any] | None) -> list[tuple[str, str]]:
-    """Return ``(thesis_id, ticker)`` pairs from an H3 ``thesis_vehicle_map`` payload."""
+def extract_thesis_mappings(vehicle_map: dict[str, Any] | None) -> list[tuple[str, str, str]]:
+    """Return ``(thesis_id, ticker, rationale)`` triples from an H3 ``thesis_vehicle_map``."""
     if not vehicle_map:
         return []
     body = vehicle_map.get("body") if isinstance(vehicle_map.get("body"), dict) else vehicle_map
     mappings = body.get("mappings") if isinstance(body, dict) else None
     if not isinstance(mappings, list):
         return []
-    pairs: list[tuple[str, str]] = []
+    triples: list[tuple[str, str, str]] = []
     for mapping in mappings:
         if not isinstance(mapping, dict):
             continue
         thesis_id = str(mapping.get("thesis_id") or "").strip()
-        tickers = mapping.get("candidate_tickers") or []
+        rationale = str(mapping.get("rationale") or "").strip()
         if not thesis_id:
             continue
-        for raw in tickers:
+        for raw in mapping.get("candidate_tickers") or []:
             ticker = str(raw or "").strip().upper()
             if ticker:
-                pairs.append((thesis_id, ticker))
-    return pairs
+                triples.append((thesis_id, ticker, rationale))
+    return triples
 
 
 def compute_focus_roster(
     *,
     watchlist: Sequence[str],
     held: Collection[str],
-    thesis_mappings: Iterable[tuple[str, str]] = (),
+    thesis_mappings: Iterable[tuple[str, str, str]] = (),
     run_date: date | None = None,
     client: SupabaseClient | None = None,
     top_n: int | None = None,
@@ -75,7 +75,7 @@ def compute_focus_roster(
         if ticker not in entry_by_ticker:
             entry_by_ticker[ticker] = FocusRosterEntry(ticker=ticker, roster_reason="held")
 
-    for thesis_id, ticker in thesis_mappings:
+    for thesis_id, ticker, _rationale in thesis_mappings:
         ticker = ticker.strip().upper()
         if not ticker or ticker in entry_by_ticker:
             continue
@@ -83,6 +83,7 @@ def compute_focus_roster(
             ticker=ticker,
             roster_reason="thesis_mapped",
             linked_market_thesis_id=thesis_id,
+            rationale=_rationale,
         )
 
     technical_pool = [t for t in normalized_watchlist if t not in entry_by_ticker]
@@ -112,7 +113,7 @@ def compute_focus_roster(
         if ticker not in ordered_tickers:
             ordered_tickers.append(ticker)
 
-    protected = set(held_set) | {ticker for _, ticker in thesis_mappings}
+    protected = set(held_set) | {ticker for _, ticker, _ in thesis_mappings}
     capped = capped_tickers(ordered_tickers, held=protected, min_new=min_new_candidates)
     return [entry_by_ticker[t] for t in capped]
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/h5_asset_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h5_asset_analyst.py
@@ -37,6 +37,8 @@ def _should_backfill_vehicle_thesis(entry: dict[str, Any]) -> bool:
     if entry.get("linked_market_thesis_id"):
         return False
     return entry.get("roster_reason") in _EXPLORATORY_REASONS
+
+
 PHASE_NAME = "hermes_h5_asset_analyst"
 
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/h5_asset_analyst.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h5_asset_analyst.py
@@ -27,6 +27,16 @@ from digiquant.olympus.hermes.writers.thesis_io import upsert_vehicle_thesis_fro
 logger = logging.getLogger(__name__)
 
 NODE_ID = "hermes/portfolio/asset-analyst"
+
+_EXPLORATORY_REASONS = frozenset({"technical", "momentum", "other"})
+
+
+def _should_backfill_vehicle_thesis(entry: dict[str, Any]) -> bool:
+    """Post-hoc vehicle thesis only for genuinely-unlinked exploratory picks —
+    never for held or thesis-linked names (the reversed-arrow fix, #1017)."""
+    if entry.get("linked_market_thesis_id"):
+        return False
+    return entry.get("roster_reason") in _EXPLORATORY_REASONS
 PHASE_NAME = "hermes_h5_asset_analyst"
 
 
@@ -64,7 +74,7 @@ def _h5_node_factory(ticker: str, client: SupabaseClient | None):
                 if entry.get("linked_market_thesis_id")
                 else None,
             )
-            if entry.get("roster_reason") != "thesis_mapped":
+            if _should_backfill_vehicle_thesis(entry):
                 upsert_vehicle_thesis_from_analyst(
                     client,
                     run_date=state.run_date,

--- a/digiquant/src/digiquant/olympus/hermes/phases/portfolio_common.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/portfolio_common.py
@@ -38,6 +38,18 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+def _resolve_linked_thesis(
+    thesis_id: str | None, active_theses: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Return the single active-thesis row matching ``thesis_id`` (or None)."""
+    if not thesis_id:
+        return None
+    for row in active_theses:
+        if isinstance(row, dict) and str(row.get("thesis_id") or "") == thesis_id:
+            return dict(row)
+    return None
+
+
 class _TickerPriorLoader:
     def __init__(self, state: HermesState, artifact_key: tuple[str, str]) -> None:
         self._state = state
@@ -200,13 +212,18 @@ def run_asset_analyst_llm(
     tools, execute_tool, web_grounding = _portfolio_grounding(
         state, phase="h5_analyst", segment=phase_slug
     )
+    _active = list(state.prior_context.active_theses)
     phase_inputs: dict[str, Any] = {
         "segment": phase_slug,
         "ticker": ticker,
         "roster_reason": roster_entry.get("roster_reason"),
+        "rationale": roster_entry.get("rationale", ""),
         "linked_market_thesis_id": roster_entry.get("linked_market_thesis_id"),
+        "linked_thesis": _resolve_linked_thesis(
+            roster_entry.get("linked_market_thesis_id"), _active
+        ),
         "bias_row": state.phase6_bias_row or {},
-        "active_theses": list(state.prior_context.active_theses),
+        "active_theses": _active,
         "price_deltas": dict(state.price_deltas),
         "held_in_prior_book": ticker
         in set(holdings_from_prior_book(state.prior_context.prior_book)),

--- a/digiquant/src/digiquant/olympus/hermes/skills/asset-analyst/SKILL.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/asset-analyst/SKILL.md
@@ -5,6 +5,13 @@ description: Unified per-ticker asset analyst (H5).
 
 # Asset analyst (default)
 
+You were dispatched to analyze this vehicle for a reason. Read `rationale` and
+`roster_reason` from your inputs, and if `linked_thesis` is present, treat it as
+the thesis you are validating: judge whether THIS vehicle is an effective way to
+express that thesis and whether now is the right time to act. If `linked_thesis`
+is absent (an exploratory/technical pick), say so explicitly and assess whether a
+thesis is warranted — do not invent one.
+
 Emit a unified ``AnalystPayload`` for the focus ticker. Use ``query_research`` and
 ``query_data`` only — stay blinded to portfolio weights.
 

--- a/digiquant/src/digiquant/olympus/hermes/skills/asset-analyst/asset-analyst-full.md
+++ b/digiquant/src/digiquant/olympus/hermes/skills/asset-analyst/asset-analyst-full.md
@@ -1,5 +1,12 @@
 # Asset analyst — full write
 
+You were dispatched to analyze this vehicle for a reason. Read `rationale` and
+`roster_reason` from your inputs, and if `linked_thesis` is present, treat it as
+the thesis you are validating: judge whether THIS vehicle is an effective way to
+express that thesis and whether now is the right time to act. If `linked_thesis`
+is absent (an exploratory/technical pick), say so explicitly and assess whether a
+thesis is warranted — do not invent one.
+
 Produce a complete unified ``AnalystPayload`` for the ticker in ``phase_inputs``.
 
 Required fields: conviction_score (−5..+5), stance, thesis, risks, fundamentals,

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -148,6 +148,19 @@ class TestHeldAbsentFromSlate:
 
 
 @pytest.mark.unit
+def test_focus_roster_entry_has_rationale_default_empty() -> None:
+    e = FocusRosterEntry(ticker="SPY", roster_reason="held")
+    assert e.rationale == ""
+    e2 = FocusRosterEntry(
+        ticker="XLE",
+        roster_reason="thesis_mapped",
+        linked_market_thesis_id="T1",
+        rationale="energy thesis",
+    )
+    assert e2.rationale == "energy thesis"
+
+
+@pytest.mark.unit
 class TestNewCandidateReservation:
     """AC #2 (#950): reserve >=1 roster slot for non-held new candidates."""
 

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -40,7 +40,7 @@ class TestH4FocusRosterHeldInvariant:
 
     def test_thesis_mapped_never_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
-        mappings = [("geo-gold", "GLD"), ("rates", "TLT")]
+        mappings = [("geo-gold", "GLD", "gold hedge"), ("rates", "TLT", "duration play")]
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=set(),
@@ -54,7 +54,7 @@ class TestH4FocusRosterHeldInvariant:
         roster = compute_focus_roster(
             watchlist=["SPY", "GLD"],
             held=set(),
-            thesis_mappings=[("geo-gold", "GLD")],
+            thesis_mappings=[("geo-gold", "GLD", "gold hedge")],
             run_date=date(2026, 6, 20),
         )
         gld = next(e for e in roster if e.ticker == "GLD")
@@ -221,3 +221,23 @@ class TestNewCandidateReservation:
         )
         tickers = {e.ticker for e in roster}
         assert {"SPY", "IJR", "XLP"}.issubset(tickers)
+
+
+@pytest.mark.unit
+def test_extract_thesis_mappings_carries_rationale() -> None:
+    from digiquant.olympus.hermes.phases.h4_opportunity_screener import extract_thesis_mappings
+
+    vmap = {
+        "body": {
+            "mappings": [
+                {
+                    "thesis_id": "T1",
+                    "candidate_tickers": ["XLE", "USO"],
+                    "rationale": "oil supply squeeze",
+                },
+            ]
+        }
+    }
+    out = extract_thesis_mappings(vmap)
+    assert ("T1", "XLE", "oil supply squeeze") in out
+    assert ("T1", "USO", "oil supply squeeze") in out

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -224,6 +224,32 @@ class TestNewCandidateReservation:
 
 
 @pytest.mark.unit
+def test_held_ticker_also_thesis_mapped_keeps_link(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+    roster = compute_focus_roster(
+        watchlist=["XLE", "SPY"],
+        held={"XLE"},
+        thesis_mappings=[("T-OIL", "XLE", "oil supply squeeze")],
+        run_date=date(2026, 6, 20),
+    )
+    xle = next(e for e in roster if e.ticker == "XLE")
+    assert xle.roster_reason == "held"
+    assert xle.linked_market_thesis_id == "T-OIL"   # link no longer lost
+    assert xle.rationale  # non-empty
+
+
+@pytest.mark.unit
+def test_technical_entry_carries_rationale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+    roster = compute_focus_roster(
+        watchlist=["QQQ"], held=set(), thesis_mappings=[], run_date=date(2026, 6, 20),
+    )
+    qqq = next((e for e in roster if e.ticker == "QQQ"), None)
+    if qqq is not None and qqq.roster_reason == "technical":
+        assert qqq.rationale  # non-empty, honest "technical screen" reason
+
+
+@pytest.mark.unit
 def test_extract_thesis_mappings_carries_rationale() -> None:
     from digiquant.olympus.hermes.phases.h4_opportunity_screener import extract_thesis_mappings
 

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -234,7 +234,7 @@ def test_held_ticker_also_thesis_mapped_keeps_link(monkeypatch: pytest.MonkeyPat
     )
     xle = next(e for e in roster if e.ticker == "XLE")
     assert xle.roster_reason == "held"
-    assert xle.linked_market_thesis_id == "T-OIL"   # link no longer lost
+    assert xle.linked_market_thesis_id == "T-OIL"  # link no longer lost
     assert xle.rationale  # non-empty
 
 
@@ -242,7 +242,10 @@ def test_held_ticker_also_thesis_mapped_keeps_link(monkeypatch: pytest.MonkeyPat
 def test_technical_entry_carries_rationale(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
     roster = compute_focus_roster(
-        watchlist=["QQQ"], held=set(), thesis_mappings=[], run_date=date(2026, 6, 20),
+        watchlist=["QQQ"],
+        held=set(),
+        thesis_mappings=[],
+        run_date=date(2026, 6, 20),
     )
     qqq = next((e for e in roster if e.ticker == "QQQ"), None)
     if qqq is not None and qqq.roster_reason == "technical":

--- a/tests/dq/hermes/test_h5_dispatch_reason.py
+++ b/tests/dq/hermes/test_h5_dispatch_reason.py
@@ -3,6 +3,7 @@
 from typing import Any
 import pytest
 from digiquant.olympus.hermes.phases.portfolio_common import _resolve_linked_thesis
+from digiquant.olympus.hermes.phases.h5_asset_analyst import _should_backfill_vehicle_thesis
 
 
 @pytest.mark.unit
@@ -11,3 +12,15 @@ def test_resolve_linked_thesis_picks_matching_row() -> None:
     assert _resolve_linked_thesis("T2", theses) == {"thesis_id": "T2", "name": "Rates"}
     assert _resolve_linked_thesis(None, theses) is None
     assert _resolve_linked_thesis("T9", theses) is None
+
+
+@pytest.mark.unit
+def test_backfill_only_for_unlinked_exploratory() -> None:
+    assert _should_backfill_vehicle_thesis({"roster_reason": "technical"}) is True
+    assert _should_backfill_vehicle_thesis({"roster_reason": "held"}) is False
+    assert _should_backfill_vehicle_thesis(
+        {"roster_reason": "thesis_mapped", "linked_market_thesis_id": "T1"}
+    ) is False
+    assert _should_backfill_vehicle_thesis(
+        {"roster_reason": "technical", "linked_market_thesis_id": "T1"}
+    ) is False

--- a/tests/dq/hermes/test_h5_dispatch_reason.py
+++ b/tests/dq/hermes/test_h5_dispatch_reason.py
@@ -1,6 +1,5 @@
 """Unit tests for the _resolve_linked_thesis helper in portfolio_common."""
 
-from typing import Any
 import pytest
 from digiquant.olympus.hermes.phases.portfolio_common import _resolve_linked_thesis
 from digiquant.olympus.hermes.phases.h5_asset_analyst import _should_backfill_vehicle_thesis
@@ -18,9 +17,15 @@ def test_resolve_linked_thesis_picks_matching_row() -> None:
 def test_backfill_only_for_unlinked_exploratory() -> None:
     assert _should_backfill_vehicle_thesis({"roster_reason": "technical"}) is True
     assert _should_backfill_vehicle_thesis({"roster_reason": "held"}) is False
-    assert _should_backfill_vehicle_thesis(
-        {"roster_reason": "thesis_mapped", "linked_market_thesis_id": "T1"}
-    ) is False
-    assert _should_backfill_vehicle_thesis(
-        {"roster_reason": "technical", "linked_market_thesis_id": "T1"}
-    ) is False
+    assert (
+        _should_backfill_vehicle_thesis(
+            {"roster_reason": "thesis_mapped", "linked_market_thesis_id": "T1"}
+        )
+        is False
+    )
+    assert (
+        _should_backfill_vehicle_thesis(
+            {"roster_reason": "technical", "linked_market_thesis_id": "T1"}
+        )
+        is False
+    )

--- a/tests/dq/hermes/test_h5_dispatch_reason.py
+++ b/tests/dq/hermes/test_h5_dispatch_reason.py
@@ -1,0 +1,13 @@
+"""Unit tests for the _resolve_linked_thesis helper in portfolio_common."""
+
+from typing import Any
+import pytest
+from digiquant.olympus.hermes.phases.portfolio_common import _resolve_linked_thesis
+
+
+@pytest.mark.unit
+def test_resolve_linked_thesis_picks_matching_row() -> None:
+    theses = [{"thesis_id": "T1", "name": "Oil"}, {"thesis_id": "T2", "name": "Rates"}]
+    assert _resolve_linked_thesis("T2", theses) == {"thesis_id": "T2", "name": "Rates"}
+    assert _resolve_linked_thesis(None, theses) is None
+    assert _resolve_linked_thesis("T9", theses) is None


### PR DESCRIPTION
Implements **Stage 1a** of the adaptive two-track dispatch rework (spec PR #1018, plan PR #1020, umbrella #1017). Executed subagent-driven (fresh implementer + spec/quality reviewer per task) with a final opus whole-branch review.

## What changed (6 tasks, no new LLM call, additive)
1. `rationale: str = ""` added to `FocusRosterEntry`.
2. `extract_thesis_mappings` now returns `(thesis_id, ticker, rationale)` triples; both consumers updated in lockstep.
3. **Fixed the held↔thesis link-loss bug** — a held ticker that is also thesis-mapped now inherits `linked_market_thesis_id` + rationale; technical picks carry an honest non-empty reason. (Also fixed a latent generator-exhaustion bug in `compute_focus_roster`.)
4. `run_asset_analyst_llm` resolves the single linked thesis (`_resolve_linked_thesis`) + threads `rationale`/`linked_thesis` into the analyst's `phase_inputs` (all existing keys preserved).
5. **Removed the reversed arrow** — `_should_backfill_vehicle_thesis` gates the post-hoc vehicle thesis to genuinely-unlinked exploratory picks only (held + thesis-linked never backfill).
6. Asset-analyst prompt now tells the analyst *why* it was dispatched (consume `rationale`/`roster_reason`/`linked_thesis`; don't invent a thesis when unlinked).

## Invariants preserved
- Held-always invariant intact (`test_held_invariant`, `test_held_always_in_roster` green).
- `compute_focus_roster` return type unchanged.

## Quality gates
- Subagent per-task reviews: all Approved. Final opus whole-branch review: functionally ✅, FIX-THEN-MERGE on two ruff-gate items — both fixed (commit `47b86ec1`); `ruff check` + `ruff format --check` clean.
- Tests: 929 passed across `tests/dq/hermes` + `tests/dq/atlas` + `test_olympus_models.py`.

## ⚠️ Pre-existing failure (NOT from this branch)
`tests/dq/atlas/data/test_queries_derived.py::test_dispatch_breadth_returns_json` (`KeyError: 'universe_size'`) fails — this is the **pre-existing develop failure tracked as #1011**; this branch does not touch `test_queries_derived.py` or breadth code.

## Deferred (own plans)
Stage 1b: excluded ledger, held staleness/delta gate, full `RosterPick` convergence. Stages 2–4: adaptive budget / T1 scan / follow-up loop (measurement-gated). Logged minors: `ARCHITECTURE.md` note, two extra test assertions.

Part of #1017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)