### PR TITLE
Promote develop → main: regime-adaptive analyst budget (Stage 2, #1043)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/budget_controller.py
+++ b/digiquant/src/digiquant/olympus/hermes/budget_controller.py
@@ -1,0 +1,42 @@
+"""Stage 2 — regime-conditioned analyst dispatch budget (#1017).
+
+Turns market state (VIX term structure + breadth + cross-sectional return
+dispersion) into a dispatch budget for H4's focus roster, with a fail-soft
+fallback to the static ATLAS_MAX_ANALYSTS cap. See
+docs/superpowers/specs/2026-06-23-adaptive-two-track-dispatch-design.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from collections.abc import Mapping
+from typing import Literal
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+RegimeLabel = Literal["stress", "neutral", "dispersion"]
+
+
+class RegimeAssessment(BaseModel):
+    """The classified regime plus the signals that produced it (for the audit log)."""
+
+    regime: RegimeLabel
+    vix_state: str | None = None
+    vix_ratio: float | None = None
+    pct_above_50dma: float | None = None
+    return_dispersion: float | None = None
+    note: str = ""
+
+
+def cross_sectional_dispersion(price_deltas: Mapping[str, float]) -> float | None:
+    """Population stdev of per-ticker daily returns — a no-DB dispersion proxy.
+
+    Returns ``None`` when fewer than two finite values are present.
+    """
+    vals = [float(v) for v in price_deltas.values() if v is not None]
+    if len(vals) < 2:
+        return None
+    return statistics.pstdev(vals)

--- a/digiquant/src/digiquant/olympus/hermes/budget_controller.py
+++ b/digiquant/src/digiquant/olympus/hermes/budget_controller.py
@@ -12,9 +12,14 @@ import logging
 import os
 import statistics
 from collections.abc import Mapping
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
+
+from digiquant.olympus.atlas.data.queries import (
+    get_market_breadth,
+    get_vix_term_structure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -140,3 +145,59 @@ def budget_for(assessment: RegimeAssessment, *, static_cap: int) -> tuple[int, i
         return budget, explore_floor
     else:  # neutral
         return static_cap, 1
+
+
+def assess_budget(
+    state: Any, client: Any, *, static_cap: int
+) -> tuple[int, int, RegimeAssessment | None]:
+    """Fail-soft entry point: turn market state into regime-conditioned budget.
+
+    On any failure or if client is None, returns (static_cap, 1, None) and
+    logs a warning — never raises. Wraps query calls to data layer in
+    try/except.
+
+    Returns (budget, explore_floor, assessment) where assessment is None on
+    failure.
+    """
+    try:
+        # Fast-fail if client is None
+        if client is None:
+            logger.warning("assess_budget: client is None, falling back to static budget")
+            return (static_cap, 1, None)
+
+        # Compute return dispersion (no DB, always present post-Stage-1b)
+        return_dispersion = cross_sectional_dispersion(state.price_deltas)
+
+        # Fetch advisory signals (must not block the book on DB failure)
+        try:
+            vix_data = get_vix_term_structure(client=client, run_date=state.run_date)
+            breadth_data = get_market_breadth(client=client, run_date=state.run_date)
+        except Exception as e:
+            logger.warning(f"assess_budget: query failed ({e}), falling back to static budget")
+            return (static_cap, 1, None)
+
+        # Extract signals (tolerate {} or missing keys)
+        vix_state = vix_data.get("state")
+        vix_ratio = vix_data.get("ratio")
+        pct_above_50dma = breadth_data.get("pct_above_50dma")
+
+        # Classify and budget
+        assessment = classify_regime(
+            vix_state=vix_state,
+            vix_ratio=vix_ratio,
+            pct_above_50dma=pct_above_50dma,
+            return_dispersion=return_dispersion,
+        )
+        budget, explore_floor = budget_for(assessment, static_cap=static_cap)
+
+        # Audit log
+        logger.info(
+            f"H4 budget: regime={assessment.regime} vix={vix_state} breadth={pct_above_50dma} "
+            f"dispersion={return_dispersion} -> B={budget} explore_floor={explore_floor}"
+        )
+
+        return (budget, explore_floor, assessment)
+
+    except Exception as e:
+        logger.warning(f"assess_budget: uncaught error ({e}), falling back to static budget")
+        return (static_cap, 1, None)

--- a/digiquant/src/digiquant/olympus/hermes/budget_controller.py
+++ b/digiquant/src/digiquant/olympus/hermes/budget_controller.py
@@ -9,6 +9,7 @@ docs/superpowers/specs/2026-06-23-adaptive-two-track-dispatch-design.md.
 from __future__ import annotations
 
 import logging
+import os
 import statistics
 from collections.abc import Mapping
 from typing import Literal
@@ -16,6 +17,10 @@ from typing import Literal
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+# Module constants, overridable via environment variables
+STRESS_FLOOR = int(os.getenv("ATLAS_BUDGET_STRESS_FLOOR", "3"))
+DISPERSION_HI = float(os.getenv("ATLAS_BUDGET_DISPERSION_HI", "0.015"))
 
 RegimeLabel = Literal["stress", "neutral", "dispersion"]
 
@@ -40,3 +45,98 @@ def cross_sectional_dispersion(price_deltas: Mapping[str, float]) -> float | Non
     if len(vals) < 2:
         return None
     return statistics.pstdev(vals)
+
+
+def classify_regime(
+    *,
+    vix_state: str | None,
+    vix_ratio: float | None,
+    pct_above_50dma: float | None,
+    return_dispersion: float | None,
+) -> RegimeAssessment:
+    """Deterministic regime classifier based on VIX term structure, breadth,
+    and cross-sectional dispersion.
+
+    Decision tree:
+    - `stress`: VIX backwardation OR weak breadth (<40% above 50dma)
+    - `dispersion`: high cross-sectional dispersion (>= DISPERSION_HI)
+    - `neutral`: otherwise (including when all signals are None)
+
+    Returns a RegimeAssessment with the classified regime and the input
+    signals for audit logging.
+    """
+    # Stress condition 1: backwardation dominates
+    if vix_state == "backwardation":
+        return RegimeAssessment(
+            regime="stress",
+            vix_state=vix_state,
+            vix_ratio=vix_ratio,
+            pct_above_50dma=pct_above_50dma,
+            return_dispersion=return_dispersion,
+        )
+
+    # Stress condition 2: weak breadth
+    if pct_above_50dma is not None and pct_above_50dma < 40.0:
+        return RegimeAssessment(
+            regime="stress",
+            vix_state=vix_state,
+            vix_ratio=vix_ratio,
+            pct_above_50dma=pct_above_50dma,
+            return_dispersion=return_dispersion,
+        )
+
+    # Dispersion condition: high cross-sectional dispersion
+    if return_dispersion is not None and return_dispersion >= DISPERSION_HI:
+        return RegimeAssessment(
+            regime="dispersion",
+            vix_state=vix_state,
+            vix_ratio=vix_ratio,
+            pct_above_50dma=pct_above_50dma,
+            return_dispersion=return_dispersion,
+        )
+
+    # Default to neutral
+    return RegimeAssessment(
+        regime="neutral",
+        vix_state=vix_state,
+        vix_ratio=vix_ratio,
+        pct_above_50dma=pct_above_50dma,
+        return_dispersion=return_dispersion,
+    )
+
+
+def budget_for(assessment: RegimeAssessment, *, static_cap: int) -> tuple[int, int]:
+    """Map regime assessment to a dispatch budget and explore floor.
+
+    Budget policy (cost-safe — budget never exceeds static_cap when > 0):
+    - `stress` → budget = max(STRESS_FLOOR, round(static_cap * 0.5)),
+                 explore_floor = 0
+    - `neutral` → budget = static_cap, explore_floor = 1
+    - `dispersion` → budget = static_cap,
+                     explore_floor = max(2, round(static_cap * 0.25))
+    - When static_cap <= 0 (no cap), return (0, explore_floor) for
+      uncapped roster; explore_floor still follows the regime.
+
+    Returns (budget, explore_floor).
+    """
+    regime = assessment.regime
+
+    # When static_cap <= 0, no cap is configured
+    if static_cap <= 0:
+        if regime == "stress":
+            return 0, 0
+        elif regime == "dispersion":
+            return 0, max(2, round(0 * 0.25))  # yields 0 but follow logic
+        else:  # neutral
+            return 0, 1
+
+    # When static_cap > 0, apply regime-specific budgeting
+    if regime == "stress":
+        budget = max(STRESS_FLOOR, round(static_cap * 0.5))
+        return budget, 0
+    elif regime == "dispersion":
+        budget = static_cap
+        explore_floor = max(2, round(static_cap * 0.25))
+        return budget, explore_floor
+    else:  # neutral
+        return static_cap, 1

--- a/digiquant/src/digiquant/olympus/hermes/budget_controller.py
+++ b/digiquant/src/digiquant/olympus/hermes/budget_controller.py
@@ -23,9 +23,22 @@ from digiquant.olympus.atlas.data.queries import (
 
 logger = logging.getLogger(__name__)
 
-# Module constants, overridable via environment variables
-STRESS_FLOOR = int(os.getenv("ATLAS_BUDGET_STRESS_FLOOR", "3"))
-DISPERSION_HI = float(os.getenv("ATLAS_BUDGET_DISPERSION_HI", "0.015"))
+
+# Module constants, overridable via environment variables. Parsed defensively: a
+# malformed operator value falls back to the default and logs, never raising at
+# import (this module is imported transitively by the graph builder — a crash here
+# would take down the whole daily run, defeating the fail-soft guarantee).
+def _env_num(name: str, default: str, cast: type) -> float:
+    raw = os.getenv(name, default)
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        logger.warning("budget_controller: ignoring malformed %s=%r; using %s", name, raw, default)
+        return cast(default)
+
+
+STRESS_FLOOR = int(_env_num("ATLAS_BUDGET_STRESS_FLOOR", "3", int))
+DISPERSION_HI = _env_num("ATLAS_BUDGET_DISPERSION_HI", "0.015", float)
 
 RegimeLabel = Literal["stress", "neutral", "dispersion"]
 
@@ -126,12 +139,14 @@ def budget_for(assessment: RegimeAssessment, *, static_cap: int) -> tuple[int, i
     """
     regime = assessment.regime
 
-    # When static_cap <= 0, no cap is configured
+    # No cap configured (static_cap <= 0): budget 0 == "no cap" downstream, so the
+    # explore_floor is irrelevant (capped_tickers early-returns uncapped). Keep the
+    # per-regime floor for log/telemetry parity only.
     if static_cap <= 0:
         if regime == "stress":
             return 0, 0
         elif regime == "dispersion":
-            return 0, max(2, round(0 * 0.25))  # yields 0 but follow logic
+            return 0, 2
         else:  # neutral
             return 0, 1
 

--- a/digiquant/src/digiquant/olympus/hermes/docs/ARCHITECTURE.md
+++ b/digiquant/src/digiquant/olympus/hermes/docs/ARCHITECTURE.md
@@ -35,7 +35,7 @@ on-demand (`refresh_scope=beliefs` or backlog > `OLYMPUS_BELIEFS_BACKLOG`).
 | **H1** | `hermes/thesis/market-review` | `phases/h1_thesis_review.py` | `edit` active market theses | `theses` rows + review doc |
 | **H2** | `hermes/thesis/market-exploration` | `phases/h2_market_thesis_exploration.py` | `edit` exploration doc | market thesis proposals |
 | **H3** | `hermes/thesis/vehicle-map` | `phases/h3_thesis_vehicle_map.py` | `full`/`edit` | `thesis_vehicles` |
-| **H4** | `hermes/thesis/opportunity-screener` | `phases/h4_opportunity_screener.py` | deterministic | focus roster (held + mapped + unlinked) |
+| **H4** | `hermes/thesis/opportunity-screener` | `phases/h4_opportunity_screener.py` | deterministic | focus roster (held + mapped + unlinked), capped by a **regime-adaptive budget** |
 | **H5** | `hermes/portfolio/asset-analyst` (×N) | `phases/h5_asset_analyst.py` | `skip`/`edit`/`full` per ticker | unified `AnalystPayload` |
 | **H6** | `hermes/portfolio/deliberation` (×N) | `phases/h6_deliberation.py` | cyclic PM↔analyst sub-graph | `deliberation_transcript` + summary |
 | **H7** | `hermes/portfolio/pm-direction` | `phases/h7_pm_direction.py` | `edit` prior memo | `PMDirectionMemo` — **no weights** |
@@ -45,6 +45,29 @@ on-demand (`refresh_scope=beliefs` or backlog > `OLYMPUS_BELIEFS_BACKLOG`).
 Graph builder: `graph.build_hermes_phases_thesis()` → `build_hermes_graph()`.
 Legacy `build_hermes_phases` aliases the thesis path. **Removed from graph:** 4-axis 7C,
 `phase7cd_debate`, risk debaters, `portfolio_materialize`, phase9 evolution on daily path.
+
+---
+
+## H4 dispatch budget (regime-adaptive, Stage 2 — #1043 / #1017)
+
+`_h4_node` calls `budget_controller.assess_budget(state, client, static_cap)` to size the
+analyst roster instead of relying solely on the static `ATLAS_MAX_ANALYSTS`. A deterministic
+classifier (`budget_controller.py`) maps three signals Atlas already produces — VIX
+term-structure state, market breadth (`pct_above_50dma`), and cross-sectional return
+dispersion derived for free from `state.price_deltas` — to a regime:
+
+- **stress** (VIX backwardation OR breadth < 40%) → budget tightened (`max(STRESS_FLOOR, round(cap*0.5))`), explore floor 0 — fewer idiosyncratic dives when correlation is high / risk-off.
+- **dispersion** (return spread ≥ `DISPERSION_HI`) → budget = cap, explore floor raised — probe more new names.
+- **neutral** (incl. sparse signals) → budget = cap, explore floor 1 (today's default).
+
+The result feeds `compute_focus_roster(..., adaptive_max_analysts=budget, min_new_candidates=explore_floor)`
+→ `roster_cap.capped_tickers`. **Invariants:** *cost-safe* — `budget ≤ ATLAS_MAX_ANALYSTS`
+always (the adaptive budget only tightens, never increases spend); *fail-soft* — any missing
+signal, absent client, or reader error degrades to the static cap and logs (never raises).
+Env knobs: `ATLAS_MAX_ANALYSTS` (the cap/baseline), `ATLAS_BUDGET_STRESS_FLOOR` (default 3),
+`ATLAS_BUDGET_DISPERSION_HI` (default 0.015). Deferred (cost-/measurement-gated): budget > cap
+in dispersion regimes, a dedicated cross-asset dispersion metric, and the `dispatch_outcomes`
+feedback table (Stage 4).
 
 ---
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -83,12 +83,17 @@ def compute_focus_roster(
     client: SupabaseClient | None = None,
     top_n: int | None = None,
     min_new_candidates: int = 1,
+    adaptive_max_analysts: int | None = None,
 ) -> list[FocusRosterEntry]:
     """Deterministic focus roster: held + thesis-mapped + technical candidates.
 
     ``min_new_candidates`` (#950): the roster cap expands (if necessary) so
     that at least this many non-held, non-thesis-mapped candidates survive
     when new candidates are available. Prevents roster freeze.
+
+    ``adaptive_max_analysts`` (optional): when not None, overrides the
+    ATLAS_MAX_ANALYSTS environment variable as the analyst cap for this
+    run. When None, falls back to the env var.
     """
     held_set = {str(t).strip().upper() for t in held if str(t).strip()}
     normalized_watchlist = [str(t).strip().upper() for t in watchlist if str(t).strip()]
@@ -177,7 +182,12 @@ def compute_focus_roster(
 
     active_held = held_set - gated_out_held
     protected = active_held | {ticker for _, ticker, _ in thesis_mappings}
-    capped = capped_tickers(ordered_tickers, held=protected, min_new=min_new_candidates)
+    capped = capped_tickers(
+        ordered_tickers,
+        held=protected,
+        min_new=min_new_candidates,
+        adaptive_max_analysts=adaptive_max_analysts,
+    )
     return [entry_by_ticker[t] for t in capped]
 
 

--- a/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py
@@ -16,6 +16,7 @@ from digigraph.graph.pipeline_builder import NodeSpec, PipelinePhase
 
 from digiquant.olympus.atlas.state import ExcludedTicker, FocusRosterEntry
 from digiquant.olympus.atlas.supabase_io import SupabaseClient
+from digiquant.olympus.hermes.budget_controller import assess_budget
 from digiquant.olympus.hermes.candidates import select_focus_tickers
 from digiquant.olympus.hermes.roster_cap import capped_tickers
 from digiquant.olympus.hermes.state import HermesState
@@ -245,6 +246,8 @@ def _h4_node_factory(client: SupabaseClient | None):
         watchlist = list(state.config.watchlist)
         held = holdings_from_state(state)
         mappings = extract_thesis_mappings(state.phase_hermes.thesis_vehicle_map)
+        static_cap = int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
+        budget, explore_floor, assessment = assess_budget(state, client, static_cap=static_cap)
         roster = compute_focus_roster(
             watchlist=watchlist,
             held=held,
@@ -252,11 +255,14 @@ def _h4_node_factory(client: SupabaseClient | None):
             price_deltas=dict(state.price_deltas),
             run_date=state.run_date,
             client=client,
+            adaptive_max_analysts=budget,
+            min_new_candidates=explore_floor,
         )
         excluded = compute_focus_roster_excluded(watchlist, roster, held=held)
         logger.info(
-            "H4 focus roster (%d): %s",
+            "H4 focus roster (%d, regime=%s): %s",
             len(roster),
+            assessment.regime if assessment else "static",
             ", ".join(f"{e.ticker}:{e.roster_reason}" for e in roster),
         )
         logger.info(

--- a/digiquant/src/digiquant/olympus/hermes/roster_cap.py
+++ b/digiquant/src/digiquant/olympus/hermes/roster_cap.py
@@ -16,6 +16,7 @@ def capped_tickers(
     held: Collection[str] = (),
     *,
     min_new: int = _DEFAULT_MIN_NEW,
+    adaptive_max_analysts: int | None = None,
 ) -> list[str]:
     """Apply ``ATLAS_MAX_ANALYSTS`` while preserving the held-ticker invariant (#936).
 
@@ -23,8 +24,16 @@ def capped_tickers(
     necessary) so that at least *min_new* non-held tickers survive. This
     prevents the roster from freezing on prior-book holdings and never
     surfacing new opportunities.
+
+    ``adaptive_max_analysts`` (optional): when not None, overrides the
+    ATLAS_MAX_ANALYSTS environment variable as the analyst cap. When None,
+    falls back to the env var.
     """
-    max_analysts = int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
+    max_analysts = (
+        adaptive_max_analysts
+        if adaptive_max_analysts is not None
+        else int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
+    )
     if max_analysts <= 0 or len(tickers) <= max_analysts:
         return list(tickers)
 

--- a/docs/superpowers/plans/2026-06-25-adaptive-dispatch-stage2.md
+++ b/docs/superpowers/plans/2026-06-25-adaptive-dispatch-stage2.md
@@ -1,0 +1,457 @@
+# Adaptive Regime-Conditioned Analyst Budget (Stage 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace H4's static `ATLAS_MAX_ANALYSTS` analyst-dispatch cap with a market-regime-driven budget `B` and explore/exploit split, computed at H4 from signals Atlas already computes, with a fail-soft fallback to the static cap.
+
+**Architecture:** A new pure-ish `budget_controller` module classifies a market regime from VIX term-structure + market breadth + cross-sectional return dispersion, and maps it to `(budget, explore_floor)`. H4's `_h4_node` calls it (the node already holds the Supabase client) and threads `budget`/`explore_floor` into `compute_focus_roster` → `roster_cap.capped_tickers`. Signal gathering is fail-soft: any missing signal or read error degrades to the static `ATLAS_MAX_ANALYSTS` cap and logs, never raising (H4 must not crash the daily run). This is Stage 2 of the adaptive two-track dispatch design (spec `docs/superpowers/specs/2026-06-23-adaptive-two-track-dispatch-design.md`, umbrella #1017).
+
+**Tech Stack:** Python 3.12, Pydantic v2, Polars (not pandas), pytest (`@pytest.mark.unit`). LangGraph H1–H9 Hermes sub-graph.
+
+## Global Constraints
+
+- **Polars only** — never pandas. Pydantic v2; ruff line-length 100; ruff-compliant.
+- **Backward compatible.** `ATLAS_MAX_ANALYSTS` remains the fallback cap. `capped_tickers` gains an optional `adaptive_max_analysts: int | None = None` that, when set, is preferred over the env var; when `None`, behavior is byte-identical to today. Every existing test that monkeypatches `ATLAS_MAX_ANALYSTS` must stay green unchanged.
+- **Fail-soft, never raise.** Any failure to compute the regime (client unavailable, DB read error, empty signals) → return `None` budget → H4 falls back to the static cap and logs a warning. The budget controller must never propagate an exception into the H4 node.
+- **Cost-safe by default.** The adaptive budget may only *tighten* dispatch relative to the configured cap — `B ≤ effective_static_cap` always (when a finite cap is configured). It never increases analyst spend beyond today's cap. Regimes with low idiosyncratic information value (high-correlation / risk-off) shrink `B`; calm/dispersion regimes keep the cap. (Increasing `B` above the cap in dispersion regimes is explicitly deferred until measurement justifies it — spec build-sequence note.)
+- **Instrumentation is load-bearing.** Every run logs the regime label, the signal values used, and the resulting `(budget, explore_floor)` at INFO. Measurement of whether the adaptive budget helps depends on this log line.
+- **Deterministic mapping.** `regime → (budget, explore_floor)` is a pure function of the assessment, fully unit-testable with no I/O.
+- **No model churn.** Do not touch `RosterPick`/`OpportunityScreenOutput` (dead) or replace `FocusRosterEntry` — out of Stage 2 scope.
+- **Issue linkage.** Open a Stage 2 sub-issue under #1017; use a `task/<N>-slug` branch and/or `Fixes #<N>` in the PR body.
+
+## File Structure
+
+- **Create** `digiquant/src/digiquant/olympus/hermes/budget_controller.py` — the regime classifier, the deterministic budget mapping, and the fail-soft `assess_budget(state, client, *, static_cap)` entry point. One responsibility: turn market state into a dispatch budget.
+- **Create** `tests/dq/hermes/test_budget_controller.py` — unit tests for the model, classifier, mapping, and fail-soft assessment.
+- **Modify** `digiquant/src/digiquant/olympus/hermes/roster_cap.py` — add the optional `adaptive_max_analysts` param to `capped_tickers`.
+- **Modify** `digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py` — thread `adaptive_max_analysts` + `min_new` through `compute_focus_roster`; call the budget controller in `_h4_node` and log the decision.
+- **Modify** `tests/dq/hermes/test_roster_cap.py` (create if absent) and `tests/dq/hermes/test_h4_focus_roster.py` — cover the new param + wiring.
+- **Modify** `digiquant/src/digiquant/olympus/hermes/docs/ARCHITECTURE.md` — document the regime-adaptive budget at H4.
+
+---
+
+### Task 1: `RegimeAssessment` model + signal dispersion helper
+
+**Files:**
+- Create: `digiquant/src/digiquant/olympus/hermes/budget_controller.py`
+- Test: `tests/dq/hermes/test_budget_controller.py`
+
+**Interfaces:**
+- Produces: `RegimeLabel = Literal["stress", "neutral", "dispersion"]`; `RegimeAssessment(BaseModel)` with fields `regime: RegimeLabel`, `vix_state: str | None`, `vix_ratio: float | None`, `pct_above_50dma: float | None`, `return_dispersion: float | None`, `note: str = ""`. `cross_sectional_dispersion(price_deltas: Mapping[str, float]) -> float | None` (population stdev of the delta values; `None` if fewer than 2 non-null values).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/dq/hermes/test_budget_controller.py
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.hermes.budget_controller import (
+    RegimeAssessment,
+    cross_sectional_dispersion,
+)
+
+
+@pytest.mark.unit
+def test_regime_assessment_defaults() -> None:
+    a = RegimeAssessment(regime="neutral")
+    assert a.regime == "neutral"
+    assert a.vix_state is None and a.return_dispersion is None and a.note == ""
+
+
+@pytest.mark.unit
+def test_cross_sectional_dispersion_population_stdev() -> None:
+    # stdev of {0.01, -0.01, 0.03, -0.03} (population) == 0.02
+    out = cross_sectional_dispersion({"A": 0.01, "B": -0.01, "C": 0.03, "D": -0.03})
+    assert out == pytest.approx(0.02, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_cross_sectional_dispersion_insufficient_data_is_none() -> None:
+    assert cross_sectional_dispersion({}) is None
+    assert cross_sectional_dispersion({"A": 0.01}) is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/dq/hermes/test_budget_controller.py -q`
+Expected: FAIL — module/symbols not defined.
+
+- [ ] **Step 3: Minimal implementation**
+
+```python
+# digiquant/src/digiquant/olympus/hermes/budget_controller.py
+"""Stage 2 — regime-conditioned analyst dispatch budget (#1017).
+
+Turns market state (VIX term structure + breadth + cross-sectional return
+dispersion) into a dispatch budget for H4's focus roster, with a fail-soft
+fallback to the static ATLAS_MAX_ANALYSTS cap. See
+docs/superpowers/specs/2026-06-23-adaptive-two-track-dispatch-design.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+RegimeLabel = Literal["stress", "neutral", "dispersion"]
+
+
+class RegimeAssessment(BaseModel):
+    """The classified regime plus the signals that produced it (for the audit log)."""
+
+    regime: RegimeLabel
+    vix_state: str | None = None
+    vix_ratio: float | None = None
+    pct_above_50dma: float | None = None
+    return_dispersion: float | None = None
+    note: str = ""
+
+
+def cross_sectional_dispersion(price_deltas: Mapping[str, float]) -> float | None:
+    """Population stdev of per-ticker daily returns — a no-DB dispersion proxy.
+
+    Returns ``None`` when fewer than two finite values are present.
+    """
+    vals = [float(v) for v in price_deltas.values() if v is not None]
+    if len(vals) < 2:
+        return None
+    return statistics.pstdev(vals)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/dq/hermes/test_budget_controller.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add digiquant/src/digiquant/olympus/hermes/budget_controller.py tests/dq/hermes/test_budget_controller.py
+git commit -m "feat(olympus): RegimeAssessment model + dispersion helper (Stage 2, #1017)"
+```
+
+---
+
+### Task 2: Deterministic regime classifier + budget/split mapping
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/budget_controller.py`
+- Test: `tests/dq/hermes/test_budget_controller.py`
+
+**Interfaces:**
+- Consumes: `RegimeAssessment`, `cross_sectional_dispersion` (Task 1).
+- Produces:
+  - `classify_regime(*, vix_state, vix_ratio, pct_above_50dma, return_dispersion) -> RegimeAssessment` — pure function.
+  - `budget_for(assessment: RegimeAssessment, *, static_cap: int) -> tuple[int, int]` — returns `(budget, explore_floor)`, pure, cost-safe (`budget <= static_cap` when `static_cap > 0`).
+
+**Classifier policy (deterministic):**
+- `stress` if VIX backwardation (`vix_state == "backwardation"`) OR breadth weak (`pct_above_50dma is not None and pct_above_50dma < 40.0`). Risk-off / likely high correlation → idiosyncratic dives low-value.
+- `dispersion` else if `return_dispersion is not None and return_dispersion >= DISPERSION_HI` (default 0.015 = 1.5% cross-sectional stdev). Wide dispersion → idiosyncratic dives high-value.
+- `neutral` otherwise (including when signals are sparse/None).
+
+**Budget policy (cost-safe — only tightens):** for `static_cap > 0`:
+- `stress` → `budget = max(STRESS_FLOOR, round(static_cap * 0.5))`, `explore_floor = 0` (bias to held/thesis exploit).
+- `neutral` → `budget = static_cap`, `explore_floor = 1` (today's default min_new).
+- `dispersion` → `budget = static_cap`, `explore_floor = max(2, round(static_cap * 0.25))` (probe more new names, still within cap).
+- When `static_cap <= 0` (no cap configured), return `(0, explore_floor)` so the roster stays uncapped exactly as today; `explore_floor` still follows the regime.
+
+`STRESS_FLOOR` default 3, `DISPERSION_HI` default 0.015, both module constants overridable via env (`ATLAS_BUDGET_STRESS_FLOOR`, `ATLAS_BUDGET_DISPERSION_HI`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/dq/hermes/test_budget_controller.py
+from digiquant.olympus.hermes.budget_controller import budget_for, classify_regime
+
+
+@pytest.mark.unit
+class TestClassifyRegime:
+    def test_backwardation_is_stress(self) -> None:
+        a = classify_regime(vix_state="backwardation", vix_ratio=1.1,
+                             pct_above_50dma=70.0, return_dispersion=0.02)
+        assert a.regime == "stress"  # backwardation dominates even with wide dispersion
+
+    def test_weak_breadth_is_stress(self) -> None:
+        a = classify_regime(vix_state="contango", vix_ratio=0.9,
+                             pct_above_50dma=30.0, return_dispersion=0.005)
+        assert a.regime == "stress"
+
+    def test_wide_dispersion_is_dispersion(self) -> None:
+        a = classify_regime(vix_state="contango", vix_ratio=0.9,
+                             pct_above_50dma=65.0, return_dispersion=0.02)
+        assert a.regime == "dispersion"
+
+    def test_calm_is_neutral(self) -> None:
+        a = classify_regime(vix_state="contango", vix_ratio=0.95,
+                             pct_above_50dma=55.0, return_dispersion=0.005)
+        assert a.regime == "neutral"
+
+    def test_all_signals_none_is_neutral(self) -> None:
+        a = classify_regime(vix_state=None, vix_ratio=None,
+                            pct_above_50dma=None, return_dispersion=None)
+        assert a.regime == "neutral"
+
+
+@pytest.mark.unit
+class TestBudgetFor:
+    def test_stress_tightens_below_cap(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="stress"), static_cap=20)
+        assert b == 10 and b <= 20
+        assert floor == 0
+
+    def test_stress_respects_floor(self) -> None:
+        b, _ = budget_for(RegimeAssessment(regime="stress"), static_cap=4)
+        assert b == 3  # STRESS_FLOOR, not round(4*0.5)=2
+
+    def test_neutral_equals_cap(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="neutral"), static_cap=20)
+        assert b == 20 and floor == 1
+
+    def test_dispersion_keeps_cap_raises_explore_floor(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="dispersion"), static_cap=20)
+        assert b == 20  # never exceeds cap (cost-safe)
+        assert floor == 5  # round(20*0.25)
+
+    def test_no_cap_configured_stays_uncapped(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="neutral"), static_cap=0)
+        assert b == 0  # 0 == "no cap" downstream
+        assert floor == 1
+
+    def test_budget_never_exceeds_cap_any_regime(self) -> None:
+        for regime in ("stress", "neutral", "dispersion"):
+            b, _ = budget_for(RegimeAssessment(regime=regime), static_cap=12)
+            assert b <= 12
+```
+
+- [ ] **Step 2: Run to verify fail** — `... -k "ClassifyRegime or BudgetFor"`; expected FAIL (undefined).
+
+- [ ] **Step 3: Implement** `classify_regime` + `budget_for` + the module constants (read env with the documented defaults) exactly per the policy above.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(olympus): regime classifier + cost-safe budget mapping (Stage 2, #1017)`.
+
+---
+
+### Task 3: Fail-soft `assess_budget(state, client, *, static_cap)` entry point
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/budget_controller.py`
+- Test: `tests/dq/hermes/test_budget_controller.py`
+
+**Interfaces:**
+- Consumes: `classify_regime`, `budget_for`, `cross_sectional_dispersion`; `get_market_breadth` + `get_vix_term_structure` from `digiquant.olympus.atlas.data.queries`.
+- Produces: `assess_budget(state: Any, client: Any, *, static_cap: int) -> tuple[int, int, RegimeAssessment | None]` returning `(budget, explore_floor, assessment)`. On ANY failure or `client is None`, returns `(static_cap, 1, None)` (static fallback) and logs a warning — never raises.
+
+**Behavior:**
+- `return_dispersion = cross_sectional_dispersion(state.price_deltas)` (no DB; `state.price_deltas` always present post-Stage-1b).
+- If `client is not None`: fetch `get_vix_term_structure(client=client, run_date=state.run_date)` and `get_market_breadth(client=client, run_date=state.run_date)` inside a `try/except Exception` (advisory — must not block the book). Pull `vix_state`/`ratio`/`pct_above_50dma` (`.get(...)`, tolerate `{}`).
+- `assessment = classify_regime(...)`; `(budget, floor) = budget_for(assessment, static_cap=static_cap)`.
+- Log INFO: `"H4 budget: regime=%s vix=%s breadth=%s dispersion=%s -> B=%d explore_floor=%d"`.
+- Wrap the whole body in `try/except Exception`; on exception log a warning and return `(static_cap, 1, None)`.
+
+- [ ] **Step 1: Write the failing tests** (use a fake client + a minimal state stub):
+
+```python
+# append to tests/dq/hermes/test_budget_controller.py
+from datetime import date
+from types import SimpleNamespace
+
+from digiquant.olympus.hermes.budget_controller import assess_budget
+
+
+def _state(price_deltas: dict[str, float]) -> SimpleNamespace:
+    return SimpleNamespace(price_deltas=price_deltas, run_date=date(2026, 6, 25))
+
+
+@pytest.mark.unit
+class TestAssessBudget:
+    def test_none_client_falls_back_to_static(self) -> None:
+        b, floor, a = assess_budget(_state({"A": 0.01, "B": -0.01}), None, static_cap=20)
+        assert (b, floor) == (20, 1) and a is None
+
+    def test_reader_error_falls_back_to_static(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(**_kw: object) -> dict:
+            raise RuntimeError("db down")
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_vix_term_structure", boom
+        )
+        b, floor, a = assess_budget(_state({"A": 0.01}), object(), static_cap=15)
+        assert (b, floor) == (15, 1) and a is None
+
+    def test_stress_signals_tighten_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_vix_term_structure",
+            lambda **_k: {"state": "backwardation", "ratio": 1.2},
+        )
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_market_breadth",
+            lambda **_k: {"pct_above_50dma": 35.0, "universe_size": 50},
+        )
+        b, floor, a = assess_budget(_state({"A": 0.001, "B": -0.001}), object(), static_cap=20)
+        assert a is not None and a.regime == "stress"
+        assert b == 10 and floor == 0
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `assess_budget` per behavior; import the two query readers at module top so the monkeypatch targets resolve.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `feat(olympus): fail-soft assess_budget entry point (Stage 2, #1017)`.
+
+---
+
+### Task 4: `capped_tickers` accepts `adaptive_max_analysts` (backward-compatible)
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/roster_cap.py:14-27`
+- Test: `tests/dq/hermes/test_roster_cap.py` (create if absent)
+
+**Interfaces:**
+- Produces: `capped_tickers(tickers, held=(), *, min_new=_DEFAULT_MIN_NEW, adaptive_max_analysts: int | None = None) -> list[str]`. When `adaptive_max_analysts is not None`, it is used as the cap; otherwise the existing `os.environ.get("ATLAS_MAX_ANALYSTS", "0")` read is used. All downstream cap logic (held protection, min_new expansion, over-budget) is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/dq/hermes/test_roster_cap.py
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.hermes.roster_cap import capped_tickers
+
+
+@pytest.mark.unit
+class TestCappedTickersAdaptive:
+    def test_adaptive_param_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "100")  # env says no real cap
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=2)
+        assert len(out) == 2  # adaptive cap wins
+
+    def test_none_adaptive_uses_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=None)
+        assert len(out) == 2  # env cap, exactly today's behavior
+
+    def test_adaptive_zero_means_no_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=0)
+        assert len(out) == 4  # 0 == no cap, overriding the env's 2
+```
+
+- [ ] **Step 2: Run → FAIL** (unexpected kwarg / wrong counts).
+- [ ] **Step 3: Implement.** Add the kwarg; replace the cap read with:
+
+```python
+max_analysts = (
+    adaptive_max_analysts
+    if adaptive_max_analysts is not None
+    else int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")
+)
+```
+
+Leave all subsequent logic untouched.
+
+- [ ] **Step 4: Run → PASS**, then run the existing cap tests to prove no regression: `.venv/bin/python -m pytest tests/dq/hermes/test_held_invariant.py tests/dq/hermes/test_h4_focus_roster.py -q`.
+- [ ] **Step 5: Commit** — `feat(olympus): capped_tickers accepts adaptive_max_analysts (Stage 2, #1017)`.
+
+---
+
+### Task 5: Thread budget + explore_floor through `compute_focus_roster`
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py` (`compute_focus_roster` signature + the `capped_tickers` call at ~line 180)
+- Test: `tests/dq/hermes/test_h4_focus_roster.py`
+
+**Interfaces:**
+- Produces: `compute_focus_roster(..., adaptive_max_analysts: int | None = None, min_new_candidates: int = 1)` — passes `adaptive_max_analysts=adaptive_max_analysts` to `capped_tickers`; `min_new_candidates` already exists and maps to the explore floor.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/dq/hermes/test_h4_focus_roster.py
+@pytest.mark.unit
+def test_compute_focus_roster_honors_adaptive_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "100")  # env would allow all
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    roster = compute_focus_roster(
+        watchlist=["AAA", "BBB", "CCC", "DDD"],
+        held=set(),
+        run_date=date(2026, 6, 20),
+        adaptive_max_analysts=2,  # regime budget tightens to 2
+        min_new_candidates=1,
+    )
+    assert len(roster) == 2
+```
+
+- [ ] **Step 2: Run → FAIL** (unexpected kwarg).
+- [ ] **Step 3: Implement** — add the param; change the call to `capped_tickers(ordered_tickers, held=protected, min_new=min_new_candidates, adaptive_max_analysts=adaptive_max_analysts)`.
+- [ ] **Step 4: Run → PASS**; re-run the full `tests/dq/hermes/test_h4_focus_roster.py` to confirm no regression.
+- [ ] **Step 5: Commit** — `feat(olympus): thread adaptive budget through compute_focus_roster (Stage 2, #1017)`.
+
+---
+
+### Task 6: Wire the budget controller into `_h4_node` + log the decision
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/phases/h4_opportunity_screener.py` (`_h4_node`)
+- Test: `tests/dq/hermes/test_h4_focus_roster.py` (or the chain test)
+
+**Interfaces:**
+- Consumes: `assess_budget` (Task 3).
+- `_h4_node` reads the static cap once (`int(os.environ.get("ATLAS_MAX_ANALYSTS", "0") or "0")`), calls `budget, explore_floor, assessment = assess_budget(state, client, static_cap=static_cap)`, and passes `adaptive_max_analysts=budget, min_new_candidates=explore_floor` into `compute_focus_roster`. The existing `compute_focus_roster_excluded` + logging stay; add the regime to the H4 log line.
+
+- [ ] **Step 1: Write the failing test** — assert that when `assess_budget` is monkeypatched to return a tight budget, `_h4_node` (run via the built phase node) produces a capped roster; and when it returns the static fallback, behavior matches today. (Construct a `HermesState` with a small watchlist + a fake client; patch `h4_opportunity_screener.assess_budget`.)
+
+```python
+# append to tests/dq/hermes/test_h4_focus_roster.py
+@pytest.mark.unit
+def test_h4_node_applies_adaptive_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    from digiquant.olympus.hermes.phases import h4_opportunity_screener as h4
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    monkeypatch.setattr(h4, "assess_budget", lambda *a, **k: (1, 0, None))
+    node = h4.build_h4_opportunity_screener(client=None).nodes[0].run
+    # Build a minimal HermesState with watchlist of 3, no held, no thesis map.
+    state = _make_min_hermes_state(watchlist=["AAA", "BBB", "CCC"])  # helper in this file
+    out = node(state)
+    roster = out["phase_hermes"].focus_roster
+    assert len(roster) == 1  # adaptive budget=1 applied
+```
+
+(If a `_make_min_hermes_state` helper does not yet exist, add one mirroring the construction in the existing simulator/chain tests; keep it minimal.)
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the `_h4_node` wiring + import `assess_budget`; extend the existing `logger.info` H4 line (or add one) to include `assessment.regime` when present.
+- [ ] **Step 4: Run → PASS**; then run the integration path: `.venv/bin/python -m pytest tests/dq/atlas/test_simulator_gates.py tests/dq/hermes/test_chain_atlas_then_hermes.py -q` to confirm the daily/quiet paths still pass (budget controller fail-soft → static cap when the sim client lacks VIX/breadth data).
+- [ ] **Step 5: Commit** — `feat(olympus): H4 applies regime-adaptive dispatch budget (Stage 2, #1017)`.
+
+---
+
+### Task 7: Document the regime-adaptive budget
+
+**Files:**
+- Modify: `digiquant/src/digiquant/olympus/hermes/docs/ARCHITECTURE.md` (H4 row/section)
+
+- [ ] **Step 1:** Update the H4 description to note: focus roster is capped by a regime-adaptive budget (`budget_controller.assess_budget`) that tightens dispatch in stress/high-correlation regimes and falls back to `ATLAS_MAX_ANALYSTS` when signals are unavailable; document the `stress/neutral/dispersion` taxonomy, the cost-safe invariant (`B ≤ cap`), and the env knobs (`ATLAS_MAX_ANALYSTS`, `ATLAS_BUDGET_STRESS_FLOOR`, `ATLAS_BUDGET_DISPERSION_HI`).
+- [ ] **Step 2:** Run `make doc-check` (validate internal links). Expected: PASS.
+- [ ] **Step 3: Commit** — `docs(olympus): document regime-adaptive H4 budget (Stage 2, #1017)`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** regime classifier ✓ (Task 2, signals = VIX term + breadth + dispersion per spec §"Budget controller"; dispersion sourced free from `price_deltas` rather than a new metric, matching spec's "resolve exact signal set during planning"); adaptive `B` ✓; explore/exploit split ✓ (via `explore_floor`→`min_new`); applied at the real choke point `compute_focus_roster`→`capped_tickers` (spec build-sequence Stage 2, NOT the test-only `build_h5_asset_analyst`) ✓; fail-soft + static fallback ✓ (spec error-handling); instrumentation/logging ✓. **Deferred (explicit, per spec):** increasing `B` above the cap in dispersion regimes (cost-gated), a dedicated cross-asset dispersion metric, and the `dispatch_outcomes` feedback table (Stage 4).
+- **Placeholder scan:** none — every step has concrete code or an exact command. The one helper (`_make_min_hermes_state`) is flagged as "add if absent, mirror existing tests".
+- **Type consistency:** `assess_budget` returns `(int, int, RegimeAssessment | None)` used identically in Task 6; `adaptive_max_analysts: int | None` consistent across `capped_tickers` (Task 4) and `compute_focus_roster` (Task 5); `RegimeLabel` literal consistent across Tasks 1–3.
+- **Backward-compat check:** `adaptive_max_analysts=None` path is byte-identical to today; Task 4 Step 4 + Task 5 Step 4 re-run existing cap tests to prove it.
+
+## Execution Handoff
+
+Plan saved. **Recommended: subagent-driven-development** — fresh implementer per task, task review (spec + quality) after each, broad final review. Tasks 1–3 are mechanical (clear specs, isolated module) → cheap model; Tasks 4–6 touch shared/wired code → standard model + the existing-test regression gate; final whole-branch review on the most capable model (it changes a dispatch-budget path).

--- a/tests/dq/hermes/test_budget_controller.py
+++ b/tests/dq/hermes/test_budget_controller.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from datetime import date
+from types import SimpleNamespace
+
 import pytest
 
 from digiquant.olympus.hermes.budget_controller import (
     RegimeAssessment,
+    assess_budget,
     budget_for,
     classify_regime,
     cross_sectional_dispersion,
@@ -106,3 +110,37 @@ class TestBudgetFor:
         for regime in ("stress", "neutral", "dispersion"):
             b, _ = budget_for(RegimeAssessment(regime=regime), static_cap=12)
             assert b <= 12
+
+
+def _state(price_deltas: dict[str, float]) -> SimpleNamespace:
+    return SimpleNamespace(price_deltas=price_deltas, run_date=date(2026, 6, 25))
+
+
+@pytest.mark.unit
+class TestAssessBudget:
+    def test_none_client_falls_back_to_static(self) -> None:
+        b, floor, a = assess_budget(_state({"A": 0.01, "B": -0.01}), None, static_cap=20)
+        assert (b, floor) == (20, 1) and a is None
+
+    def test_reader_error_falls_back_to_static(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(**_kw: object) -> dict:
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_vix_term_structure", boom
+        )
+        b, floor, a = assess_budget(_state({"A": 0.01}), object(), static_cap=15)
+        assert (b, floor) == (15, 1) and a is None
+
+    def test_stress_signals_tighten_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_vix_term_structure",
+            lambda **_k: {"state": "backwardation", "ratio": 1.2},
+        )
+        monkeypatch.setattr(
+            "digiquant.olympus.hermes.budget_controller.get_market_breadth",
+            lambda **_k: {"pct_above_50dma": 35.0, "universe_size": 50},
+        )
+        b, floor, a = assess_budget(_state({"A": 0.001, "B": -0.001}), object(), static_cap=20)
+        assert a is not None and a.regime == "stress"
+        assert b == 10 and floor == 0

--- a/tests/dq/hermes/test_budget_controller.py
+++ b/tests/dq/hermes/test_budget_controller.py
@@ -17,8 +17,10 @@ def test_regime_assessment_defaults() -> None:
 
 @pytest.mark.unit
 def test_cross_sectional_dispersion_population_stdev() -> None:
-    # stdev of {0.02, -0.02, 0.02, -0.02} (population) == 0.02
-    out = cross_sectional_dispersion({"A": 0.02, "B": -0.02, "C": 0.02, "D": -0.02})
+    # Non-degenerate input (a quiet name + a mover): pstdev({0.0, 0.04}) == 0.02
+    # (mean 0.02, deviations ±0.02). Distinct magnitudes, so this catches a
+    # mean-abs-deviation or sample-stdev mix-up, not just a constant-input pass.
+    out = cross_sectional_dispersion({"A": 0.0, "B": 0.04})
     assert out == pytest.approx(0.02, abs=1e-9)
 
 

--- a/tests/dq/hermes/test_budget_controller.py
+++ b/tests/dq/hermes/test_budget_controller.py
@@ -4,6 +4,8 @@ import pytest
 
 from digiquant.olympus.hermes.budget_controller import (
     RegimeAssessment,
+    budget_for,
+    classify_regime,
     cross_sectional_dispersion,
 )
 
@@ -28,3 +30,79 @@ def test_cross_sectional_dispersion_population_stdev() -> None:
 def test_cross_sectional_dispersion_insufficient_data_is_none() -> None:
     assert cross_sectional_dispersion({}) is None
     assert cross_sectional_dispersion({"A": 0.01}) is None
+
+
+@pytest.mark.unit
+class TestClassifyRegime:
+    def test_backwardation_is_stress(self) -> None:
+        a = classify_regime(
+            vix_state="backwardation",
+            vix_ratio=1.1,
+            pct_above_50dma=70.0,
+            return_dispersion=0.02,
+        )
+        assert a.regime == "stress"  # backwardation dominates even with wide dispersion
+
+    def test_weak_breadth_is_stress(self) -> None:
+        a = classify_regime(
+            vix_state="contango",
+            vix_ratio=0.9,
+            pct_above_50dma=30.0,
+            return_dispersion=0.005,
+        )
+        assert a.regime == "stress"
+
+    def test_wide_dispersion_is_dispersion(self) -> None:
+        a = classify_regime(
+            vix_state="contango",
+            vix_ratio=0.9,
+            pct_above_50dma=65.0,
+            return_dispersion=0.02,
+        )
+        assert a.regime == "dispersion"
+
+    def test_calm_is_neutral(self) -> None:
+        a = classify_regime(
+            vix_state="contango",
+            vix_ratio=0.95,
+            pct_above_50dma=55.0,
+            return_dispersion=0.005,
+        )
+        assert a.regime == "neutral"
+
+    def test_all_signals_none_is_neutral(self) -> None:
+        a = classify_regime(
+            vix_state=None, vix_ratio=None, pct_above_50dma=None, return_dispersion=None
+        )
+        assert a.regime == "neutral"
+
+
+@pytest.mark.unit
+class TestBudgetFor:
+    def test_stress_tightens_below_cap(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="stress"), static_cap=20)
+        assert b == 10 and b <= 20
+        assert floor == 0
+
+    def test_stress_respects_floor(self) -> None:
+        b, _ = budget_for(RegimeAssessment(regime="stress"), static_cap=4)
+        assert b == 3  # STRESS_FLOOR, not round(4*0.5)=2
+
+    def test_neutral_equals_cap(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="neutral"), static_cap=20)
+        assert b == 20 and floor == 1
+
+    def test_dispersion_keeps_cap_raises_explore_floor(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="dispersion"), static_cap=20)
+        assert b == 20  # never exceeds cap (cost-safe)
+        assert floor == 5  # round(20*0.25)
+
+    def test_no_cap_configured_stays_uncapped(self) -> None:
+        b, floor = budget_for(RegimeAssessment(regime="neutral"), static_cap=0)
+        assert b == 0  # 0 == "no cap" downstream
+        assert floor == 1
+
+    def test_budget_never_exceeds_cap_any_regime(self) -> None:
+        for regime in ("stress", "neutral", "dispersion"):
+            b, _ = budget_for(RegimeAssessment(regime=regime), static_cap=12)
+            assert b <= 12

--- a/tests/dq/hermes/test_budget_controller.py
+++ b/tests/dq/hermes/test_budget_controller.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.hermes.budget_controller import (
+    RegimeAssessment,
+    cross_sectional_dispersion,
+)
+
+
+@pytest.mark.unit
+def test_regime_assessment_defaults() -> None:
+    a = RegimeAssessment(regime="neutral")
+    assert a.regime == "neutral"
+    assert a.vix_state is None and a.return_dispersion is None and a.note == ""
+
+
+@pytest.mark.unit
+def test_cross_sectional_dispersion_population_stdev() -> None:
+    # stdev of {0.02, -0.02, 0.02, -0.02} (population) == 0.02
+    out = cross_sectional_dispersion({"A": 0.02, "B": -0.02, "C": 0.02, "D": -0.02})
+    assert out == pytest.approx(0.02, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_cross_sectional_dispersion_insufficient_data_is_none() -> None:
+    assert cross_sectional_dispersion({}) is None
+    assert cross_sectional_dispersion({"A": 0.01}) is None

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -465,3 +465,42 @@ def test_compute_focus_roster_honors_adaptive_budget(monkeypatch: pytest.MonkeyP
         min_new_candidates=1,
     )
     assert len(roster) == 2
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 Task 6: H4 node wires the regime-adaptive dispatch budget
+# ---------------------------------------------------------------------------
+
+
+def _make_min_hermes_state(*, watchlist: list[str]) -> "object":
+    """Minimal HermesState for node-level tests: a watchlist, no held, no thesis map.
+
+    Mirrors the construction in test_build_hermes_phases_thesis /
+    test_chain_safety_net (run_type/run_date/config + empty phase_hermes).
+    """
+    from datetime import date as _date
+
+    from digiquant.olympus.atlas.state import AtlasConfigBundle, PhaseHermesState
+    from digiquant.olympus.hermes.state import HermesState
+
+    state = HermesState(
+        run_type="delta",
+        run_date=_date(2026, 6, 20),
+        config=AtlasConfigBundle(watchlist=list(watchlist)),
+    )
+    state.phase_hermes = PhaseHermesState()
+    return state
+
+
+@pytest.mark.unit
+def test_h4_node_applies_adaptive_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    from digiquant.olympus.hermes.phases import h4_opportunity_screener as h4
+
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    monkeypatch.setattr(h4, "assess_budget", lambda *a, **k: (1, 0, None))
+    node = h4.build_h4_opportunity_screener(client=None).nodes[0].run
+    # Build a minimal HermesState with watchlist of 3, no held, no thesis map.
+    state = _make_min_hermes_state(watchlist=["AAA", "BBB", "CCC"])
+    out = node(state)
+    roster = out["phase_hermes"].focus_roster
+    assert len(roster) == 1  # adaptive budget=1 applied

--- a/tests/dq/hermes/test_h4_focus_roster.py
+++ b/tests/dq/hermes/test_h4_focus_roster.py
@@ -451,3 +451,17 @@ def test_excluded_ledger_records_gated_held_absent_from_watchlist() -> None:
     )
     aapl_entry = next(e for e in excluded if e.ticker == "AAPL")
     assert aapl_entry.reason, "gated-out held must carry a non-empty reason"
+
+
+@pytest.mark.unit
+def test_compute_focus_roster_honors_adaptive_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "100")  # env would allow all
+    monkeypatch.setenv("HERMES_HELD_GATE", "off")
+    roster = compute_focus_roster(
+        watchlist=["AAA", "BBB", "CCC", "DDD"],
+        held=set(),
+        run_date=date(2026, 6, 20),
+        adaptive_max_analysts=2,  # regime budget tightens to 2
+        min_new_candidates=1,
+    )
+    assert len(roster) == 2

--- a/tests/dq/hermes/test_roster_cap.py
+++ b/tests/dq/hermes/test_roster_cap.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from digiquant.olympus.hermes.roster_cap import capped_tickers
+
+
+@pytest.mark.unit
+class TestCappedTickersAdaptive:
+    def test_adaptive_param_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "100")  # env says no real cap
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=2)
+        assert len(out) == 2  # adaptive cap wins
+
+    def test_none_adaptive_uses_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=None)
+        assert len(out) == 2  # env cap, exactly today's behavior
+
+    def test_adaptive_zero_means_no_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAS_MAX_ANALYSTS", "2")
+        out = capped_tickers(["A", "B", "C", "D"], held=(), min_new=1, adaptive_max_analysts=0)
+        assert len(out) == 4  # 0 == no cap, overriding the env's 2


### PR DESCRIPTION
Promotes Stage 2 (regime-adaptive analyst dispatch budget, #1043 / #1017) to production. Authorized by the repo owner. Clean scope — every commit in range is Stage 2.

- New `budget_controller.py`: regime classifier (VIX term-structure + breadth + price_deltas dispersion) → cost-safe budget (`B ≤ ATLAS_MAX_ANALYSTS`, only tightens) + explore floor, fail-soft to the static cap.
- H4 wires it via `compute_focus_roster` → `capped_tickers`; backward-compatible (no-op when `adaptive_max_analysts=None`).
- 7 TDD tasks + opus whole-branch review (approve-with-nits → fixed). All gates green on #1050.

Deferred (per spec): B>cap in dispersion regimes, dedicated dispersion metric, dispatch_outcomes feedback table (Stage 4).