### PR TITLE
Promote develop → main: broker-focused drill-in

### DIFF
--- a/frontend/olympus/components/twelve-x/BrokerProfilePanel.test.tsx
+++ b/frontend/olympus/components/twelve-x/BrokerProfilePanel.test.tsx
@@ -1,0 +1,75 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import BrokerProfilePanel from './BrokerProfilePanel';
+import type { MatrixCell } from '@/lib/twelve-x/types';
+
+function cell(partial: Partial<MatrixCell> & { broker: string; column: MatrixCell['column'] }): MatrixCell {
+  return {
+    currency: partial.column,
+    direction: 'bullish',
+    conviction: 'high',
+    run_date: '2026-06-24',
+    report_date: null,
+    source_file: `${partial.broker}-${partial.column}.md`,
+    ...partial,
+  };
+}
+
+const CELLS: MatrixCell[] = [
+  cell({ broker: 'Atlas Macro', column: 'USD', direction: 'bullish', conviction: 'high', currency: 'USD', rationale: 'Dollar smile intact', key_facts: ['Real yields rising'], targets: [{ label: 'TP', level: 1.05 }], signal: 'Add on dips' }),
+  cell({ broker: 'Atlas Macro', column: 'EUR', direction: 'bearish', conviction: 'medium', currency: 'EUR/USD', source_file: 'atlas-eur.md', run_date: '2026-06-23' }),
+  cell({ broker: 'Meridian FX', column: 'JPY', direction: 'watch', conviction: 'low', currency: 'JPY' }),
+];
+
+function render(broker: string | null) {
+  return renderToStaticMarkup(
+    createElement(BrokerProfilePanel, {
+      broker,
+      cells: CELLS,
+      onClose: () => {},
+      onOpenBrief: () => {},
+    }),
+  );
+}
+
+describe('BrokerProfilePanel', () => {
+  it('renders nothing when no broker is selected', () => {
+    expect(render(null)).toBe('');
+  });
+
+  it('renders only the focused broker’s views (a slide-over dialog)', () => {
+    const html = render('Atlas Macro');
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('Atlas Macro');
+    // Atlas's two instruments show; Meridian's JPY view must NOT leak in.
+    expect(html).toContain('USD');
+    expect(html).toContain('EUR/USD');
+    expect(html).not.toContain('Meridian FX');
+  });
+
+  it('shows the desk’s rationale, key facts, signal and target levels', () => {
+    const html = render('Atlas Macro');
+    expect(html).toContain('Dollar smile intact');
+    expect(html).toContain('Real yields rising');
+    expect(html).toContain('Add on dips');
+    expect(html).toContain('TP 1.05');
+  });
+
+  it('tallies the net tilt across the desk’s views (1 bull / 1 bear here)', () => {
+    const html = render('Atlas Macro');
+    expect(html).toContain('2 views');
+    expect(html).toContain('1 bull');
+    expect(html).toContain('1 bear');
+  });
+
+  it('offers an open-brief affordance per view', () => {
+    const html = render('Atlas Macro');
+    expect(html).toContain('Open brief');
+  });
+
+  it('handles a broker with no views gracefully', () => {
+    const html = render('Nonexistent Desk');
+    expect(html).toContain('No standing views from this desk');
+  });
+});

--- a/frontend/olympus/components/twelve-x/BrokerProfilePanel.tsx
+++ b/frontend/olympus/components/twelve-x/BrokerProfilePanel.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { Building2, ExternalLink, X } from 'lucide-react';
+
+import { MATRIX_COLUMNS } from '@/lib/twelve-x/types';
+import type { MatrixCell } from '@/lib/twelve-x/types';
+import { directionStyle, directionBucket, formatTargets } from '@/lib/twelve-x/matrix-format';
+
+/**
+ * Right-side slide-over profiling a SINGLE broker/desk — the "focus on one
+ * broker, drill into what they're thinking" view. Opened by clicking a broker's
+ * row label in the Matrix. Mirrors EventDetailPanel/BriefPanel (scrim + right
+ * panel, Esc-to-close, body scroll-lock). Fully derived from the MatrixCell set
+ * already in the Matrix (filtered to this broker) — no extra fetch.
+ */
+export default function BrokerProfilePanel({
+  broker,
+  cells,
+  onClose,
+  onOpenBrief,
+}: {
+  broker: string | null;
+  cells: MatrixCell[];
+  onClose: () => void;
+  onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+}) {
+  const open = broker != null;
+  const handleClose = useCallback(() => onClose(), [onClose]);
+
+  // Close on Escape while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, handleClose]);
+
+  // Lock body scroll while open (mirrors EventDetailPanel / BriefPanel).
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // This broker's views, in canonical board-column order (extras after).
+  const views = useMemo<MatrixCell[]>(() => {
+    if (!broker) return [];
+    const mine = cells.filter((c) => c.broker === broker);
+    const order = new Map(MATRIX_COLUMNS.map((c, i) => [c as string, i]));
+    return [...mine].sort((a, b) => {
+      const ai = order.get(a.column) ?? 99;
+      const bi = order.get(b.column) ?? 99;
+      if (ai !== bi) return ai - bi;
+      return a.currency.localeCompare(b.currency);
+    });
+  }, [broker, cells]);
+
+  // Net tilt tally across this desk's views.
+  const tally = useMemo(() => {
+    let bull = 0;
+    let bear = 0;
+    let watch = 0;
+    for (const v of views) {
+      const b = directionBucket(v.direction);
+      if (b === 'bull') bull++;
+      else if (b === 'bear') bear++;
+      else if (b === 'watch') watch++;
+    }
+    return { bull, bear, watch };
+  }, [views]);
+
+  if (!broker) return null;
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label="Broker profile">
+      {/* Scrim */}
+      <button
+        type="button"
+        aria-label="Close broker profile"
+        onClick={handleClose}
+        className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
+      />
+
+      {/* Panel */}
+      <div className="absolute inset-y-0 right-0 flex w-full max-w-xl flex-col border-l border-border-subtle bg-bg-secondary shadow-2xl">
+        <div className="flex shrink-0 justify-center pt-2 sm:hidden" aria-hidden>
+          <span className="h-1 w-9 rounded-full bg-white/20" />
+        </div>
+        <div className="flex items-start gap-3 border-b border-border-subtle px-5 py-4">
+          <Building2 size={18} className="mt-0.5 shrink-0 text-fin-blue" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-base font-semibold text-text-primary">{broker}</h2>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-text-muted">
+              <span className="tabular-nums">
+                {views.length} {views.length === 1 ? 'view' : 'views'}
+              </span>
+              {tally.bull > 0 ? (
+                <span className="flex items-center gap-1 text-fin-green">
+                  <span aria-hidden>▲</span> {tally.bull} bull
+                </span>
+              ) : null}
+              {tally.bear > 0 ? (
+                <span className="flex items-center gap-1 text-fin-red">
+                  <span aria-hidden>▼</span> {tally.bear} bear
+                </span>
+              ) : null}
+              {tally.watch > 0 ? (
+                <span className="flex items-center gap-1 text-fin-amber">
+                  <span aria-hidden>◆</span> {tally.watch} watch
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="Close"
+            className="-mr-1.5 -mt-1.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-text-muted transition-colors hover:bg-white/[0.06] hover:text-text-primary sm:h-9 sm:w-9"
+          >
+            <X size={18} aria-hidden />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-5 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          {views.length === 0 ? (
+            <p className="text-xs text-text-muted">No standing views from this desk in the window.</p>
+          ) : (
+            views.map((v, i) => {
+              const s = directionStyle(v.direction);
+              const levels = formatTargets(v.targets);
+              const asOf = v.report_date ?? v.run_date;
+              return (
+                <div
+                  key={`${v.column}-${v.currency}-${i}`}
+                  className={`rounded-lg border ${s.border} bg-white/[0.02] p-3`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className={`text-sm leading-none ${s.text}`} aria-hidden>
+                      {s.glyph}
+                    </span>
+                    <span className="font-mono text-sm font-semibold text-text-primary">
+                      {v.currency}
+                    </span>
+                    <span className={`text-xs font-medium ${s.text}`}>{v.direction}</span>
+                    {v.conviction ? (
+                      <span className="text-[11px] uppercase text-text-muted">· {v.conviction}</span>
+                    ) : null}
+                    <span className="ml-auto font-mono text-[10px] tabular-nums text-text-muted">
+                      {asOf}
+                    </span>
+                  </div>
+
+                  {v.signal ? (
+                    <p className="mt-1.5 text-xs font-medium text-text-secondary">{v.signal}</p>
+                  ) : null}
+                  {v.rationale ? (
+                    <p className="mt-1 text-xs leading-snug text-text-secondary">{v.rationale}</p>
+                  ) : null}
+                  {v.key_facts && v.key_facts.length > 0 ? (
+                    <ul className="mt-1.5 list-disc space-y-0.5 pl-4 text-xs text-text-muted">
+                      {v.key_facts.map((f, n) => (
+                        <li key={n}>{f}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  {levels ? (
+                    <p className="mt-1.5 text-[11px] text-text-muted">
+                      <span className="text-text-secondary">Levels:</span> {levels}
+                    </p>
+                  ) : null}
+
+                  <button
+                    type="button"
+                    onClick={() => onOpenBrief(v.source_file, v.run_date)}
+                    className="mt-2 inline-flex items-center gap-1 text-[11px] font-medium text-fin-blue hover:underline"
+                  >
+                    Open brief <ExternalLink size={11} aria-hidden />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/olympus/components/twelve-x/MatrixTab.test.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.test.tsx
@@ -1,0 +1,57 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import MatrixTab from './MatrixTab';
+import type { MatrixCell } from '@/lib/twelve-x/types';
+
+function cell(partial: Partial<MatrixCell> & { broker: string; column: MatrixCell['column'] }): MatrixCell {
+  return {
+    currency: partial.column,
+    direction: 'bullish',
+    conviction: 'high',
+    run_date: '2026-06-24',
+    report_date: null,
+    source_file: `${partial.broker}-${partial.column}.md`,
+    ...partial,
+  };
+}
+
+const CELLS: MatrixCell[] = [
+  cell({ broker: 'Atlas Macro', column: 'USD', rationale: 'Dollar smile intact' }),
+  cell({ broker: 'Meridian FX', column: 'JPY', direction: 'bearish', currency: 'JPY' }),
+];
+
+function render(initialSelectedBroker: string | null = null) {
+  return renderToStaticMarkup(
+    createElement(MatrixTab, { cells: CELLS, onOpenBrief: () => {}, initialSelectedBroker }),
+  );
+}
+
+describe('MatrixTab', () => {
+  it('renders the desk grid with a row per broker', () => {
+    const html = render();
+    expect(html).toContain('Desk view matrix');
+    expect(html).toContain('Atlas Macro');
+    expect(html).toContain('Meridian FX');
+  });
+
+  it('makes each broker label a button that opens its profile', () => {
+    const html = render();
+    // The desk label is an interactive button (the drill-in affordance), and the
+    // copy advertises it.
+    expect(html).toMatch(/<button[^>]*>\s*<span class="truncate">Atlas Macro<\/span>/);
+    expect(html).toContain('desk name to see that broker');
+  });
+
+  it('does not open the broker profile by default', () => {
+    const html = render();
+    expect(html).not.toContain('role="dialog"');
+  });
+
+  it('opens the broker-profile slide-over when a broker is pre-selected', () => {
+    const html = render('Atlas Macro');
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('Dollar smile intact'); // Atlas's view detail
+    expect(html).toContain('1 view');
+  });
+});

--- a/frontend/olympus/components/twelve-x/MatrixTab.tsx
+++ b/frontend/olympus/components/twelve-x/MatrixTab.tsx
@@ -1,65 +1,25 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Grid3x3 } from 'lucide-react';
 
 import { MATRIX_COLUMNS } from '@/lib/twelve-x/types';
 import type { MatrixCell } from '@/lib/twelve-x/types';
-
-/** Map a currency-view direction to a .fin-* color + glyph for the matrix cell. */
-function directionStyle(direction: string): { text: string; bg: string; border: string; glyph: string } {
-  const d = direction.trim().toLowerCase();
-  if (d === 'bullish' || d === 'long' || d === 'buy')
-    return { text: 'text-fin-green', bg: 'bg-fin-green/10', border: 'border-fin-green/30', glyph: '▲' };
-  if (d === 'bearish' || d === 'short' || d === 'sell')
-    return { text: 'text-fin-red', bg: 'bg-fin-red/10', border: 'border-fin-red/30', glyph: '▼' };
-  if (d === 'watch')
-    return { text: 'text-fin-amber', bg: 'bg-fin-amber/10', border: 'border-fin-amber/30', glyph: '◆' };
-  return { text: 'text-text-secondary', bg: 'bg-white/[0.03]', border: 'border-border-subtle', glyph: '•' };
-}
-
-/** Flatten a cell's broker targets (unknown[]) into a short, human-readable string. */
-function formatTargets(targets: unknown[] | undefined): string | null {
-  if (!targets || targets.length === 0) return null;
-  const parts = targets
-    .map((t) => {
-      if (typeof t === 'string' || typeof t === 'number') return String(t);
-      if (t && typeof t === 'object') {
-        const o = t as Record<string, unknown>;
-        const label = typeof o.label === 'string' ? o.label : typeof o.type === 'string' ? o.type : null;
-        const level =
-          typeof o.level === 'number' || typeof o.level === 'string'
-            ? String(o.level)
-            : typeof o.value === 'number' || typeof o.value === 'string'
-              ? String(o.value)
-              : typeof o.price === 'number' || typeof o.price === 'string'
-                ? String(o.price)
-                : null;
-        if (label && level) return `${label} ${level}`;
-        return level ?? label;
-      }
-      return null;
-    })
-    .filter((p): p is string => !!p);
-  return parts.length > 0 ? parts.join(', ') : null;
-}
-
-/** Conviction → opacity weight so high-conviction cells read louder. */
-function convictionOpacity(conviction: string): number {
-  const c = conviction.trim().toLowerCase();
-  if (c === 'high') return 1;
-  if (c === 'medium' || c === 'mid') return 0.85;
-  if (c === 'low') return 0.65;
-  return 0.78;
-}
+import { directionStyle, formatTargets, convictionOpacity } from '@/lib/twelve-x/matrix-format';
+import BrokerProfilePanel from './BrokerProfilePanel';
 
 export default function MatrixTab({
   cells,
   onOpenBrief,
+  initialSelectedBroker = null,
 }: {
   cells: MatrixCell[];
   onOpenBrief: (sourceFile: string, runDate: string | null) => void;
+  /** Pre-open a broker's profile (deterministic SSR / tests). */
+  initialSelectedBroker?: string | null;
 }) {
+  // The broker whose profile slide-over is open (the "focus on one broker" drill-in).
+  const [selectedBroker, setSelectedBroker] = useState<string | null>(initialSelectedBroker);
   // Brokers present (rows), alphabetical.
   const brokers = useMemo(
     () => [...new Set(cells.map((c) => c.broker))].sort((a, b) => a.localeCompare(b)),
@@ -93,7 +53,8 @@ export default function MatrixTab({
         Each desk&apos;s latest standing view per board currency (8 of G10 — NOK/SEK desk views appear
         in Consensus, not here) over a recent window — consolidated the same way as the
         Notion board: a pair files under its base currency (EUR/USD → EUR), shown as stated. Cells are
-        colored by direction and shaded by conviction; click any cell to open the source brief.
+        colored by direction and shaded by conviction; click a cell to open its source brief, or a
+        desk name to see that broker&apos;s full standing-view profile.
       </p>
 
       {hasData ? (
@@ -134,10 +95,16 @@ export default function MatrixTab({
                   >
                     <div
                       role="rowheader"
-                      className="sticky left-0 z-10 flex items-center truncate bg-bg-secondary px-4 py-2 font-medium text-text-primary"
-                      title={broker}
+                      className="sticky left-0 z-10 bg-bg-secondary"
                     >
-                      <span className="truncate">{broker}</span>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedBroker(broker)}
+                        className="flex w-full items-center gap-1.5 truncate px-4 py-2 text-left font-medium text-text-primary transition-colors hover:text-fin-blue"
+                        title={`${broker} — open desk profile`}
+                      >
+                        <span className="truncate">{broker}</span>
+                      </button>
                     </div>
                     {MATRIX_COLUMNS.map((ccy) => {
                       const cell = byCell.get(`${broker}|${ccy}`);
@@ -216,6 +183,14 @@ export default function MatrixTab({
           No desk views available in the recent window.
         </div>
       )}
+
+      {/* Single-broker drill-in: click a desk label → its full standing-view profile. */}
+      <BrokerProfilePanel
+        broker={selectedBroker}
+        cells={cells}
+        onClose={() => setSelectedBroker(null)}
+        onOpenBrief={onOpenBrief}
+      />
     </div>
   );
 }

--- a/frontend/olympus/lib/twelve-x/matrix-format.test.ts
+++ b/frontend/olympus/lib/twelve-x/matrix-format.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { directionStyle, directionBucket, formatTargets, convictionOpacity } from './matrix-format';
+
+describe('matrix-format', () => {
+  describe('directionBucket', () => {
+    it('maps bullish synonyms → bull', () => {
+      for (const d of ['bullish', 'Long', 'BUY']) expect(directionBucket(d)).toBe('bull');
+    });
+    it('maps bearish synonyms → bear', () => {
+      for (const d of ['bearish', 'short', 'Sell']) expect(directionBucket(d)).toBe('bear');
+    });
+    it('maps watch → watch and anything else → neutral', () => {
+      expect(directionBucket('watch')).toBe('watch');
+      expect(directionBucket('neutral')).toBe('neutral');
+      expect(directionBucket('')).toBe('neutral');
+    });
+  });
+
+  describe('directionStyle', () => {
+    it('gives green ▲ for bullish, red ▼ for bearish, amber ◆ for watch', () => {
+      expect(directionStyle('bullish')).toMatchObject({ text: 'text-fin-green', glyph: '▲' });
+      expect(directionStyle('short')).toMatchObject({ text: 'text-fin-red', glyph: '▼' });
+      expect(directionStyle('watch')).toMatchObject({ text: 'text-fin-amber', glyph: '◆' });
+      expect(directionStyle('mixed')).toMatchObject({ text: 'text-text-secondary', glyph: '•' });
+    });
+  });
+
+  describe('convictionOpacity', () => {
+    it('high=1, medium=0.85, low=0.65, unknown=0.78', () => {
+      expect(convictionOpacity('high')).toBe(1);
+      expect(convictionOpacity('Medium')).toBe(0.85);
+      expect(convictionOpacity('low')).toBe(0.65);
+      expect(convictionOpacity('')).toBe(0.78);
+    });
+  });
+
+  describe('formatTargets', () => {
+    it('returns null for empty/undefined', () => {
+      expect(formatTargets(undefined)).toBeNull();
+      expect(formatTargets([])).toBeNull();
+    });
+    it('joins strings/numbers and label+level objects', () => {
+      expect(formatTargets(['1.10', 1.05])).toBe('1.10, 1.05');
+      expect(formatTargets([{ label: 'TP', level: 1.2 }, { type: 'SL', value: 1.05 }])).toBe(
+        'TP 1.2, SL 1.05',
+      );
+    });
+    it('drops entries with no usable level/label', () => {
+      expect(formatTargets([{ foo: 'bar' }, '1.10'])).toBe('1.10');
+    });
+  });
+});

--- a/frontend/olympus/lib/twelve-x/matrix-format.ts
+++ b/frontend/olympus/lib/twelve-x/matrix-format.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure presentational helpers for the desk-view matrix and the broker drill-in.
+ * Shared by MatrixTab (the grid) and BrokerProfilePanel (the single-broker
+ * slide-over) so both render a desk's direction/conviction/targets identically.
+ */
+
+/** Map a currency-view direction to a .fin-* color + glyph for a matrix cell. */
+export function directionStyle(direction: string): {
+  text: string;
+  bg: string;
+  border: string;
+  glyph: string;
+} {
+  const d = direction.trim().toLowerCase();
+  if (d === 'bullish' || d === 'long' || d === 'buy')
+    return { text: 'text-fin-green', bg: 'bg-fin-green/10', border: 'border-fin-green/30', glyph: '▲' };
+  if (d === 'bearish' || d === 'short' || d === 'sell')
+    return { text: 'text-fin-red', bg: 'bg-fin-red/10', border: 'border-fin-red/30', glyph: '▼' };
+  if (d === 'watch')
+    return { text: 'text-fin-amber', bg: 'bg-fin-amber/10', border: 'border-fin-amber/30', glyph: '◆' };
+  return { text: 'text-text-secondary', bg: 'bg-white/[0.03]', border: 'border-border-subtle', glyph: '•' };
+}
+
+/** Coarse direction bucket for tallying a desk's net tilt. */
+export function directionBucket(direction: string): 'bull' | 'bear' | 'watch' | 'neutral' {
+  const d = direction.trim().toLowerCase();
+  if (d === 'bullish' || d === 'long' || d === 'buy') return 'bull';
+  if (d === 'bearish' || d === 'short' || d === 'sell') return 'bear';
+  if (d === 'watch') return 'watch';
+  return 'neutral';
+}
+
+/** Flatten a cell's broker targets (unknown[]) into a short, human-readable string. */
+export function formatTargets(targets: unknown[] | undefined): string | null {
+  if (!targets || targets.length === 0) return null;
+  const parts = targets
+    .map((t) => {
+      if (typeof t === 'string' || typeof t === 'number') return String(t);
+      if (t && typeof t === 'object') {
+        const o = t as Record<string, unknown>;
+        const label = typeof o.label === 'string' ? o.label : typeof o.type === 'string' ? o.type : null;
+        const level =
+          typeof o.level === 'number' || typeof o.level === 'string'
+            ? String(o.level)
+            : typeof o.value === 'number' || typeof o.value === 'string'
+              ? String(o.value)
+              : typeof o.price === 'number' || typeof o.price === 'string'
+                ? String(o.price)
+                : null;
+        if (label && level) return `${label} ${level}`;
+        return level ?? label;
+      }
+      return null;
+    })
+    .filter((p): p is string => !!p);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+/** Conviction → opacity weight so high-conviction cells read louder. */
+export function convictionOpacity(conviction: string): number {
+  const c = conviction.trim().toLowerCase();
+  if (c === 'high') return 1;
+  if (c === 'medium' || c === 'mid') return 0.85;
+  if (c === 'low') return 0.65;
+  return 0.78;
+}


### PR DESCRIPTION
Fixes #1040

Promotes refinement-loop iteration 2 to production: the **broker-focused drill-in** (#1041). Clicking a desk's row label in the Matrix opens a slide-over with that broker's full standing view (per-currency direction/conviction/rationale/key-facts/targets + net tilt + open-brief links). Self-contained from existing Matrix data.

Gate: 381 tests · next build green · tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WAhN5uDktn2yw3brEunnD