### PR TITLE
fix(olympus): drop stale Ledger reference in Matrix tab copy

### DIFF
--- a/frontend/olympus/components/twelve-x/MatrixTab.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.tsx
@@ -91,7 +91,7 @@ export default function MatrixTab({
 
       <p className="max-w-2xl px-1 text-xs text-text-muted">
         Each desk&apos;s latest standing view per board currency (8 of G10 — NOK/SEK desk views appear
-        in Consensus &amp; Ledger, not here) over a recent window — consolidated the same way as the
+        in Consensus, not here) over a recent window — consolidated the same way as the
         Notion board: a pair files under its base currency (EUR/USD → EUR), shown as stated. Cells are
         colored by direction and shaded by conviction; click any cell to open the source brief.
       </p>


### PR DESCRIPTION
Fixes #1035

Final-review follow-up to the twelve-x redesign. `MatrixTab.tsx` user-visible copy still read "...NOK/SEK desk views appear in Consensus **& Ledger**, not here..." — but the Ledger tab was removed (final 5-tab set). MatrixTab predates Phase 6 and wasn't in the redesign diff, so the dangling reference survived.

Copy-only change: "appear in Consensus, not here". NOK/SEK consensus still surfaces in the Consensus tab (`getLatestConsensus` applies no currency filter; only the Matrix grid restricts to the 8 board columns).

Whole-tree grep confirms no other user-facing "Ledger" strings remain (only kept identifiers `getLedger`/`FxLedgerRow`/`fx_relevance_ledger`, which Intelligence Tier-3 depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WAhN5uDktn2yw3brEunnD