### PR TITLE
fix(atlas): get_market_breadth stamped-empty shape + de-timebomb test (#1011)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/data/queries.py
+++ b/digiquant/src/digiquant/olympus/atlas/data/queries.py
@@ -189,8 +189,9 @@ def get_market_breadth(
         if len(batch) < page_size:
             break
         start += page_size
-    if not rows:
-        return {}
+    # compute_breadth returns the stamped-empty shape ({as_of, universe_size: 0}) for an
+    # empty frame, so the no-rows path keeps the breadth contract (universe_size always
+    # present) instead of a bare {} that KeyErrors downstream (#1011).
     return compute_breadth(pl.DataFrame(rows), as_of=run_date)
 
 

--- a/tests/dq/atlas/data/test_queries_derived.py
+++ b/tests/dq/atlas/data/test_queries_derived.py
@@ -118,7 +118,12 @@ class TestReaders:
         assert out["pct_above_50dma"] == 75.0
 
     def test_get_market_breadth_empty(self) -> None:
-        assert get_market_breadth(client=_FakeClient({}), run_date=date(2026, 6, 15)) == {}
+        # Empty universe returns the stamped-empty shape (universe_size always present),
+        # not a bare {} — consistent with compute_breadth + the breadth contract (#1011).
+        assert get_market_breadth(client=_FakeClient({}), run_date=date(2026, 6, 15)) == {
+            "as_of": "2026-06-15",
+            "universe_size": 0,
+        }
 
     def test_get_sector_relative_strength(self) -> None:
         client = _FakeClient({"price_history": _rs_rows()})
@@ -268,10 +273,21 @@ class TestToolDispatcher:
         assert result["rows"][0]["ticker"] == "XLK"
 
     def test_dispatch_breadth_returns_json(self) -> None:
+        # Pin run_date to the fixture's date so the breadth window includes the rows
+        # regardless of today (previously defaulted to date.today() — a time-bomb that
+        # broke once today drifted >7 days past the fixture, #1011).
         client = _FakeClient({"price_technicals": _breadth_rows()})
-        execute = build_data_tool_dispatcher(client)
+        execute = build_data_tool_dispatcher(client, run_date=date(2026, 6, 15))
         result = json.loads(execute("get_market_breadth", {}))
         assert result["universe_size"] == 4
+
+    def test_dispatch_breadth_no_rows_returns_stamped_universe_size(self) -> None:
+        # No price_technicals in window → stamped-empty shape (universe_size: 0),
+        # never a bare {} that KeyErrors on universe_size downstream (#1011).
+        client = _FakeClient({"price_technicals": []})
+        execute = build_data_tool_dispatcher(client, run_date=date(2026, 6, 15))
+        result = json.loads(execute("get_market_breadth", {}))
+        assert result["universe_size"] == 0
 
     def test_dispatch_query_data_price_history(self) -> None:
         # Raw OHLCV now flows through the generic query_data reader (get_price_history retired).


### PR DESCRIPTION
## Root cause
`get_market_breadth` (`atlas/data/queries.py`) returned a bare `{}` on the no-rows path instead of the stamped `{as_of, universe_size: 0}` shape its contract + siblings (`compute_breadth`, `compute_etf_flows_proxy`) guarantee — so a consumer reading `result["universe_size"]` hits `KeyError` on a no-data day.

The failing test `test_dispatch_breadth_returns_json` was **also a time-bomb**: it built the dispatcher with no `run_date`, so `as_of` defaulted to `date.today()`; the `2026-06-15` fixture rows fell outside the 7-day breadth window once today drifted past 2026-06-22 → no rows → bare `{}` → `KeyError`. That's why it started failing ~2026-06-23.

## Fix
- `get_market_breadth` delegates the empty case to `compute_breadth(pl.DataFrame(rows), …)` (which returns the stamped shape) — `universe_size` is now always present.
- Pin `run_date` in `test_dispatch_breadth_returns_json` (deterministic, exercises the rows path → `universe_size == 4`).
- Add `test_dispatch_breadth_no_rows_returns_stamped_universe_size` (no rows → `universe_size: 0`, not `KeyError`).
- Update `test_get_market_breadth_empty` to the corrected contract.

Only the dispatcher consumes `get_market_breadth` (it `json.dumps`es the result) — no caller relied on the falsy `{}`. TDD RED→GREEN; 39 atlas-data tests pass; ruff clean.

Fixes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)