### PR TITLE
ci: exclude docs/superpowers/** from the score-gate diff (Fixes #1032)

### DIFF
--- a/.github/workflows/test-score.yml
+++ b/.github/workflows/test-score.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install -U pip
           git fetch origin "${{ github.base_ref }}"
-          git diff "origin/${{ github.base_ref }}...HEAD" -- . ':(exclude)docs/reviews/**' > /tmp/pr-code.diff || true
+          git diff "origin/${{ github.base_ref }}...HEAD" -- . ':(exclude)docs/reviews/**' ':(exclude)docs/superpowers/**' > /tmp/pr-code.diff || true
           if [ -s /tmp/pr-code.diff ]; then
             python3 scripts/score.py --diff-file /tmp/pr-code.diff
             python3 scripts/score.py --diff-file /tmp/pr-code.diff --format json > /tmp/score.json


### PR DESCRIPTION
Fixes #1032

The `score / score` gate (`scripts/score.py`) is a regex heuristic for **code** anti-patterns. `docs/superpowers/**` holds design specs + implementation plans — process docs, not code, exactly like the already-excluded `docs/reviews/**`. Self-contained spec HTML embeds base64 woff2 fonts whose byte sequences the Accuracy regex misreads as `TODO/FIXME` markers, failing the gate on any PR that touches those docs (e.g. #1028, the twelve-x redesign).

One-line change: extend the score-diff exclude to also skip `docs/superpowers/**`.

Verified: with this exclude the #1028 diff scores Security 9 / Quality 10 / Optimization 10 / Accuracy 9 — all thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WAhN5uDktn2yw3brEunnD