### PR TITLE
fix(olympus): doc_type case mismatch + held-gate commit-run carry (#1010, #1030)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -465,6 +465,7 @@ def _merge_phase_hermes(
         "market_thesis_exploration",
         "thesis_vehicle_map",
         "focus_roster",
+        "focus_roster_excluded",
         "pm_direction_memo",
         "sized_book",
         "commit_manifest",

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -282,7 +282,10 @@ def publish_document_delta(
         client=client,
         document_key=delta_key,
         payload=patch,
-        doc_type="document_delta",
+        # Title-Case to satisfy chk_documents_doc_type (#1010); the snake_case
+        # "document_delta" lives only inside the patch payload (the DocumentPatch
+        # model discriminator), never in the documents.doc_type column.
+        doc_type="Document Delta",
         run_type=run_type,
         title=f"delta {target_document_key} {date_str}",
         date_str=date_str,

--- a/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
+++ b/digiquant/src/digiquant/olympus/atlas/testing/simulator.py
@@ -609,7 +609,11 @@ def build_quiet_day_canned_extras(
             }
         )
         positions.append({"date": prior_date, "ticker": ticker, "weight_pct": 50.0, "shares": 10})
-        # Held names: ~2% move triggers H5 ``edit`` (above 1.5% quiet threshold).
+        # Held names are quiet: prior_date close == two_days_ago close (0% delta).
+        # query_price_deltas reads strictly before run_date (``.lt(date, run_date)``),
+        # so the run_date 102.0 close is invisible to the staleness gate — it only
+        # affects the NAV calc. Delta 0.0 < 0.5% threshold → gated out of H5 and
+        # carried, not re-analyzed (Stage 1b held gate, #1030).
         price_history.extend(
             [
                 CannedPriceHistoryRow(date=two_days_ago, ticker=ticker, close=100.0),

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -187,19 +187,27 @@ def compute_focus_roster_excluded(
     *,
     held: Collection[str],
 ) -> list[ExcludedTicker]:
-    """Return exclusion ledger entries for watchlist tickers NOT in the focus roster.
+    """Return exclusion ledger entries for tickers NOT in the focus roster.
 
-    For each normalized watchlist ticker absent from *roster*:
+    Considers the union of the watchlist and *held* — a prior-book holding is not
+    necessarily on today's watchlist (the watchlist is the research universe; the
+    book is what we own), yet a quiet held name gated out of the roster must still
+    be recorded so commit-run can carry it instead of failing closed (#1030).
+
+    For each candidate ticker absent from *roster*:
     - If the ticker is in *held*: reason = "held, no material change (below staleness threshold)".
     - Otherwise: reason = "not thesis-mapped and below technical screen".
     """
     rostered = {e.ticker for e in roster}
     held_upper = {str(t).strip().upper() for t in held if str(t).strip()}
+    candidates = [str(raw).strip().upper() for raw in watchlist]
+    candidates += sorted(held_upper)  # held names not on the watchlist (deduped below)
     excluded: list[ExcludedTicker] = []
-    for raw in watchlist:
-        ticker = str(raw).strip().upper()
-        if not ticker or ticker in rostered:
+    seen: set[str] = set()
+    for ticker in candidates:
+        if not ticker or ticker in rostered or ticker in seen:
             continue
+        seen.add(ticker)
         if ticker in held_upper:
             reason = "held, no material change (below staleness threshold)"
         else:

--- a/digiquant/src/digiquant/olympus/hermes/writers/commit_io.py
+++ b/digiquant/src/digiquant/olympus/hermes/writers/commit_io.py
@@ -473,11 +473,24 @@ def flat_tickers_from_memo(state: AtlasResearchState) -> set[str]:
     return flats
 
 
+def gated_out_tickers(state: AtlasResearchState) -> set[str]:
+    """Held names deliberately not dispatched to H5 (Stage 1b staleness gate, #1030).
+
+    The H4 staleness/delta gate records a quiet, unlinked held name in
+    ``focus_roster_excluded`` instead of dispatching an analyst. The position is
+    still carried in the book at its prior weight — "we own it and nothing
+    material changed" is its decision — so commit-run treats it as an intentional
+    carry, not a missing analyst doc.
+    """
+    return {e.ticker.strip().upper() for e in state.phase_hermes.focus_roster_excluded if e.ticker}
+
+
 def coherence_errors(state: AtlasResearchState, weights: dict[str, float]) -> list[str]:
     """Fail-closed checks before terminal write."""
     errors: list[str] = []
     flats = flat_tickers_from_memo(state)
     analysts = set(analyst_payloads(state).keys())
+    gated = gated_out_tickers(state)
 
     for ticker in held_tickers(state):
         if weights.get(ticker, 0.0) <= 0 and ticker not in flats:
@@ -486,7 +499,11 @@ def coherence_errors(state: AtlasResearchState, weights: dict[str, float]) -> li
     for ticker, weight in weights.items():
         if weight <= 0:
             continue
-        if ticker not in analysts and ticker not in flats:
+        # A deliberately-gated held name (#1030) is a carry: no fresh analyst doc
+        # is expected. The exemption only suppresses errors for names H4 chose not
+        # to re-analyze; a genuine missing-doc gap (not in the excluded ledger)
+        # still fails closed.
+        if ticker not in analysts and ticker not in flats and ticker not in gated:
             errors.append(f"open position {ticker} lacks H5 analyst doc and is not flat in H7")
 
     return errors

--- a/digiquant/src/digiquant/olympus/hermes/writers/commit_io.py
+++ b/digiquant/src/digiquant/olympus/hermes/writers/commit_io.py
@@ -474,15 +474,24 @@ def flat_tickers_from_memo(state: AtlasResearchState) -> set[str]:
 
 
 def gated_out_tickers(state: AtlasResearchState) -> set[str]:
-    """Held names deliberately not dispatched to H5 (Stage 1b staleness gate, #1030).
+    """HELD names deliberately not dispatched to H5 (Stage 1b staleness gate, #1030).
 
     The H4 staleness/delta gate records a quiet, unlinked held name in
     ``focus_roster_excluded`` instead of dispatching an analyst. The position is
     still carried in the book at its prior weight — "we own it and nothing
     material changed" is its decision — so commit-run treats it as an intentional
     carry, not a missing analyst doc.
+
+    Intersected with :func:`held_tickers` so ONLY held carries are exempt: the
+    ledger also records non-held below-screen names, and one of those reaching the
+    book with a positive weight (a stray name never analyzed) must still fail
+    closed — the exemption is a held-carry pass, not a blanket "anything in the
+    ledger" pass.
     """
-    return {e.ticker.strip().upper() for e in state.phase_hermes.focus_roster_excluded if e.ticker}
+    excluded = {
+        e.ticker.strip().upper() for e in state.phase_hermes.focus_roster_excluded if e.ticker
+    }
+    return excluded & held_tickers(state)
 
 
 def coherence_errors(state: AtlasResearchState, weights: dict[str, float]) -> list[str]:

--- a/tests/dq/atlas/test_migration_045.py
+++ b/tests/dq/atlas/test_migration_045.py
@@ -19,9 +19,7 @@ from pathlib import Path
 
 import pytest
 
-MIGRATIONS_DIR = (
-    Path(__file__).resolve().parents[3] / "digiquant" / "supabase" / "migrations"
-)
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "digiquant" / "supabase" / "migrations"
 COMMIT_IO = (
     Path(__file__).resolve().parents[3]
     / "digiquant"
@@ -31,6 +29,15 @@ COMMIT_IO = (
     / "hermes"
     / "writers"
     / "commit_io.py"
+)
+SUPABASE_IO = (
+    Path(__file__).resolve().parents[3]
+    / "digiquant"
+    / "src"
+    / "digiquant"
+    / "olympus"
+    / "atlas"
+    / "supabase_io.py"
 )
 
 # Full allow-list as of migration 043 — 045 must preserve every entry (no regression),
@@ -129,6 +136,27 @@ class TestDocTypeConstraintPermitsPmDirectionMemo:
         assert literals, "expected at least one doc_type= literal in commit_io.py"
         disallowed = literals - allowed
         assert not disallowed, (
-            f"commit_io.py writes doc_type(s) not in chk_documents_doc_type: "
-            f"{sorted(disallowed)}"
+            f"commit_io.py writes doc_type(s) not in chk_documents_doc_type: {sorted(disallowed)}"
+        )
+
+    def test_supabase_io_doc_type_literals_are_constraint_allowed(
+        self, latest: tuple[Path, frozenset[str]]
+    ) -> None:
+        """Every doc_type literal supabase_io.py writes must be DB-allowed.
+
+        Regression guard for #1010: ``publish_document_delta`` wrote the
+        snake_case ``doc_type="document_delta"`` while the constraint only
+        permits the Title-Case ``"Document Delta"`` (cf. its siblings
+        ``"Daily Delta"`` / ``"Research Delta"``). The FakeSupabaseClient in
+        unit tests does not enforce ``chk_documents_doc_type``, so the mismatch
+        only surfaced as APIError 23514 in production. This static scan — the
+        same guard already applied to commit_io.py — catches the whole class.
+        """
+        _path, allowed = latest
+        src = SUPABASE_IO.read_text(encoding="utf-8")
+        literals = set(re.findall(r'doc_type="([^"]+)"', src))
+        assert literals, "expected at least one doc_type= literal in supabase_io.py"
+        disallowed = literals - allowed
+        assert not disallowed, (
+            f"supabase_io.py writes doc_type(s) not in chk_documents_doc_type: {sorted(disallowed)}"
         )

--- a/tests/dq/atlas/test_publish_phase.py
+++ b/tests/dq/atlas/test_publish_phase.py
@@ -174,6 +174,10 @@ class TestPublishNode:
         ]
         assert len(delta_rows) == 1
         assert delta_rows[0]["document_key"] == "document-deltas/macro"
+        # The audit row's *column* doc_type must be the constraint-allowed
+        # Title-Case value (#1010); the snake_case form lives only inside the
+        # patch payload (the DocumentPatch model discriminator) and is unchanged.
+        assert delta_rows[0]["doc_type"] == "Document Delta"
         assert delta_rows[0]["payload"]["doc_type"] == "document_delta"
 
     def test_writes_one_daily_snapshot_row(self) -> None:

--- a/tests/dq/atlas/test_simulator_gates.py
+++ b/tests/dq/atlas/test_simulator_gates.py
@@ -5,8 +5,9 @@ Gate thresholds (spec §12.2 / §16 ``test_quiet_day``) — re-baselined 2026-06
   from phase5 sector bypass until #929 triage wiring lands).
 - ``QUIET_DAY_MIN_PATCH_RATIO`` ≥ 0.10 — patch calls are a minority until phase5 respects
   triage carry; numerator still gates mandatory δ ``DocumentPatch`` paths.
-- Hermes quiet path: H1 thesis review + held-ticker H5 edits; H6 deliberation skipped when
-  analyst stance is unchanged.
+- Hermes quiet path: H1 thesis review runs; a quiet, unlinked held name is gated out of
+  H5 (Stage 1b staleness gate, #1030) and carried by commit-run, not re-analyzed; H6
+  deliberation skipped when analyst stance is unchanged.
 """
 
 from __future__ import annotations
@@ -132,12 +133,13 @@ class TestQuietDayGates:
         # may converge, so a single fresh deliberation now also runs one analyst turn.
         assert telemetry.by_schema.get("DeliberationAnalystTurn", 0) <= 1
 
-        # Held ticker H5: at least one analyst/patch call for AAPL.
-        h5_calls = telemetry.by_schema.get("AnalystPayload", 0) + telemetry.by_schema.get(
-            "DocumentPatch", 0
-        )
-        assert h5_calls >= 1
-        assert "AAPL" in final.phase_hermes.asset_analysts
+        # Stage 1b held staleness gate (#1017 / #1030): a quiet, unlinked held name is
+        # NOT re-analyzed — H4 records it in the excluded ledger and dispatches no H5,
+        # and H9 commit-run carries the position rather than failing closed on a missing
+        # analyst doc. (Pre-Stage-1b this path ran a cheap held-ticker H5 edit; the gate
+        # eliminates that re-analysis as the anti-waste win.)
+        assert "AAPL" not in final.phase_hermes.asset_analysts
+        assert "AAPL" in {e.ticker for e in final.phase_hermes.focus_roster_excluded}
 
         # Gate: edit-mode patch calls for mandatory δ segments (macro/crypto/equity).
         assert telemetry.by_schema.get("DocumentPatch", 0) >= 3

--- a/tests/dq/atlas/test_state.py
+++ b/tests/dq/atlas/test_state.py
@@ -14,15 +14,50 @@ from digiquant.olympus.atlas.state import (
     DataLayerSnapshot,
     DeltaTriageDecision,
     DeltaTriageResult,
+    ExcludedTicker,
+    FocusRosterEntry,
     PhaseError,
+    PhaseHermesState,
     PriorContext,
     PublishedArtifact,
     SegmentPayload,
     SegmentSlot,
     SegmentSlotCollisionError,
+    _merge_phase_hermes,
     _merge_right_wins_dict,
     _merge_segment_dict,
 )
+
+
+@pytest.mark.unit
+class TestMergePhaseHermes:
+    """Reducer for nested ``phase_hermes`` writes across H4–H9 (#1030)."""
+
+    def test_preserves_focus_roster_excluded_from_right(self) -> None:
+        """H4 writes the excluded ledger as the *right* operand; the reducer must
+        carry it forward, not drop it to ``left``'s empty default (#1030).
+
+        Before the fix, ``focus_roster_excluded`` was absent from the reducer's
+        field list, so the ledger H4 produced was silently lost before H9
+        commit-run read it — orphaning gated-out held positions.
+        """
+        left = PhaseHermesState()  # prior state, no ledger yet
+        right = PhaseHermesState(  # H4's write
+            focus_roster=[FocusRosterEntry(ticker="SPY", roster_reason="held")],
+            focus_roster_excluded=[ExcludedTicker(ticker="AAPL", reason="held, quiet")],
+        )
+        merged = _merge_phase_hermes(left, right)
+        assert [e.ticker for e in merged.focus_roster_excluded] == ["AAPL"]
+
+    def test_later_phase_does_not_clobber_existing_ledger(self) -> None:
+        """A downstream phase (right) with no ledger must not wipe H4's ledger (left)."""
+        left = PhaseHermesState(
+            focus_roster_excluded=[ExcludedTicker(ticker="AAPL", reason="held, quiet")],
+        )
+        right = PhaseHermesState(asset_analysts={"SPY": {"ticker": "SPY"}})
+        merged = _merge_phase_hermes(left, right)
+        assert [e.ticker for e in merged.focus_roster_excluded] == ["AAPL"]
+        assert "SPY" in merged.asset_analysts
 
 
 @pytest.mark.unit

--- a/tests/dq/hermes/test_commit_run.py
+++ b/tests/dq/hermes/test_commit_run.py
@@ -12,6 +12,7 @@ from digiquant.olympus.atlas.state import (
     ExcludedTicker,
     FocusRosterEntry,
     PhaseHermesState,
+    PriorContext,
 )
 from digiquant.olympus.hermes.models.pm_direction import PMDirectionMemo, TickerDirection
 from digiquant.olympus.hermes.phases.h9_commit_run import CommitRunDeps, build_commit_run_node
@@ -37,21 +38,29 @@ def _state(
     with_sized_book: bool = True,
     sized_book: dict | None = None,
     held: tuple[str, ...] = (),
+    prior_book_held: tuple[str, ...] = (),
     excluded: tuple[str, ...] = (),
+    excluded_reason: str = "held, no material change (below staleness threshold)",
     analysts: dict | None = None,
     pm_memo: PMDirectionMemo | None = None,
 ) -> AtlasResearchState:
+    # Prior-book holdings make a name "held" without putting it in the roster — the
+    # real shape of a gated-out held position (held in the book, excluded from H5).
+    # PriorContext is frozen, so it must be built at construction time.
+    prior_context = (
+        PriorContext(prior_book=[{"ticker": t, "weight_pct": 0.0} for t in prior_book_held])
+        if prior_book_held
+        else PriorContext()
+    )
     state = AtlasResearchState(
         run_id=_SOURCE_RUN_ID,
         run_type="delta",
         run_date=RUN_DATE,
         baseline_date=date(2026, 6, 9),
+        prior_context=prior_context,
     )
     roster = [FocusRosterEntry(ticker=t, roster_reason="held") for t in held]
-    excluded_ledger = [
-        ExcludedTicker(ticker=t, reason="held, no material change (below staleness threshold)")
-        for t in excluded
-    ]
+    excluded_ledger = [ExcludedTicker(ticker=t, reason=excluded_reason) for t in excluded]
     hermes_fields: dict = dict(
         focus_roster=roster,
         focus_roster_excluded=excluded_ledger,
@@ -222,11 +231,11 @@ class TestCommitRunCoherence:
         """A held position deliberately gated out of H5 (Stage 1b staleness gate) is
         carried, not orphaned (#1030).
 
-        The held name is below the staleness threshold, so H4 records it in
-        ``focus_roster_excluded`` and dispatches no analyst. The position is still
-        carried in the book (weight > 0) and is not flat — without the carry
-        exemption, ``coherence_errors`` would fail-close with "lacks H5 analyst doc",
-        which is exactly the live regression that broke the quiet-day path.
+        AAPL is a prior-book holding (held) below the staleness threshold, so H4
+        records it in ``focus_roster_excluded`` and dispatches no analyst. The
+        position is still carried in the book (weight > 0) and is not flat — without
+        the held-carry exemption, ``coherence_errors`` would fail-close with "lacks
+        H5 analyst doc", the live regression that broke the quiet-day path.
         """
         client = FakeSupabaseClient()
         state = _state(
@@ -248,6 +257,7 @@ class TestCommitRunCoherence:
                     "sources": [],
                 }
             },
+            prior_book_held=("AAPL",),  # AAPL is genuinely held (prior book), not just excluded
             excluded=("AAPL",),  # gated out of H5 as a quiet held name — carried, not flat
             pm_memo=PMDirectionMemo(
                 date=RUN_DATE,
@@ -258,6 +268,46 @@ class TestCommitRunCoherence:
         assert not out.get("errors"), out.get("errors")
         manifest = (out.get("phase_hermes") or PhaseHermesState()).commit_manifest or {}
         assert manifest.get("status") == "committed"
+
+    def test_non_held_excluded_ticker_still_fails_closed(self) -> None:
+        """The carry exemption is HELD-only (#1030 review).
+
+        A non-held watchlist name in the excluded ledger (reason: below technical
+        screen) that nonetheless lands in the book with a positive weight and no
+        analyst doc must STILL fail closed — it was never owned, so it is not a
+        carry. Guards against over-broadening the fail-closed exemption.
+        """
+        client = FakeSupabaseClient()
+        state = _state(
+            sized_book={
+                "recommended_portfolio": [
+                    {"ticker": "SPY", "target_pct": 60.0},
+                    {"ticker": "QQQ", "target_pct": 40.0},
+                ],
+                "actions": [],
+                "notes": "",
+            },
+            analysts={
+                "SPY": {
+                    "ticker": "SPY",
+                    "stance": "buy",
+                    "conviction_score": 4,
+                    "thesis": "x",
+                    "risks": "",
+                    "sources": [],
+                }
+            },
+            # QQQ is in the ledger but NOT held — a below-screen name, not a carry.
+            excluded=("QQQ",),
+            excluded_reason="not thesis-mapped and below technical screen",
+            pm_memo=PMDirectionMemo(
+                date=RUN_DATE,
+                roster=[TickerDirection(ticker="SPY", direction="long", conviction_rank=1)],
+            ),
+        )
+        result = _run(client, state)
+        assert result.get("errors"), "non-held excluded ticker with weight must fail closed"
+        assert "positions" not in client.store
 
 
 class TestCommitRunIdempotency:

--- a/tests/dq/hermes/test_commit_run.py
+++ b/tests/dq/hermes/test_commit_run.py
@@ -9,6 +9,7 @@ import pytest
 
 from digiquant.olympus.atlas.state import (
     AtlasResearchState,
+    ExcludedTicker,
     FocusRosterEntry,
     PhaseHermesState,
 )
@@ -36,6 +37,7 @@ def _state(
     with_sized_book: bool = True,
     sized_book: dict | None = None,
     held: tuple[str, ...] = (),
+    excluded: tuple[str, ...] = (),
     analysts: dict | None = None,
     pm_memo: PMDirectionMemo | None = None,
 ) -> AtlasResearchState:
@@ -46,8 +48,13 @@ def _state(
         baseline_date=date(2026, 6, 9),
     )
     roster = [FocusRosterEntry(ticker=t, roster_reason="held") for t in held]
+    excluded_ledger = [
+        ExcludedTicker(ticker=t, reason="held, no material change (below staleness threshold)")
+        for t in excluded
+    ]
     hermes_fields: dict = dict(
         focus_roster=roster,
+        focus_roster_excluded=excluded_ledger,
         asset_analysts=analysts
         or {
             "SPY": {
@@ -210,6 +217,47 @@ class TestCommitRunCoherence:
         result = node(state)
         assert result.get("errors")
         assert "positions" not in client.store
+
+    def test_gated_out_held_position_in_excluded_ledger_is_allowed(self) -> None:
+        """A held position deliberately gated out of H5 (Stage 1b staleness gate) is
+        carried, not orphaned (#1030).
+
+        The held name is below the staleness threshold, so H4 records it in
+        ``focus_roster_excluded`` and dispatches no analyst. The position is still
+        carried in the book (weight > 0) and is not flat — without the carry
+        exemption, ``coherence_errors`` would fail-close with "lacks H5 analyst doc",
+        which is exactly the live regression that broke the quiet-day path.
+        """
+        client = FakeSupabaseClient()
+        state = _state(
+            sized_book={
+                "recommended_portfolio": [
+                    {"ticker": "SPY", "target_pct": 60.0},
+                    {"ticker": "AAPL", "target_pct": 40.0},
+                ],
+                "actions": [],
+                "notes": "",
+            },
+            analysts={
+                "SPY": {
+                    "ticker": "SPY",
+                    "stance": "buy",
+                    "conviction_score": 4,
+                    "thesis": "x",
+                    "risks": "",
+                    "sources": [],
+                }
+            },
+            excluded=("AAPL",),  # gated out of H5 as a quiet held name — carried, not flat
+            pm_memo=PMDirectionMemo(
+                date=RUN_DATE,
+                roster=[TickerDirection(ticker="SPY", direction="long", conviction_rank=1)],
+            ),
+        )
+        out = _run(client, state)
+        assert not out.get("errors"), out.get("errors")
+        manifest = (out.get("phase_hermes") or PhaseHermesState()).commit_manifest or {}
+        assert manifest.get("status") == "committed"
 
 
 class TestCommitRunIdempotency:

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -419,3 +419,35 @@ def test_compute_focus_roster_excluded_ledger(monkeypatch: pytest.MonkeyPatch) -
     # Reason for gated-out held must hint at the held+staleness cause.
     tlt_entry = next(e for e in excluded if e.ticker == "TLT")
     assert "held" in tlt_entry.reason.lower() or "material" in tlt_entry.reason.lower()
+
+
+@pytest.mark.unit
+def test_excluded_ledger_records_gated_held_absent_from_watchlist() -> None:
+    """A held position gated out of the roster must land in the excluded ledger even
+    when it is NOT on today's watchlist (#1030).
+
+    Prior-book holdings are not necessarily on the watchlist (the watchlist is the
+    research universe; the book is what we own). A quiet held name absent from the
+    watchlist is still gated out of H5 — and commit-run relies on the excluded
+    ledger to carry it instead of failing closed on a missing analyst doc. Iterating
+    only the watchlist silently dropped it.
+    """
+    from digiquant.olympus.hermes.phases.h4_opportunity_screener import (
+        compute_focus_roster_excluded,
+    )
+
+    roster = compute_focus_roster(
+        watchlist=[],  # AAPL is held but NOT on the watchlist
+        held={"AAPL"},
+        price_deltas={"SPY": 0.0},  # non-empty signal; AAPL absent → 0.0 → quiet → gated
+        run_date=date(2026, 6, 20),
+    )
+    assert roster == [], "quiet unlinked held AAPL must be gated out"
+
+    excluded = compute_focus_roster_excluded([], roster, held={"AAPL"})
+    excluded_tickers = {e.ticker for e in excluded}
+    assert "AAPL" in excluded_tickers, (
+        "gated-out held absent from watchlist was dropped from ledger"
+    )
+    aapl_entry = next(e for e in excluded if e.ticker == "AAPL")
+    assert aapl_entry.reason, "gated-out held must carry a non-empty reason"


### PR DESCRIPTION
Two validation-surfaced Olympus fixes, combined because the `atlas-graph/tests` CI gate runs the whole suite and the two are coupled through it (the held-gate fix repairs the quiet-day test the suite runs; the doc_type commit reformats a pre-existing develop ruff-format failure that otherwise blocks the gate). One commit per issue.

## Commit 1 — #1010: `document_delta` doc_type case mismatch

`publish_document_delta` wrote the `documents.doc_type` **column** as snake_case `"document_delta"`, absent from `chk_documents_doc_type` (which permits the Title-Case `"Document Delta"`). Every delta run's publish-supabase phase raised `APIError 23514` → `degraded:true`, silently never persisting document deltas. Fix: retitle the column write (no migration — the value already exists in the constraint); the snake_case form correctly stays in the patch payload. Adds a static doc_type-literal scan over `supabase_io.py` + a column-value assertion. **Fixes #1010**

## Commit 2 — #1030: held gate breaks commit-run coherence

Stage 1b's held staleness gate drops a quiet, unlinked held position from H5 entirely; three coordinated gaps then orphaned it (all live on `main`, masked only by the empty book):
1. **commit-run** fail-closes ("lacks H5 analyst doc") on a carried held position → exempt names in the excluded ledger (`gated_out_tickers`); the guard still fires for genuine gaps.
2. **`compute_focus_roster_excluded`** only iterated the watchlist → a prior-book holding off the watchlist was never recorded → now iterates `watchlist ∪ held`.
3. **`_merge_phase_hermes`** didn't list `focus_roster_excluded` → H4's ledger was dropped before H9 read it → added to the merge list.

Also re-baselines the spec §16 quiet-day gate to Stage 1b's intent (quiet unlinked held → gated out and carried, not re-analyzed). **Fixes #1030**

## Verification

TDD per defect (RED→GREEN): reducer preservation, off-watchlist held ledger, commit-run carry, doc_type scan/column, end-to-end quiet-day path. `make score` 10/10 each half; ruff check + `format --check` clean across atlas/hermes/learning + tests; 107+ tests green across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)