### PR TITLE
feat(olympus): Stage 1b — excluded ledger + held staleness gate (#1017)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -415,6 +415,13 @@ class FocusRosterEntry(BaseModel):
     rationale: str = ""
 
 
+class ExcludedTicker(BaseModel):
+    """A watchlist ticker that was NOT dispatched to an analyst, and why."""
+
+    ticker: str
+    reason: str
+
+
 class PhaseHermesState(BaseModel):
     """Thesis-first Hermes slots (H1–H9)."""
 
@@ -422,6 +429,7 @@ class PhaseHermesState(BaseModel):
     market_thesis_exploration: dict[str, Any] | None = None
     thesis_vehicle_map: dict[str, Any] | None = None
     focus_roster: list[FocusRosterEntry] = Field(default_factory=list)
+    focus_roster_excluded: list[ExcludedTicker] = Field(default_factory=list)
     asset_analysts: Annotated[dict[str, dict[str, Any]], _merge_right_wins_dict] = Field(
         default_factory=dict
     )

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -14,7 +14,7 @@ from datetime import date
 from typing import Any  # noqa  # scored-lint suppression: heterogeneous graph / dict shapes
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 
-from digiquant.olympus.atlas.state import FocusRosterEntry
+from digiquant.olympus.atlas.state import ExcludedTicker, FocusRosterEntry
 from digiquant.olympus.atlas.supabase_io import SupabaseClient
 from digiquant.olympus.hermes.candidates import select_focus_tickers
 from digiquant.olympus.hermes.roster_cap import capped_tickers
@@ -177,6 +177,33 @@ def compute_focus_roster(
     return [entry_by_ticker[t] for t in capped]
 
 
+def compute_focus_roster_excluded(
+    watchlist: Sequence[str],
+    roster: list[FocusRosterEntry],
+    *,
+    held: Collection[str],
+) -> list[ExcludedTicker]:
+    """Return exclusion ledger entries for watchlist tickers NOT in the focus roster.
+
+    For each normalized watchlist ticker absent from *roster*:
+    - If the ticker is in *held*: reason = "held, no material change (below staleness threshold)".
+    - Otherwise: reason = "not thesis-mapped and below technical screen".
+    """
+    rostered = {e.ticker for e in roster}
+    held_upper = {str(t).strip().upper() for t in held if str(t).strip()}
+    excluded: list[ExcludedTicker] = []
+    for raw in watchlist:
+        ticker = str(raw).strip().upper()
+        if not ticker or ticker in rostered:
+            continue
+        if ticker in held_upper:
+            reason = "held, no material change (below staleness threshold)"
+        else:
+            reason = "not thesis-mapped and below technical screen"
+        excluded.append(ExcludedTicker(ticker=ticker, reason=reason))
+    return excluded
+
+
 def preview_focus_roster_tickers(
     *,
     watchlist: Sequence[str],
@@ -193,21 +220,32 @@ def preview_focus_roster_tickers(
 
 def _h4_node_factory(client: SupabaseClient | None):
     def _h4_node(state: HermesState) -> dict[str, Any]:
+        watchlist = list(state.config.watchlist)
+        held = holdings_from_state(state)
         mappings = extract_thesis_mappings(state.phase_hermes.thesis_vehicle_map)
         roster = compute_focus_roster(
-            watchlist=list(state.config.watchlist),
-            held=holdings_from_state(state),
+            watchlist=watchlist,
+            held=held,
             thesis_mappings=mappings,
+            price_deltas=dict(state.price_deltas),
             run_date=state.run_date,
             client=client,
         )
+        excluded = compute_focus_roster_excluded(watchlist, roster, held=held)
         logger.info(
             "H4 focus roster (%d): %s",
             len(roster),
             ", ".join(f"{e.ticker}:{e.roster_reason}" for e in roster),
         )
+        logger.info(
+            "H4 excluded ledger (%d): %s",
+            len(excluded),
+            ", ".join(e.ticker for e in excluded),
+        )
         return {
-            "phase_hermes": state.phase_hermes.model_copy(update={"focus_roster": roster}),
+            "phase_hermes": state.phase_hermes.model_copy(
+                update={"focus_roster": roster, "focus_roster_excluded": excluded}
+            ),
         }
 
     return _h4_node

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -42,6 +42,10 @@ def _held_passes_gate(
         return True
     if linked_thesis_id:
         return True
+    if not price_deltas:
+        # No delta signal at all this run (e.g. a baseline/monthly run, where price_deltas
+        # is empty) — staleness is unjudgeable, so don't gate; keep full held coverage (#1017).
+        return True
     threshold = float(os.environ.get("HERMES_HELD_STALENESS_DELTA", "0.005"))
     return abs((price_deltas or {}).get(ticker, 0.0)) >= threshold
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -8,7 +8,8 @@ thesis-mapped vehicles from H3 and technical opportunity candidates. Replaces
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection, Iterable, Sequence
+import os
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import date
 from typing import Any  # noqa  # scored-lint suppression: heterogeneous graph / dict shapes
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
@@ -23,6 +24,26 @@ logger = logging.getLogger(__name__)
 
 NODE_ID = "hermes/thesis/opportunity-screener"
 PHASE_NAME = "hermes_h4_opportunity_screener"
+
+
+def _held_passes_gate(
+    ticker: str,
+    linked_thesis_id: str | None,
+    price_deltas: Mapping[str, float] | None,
+) -> bool:
+    """Return True if a held ticker should be dispatched to the focus roster.
+
+    Gate is disabled (always-analyze) when ``HERMES_HELD_GATE=off``.
+    Otherwise, a held ticker passes when it has a linked thesis OR its absolute
+    price delta meets or exceeds the staleness threshold (``HERMES_HELD_STALENESS_DELTA``,
+    default 0.005 = 0.5%).
+    """
+    if os.environ.get("HERMES_HELD_GATE", "on").strip().lower() == "off":
+        return True
+    if linked_thesis_id:
+        return True
+    threshold = float(os.environ.get("HERMES_HELD_STALENESS_DELTA", "0.005"))
+    return abs((price_deltas or {}).get(ticker, 0.0)) >= threshold
 
 
 def extract_thesis_mappings(vehicle_map: dict[str, Any] | None) -> list[tuple[str, str, str]]:
@@ -53,6 +74,7 @@ def compute_focus_roster(
     watchlist: Sequence[str],
     held: Collection[str],
     thesis_mappings: Iterable[tuple[str, str, str]] = (),
+    price_deltas: Mapping[str, float] | None = None,
     run_date: date | None = None,
     client: SupabaseClient | None = None,
     top_n: int | None = None,
@@ -87,12 +109,23 @@ def compute_focus_roster(
             ),
         )
 
+    gated_out_held: set[str] = set()
     for ticker in normalized_watchlist:
         if ticker in held_set:
-            entry_by_ticker[ticker] = _held_entry(ticker)
+            tid_rat = thesis_by_ticker.get(ticker)
+            linked_thesis_id = tid_rat[0] if tid_rat else None
+            if _held_passes_gate(ticker, linked_thesis_id, price_deltas):
+                entry_by_ticker[ticker] = _held_entry(ticker)
+            else:
+                gated_out_held.add(ticker)
     for ticker in sorted(held_set):
-        if ticker not in entry_by_ticker:
-            entry_by_ticker[ticker] = _held_entry(ticker)
+        if ticker not in entry_by_ticker and ticker not in gated_out_held:
+            tid_rat = thesis_by_ticker.get(ticker)
+            linked_thesis_id = tid_rat[0] if tid_rat else None
+            if _held_passes_gate(ticker, linked_thesis_id, price_deltas):
+                entry_by_ticker[ticker] = _held_entry(ticker)
+            else:
+                gated_out_held.add(ticker)
 
     for thesis_id, ticker, _rationale in thesis_mappings:
         ticker = ticker.strip().upper()
@@ -105,7 +138,9 @@ def compute_focus_roster(
             rationale=_rationale,
         )
 
-    technical_pool = [t for t in normalized_watchlist if t not in entry_by_ticker]
+    technical_pool = [
+        t for t in normalized_watchlist if t not in entry_by_ticker and t not in gated_out_held
+    ]
     technical_picks: list[str] = []
     if technical_pool and run_date is not None:
         technical_picks = (
@@ -136,7 +171,8 @@ def compute_focus_roster(
         if ticker not in ordered_tickers:
             ordered_tickers.append(ticker)
 
-    protected = set(held_set) | {ticker for _, ticker, _ in thesis_mappings}
+    active_held = held_set - gated_out_held
+    protected = active_held | {ticker for _, ticker, _ in thesis_mappings}
     capped = capped_tickers(ordered_tickers, held=protected, min_new=min_new_candidates)
     return [entry_by_ticker[t] for t in capped]
 

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -253,6 +253,15 @@ def test_technical_entry_carries_rationale(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.unit
+def test_excluded_ticker_and_state_slot() -> None:
+    from digiquant.olympus.atlas.state import ExcludedTicker, PhaseHermesState
+
+    e = ExcludedTicker(ticker="TLT", reason="held, no material change (Δ<0.5%)")
+    assert e.ticker == "TLT" and e.reason
+    assert PhaseHermesState().focus_roster_excluded == []
+
+
+@pytest.mark.unit
 def test_extract_thesis_mappings_carries_rationale() -> None:
     from digiquant.olympus.hermes.phases.h4_opportunity_screener import extract_thesis_mappings
 

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -324,3 +324,72 @@ def test_held_gate_off_keeps_all(monkeypatch: pytest.MonkeyPatch) -> None:
         run_date=date(2026, 6, 20),
     )
     assert "TLT" in {e.ticker for e in roster}  # kill-switch → always-analyze
+
+
+# ---------------------------------------------------------------------------
+# Stage 1b Task 3: populate + emit the excluded ledger in the H4 node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_focus_roster_excluded_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Watchlist of 3: 1 rostered, 1 gated-out held, 1 below-screen (client returns empty).
+
+    ``compute_focus_roster_excluded`` must return exactly 2 ExcludedTicker
+    entries (the non-rostered ones) with non-empty reasons.  The rostered
+    ticker must be absent from the ledger.
+    """
+    from digiquant.olympus.atlas.state import ExcludedTicker
+    from digiquant.olympus.hermes.phases.h4_opportunity_screener import (
+        compute_focus_roster_excluded,
+    )
+    from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+
+    # A stub client that selects nothing — QQQ stays below-screen.
+    def _stub_select(*, client: object, watchlist: list[str], **kwargs: object) -> list[str]:
+        return []
+
+    monkeypatch.setattr(
+        "digiquant.olympus.hermes.phases.h4_opportunity_screener.select_focus_tickers",
+        _stub_select,
+    )
+
+    # Build the roster: SPY is thesis-mapped → rostered; TLT is gated-out held
+    # (quiet, no thesis link); QQQ fails the technical screen → excluded.
+    watchlist = ["SPY", "TLT", "QQQ"]
+    held = {"TLT"}
+
+    roster = compute_focus_roster(
+        watchlist=watchlist,
+        held=held,
+        thesis_mappings=[("T-US", "SPY", "US equity core")],
+        price_deltas={"TLT": 0.001},  # below 0.5% threshold → gated out
+        run_date=date(2026, 6, 20),
+        client=FakeSupabaseClient(),
+    )
+
+    rostered_tickers = {e.ticker for e in roster}
+    assert "SPY" in rostered_tickers, "thesis-mapped SPY must survive"
+    assert "TLT" not in rostered_tickers, "gated-out held TLT must be excluded"
+    assert "QQQ" not in rostered_tickers, "below-screen QQQ must be excluded"
+
+    excluded = compute_focus_roster_excluded(watchlist, roster, held=held)
+
+    assert isinstance(excluded, list)
+    assert all(isinstance(e, ExcludedTicker) for e in excluded)
+
+    excluded_tickers = {e.ticker for e in excluded}
+    assert "SPY" not in excluded_tickers, "rostered ticker must not appear in excluded ledger"
+    assert "TLT" in excluded_tickers, "gated-out held must appear in excluded ledger"
+    assert "QQQ" in excluded_tickers, "below-screen ticker must appear in excluded ledger"
+
+    # Every excluded entry must carry a non-empty human-readable reason.
+    for entry in excluded:
+        assert entry.reason, f"empty reason for {entry.ticker}"
+
+    # Reason for gated-out held must hint at the held+staleness cause.
+    tlt_entry = next(e for e in excluded if e.ticker == "TLT")
+    assert "held" in tlt_entry.reason.lower() or "material" in tlt_entry.reason.lower()

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -338,6 +338,20 @@ def test_held_gate_off_keeps_all(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "TLT" in {e.ticker for e in roster}  # kill-switch → always-analyze
 
 
+@pytest.mark.unit
+def test_held_gate_no_signal_keeps_held(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No delta signal at all this run (e.g. a baseline/monthly run where price_deltas is
+    # empty) → the gate can't judge staleness, so it must NOT gate out held names (#1017).
+    monkeypatch.setenv("HERMES_HELD_GATE", "on")
+    roster = compute_focus_roster(
+        watchlist=["TLT", "AGG"],
+        held={"TLT", "AGG"},
+        price_deltas={},  # empty → no signal
+        run_date=date(2026, 6, 20),
+    )
+    assert {"TLT", "AGG"}.issubset({e.ticker for e in roster})
+
+
 # ---------------------------------------------------------------------------
 # Stage 1b Task 3: populate + emit the excluded ledger in the H4 node
 # ---------------------------------------------------------------------------

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -19,7 +19,9 @@ _HELD = {"SPY", "IJR", "XLP"}
 @pytest.mark.unit
 class TestH4FocusRosterHeldInvariant:
     def test_held_always_in_roster(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With the staleness gate disabled, every held name must appear in the roster."""
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "4")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -28,7 +30,8 @@ class TestH4FocusRosterHeldInvariant:
         tickers = {e.ticker for e in roster}
         assert _HELD.issubset(tickers), f"held dropped from H4 roster: {_HELD - tickers}"
 
-    def test_held_entries_tagged_held(self) -> None:
+    def test_held_entries_tagged_held(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -63,6 +66,7 @@ class TestH4FocusRosterHeldInvariant:
 
     def test_held_over_cap_keeps_all_held(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -125,8 +129,11 @@ def test_compute_focus_roster_passes_client_to_technical_screen(
 class TestHeldAbsentFromSlate:
     """AC #3 (#950): a held name absent from the raw slate still appears."""
 
-    def test_held_ticker_not_in_watchlist_still_in_roster(self) -> None:
+    def test_held_ticker_not_in_watchlist_still_in_roster(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """IJR is held but NOT in the watchlist — must still appear in roster."""
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["AAA", "BBB", "CCC"],
             held={"IJR"},
@@ -135,8 +142,11 @@ class TestHeldAbsentFromSlate:
         tickers = {e.ticker for e in roster}
         assert "IJR" in tickers, "held ticker absent from watchlist was dropped"
 
-    def test_held_ticker_absent_from_slate_tagged_held(self) -> None:
+    def test_held_ticker_absent_from_slate_tagged_held(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Held ticker injected into roster must carry roster_reason='held'."""
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["AAA", "BBB"],
             held={"XLF"},
@@ -197,6 +207,7 @@ class TestNewCandidateReservation:
     ) -> None:
         """Cap=3, 3 held, 0 non-held watchlist — held-only roster is fine."""
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "3")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["SPY", "IJR", "XLP"],
             held={"SPY", "IJR", "XLP"},
@@ -214,6 +225,7 @@ class TestNewCandidateReservation:
         and no new candidates can be reserved; that is acceptable.
         """
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["SPY", "IJR", "XLP", "NEW1"],
             held={"SPY", "IJR", "XLP"},

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -279,3 +279,48 @@ def test_extract_thesis_mappings_carries_rationale() -> None:
     out = extract_thesis_mappings(vmap)
     assert ("T1", "XLE", "oil supply squeeze") in out
     assert ("T1", "USO", "oil supply squeeze") in out
+
+
+# ---------------------------------------------------------------------------
+# Stage 1b Task 2: held staleness/delta dispatch gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_held_gate_drops_stale_unlinked_held(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT", "XLE"],
+        held={"TLT", "XLE"},
+        thesis_mappings=[("T-OIL", "XLE", "oil")],
+        price_deltas={"TLT": 0.001, "XLE": 0.0},  # both quiet; XLE thesis-linked
+        run_date=date(2026, 6, 20),
+    )
+    tickers = {e.ticker for e in roster}
+    assert "TLT" not in tickers  # stale + unlinked → gated out
+    assert "XLE" in tickers  # thesis-linked → kept despite quiet
+
+
+@pytest.mark.unit
+def test_held_gate_keeps_material_move(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT"],
+        held={"TLT"},
+        price_deltas={"TLT": 0.02},
+        run_date=date(2026, 6, 20),
+    )
+    assert "TLT" in {e.ticker for e in roster}  # 2% move >= 0.5% → kept
+
+
+@pytest.mark.unit
+def test_held_gate_off_keeps_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    roster = compute_focus_roster(
+        watchlist=["TLT"],
+        held={"TLT"},
+        price_deltas={"TLT": 0.0},
+        run_date=date(2026, 6, 20),
+    )
+    assert "TLT" in {e.ticker for e in roster}  # kill-switch → always-analyze


### PR DESCRIPTION
Implements **Stage 1b** of the adaptive dispatch rework (plan PR #1024, umbrella #1017). Subagent-driven (4 tasks, per-task spec+quality reviews, final opus whole-branch review → READY TO MERGE).

## What changed (4 tasks)
1. `ExcludedTicker{ticker, reason}` model + `PhaseHermesState.focus_roster_excluded` slot (additive).
2. **Held staleness/delta gate** in `compute_focus_roster`: a held name is dispatched only if `HERMES_HELD_GATE` is "off" OR it has a linked thesis OR `abs(price_delta) >= HERMES_HELD_STALENESS_DELTA` (default 0.005). Gated-out held names are excluded from the technical pool (no re-admission).
3. **Excluded ledger** populated in the H4 node (`compute_focus_roster_excluded`) + `price_deltas` wired from `state.price_deltas`; `focus_roster` still emitted alongside.
4. Migrated the 7 held-always tests to the gated semantics via the `HERMES_HELD_GATE=off` kill-switch (assertions intact; `test_held_invariant.py` untouched).

## ⚠️ PRODUCT SIGN-OFF before promoting to main
This **changes production behavior, on by default**:
- On **delta runs**, quiet (`|Δ| < 0.5%`) held names **with no linked thesis stop being analyzed** (the anti-waste intent) and land in the excluded ledger.
- On **baseline/monthly runs `price_deltas` is empty**, so with the gate on, **every unlinked held name reads as quiet → gated out**. Confirm that's intended, or run those cadences with `HERMES_HELD_GATE=off`, or scope the gate to delta runs.
- Confirm the **0.5% threshold** (`HERMES_HELD_STALENESS_DELTA`).
- Reversible without deploy via `HERMES_HELD_GATE=off`.

## Scope notes
Ledger is **state-only** this branch (Task 5 / doc-persistence deferred — needs a new doc_type migration). `RosterPick` convergence deferred. Tests: 267 hermes pass; final review 3 minors all defer-safe.

Part of #1017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)