### PR TITLE
fix(atlas): document delta doc_type case mismatch (#1010)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -282,7 +282,10 @@ def publish_document_delta(
         client=client,
         document_key=delta_key,
         payload=patch,
-        doc_type="document_delta",
+        # Title-Case to satisfy chk_documents_doc_type (#1010); the snake_case
+        # "document_delta" lives only inside the patch payload (the DocumentPatch
+        # model discriminator), never in the documents.doc_type column.
+        doc_type="Document Delta",
         run_type=run_type,
         title=f"delta {target_document_key} {date_str}",
         date_str=date_str,

--- a/tests/dq/atlas/test_migration_045.py
+++ b/tests/dq/atlas/test_migration_045.py
@@ -19,9 +19,7 @@ from pathlib import Path
 
 import pytest
 
-MIGRATIONS_DIR = (
-    Path(__file__).resolve().parents[3] / "digiquant" / "supabase" / "migrations"
-)
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "digiquant" / "supabase" / "migrations"
 COMMIT_IO = (
     Path(__file__).resolve().parents[3]
     / "digiquant"
@@ -31,6 +29,15 @@ COMMIT_IO = (
     / "hermes"
     / "writers"
     / "commit_io.py"
+)
+SUPABASE_IO = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "src"
+    / "digiquant"
+    / "olympus"
+    / "atlas"
+    / "supabase_io.py"
 )
 
 # Full allow-list as of migration 043 — 045 must preserve every entry (no regression),
@@ -129,6 +136,27 @@ class TestDocTypeConstraintPermitsPmDirectionMemo:
         assert literals, "expected at least one doc_type= literal in commit_io.py"
         disallowed = literals - allowed
         assert not disallowed, (
-            f"commit_io.py writes doc_type(s) not in chk_documents_doc_type: "
-            f"{sorted(disallowed)}"
+            f"commit_io.py writes doc_type(s) not in chk_documents_doc_type: {sorted(disallowed)}"
+        )
+
+    def test_supabase_io_doc_type_literals_are_constraint_allowed(
+        self, latest: tuple[Path, frozenset[str]]
+    ) -> None:
+        """Every doc_type literal supabase_io.py writes must be DB-allowed.
+
+        Regression guard for #1010: ``publish_document_delta`` wrote the
+        snake_case ``doc_type="document_delta"`` while the constraint only
+        permits the Title-Case ``"Document Delta"`` (cf. its siblings
+        ``"Daily Delta"`` / ``"Research Delta"``). The FakeSupabaseClient in
+        unit tests does not enforce ``chk_documents_doc_type``, so the mismatch
+        only surfaced as APIError 23514 in production. This static scan — the
+        same guard already applied to commit_io.py — catches the whole class.
+        """
+        _path, allowed = latest
+        src = SUPABASE_IO.read_text(encoding="utf-8")
+        literals = set(re.findall(r'doc_type="([^"]+)"', src))
+        assert literals, "expected at least one doc_type= literal in supabase_io.py"
+        disallowed = literals - allowed
+        assert not disallowed, (
+            f"supabase_io.py writes doc_type(s) not in chk_documents_doc_type: {sorted(disallowed)}"
         )

--- a/tests/dq/atlas/test_publish_phase.py
+++ b/tests/dq/atlas/test_publish_phase.py
@@ -174,6 +174,10 @@ class TestPublishNode:
         ]
         assert len(delta_rows) == 1
         assert delta_rows[0]["document_key"] == "document-deltas/macro"
+        # The audit row's *column* doc_type must be the constraint-allowed
+        # Title-Case value (#1010); the snake_case form lives only inside the
+        # patch payload (the DocumentPatch model discriminator) and is unchanged.
+        assert delta_rows[0]["doc_type"] == "Document Delta"
         assert delta_rows[0]["payload"]["doc_type"] == "document_delta"
 
     def test_writes_one_daily_snapshot_row(self) -> None:


### PR DESCRIPTION
## What

`publish_document_delta` wrote the `documents.doc_type` **column** as snake_case `"document_delta"`, which is **not** in the `chk_documents_doc_type` CHECK constraint. The constraint permits the Title-Case `"Document Delta"` (consistent with its siblings `"Daily Delta"` / `"Research Delta"`).

## Impact (surfaced by the 2026-06-24 validation run on main)

Run `28112047951` (`run_type: delta`) reported `ok:true, book_materialized:true` but **`degraded:true`** — the `publish-supabase` terminal phase raised `APIError 23514` (`violates check constraint "chk_documents_doc_type"`) on every document-delta row, so **document deltas were silently never persisted**. Pre-existing; not a Stage 1a/1b regression.

## Why tests missed it

`FakeSupabaseClient` (unit tests) does not enforce the CHECK constraint, so the bad column value passed silently. The existing `test_publishes_document_delta_audit_rows` only asserted the *payload* `doc_type`, never the *column*.

## Fix

- `supabase_io.py`: retitle the **column** write to `"Document Delta"`. **No migration** — the value already exists in the constraint. The snake_case `"document_delta"` correctly remains inside the patch **payload** (the `DocumentPatch` model discriminator + JSON schema `const`) — unchanged; no reader filters the column on the lowercase form.
- `test_migration_045.py`: extend the existing static doc_type-literal scanner to cover `supabase_io.py` (the same guard already applied to `commit_io.py`) — catches the whole class of case/format mismatches.
- `test_publish_phase.py`: assert the delta audit row's **column** `doc_type == "Document Delta"`.

## Verification

- TDD: both new assertions RED before the fix, GREEN after.
- `make score`: 10/10 all dimensions (Security/Quality/Optimization/Accuracy).
- ruff check + format clean; 69 related tests green (publish_phase, migration_045, edit_mode, segment_edit_mode).

Fixes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)