### PR TITLE
Promote develop → main: Stage 1b (held gate + excluded ledger)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -415,6 +415,13 @@ class FocusRosterEntry(BaseModel):
     rationale: str = ""
 
 
+class ExcludedTicker(BaseModel):
+    """A watchlist ticker that was NOT dispatched to an analyst, and why."""
+
+    ticker: str
+    reason: str
+
+
 class PhaseHermesState(BaseModel):
     """Thesis-first Hermes slots (H1–H9)."""
 
@@ -422,6 +429,7 @@ class PhaseHermesState(BaseModel):
     market_thesis_exploration: dict[str, Any] | None = None
     thesis_vehicle_map: dict[str, Any] | None = None
     focus_roster: list[FocusRosterEntry] = Field(default_factory=list)
+    focus_roster_excluded: list[ExcludedTicker] = Field(default_factory=list)
     asset_analysts: Annotated[dict[str, dict[str, Any]], _merge_right_wins_dict] = Field(
         default_factory=dict
     )

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -8,12 +8,13 @@ thesis-mapped vehicles from H3 and technical opportunity candidates. Replaces
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection, Iterable, Sequence
+import os
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import date
 from typing import Any  # noqa  # scored-lint suppression: heterogeneous graph / dict shapes
 from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 
-from digiquant.olympus.atlas.state import FocusRosterEntry
+from digiquant.olympus.atlas.state import ExcludedTicker, FocusRosterEntry
 from digiquant.olympus.atlas.supabase_io import SupabaseClient
 from digiquant.olympus.hermes.candidates import select_focus_tickers
 from digiquant.olympus.hermes.roster_cap import capped_tickers
@@ -23,6 +24,30 @@ logger = logging.getLogger(__name__)
 
 NODE_ID = "hermes/thesis/opportunity-screener"
 PHASE_NAME = "hermes_h4_opportunity_screener"
+
+
+def _held_passes_gate(
+    ticker: str,
+    linked_thesis_id: str | None,
+    price_deltas: Mapping[str, float] | None,
+) -> bool:
+    """Return True if a held ticker should be dispatched to the focus roster.
+
+    Gate is disabled (always-analyze) when ``HERMES_HELD_GATE=off``.
+    Otherwise, a held ticker passes when it has a linked thesis OR its absolute
+    price delta meets or exceeds the staleness threshold (``HERMES_HELD_STALENESS_DELTA``,
+    default 0.005 = 0.5%).
+    """
+    if os.environ.get("HERMES_HELD_GATE", "on").strip().lower() == "off":
+        return True
+    if linked_thesis_id:
+        return True
+    if not price_deltas:
+        # No delta signal at all this run (e.g. a baseline/monthly run, where price_deltas
+        # is empty) — staleness is unjudgeable, so don't gate; keep full held coverage (#1017).
+        return True
+    threshold = float(os.environ.get("HERMES_HELD_STALENESS_DELTA", "0.005"))
+    return abs((price_deltas or {}).get(ticker, 0.0)) >= threshold
 
 
 def extract_thesis_mappings(vehicle_map: dict[str, Any] | None) -> list[tuple[str, str, str]]:
@@ -53,6 +78,7 @@ def compute_focus_roster(
     watchlist: Sequence[str],
     held: Collection[str],
     thesis_mappings: Iterable[tuple[str, str, str]] = (),
+    price_deltas: Mapping[str, float] | None = None,
     run_date: date | None = None,
     client: SupabaseClient | None = None,
     top_n: int | None = None,
@@ -87,12 +113,23 @@ def compute_focus_roster(
             ),
         )
 
+    gated_out_held: set[str] = set()
     for ticker in normalized_watchlist:
         if ticker in held_set:
-            entry_by_ticker[ticker] = _held_entry(ticker)
+            tid_rat = thesis_by_ticker.get(ticker)
+            linked_thesis_id = tid_rat[0] if tid_rat else None
+            if _held_passes_gate(ticker, linked_thesis_id, price_deltas):
+                entry_by_ticker[ticker] = _held_entry(ticker)
+            else:
+                gated_out_held.add(ticker)
     for ticker in sorted(held_set):
-        if ticker not in entry_by_ticker:
-            entry_by_ticker[ticker] = _held_entry(ticker)
+        if ticker not in entry_by_ticker and ticker not in gated_out_held:
+            tid_rat = thesis_by_ticker.get(ticker)
+            linked_thesis_id = tid_rat[0] if tid_rat else None
+            if _held_passes_gate(ticker, linked_thesis_id, price_deltas):
+                entry_by_ticker[ticker] = _held_entry(ticker)
+            else:
+                gated_out_held.add(ticker)
 
     for thesis_id, ticker, _rationale in thesis_mappings:
         ticker = ticker.strip().upper()
@@ -105,7 +142,9 @@ def compute_focus_roster(
             rationale=_rationale,
         )
 
-    technical_pool = [t for t in normalized_watchlist if t not in entry_by_ticker]
+    technical_pool = [
+        t for t in normalized_watchlist if t not in entry_by_ticker and t not in gated_out_held
+    ]
     technical_picks: list[str] = []
     if technical_pool and run_date is not None:
         technical_picks = (
@@ -136,9 +175,37 @@ def compute_focus_roster(
         if ticker not in ordered_tickers:
             ordered_tickers.append(ticker)
 
-    protected = set(held_set) | {ticker for _, ticker, _ in thesis_mappings}
+    active_held = held_set - gated_out_held
+    protected = active_held | {ticker for _, ticker, _ in thesis_mappings}
     capped = capped_tickers(ordered_tickers, held=protected, min_new=min_new_candidates)
     return [entry_by_ticker[t] for t in capped]
+
+
+def compute_focus_roster_excluded(
+    watchlist: Sequence[str],
+    roster: list[FocusRosterEntry],
+    *,
+    held: Collection[str],
+) -> list[ExcludedTicker]:
+    """Return exclusion ledger entries for watchlist tickers NOT in the focus roster.
+
+    For each normalized watchlist ticker absent from *roster*:
+    - If the ticker is in *held*: reason = "held, no material change (below staleness threshold)".
+    - Otherwise: reason = "not thesis-mapped and below technical screen".
+    """
+    rostered = {e.ticker for e in roster}
+    held_upper = {str(t).strip().upper() for t in held if str(t).strip()}
+    excluded: list[ExcludedTicker] = []
+    for raw in watchlist:
+        ticker = str(raw).strip().upper()
+        if not ticker or ticker in rostered:
+            continue
+        if ticker in held_upper:
+            reason = "held, no material change (below staleness threshold)"
+        else:
+            reason = "not thesis-mapped and below technical screen"
+        excluded.append(ExcludedTicker(ticker=ticker, reason=reason))
+    return excluded
 
 
 def preview_focus_roster_tickers(
@@ -157,21 +224,32 @@ def preview_focus_roster_tickers(
 
 def _h4_node_factory(client: SupabaseClient | None):
     def _h4_node(state: HermesState) -> dict[str, Any]:
+        watchlist = list(state.config.watchlist)
+        held = holdings_from_state(state)
         mappings = extract_thesis_mappings(state.phase_hermes.thesis_vehicle_map)
         roster = compute_focus_roster(
-            watchlist=list(state.config.watchlist),
-            held=holdings_from_state(state),
+            watchlist=watchlist,
+            held=held,
             thesis_mappings=mappings,
+            price_deltas=dict(state.price_deltas),
             run_date=state.run_date,
             client=client,
         )
+        excluded = compute_focus_roster_excluded(watchlist, roster, held=held)
         logger.info(
             "H4 focus roster (%d): %s",
             len(roster),
             ", ".join(f"{e.ticker}:{e.roster_reason}" for e in roster),
         )
+        logger.info(
+            "H4 excluded ledger (%d): %s",
+            len(excluded),
+            ", ".join(e.ticker for e in excluded),
+        )
         return {
-            "phase_hermes": state.phase_hermes.model_copy(update={"focus_roster": roster}),
+            "phase_hermes": state.phase_hermes.model_copy(
+                update={"focus_roster": roster, "focus_roster_excluded": excluded}
+            ),
         }
 
     return _h4_node

--- a/docs/superpowers/plans/2026-06-24-adaptive-dispatch-stage1b.md
+++ b/docs/superpowers/plans/2026-06-24-adaptive-dispatch-stage1b.md
@@ -1,0 +1,161 @@
+# Adaptive Dispatch Stage 1b — Excluded Ledger + Held Staleness Gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record *why each watchlist name was NOT analyzed* (the excluded ledger — the missing half of anti-waste), and stop unconditionally re-analyzing held names that haven't materially moved (the held staleness/delta gate) — the two Stage-1b items deferred from Stage 1a.
+
+**Architecture:** Builds on Stage 1a (merged): `FocusRosterEntry` carries `rationale`; `compute_focus_roster` returns `list[FocusRosterEntry]`. Stage 1b adds (a) an `ExcludedTicker` record + a `focus_roster_excluded` slot on `PhaseHermesState`, populated in the H4 node and persisted; and (b) a staleness/delta gate so a held name is dispatched only when it has a material price move OR a linked thesis — otherwise it lands in the excluded ledger.
+
+**Tech Stack:** Python 3.12, Pydantic v2, pytest, LangGraph (graph wiring unchanged).
+
+## Global Constraints
+
+- Pydantic v2; strict typing; ruff line length 100; `ruff check` + `ruff format` clean.
+- New model fields/slots additive with defaults.
+- `compute_focus_roster` keeps return type `list[FocusRosterEntry]` (excluded ledger flows via a new state slot, not a return-type change).
+- Tests: `/Users/chrisstefan/Code/digithings/.venv/bin/python -m pytest <path> -v` (pytest.ini sets pythonpath); unit tests `@pytest.mark.unit`, `monkeypatch.setenv` for env.
+- Branch from `origin/develop` as `task/1017-...`; each task ends in a commit; TDD throughout.
+
+## ⚠️ Decisions needed before/at implementation (recommended defaults in brackets)
+
+1. **Held staleness threshold** — a held name with no linked thesis is dispatched only if `abs(price_delta) >= HELD_STALENESS_DELTA` . **[default `0.005` = 0.5% daily move; env `HERMES_HELD_STALENESS_DELTA`]**. Your call on the number.
+2. **Held-always invariant** — Stage 1b *intentionally relaxes* "every held name is always analyzed" to "held analyzed iff material move OR thesis-linked." Confirm this is desired (the existing `test_held_invariant` / `test_held_always_in_roster` are updated to the new semantics). A kill-switch env **[`HERMES_HELD_GATE=on|off`, default `on`]** lets ops revert to always-analyze without a deploy.
+3. **Excluded-ledger persistence** — store the ledger **[in a new `documents` row `doc_type` = "Focus Roster Ledger" via the existing publish path]**, or only on graph state? Default: persist a compact ledger doc so it's auditable on the dashboard.
+
+---
+
+## File Structure
+
+- `digiquant/src/digiquant/olympus/atlas/state.py` — add `ExcludedTicker` model + `focus_roster_excluded: list[ExcludedTicker]` to `PhaseHermesState`.
+- `digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py` — `compute_focus_roster` gains an optional `price_deltas` input + emits exclusions; the H4 node derives + persists the ledger.
+- `digiquant/src/digiquant/olympus/hermes/roster_cap.py` — unchanged (held-gate happens before capping).
+- `digiquant/src/digiquant/olympus/hermes/writers/` — a small `publish_focus_roster_ledger` writer (if decision 3 = persist).
+- Tests: `tests/dq/hermes/test_h4_focus_roster.py`, `tests/dq/hermes/test_held_invariant.py` (updated), `tests/dq/hermes/test_focus_roster_ledger.py` (new).
+
+---
+
+### Task 1: `ExcludedTicker` model + state slot
+
+**Files:** Modify `digiquant/src/digiquant/olympus/atlas/state.py`. Test: `tests/dq/hermes/test_h4_focus_roster.py`.
+
+**Interfaces — Produces:** `ExcludedTicker(ticker: str, reason: str)`; `PhaseHermesState.focus_roster_excluded: list[ExcludedTicker] = Field(default_factory=list)`.
+
+- [ ] **Step 1 — failing test**
+```python
+@pytest.mark.unit
+def test_excluded_ticker_and_state_slot() -> None:
+    from digiquant.olympus.atlas.state import ExcludedTicker, PhaseHermesState
+    e = ExcludedTicker(ticker="TLT", reason="held, no material change (Δ<0.5%)")
+    assert e.ticker == "TLT" and e.reason
+    assert PhaseHermesState().focus_roster_excluded == []
+```
+- [ ] **Step 2 — run, expect ImportError / attribute error.** `…/.venv/bin/python -m pytest tests/dq/hermes/test_h4_focus_roster.py::test_excluded_ticker_and_state_slot -v`
+- [ ] **Step 3 — implement**
+```python
+class ExcludedTicker(BaseModel):
+    """A watchlist ticker that was NOT dispatched to an analyst, and why."""
+    ticker: str
+    reason: str
+```
+Add to `PhaseHermesState`: `focus_roster_excluded: list[ExcludedTicker] = Field(default_factory=list)`.
+- [ ] **Step 4 — run, expect pass.** **Step 5 — commit** `feat(hermes): ExcludedTicker model + focus_roster_excluded slot (#1017)`
+
+---
+
+### Task 2: Held staleness/delta gate in `compute_focus_roster`
+
+**Files:** Modify `h4_opportunity_screener.py` (`compute_focus_roster` held loop). Test: `tests/dq/hermes/test_h4_focus_roster.py`.
+
+**Interfaces:**
+- Consumes: a new keyword `price_deltas: Mapping[str, float] | None = None` on `compute_focus_roster`; env `HERMES_HELD_STALENESS_DELTA` (default 0.005), `HERMES_HELD_GATE` (default "on").
+- Produces: a held ticker is included only if gate off, OR thesis-linked, OR `abs(price_deltas.get(ticker, 0)) >= threshold`; otherwise it is omitted from the roster (Task 3 records it as excluded). Return type unchanged.
+
+- [ ] **Step 1 — failing tests**
+```python
+@pytest.mark.unit
+def test_held_gate_drops_stale_unlinked_held(monkeypatch):
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT", "XLE"], held={"TLT", "XLE"},
+        thesis_mappings=[("T-OIL", "XLE", "oil")],
+        price_deltas={"TLT": 0.001, "XLE": 0.0},  # both quiet; XLE thesis-linked
+        run_date=date(2026, 6, 20),
+    )
+    tickers = {e.ticker for e in roster}
+    assert "TLT" not in tickers          # stale + unlinked → gated out
+    assert "XLE" in tickers              # thesis-linked → kept despite quiet
+
+@pytest.mark.unit
+def test_held_gate_keeps_material_move(monkeypatch):
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT"], held={"TLT"}, price_deltas={"TLT": 0.02},
+        run_date=date(2026, 6, 20))
+    assert "TLT" in {e.ticker for e in roster}   # 2% move ≥ 0.5% → kept
+
+@pytest.mark.unit
+def test_held_gate_off_keeps_all(monkeypatch):
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    roster = compute_focus_roster(
+        watchlist=["TLT"], held={"TLT"}, price_deltas={"TLT": 0.0},
+        run_date=date(2026, 6, 20))
+    assert "TLT" in {e.ticker for e in roster}   # kill-switch → always-analyze
+```
+- [ ] **Step 2 — run, expect fail** (`price_deltas` kwarg unknown / TLT still present).
+- [ ] **Step 3 — implement** a module helper + use it in the held loop:
+```python
+def _held_passes_gate(ticker: str, linked_thesis_id: str | None,
+                      price_deltas: Mapping[str, float] | None) -> bool:
+    if os.environ.get("HERMES_HELD_GATE", "on").strip().lower() == "off":
+        return True
+    if linked_thesis_id:
+        return True
+    threshold = float(os.environ.get("HERMES_HELD_STALENESS_DELTA", "0.005"))
+    return abs((price_deltas or {}).get(ticker, 0.0)) >= threshold
+```
+Add `price_deltas: Mapping[str, float] | None = None` to `compute_focus_roster`; in `_held_entry` insertion, only insert the held entry when `_held_passes_gate(...)` is True; collect gated-out held tickers for Task 3.
+- [ ] **Step 4 — run, expect pass.** **Step 5 — commit** `feat(hermes): held staleness/delta dispatch gate (#1017)`
+
+---
+
+### Task 3: Populate + emit the excluded ledger in the H4 node
+
+**Files:** Modify `h4_opportunity_screener.py` (`compute_focus_roster` returns/exposes exclusions to the node; `_h4_node` stores `focus_roster_excluded`). Wire `price_deltas` from `state.price_deltas`. Test: `tests/dq/hermes/test_h4_focus_roster.py`.
+
+**Interfaces:** `compute_focus_roster` additionally returns its exclusions — to avoid a return-type break, add a sibling `compute_focus_roster_excluded(watchlist, roster, *, held, price_deltas, gated_held) -> list[ExcludedTicker]` that the node calls; the node sets `state.phase_hermes.focus_roster_excluded`.
+
+- [ ] **Step 1 — failing test**: a watchlist of 3 where 1 is rostered, 1 is gated-out held, 1 is unscreened → `focus_roster_excluded` has 2 entries with non-empty reasons; the rostered one is absent from the ledger.
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** the sibling + node wiring (derive excluded = watchlist − rostered, reason per cause: "held, no material change", "not thesis-mapped and below technical screen", etc.); pass `price_deltas=dict(state.price_deltas)` into `compute_focus_roster`.
+- [ ] **Step 4 — run, expect pass.** **Step 5 — commit** `feat(hermes): populate focus_roster excluded ledger in H4 node (#1017)`
+
+---
+
+### Task 4: Update the held-always invariant tests to the gated semantics
+
+**Files:** Modify `tests/dq/hermes/test_held_invariant.py`, `tests/dq/hermes/test_h4_focus_roster.py::test_held_always_in_roster`.
+
+**Interfaces:** Consumes the gate from Task 2. The invariant becomes: a held name is in the roster iff (gate off) OR (thesis-linked) OR (material move); otherwise it's in `focus_roster_excluded`.
+
+- [ ] **Step 1 — rewrite the invariant tests** to assert the new semantics (held-with-material-move or thesis-link stays; stale-unlinked held moves to the ledger; with `HERMES_HELD_GATE=off`, all held stay). These are existing tests asserting the OLD always-in invariant — update them, do not delete (the gate is a deliberate behavior change, plan-mandated; see Decision 2).
+- [ ] **Step 2 — run** the two files, expect pass. **Step 3 — commit** `test(hermes): held invariant reflects staleness gate (#1017)`
+
+---
+
+### Task 5 (optional, gated on Decision 3): Persist the excluded ledger
+
+**Files:** new `publish_focus_roster_ledger` writer + H4/commit wiring; migration to allow `doc_type="Focus Roster Ledger"` (⚠️ prod-apply via the db-migrate gate). Test: `tests/dq/hermes/test_focus_roster_ledger.py`.
+
+- [ ] Add the doc_type to `chk_documents_doc_type` (new migration, applied to prod by the db-migrate gate); publish a compact `{date, rostered:[…], excluded:[{ticker,reason}]}` document; test the writer with `FakeSupabaseClient`. Commit `feat(hermes): persist focus-roster excluded ledger (#1017)`.
+
+> If Decision 3 = state-only, skip Task 5; the ledger lives on `phase_hermes.focus_roster_excluded` for downstream/PM use without a new doc_type.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** excluded ledger (Tasks 1–3, 5) + held staleness/delta gate (Tasks 2, 4) — the two Stage-1b deferrals. `RosterPick` full convergence remains a separate refactor (not behavior-changing; defer).
+- **Placeholders:** none — helper code + tests are concrete; the three genuinely-open product choices are isolated in "Decisions needed" with defaults so the plan is executable as written.
+- **Type consistency:** `compute_focus_roster` return type unchanged; exclusions flow via the new sibling + state slot; `_held_passes_gate` / `compute_focus_roster_excluded` names consistent across tasks.
+- **Risk:** Task 2 changes a tested invariant (held-always) — Task 4 updates those tests in lockstep, and the `HERMES_HELD_GATE=off` kill-switch makes the change reversible without a deploy.

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -19,7 +19,9 @@ _HELD = {"SPY", "IJR", "XLP"}
 @pytest.mark.unit
 class TestH4FocusRosterHeldInvariant:
     def test_held_always_in_roster(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With the staleness gate disabled, every held name must appear in the roster."""
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "4")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -28,7 +30,8 @@ class TestH4FocusRosterHeldInvariant:
         tickers = {e.ticker for e in roster}
         assert _HELD.issubset(tickers), f"held dropped from H4 roster: {_HELD - tickers}"
 
-    def test_held_entries_tagged_held(self) -> None:
+    def test_held_entries_tagged_held(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -63,6 +66,7 @@ class TestH4FocusRosterHeldInvariant:
 
     def test_held_over_cap_keeps_all_held(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=list(_BOOK),
             held=_HELD,
@@ -125,8 +129,11 @@ def test_compute_focus_roster_passes_client_to_technical_screen(
 class TestHeldAbsentFromSlate:
     """AC #3 (#950): a held name absent from the raw slate still appears."""
 
-    def test_held_ticker_not_in_watchlist_still_in_roster(self) -> None:
+    def test_held_ticker_not_in_watchlist_still_in_roster(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """IJR is held but NOT in the watchlist — must still appear in roster."""
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["AAA", "BBB", "CCC"],
             held={"IJR"},
@@ -135,8 +142,11 @@ class TestHeldAbsentFromSlate:
         tickers = {e.ticker for e in roster}
         assert "IJR" in tickers, "held ticker absent from watchlist was dropped"
 
-    def test_held_ticker_absent_from_slate_tagged_held(self) -> None:
+    def test_held_ticker_absent_from_slate_tagged_held(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Held ticker injected into roster must carry roster_reason='held'."""
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["AAA", "BBB"],
             held={"XLF"},
@@ -197,6 +207,7 @@ class TestNewCandidateReservation:
     ) -> None:
         """Cap=3, 3 held, 0 non-held watchlist — held-only roster is fine."""
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "3")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["SPY", "IJR", "XLP"],
             held={"SPY", "IJR", "XLP"},
@@ -214,6 +225,7 @@ class TestNewCandidateReservation:
         and no new candidates can be reserved; that is acceptable.
         """
         monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        monkeypatch.setenv("HERMES_HELD_GATE", "off")
         roster = compute_focus_roster(
             watchlist=["SPY", "IJR", "XLP", "NEW1"],
             held={"SPY", "IJR", "XLP"},
@@ -253,6 +265,15 @@ def test_technical_entry_carries_rationale(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.unit
+def test_excluded_ticker_and_state_slot() -> None:
+    from digiquant.olympus.atlas.state import ExcludedTicker, PhaseHermesState
+
+    e = ExcludedTicker(ticker="TLT", reason="held, no material change (Δ<0.5%)")
+    assert e.ticker == "TLT" and e.reason
+    assert PhaseHermesState().focus_roster_excluded == []
+
+
+@pytest.mark.unit
 def test_extract_thesis_mappings_carries_rationale() -> None:
     from digiquant.olympus.hermes.phases.h4_opportunity_screener import extract_thesis_mappings
 
@@ -270,3 +291,131 @@ def test_extract_thesis_mappings_carries_rationale() -> None:
     out = extract_thesis_mappings(vmap)
     assert ("T1", "XLE", "oil supply squeeze") in out
     assert ("T1", "USO", "oil supply squeeze") in out
+
+
+# ---------------------------------------------------------------------------
+# Stage 1b Task 2: held staleness/delta dispatch gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_held_gate_drops_stale_unlinked_held(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT", "XLE"],
+        held={"TLT", "XLE"},
+        thesis_mappings=[("T-OIL", "XLE", "oil")],
+        price_deltas={"TLT": 0.001, "XLE": 0.0},  # both quiet; XLE thesis-linked
+        run_date=date(2026, 6, 20),
+    )
+    tickers = {e.ticker for e in roster}
+    assert "TLT" not in tickers  # stale + unlinked → gated out
+    assert "XLE" in tickers  # thesis-linked → kept despite quiet
+
+
+@pytest.mark.unit
+def test_held_gate_keeps_material_move(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    roster = compute_focus_roster(
+        watchlist=["TLT"],
+        held={"TLT"},
+        price_deltas={"TLT": 0.02},
+        run_date=date(2026, 6, 20),
+    )
+    assert "TLT" in {e.ticker for e in roster}  # 2% move >= 0.5% → kept
+
+
+@pytest.mark.unit
+def test_held_gate_off_keeps_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    roster = compute_focus_roster(
+        watchlist=["TLT"],
+        held={"TLT"},
+        price_deltas={"TLT": 0.0},
+        run_date=date(2026, 6, 20),
+    )
+    assert "TLT" in {e.ticker for e in roster}  # kill-switch → always-analyze
+
+
+@pytest.mark.unit
+def test_held_gate_no_signal_keeps_held(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No delta signal at all this run (e.g. a baseline/monthly run where price_deltas is
+    # empty) → the gate can't judge staleness, so it must NOT gate out held names (#1017).
+    monkeypatch.setenv("HERMES_HELD_GATE", "on")
+    roster = compute_focus_roster(
+        watchlist=["TLT", "AGG"],
+        held={"TLT", "AGG"},
+        price_deltas={},  # empty → no signal
+        run_date=date(2026, 6, 20),
+    )
+    assert {"TLT", "AGG"}.issubset({e.ticker for e in roster})
+
+
+# ---------------------------------------------------------------------------
+# Stage 1b Task 3: populate + emit the excluded ledger in the H4 node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_focus_roster_excluded_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Watchlist of 3: 1 rostered, 1 gated-out held, 1 below-screen (client returns empty).
+
+    ``compute_focus_roster_excluded`` must return exactly 2 ExcludedTicker
+    entries (the non-rostered ones) with non-empty reasons.  The rostered
+    ticker must be absent from the ledger.
+    """
+    from digiquant.olympus.atlas.state import ExcludedTicker
+    from digiquant.olympus.hermes.phases.h4_opportunity_screener import (
+        compute_focus_roster_excluded,
+    )
+    from tests.dq.atlas.test_supabase_io import FakeSupabaseClient
+
+    monkeypatch.setenv("HERMES_HELD_STALENESS_DELTA", "0.005")
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "10")
+
+    # A stub client that selects nothing — QQQ stays below-screen.
+    def _stub_select(*, client: object, watchlist: list[str], **kwargs: object) -> list[str]:
+        return []
+
+    monkeypatch.setattr(
+        "digiquant.olympus.hermes.phases.h4_opportunity_screener.select_focus_tickers",
+        _stub_select,
+    )
+
+    # Build the roster: SPY is thesis-mapped → rostered; TLT is gated-out held
+    # (quiet, no thesis link); QQQ fails the technical screen → excluded.
+    watchlist = ["SPY", "TLT", "QQQ"]
+    held = {"TLT"}
+
+    roster = compute_focus_roster(
+        watchlist=watchlist,
+        held=held,
+        thesis_mappings=[("T-US", "SPY", "US equity core")],
+        price_deltas={"TLT": 0.001},  # below 0.5% threshold → gated out
+        run_date=date(2026, 6, 20),
+        client=FakeSupabaseClient(),
+    )
+
+    rostered_tickers = {e.ticker for e in roster}
+    assert "SPY" in rostered_tickers, "thesis-mapped SPY must survive"
+    assert "TLT" not in rostered_tickers, "gated-out held TLT must be excluded"
+    assert "QQQ" not in rostered_tickers, "below-screen QQQ must be excluded"
+
+    excluded = compute_focus_roster_excluded(watchlist, roster, held=held)
+
+    assert isinstance(excluded, list)
+    assert all(isinstance(e, ExcludedTicker) for e in excluded)
+
+    excluded_tickers = {e.ticker for e in excluded}
+    assert "SPY" not in excluded_tickers, "rostered ticker must not appear in excluded ledger"
+    assert "TLT" in excluded_tickers, "gated-out held must appear in excluded ledger"
+    assert "QQQ" in excluded_tickers, "below-screen ticker must appear in excluded ledger"
+
+    # Every excluded entry must carry a non-empty human-readable reason.
+    for entry in excluded:
+        assert entry.reason, f"empty reason for {entry.ticker}"
+
+    # Reason for gated-out held must hint at the held+staleness cause.
+    tlt_entry = next(e for e in excluded if e.ticker == "TLT")
+    assert "held" in tlt_entry.reason.lower() or "material" in tlt_entry.reason.lower()


### PR DESCRIPTION
Production promotion of Stage 1b (#1026 impl + #1024 plan).

**Goes live on main:**
- **Held staleness/delta gate** (`HERMES_HELD_GATE` default on, `HERMES_HELD_STALENESS_DELTA` default 0.5%): on **delta runs**, quiet (`|Δ|<0.5%`) held names with no linked thesis stop being analyzed (anti-waste). The **no-signal safeguard** keeps baseline/monthly runs (empty `price_deltas`) fully covered. Reversible via `HERMES_HELD_GATE=off`.
- **Excluded ledger** (`focus_roster_excluded` on graph state) — records why each watchlist name wasn't dispatched. State-only (dashboard persistence deferred).

Reviewed (per-task + opus whole-branch: READY TO MERGE); 267 hermes tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)