### PR TITLE
fix(olympus): Pipeline polish — expansion, smooth pan/zoom, design language, doc click-through + rename to Brief

### DIFF
--- a/frontend/olympus/app/pipeline/page.tsx
+++ b/frontend/olympus/app/pipeline/page.tsx
@@ -11,18 +11,15 @@ export default function PipelinePage() {
   return (
     <div className="flex flex-col flex-1 min-h-0 min-w-0">
       {/* Page header */}
-      <header className="px-6 pt-4 pb-2 border-b border-border">
-        <div className="text-[10.5px] font-semibold tracking-[0.16em] uppercase text-muted mb-0.5">
+      <header className="px-6 pt-4 pb-2 border-b border-border-subtle">
+        <div className="text-[10.5px] font-semibold tracking-[0.16em] uppercase text-text-muted mb-0.5">
           Pipeline
         </div>
         <div className="flex items-baseline gap-3 flex-wrap">
-          <h1
-            className="text-[28px] font-normal leading-none m-0"
-            style={{ fontFamily: 'var(--font-serif, Georgia, serif)' }}
-          >
+          <h1 className="font-display text-[28px] font-normal leading-none m-0 text-text-primary">
             How today&apos;s decision was made
           </h1>
-          <span className="text-[12.5px] text-muted">
+          <span className="text-[12.5px] text-text-muted">
             research → deliberation → selection
           </span>
         </div>

--- a/frontend/olympus/components/command-palette.test.tsx
+++ b/frontend/olympus/components/command-palette.test.tsx
@@ -42,7 +42,7 @@ function doc(partial: Partial<Doc>): Doc {
 }
 
 const baseItems = [
-  { id: 'go-today', title: 'Today', hint: 'Dashboard home', href: '/', icon: () => null },
+  { id: 'go-today', title: 'Brief', hint: 'Dashboard home', href: '/', icon: () => null },
   { id: 'go-pipeline', title: 'Pipeline', hint: 'Daily decision graph', href: '/pipeline', icon: () => null },
 ] as Parameters<typeof filterCommandItems>[0];
 

--- a/frontend/olympus/components/command-palette.tsx
+++ b/frontend/olympus/components/command-palette.tsx
@@ -49,7 +49,7 @@ export function buildCommandItems(data: ReturnType<typeof useDashboard>['data'])
   const theses = data?.portfolio?.strategy?.theses ?? [];
   const docs = data?.docs ?? [];
   const base: CmdItem[] = [
-    { id: 'go-today', title: 'Today', hint: "Today's decision & NAV", href: '/', icon: LayoutDashboard },
+    { id: 'go-today', title: 'Brief', hint: "Today's decision & NAV", href: '/', icon: LayoutDashboard },
     {
       id: 'go-holdings',
       title: 'Portfolio — Holdings',

--- a/frontend/olympus/components/pipeline/PipelineCanvas.test.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.test.tsx
@@ -12,12 +12,13 @@ vi.mock('@/components/pipeline/useCanvasCamera', async (importOriginal) => {
       zoomOut: () => {},
       fit: () => {},
       centerOn: () => {},
+      layerRef: { current: null },
+      viewportRef: { current: null },
       bind: {
         onPointerDown: () => {},
         onPointerMove: () => {},
         onPointerUp: () => {},
         onPointerCancel: () => {},
-        onWheel: () => {},
       },
     }),
   };

--- a/frontend/olympus/components/pipeline/PipelineCanvas.test.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.test.tsx
@@ -29,6 +29,7 @@ import type { PipelineStageId } from '@/lib/pipeline-topology';
 
 const emptyDay: PipelineDayData = {
   fanoutCounts: {},
+  fanoutKeys: {},
   presentKeys: new Set(),
 };
 

--- a/frontend/olympus/components/pipeline/PipelineCanvas.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.tsx
@@ -6,6 +6,7 @@ import type { PipelineDayData } from '@/lib/pipeline-graph-data';
 import type { ExpansionState, LaidOutNode } from '@/lib/pipeline-layout';
 import { layoutPipeline } from '@/lib/pipeline-layout';
 import type { PipelineStageId } from '@/lib/pipeline-topology';
+import { PIPELINE_TOPOLOGY, stageById } from '@/lib/pipeline-topology';
 import PipelineNode from './PipelineNode';
 import PipelineConnectors from './PipelineConnectors';
 import { useCanvasCamera } from './useCanvasCamera';
@@ -54,10 +55,7 @@ export default function PipelineCanvas({
 
   const handleNodeClick = useCallback(
     (node: LaidOutNode) => {
-      const isFanoutParent = node.kind === 'substep';
-      const isStage = node.kind === 'stage';
-
-      if (isStage) {
+      if (node.kind === 'stage') {
         setExpansion((prev) => {
           const next = new Set(prev.expandedStages);
           if (next.has(node.stageId)) {
@@ -70,22 +68,29 @@ export default function PipelineCanvas({
         return;
       }
 
-      if (isFanoutParent) {
-        const fanoutKey = `${node.stageId}:${node.id.split(':')[1]}`;
-        setExpansion((prev) => {
-          const next = new Set(prev.expandedFanouts);
-          if (next.has(fanoutKey)) {
-            next.delete(fanoutKey);
-          } else {
-            next.add(fanoutKey);
-          }
-          return { ...prev, expandedFanouts: next };
-        });
+      if (node.kind === 'substep') {
+        const subStepId = node.id.split(':')[1];
+        const hasFanout = !!stageById(node.stageId)?.subSteps.find((s) => s.id === subStepId)?.fanout;
+        if (hasFanout) {
+          const fanoutKey = `${node.stageId}:${subStepId}`;
+          setExpansion((prev) => {
+            const next = new Set(prev.expandedFanouts);
+            if (next.has(fanoutKey)) {
+              next.delete(fanoutKey);
+            } else {
+              next.add(fanoutKey);
+            }
+            return { ...prev, expandedFanouts: next };
+          });
+          return;
+        }
+        // Leaf sub-step: open its document when one is present.
+        if (node.documentKey) onNodeActivate(node);
         return;
       }
 
-      // Leaf / fanout-branch
-      onNodeActivate(node);
+      // fanout-branch
+      if (node.documentKey) onNodeActivate(node);
     },
     [onNodeActivate],
   );
@@ -99,6 +104,11 @@ export default function PipelineCanvas({
   const handleExpandAll = useCallback(() => {
     const allStages = new Set<PipelineStageId>(['inputs', 'research', 'synthesis', 'selection', 'decision']);
     const allFanouts = new Set<string>();
+    for (const stage of PIPELINE_TOPOLOGY) {
+      for (const sub of stage.subSteps) {
+        if (sub.fanout) allFanouts.add(`${stage.id}:${sub.id}`);
+      }
+    }
     setExpansion({ expandedStages: allStages, expandedFanouts: allFanouts });
   }, []);
 
@@ -209,21 +219,31 @@ export default function PipelineCanvas({
 
           {/* Node layer */}
           {layout.nodes.map((node) => {
-            const isFanoutParent = node.kind === 'substep';
             const isStage = node.kind === 'stage';
-            const expandable = isStage || (isFanoutParent && !!day.fanoutCounts[node.id.split(':')[1]]);
+            const subStepId = node.kind === 'substep' ? node.id.split(':')[1] : undefined;
+            // Fan-out parent identity comes from the STATIC topology, so the
+            // chevron + count badge are discoverable even before data loads.
+            const fanout = subStepId
+              ? stageById(node.stageId)?.subSteps.find((s) => s.id === subStepId)?.fanout
+              : undefined;
+            const isFanoutParent = !!fanout;
+
+            const expandable = isStage || isFanoutParent;
             const expanded = isStage
               ? expansion.expandedStages.has(node.stageId)
-              : expansion.expandedFanouts.has(`${node.stageId}:${node.id.split(':')[1]}`);
+              : expansion.expandedFanouts.has(`${node.stageId}:${subStepId}`);
 
-            // Count badge: show fanout count for parent nodes
+            // Count badge: live count if present, else the topology default.
+            // Guard with > 0 so default-0 fan-outs don't render a noisy '0'.
             let count: number | undefined;
-            if (isFanoutParent) {
-              const subStepId = node.id.split(':')[1];
-              if (subStepId && day.fanoutCounts[subStepId] != null) {
-                count = day.fanoutCounts[subStepId];
-              }
+            if (fanout && subStepId) {
+              const c = day.fanoutCounts[fanout.id] ?? fanout.defaultCount;
+              if (c > 0) count = c;
             }
+
+            // PipelineClient passes selectedNodeId = active document_key, so a
+            // node is selected by its documentKey, not its layout id.
+            const selected = !!node.documentKey && node.documentKey === selectedNodeId;
 
             return (
               <PipelineNode
@@ -232,7 +252,7 @@ export default function PipelineCanvas({
                 count={count}
                 expandable={expandable}
                 expanded={expanded}
-                selected={selectedNodeId === node.id}
+                selected={selected}
                 onActivate={() => handleNodeClick(node)}
               />
             );

--- a/frontend/olympus/components/pipeline/PipelineCanvas.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Minus, Plus, Maximize2, ChevronDown, ChevronRight } from 'lucide-react';
 import type { PipelineDayData } from '@/lib/pipeline-graph-data';
 import type { ExpansionState, LaidOutNode } from '@/lib/pipeline-layout';
@@ -32,23 +32,23 @@ export default function PipelineCanvas({
   const [expansion, setExpansion] = useState<ExpansionState>(
     initialExpansion ?? DEFAULT_EXPANSION,
   );
-  const vpRef = useRef<HTMLDivElement>(null);
   const camera = useCanvasCamera();
+  const { viewportRef, layerRef } = camera;
 
   const layout = layoutPipeline(day, expansion);
 
   // Fit on mount
   useEffect(() => {
-    if (!vpRef.current) return;
-    const { clientWidth, clientHeight } = vpRef.current;
+    if (!viewportRef.current) return;
+    const { clientWidth, clientHeight } = viewportRef.current;
     camera.fit({ width: layout.width, height: layout.height }, { width: clientWidth, height: clientHeight });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Auto-center when expansion changes (closes mockup gap #1)
   useEffect(() => {
-    if (!vpRef.current) return;
-    const { clientWidth, clientHeight } = vpRef.current;
+    if (!viewportRef.current) return;
+    const { clientWidth, clientHeight } = viewportRef.current;
     camera.fit({ width: layout.width, height: layout.height }, { width: clientWidth, height: clientHeight });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expansion]);
@@ -96,10 +96,10 @@ export default function PipelineCanvas({
   );
 
   const handleFitClick = useCallback(() => {
-    if (!vpRef.current) return;
-    const { clientWidth, clientHeight } = vpRef.current;
+    if (!viewportRef.current) return;
+    const { clientWidth, clientHeight } = viewportRef.current;
     camera.fit({ width: layout.width, height: layout.height }, { width: clientWidth, height: clientHeight });
-  }, [camera, layout]);
+  }, [camera, layout, viewportRef]);
 
   const handleExpandAll = useCallback(() => {
     const allStages = new Set<PipelineStageId>(['inputs', 'research', 'synthesis', 'selection', 'decision']);
@@ -115,12 +115,6 @@ export default function PipelineCanvas({
   const handleCollapseAll = useCallback(() => {
     setExpansion({ expandedStages: new Set(), expandedFanouts: new Set() });
   }, []);
-
-  // Check prefers-reduced-motion for transition class
-  const reducedMotion =
-    typeof window !== 'undefined'
-      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      : false;
 
   const { transform, zoomIn, zoomOut, bind } = camera;
 
@@ -192,20 +186,25 @@ export default function PipelineCanvas({
         </div>
       </div>
 
-      {/* Canvas viewport — overflow-hidden prevents page horizontal scroll */}
+      {/* Canvas viewport — overflow-hidden prevents page horizontal scroll.
+          touch-action:none + overscroll-behavior:contain stop the browser from
+          claiming the gesture; wheel is handled via a native passive:false
+          listener inside the camera hook (not a React onWheel bind). */}
       <div
-        ref={vpRef}
+        ref={viewportRef}
         className="flex-1 min-h-0 overflow-hidden relative cursor-grab active:cursor-grabbing select-none"
+        style={{ touchAction: 'none', overscrollBehavior: 'contain' }}
         {...bind}
       >
         <div
-          className={reducedMotion ? '' : 'transition-transform duration-75 will-change-transform'}
+          ref={layerRef}
           style={{
             position: 'absolute',
             top: 0,
             left: 0,
             transformOrigin: '0 0',
-            transform: `translate(${transform.x}px,${transform.y}px) scale(${transform.scale})`,
+            willChange: 'transform',
+            transform: `translate3d(${transform.x}px,${transform.y}px,0) scale(${transform.scale})`,
             padding: 30,
           }}
         >

--- a/frontend/olympus/components/pipeline/PipelineCanvas.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Minus, Plus, Maximize2, ChevronDown, ChevronRight } from 'lucide-react';
+import { Minus, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import type { PipelineDayData } from '@/lib/pipeline-graph-data';
 import type { ExpansionState, LaidOutNode } from '@/lib/pipeline-layout';
 import { layoutPipeline } from '@/lib/pipeline-layout';

--- a/frontend/olympus/components/pipeline/PipelineCanvas.tsx
+++ b/frontend/olympus/components/pipeline/PipelineCanvas.tsx
@@ -121,14 +121,14 @@ export default function PipelineCanvas({
   return (
     <div className="flex flex-col flex-1 min-h-0 min-w-0">
       {/* Toolbar */}
-      <div className="flex items-center gap-2 px-6 py-2 border-b border-border text-sm text-muted flex-wrap">
-        <div className="flex gap-0.5 bg-[var(--panel)] border border-border rounded-[9px] p-0.5">
+      <div className="flex items-center gap-2 px-6 py-2 border-b border-border-subtle text-sm text-text-muted flex-wrap">
+        <div className="flex gap-0.5 bg-bg-secondary border border-border-subtle rounded-[9px] p-0.5">
           <button
             type="button"
             data-no-pan=""
             aria-label="Zoom out"
             onClick={zoomOut}
-            className="h-7 w-7 flex items-center justify-center rounded-md text-muted hover:text-foreground hover:bg-white/6"
+            className="h-7 w-7 flex items-center justify-center rounded-md text-text-muted hover:text-text-primary hover:bg-fin-blue/10"
           >
             <Minus size={14} />
           </button>
@@ -137,7 +137,7 @@ export default function PipelineCanvas({
             data-no-pan=""
             aria-label="Fit to view"
             onClick={handleFitClick}
-            className="h-7 px-2.5 text-[12px] font-semibold rounded-md text-muted hover:text-foreground hover:bg-white/6"
+            className="h-7 px-2.5 text-[12px] font-medium rounded-md text-text-muted hover:text-text-primary hover:bg-fin-blue/10"
           >
             Fit
           </button>
@@ -146,7 +146,7 @@ export default function PipelineCanvas({
             data-no-pan=""
             aria-label="Zoom in"
             onClick={zoomIn}
-            className="h-7 w-7 flex items-center justify-center rounded-md text-muted hover:text-foreground hover:bg-white/6"
+            className="h-7 w-7 flex items-center justify-center rounded-md text-text-muted hover:text-text-primary hover:bg-fin-blue/10"
           >
             <Plus size={14} />
           </button>
@@ -156,7 +156,7 @@ export default function PipelineCanvas({
           type="button"
           data-no-pan=""
           onClick={handleExpandAll}
-          className="h-8 px-3 text-[12px] font-semibold rounded-[9px] border border-border bg-[var(--panel)] text-muted hover:text-foreground flex items-center gap-1.5"
+          className="h-8 px-3 text-[12px] font-medium rounded-[9px] border border-border-subtle bg-bg-secondary text-text-muted hover:text-text-primary hover:bg-fin-blue/10 flex items-center gap-1.5"
         >
           <ChevronDown size={13} />
           Expand all
@@ -166,21 +166,21 @@ export default function PipelineCanvas({
           type="button"
           data-no-pan=""
           onClick={handleCollapseAll}
-          className="h-8 px-3 text-[12px] font-semibold rounded-[9px] border border-border bg-[var(--panel)] text-muted hover:text-foreground flex items-center gap-1.5"
+          className="h-8 px-3 text-[12px] font-medium rounded-[9px] border border-border-subtle bg-bg-secondary text-text-muted hover:text-text-primary hover:bg-fin-blue/10 flex items-center gap-1.5"
         >
           <ChevronRight size={13} />
           Collapse
         </button>
 
-        <span className="text-[11px] text-muted ml-auto hidden sm:block">
+        <span className="text-[11px] text-text-muted ml-auto hidden sm:block">
           drag to pan · scroll to zoom · click a node to open / expand
         </span>
 
         <div className="flex gap-3 flex-wrap">
-          <span className="flex items-center gap-1.5 text-[11px] text-muted">
+          <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
             <span className="text-fin-blue text-[13px]">→</span> sequential
           </span>
-          <span className="flex items-center gap-1.5 text-[11px] text-muted">
+          <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
             <span className="text-fin-blue text-[13px]">↓</span> parallel
           </span>
         </div>

--- a/frontend/olympus/components/pipeline/PipelineClient.tsx
+++ b/frontend/olympus/components/pipeline/PipelineClient.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { buildPipelineDayData } from '@/lib/pipeline-graph-data';
+import { buildPipelineDayData, fanoutIdForKey } from '@/lib/pipeline-graph-data';
 import type { PipelineDayData } from '@/lib/pipeline-graph-data';
+import { PIPELINE_TOPOLOGY } from '@/lib/pipeline-topology';
+import type { PipelineStageId } from '@/lib/pipeline-topology';
 import type { ExpansionState, LaidOutNode } from '@/lib/pipeline-layout';
 import type { PipelineStage } from '@/lib/pipeline-links';
 import { parsePipelineParams } from '@/lib/pipeline-links';
@@ -21,9 +23,35 @@ function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function buildInitialExpansion(stage: PipelineStage | undefined): ExpansionState {
-  if (!stage) return { expandedStages: new Set(), expandedFanouts: new Set() };
-  return { expandedStages: new Set([stage]), expandedFanouts: new Set() };
+/** The owning stage + `${stageId}:${subId}` fan-out key for a fan-out id, from the static topology. */
+function fanoutOwner(fanoutId: string): { stageId: PipelineStageId; fanoutKey: string } | null {
+  for (const stage of PIPELINE_TOPOLOGY) {
+    for (const sub of stage.subSteps) {
+      if (sub.fanout?.id === fanoutId) return { stageId: stage.id, fanoutKey: `${stage.id}:${sub.id}` };
+    }
+  }
+  return null;
+}
+
+function buildInitialExpansion(
+  stage: PipelineStage | undefined,
+  node: string | undefined,
+): ExpansionState {
+  const expandedStages = new Set<PipelineStageId>(stage ? [stage] : []);
+  const expandedFanouts = new Set<string>();
+
+  // Deep-link straight to a fan-out branch (e.g. ?node=analyst/QQQ): expand the owning
+  // stage + fan-out so the branch renders and the in-graph selection highlight shows.
+  if (node) {
+    const fanoutId = fanoutIdForKey(node);
+    const owner = fanoutId ? fanoutOwner(fanoutId) : null;
+    if (owner) {
+      expandedStages.add(owner.stageId);
+      expandedFanouts.add(owner.fanoutKey);
+    }
+  }
+
+  return { expandedStages, expandedFanouts };
 }
 
 export default function PipelineClient({ searchParams = {} }: PipelineClientProps) {
@@ -50,7 +78,7 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
   const [activeDocumentKey, setActiveDocumentKey] = useState<string | null>(params.node ?? null);
 
   const initialExpansion = useMemo(
-    () => buildInitialExpansion(params.stage),
+    () => buildInitialExpansion(params.stage, params.node),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );

--- a/frontend/olympus/components/pipeline/PipelineClient.tsx
+++ b/frontend/olympus/components/pipeline/PipelineClient.tsx
@@ -37,6 +37,7 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
   const [availableDates, setAvailableDates] = useState<string[]>([selectedDate]);
   const [dayData, setDayData] = useState<PipelineDayData>({
     fanoutCounts: {},
+    fanoutKeys: {},
     presentKeys: new Set(),
   });
 

--- a/frontend/olympus/components/pipeline/PipelineConnectors.tsx
+++ b/frontend/olympus/components/pipeline/PipelineConnectors.tsx
@@ -49,7 +49,9 @@ export default function PipelineConnectors({
       viewBox={`0 0 ${width} ${height}`}
       fill="none"
     >
+      {/* Default (calm) connectors first … */}
       {connectors.map((conn) => {
+        if (conn.active) return null;
         const from = nodeById(nodes, conn.fromId);
         const to = nodeById(nodes, conn.toId);
         if (!from || !to) return null;
@@ -57,8 +59,25 @@ export default function PipelineConnectors({
           <path
             key={`${conn.fromId}→${conn.toId}`}
             d={buildPath(from, to)}
+            stroke="var(--color-border-subtle)"
+            strokeOpacity="0.9"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        );
+      })}
+      {/* … active (cyan) connectors after, so they read on top. */}
+      {connectors.map((conn) => {
+        if (!conn.active) return null;
+        const from = nodeById(nodes, conn.fromId);
+        const to = nodeById(nodes, conn.toId);
+        if (!from || !to) return null;
+        return (
+          <path
+            key={`active:${conn.fromId}→${conn.toId}`}
+            d={buildPath(from, to)}
             stroke="var(--color-fin-blue)"
-            strokeOpacity="0.35"
+            strokeOpacity="0.55"
             strokeWidth="1.5"
             strokeLinecap="round"
           />

--- a/frontend/olympus/components/pipeline/PipelineDaySelector.tsx
+++ b/frontend/olympus/components/pipeline/PipelineDaySelector.tsx
@@ -16,25 +16,25 @@ export default function PipelineDaySelector({ dates, value, onChange }: Pipeline
   const label = formatDate(value);
 
   return (
-    <div className="ml-auto flex items-center gap-2 bg-[var(--panel)] border border-border rounded-[9px] px-2.5 py-1.5 text-[12.5px]">
+    <div className="ml-auto flex items-center gap-2 bg-bg-secondary border border-border-subtle rounded-[9px] px-2.5 py-1.5 font-mono text-[12.5px] tabular-nums">
       <button
         type="button"
         aria-label="Previous day"
         disabled={!hasPrev}
         onClick={() => hasPrev && onChange(dates[idx - 1])}
-        className="text-muted hover:text-foreground disabled:opacity-30 transition-colors"
+        className="text-text-muted hover:text-text-primary disabled:opacity-30 transition-colors"
       >
         <ChevronLeft size={14} />
       </button>
 
-      <span className="text-foreground whitespace-nowrap">{label}</span>
+      <span className="text-text-primary whitespace-nowrap">{label}</span>
 
       <button
         type="button"
         aria-label="Next day"
         disabled={!hasNext}
         onClick={() => hasNext && onChange(dates[idx + 1])}
-        className="text-muted hover:text-foreground disabled:opacity-30 transition-colors"
+        className="text-text-muted hover:text-text-primary disabled:opacity-30 transition-colors"
       >
         <ChevronRight size={14} />
       </button>

--- a/frontend/olympus/components/pipeline/PipelineNode.tsx
+++ b/frontend/olympus/components/pipeline/PipelineNode.tsx
@@ -20,20 +20,20 @@ export default function PipelineNode({
   selected = false,
   onActivate,
 }: PipelineNodeProps) {
-  const isDecision = node.stageId === 'decision' && node.kind === 'stage';
   const isBranch = node.kind === 'fanout-branch';
 
-  let borderClass = 'border-border';
-  if (selected) borderClass = 'border-fin-blue';
-  else if (isDecision) borderClass = 'border-fin-green/45';
-
+  // Branches read as nested cards: recessed inset + tighter 6px radius. Standard
+  // nodes use the shared .glass-card primitive (flat panel, 8px radius, hover
+  // border-glow). Decision is NOT special-cased (F5 — no green chrome).
   const cardClass = [
-    'absolute rounded-xl border backdrop-blur-md cursor-pointer',
+    'absolute cursor-pointer',
     'transition-[border-color,box-shadow,transform] duration-150',
-    'hover:-translate-y-px hover:shadow-lg hover:border-fin-blue/55',
-    isBranch ? 'bg-[var(--panel)] text-[length:var(--text-sm)]' : 'bg-glass',
-    borderClass,
-    selected ? 'shadow-[0_0_0_1px_var(--color-fin-blue)]' : '',
+    'hover:-translate-y-px',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fin-blue/60',
+    isBranch
+      ? 'rounded-md border border-border-subtle bg-bg-secondary hover:border-border-glow'
+      : 'glass-card',
+    selected ? 'border-fin-blue/60 shadow-[0_0_0_1px_var(--color-fin-blue)]' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -60,32 +60,35 @@ export default function PipelineNode({
       }}
     >
       <div className="flex items-center gap-1.5 px-3 h-full">
-        {/* status dot */}
+        {/* status pip — calm cyan recipe (F5): active when expanded, else
+            border-subtle. No glow, no fin-green/red chrome. */}
         <span
           className={`w-2 h-2 rounded-full flex-shrink-0 ${
-            isDecision
-              ? 'bg-fin-green shadow-[0_0_8px_var(--color-fin-green)]'
-              : node.kind === 'fanout-branch'
-                ? 'bg-fin-blue'
-                : 'bg-fin-green'
+            expanded ? 'bg-fin-blue' : 'bg-border-subtle'
           }`}
         />
 
-        {/* label */}
-        <span className="text-[13px] font-semibold tracking-tight leading-tight flex-1 truncate">
+        {/* label — stage = Geist Sans 13px medium; leaf/branch = Geist Mono 12px */}
+        <span
+          className={`flex-1 truncate leading-tight ${
+            node.kind === 'stage'
+              ? 'font-sans text-[13px] font-medium text-text-primary'
+              : 'font-mono text-[12px] text-text-secondary'
+          }`}
+        >
           {node.label}
         </span>
 
-        {/* count badge — accent only */}
+        {/* count badge — accent chrome only, softened (no font-bold) */}
         {count != null && (
-          <span className="text-[10px] font-bold text-fin-blue bg-fin-blue/10 rounded-full px-1.5 py-px flex-shrink-0">
+          <span className="font-mono text-[10px] tabular-nums text-fin-blue bg-fin-blue/15 rounded-full px-1.5 py-px flex-shrink-0">
             {count}
           </span>
         )}
 
         {/* expand chevron */}
         {expandable && (
-          <span className="text-muted flex-shrink-0">
+          <span className="text-text-muted flex-shrink-0">
             {expanded ? (
               <ChevronDown size={13} />
             ) : (

--- a/frontend/olympus/components/pipeline/PipelineNodeDetail.tsx
+++ b/frontend/olympus/components/pipeline/PipelineNodeDetail.tsx
@@ -52,19 +52,19 @@ export default function PipelineNodeDetail({ documentKey, date, onClose }: Pipel
       aria-live="polite"
       className={[
         // Mobile: bottom sheet
-        'fixed inset-x-0 bottom-0 z-30 bg-[var(--panel)] border-t border-border rounded-t-2xl',
+        'fixed inset-x-0 bottom-0 z-30 bg-bg-secondary border-t border-border-subtle rounded-t-2xl',
         'h-[60vh] flex flex-col',
         // Desktop: right side panel (overrides the bottom sheet positioning)
         'md:inset-auto md:relative md:h-full md:w-[372px] md:border-t-0 md:border-l md:rounded-none',
       ].join(' ')}
     >
       {/* Header */}
-      <div className="flex items-start justify-between px-5 py-4 border-b border-border flex-shrink-0">
+      <div className="flex items-start justify-between px-5 py-4 border-b border-border-subtle flex-shrink-0">
         <div className="min-w-0 flex-1">
           <div className="text-[10px] font-bold tracking-[0.14em] uppercase text-fin-blue mb-1">
             {documentKey ? 'Document' : 'No selection'}
           </div>
-          <div className="font-mono text-sm truncate text-foreground">
+          <div className="font-mono text-sm truncate text-text-primary">
             {documentKey ?? '—'}
           </div>
         </div>
@@ -72,20 +72,20 @@ export default function PipelineNodeDetail({ documentKey, date, onClose }: Pipel
           type="button"
           aria-label="Close"
           onClick={onClose}
-          className="ml-3 flex-shrink-0 w-7 h-7 flex items-center justify-center border border-border rounded-lg text-muted hover:text-foreground transition-colors"
+          className="ml-3 flex-shrink-0 w-7 h-7 flex items-center justify-center border border-border-subtle rounded-lg text-text-muted hover:text-text-primary transition-colors"
         >
           <X size={13} />
         </button>
       </div>
 
       {/* Body */}
-      <div className="flex-1 overflow-y-auto px-5 py-4 text-sm text-muted leading-relaxed">
+      <div className="flex-1 overflow-y-auto px-5 py-4 text-sm text-text-muted leading-relaxed">
         {/* Empty state */}
         {!documentKey && (
           <div className="flex flex-col items-center justify-center h-full gap-3 text-center">
-            <FileSearch size={32} className="text-muted opacity-40" />
-            <p className="text-muted text-sm">No document selected.</p>
-            <p className="text-[12px] text-muted/60">
+            <FileSearch size={32} className="text-text-muted opacity-40" />
+            <p className="text-text-muted text-sm">No document selected.</p>
+            <p className="text-[12px] text-text-muted/60">
               Select a node in the pipeline graph to view its output here.
             </p>
           </div>
@@ -93,14 +93,14 @@ export default function PipelineNodeDetail({ documentKey, date, onClose }: Pipel
 
         {/* Loading */}
         {documentKey && loading && (
-          <div className="text-muted text-sm py-4">Loading document…</div>
+          <div className="text-text-muted text-sm py-4">Loading document…</div>
         )}
 
         {/* Error */}
         {documentKey && !loading && error && (
           <div className="space-y-2">
             <p className="text-fin-amber text-sm">{error}</p>
-            <p className="text-[12px] text-muted">
+            <p className="text-[12px] text-text-muted">
               This document may not be available for the selected date.
             </p>
           </div>
@@ -120,10 +120,10 @@ export default function PipelineNodeDetail({ documentKey, date, onClose }: Pipel
         {/* Not found */}
         {documentKey && !loading && !error && !doc && (
           <div className="space-y-2 py-4">
-            <p className="text-muted text-sm">
-              No output found for <span className="font-mono text-foreground">{documentKey}</span> on {date}.
+            <p className="text-text-muted text-sm">
+              No output found for <span className="font-mono text-text-primary">{documentKey}</span> on {date}.
             </p>
-            <p className="text-[12px] text-muted/70">
+            <p className="text-[12px] text-text-muted/70">
               This stage may not have run yet, or the output was not persisted.
             </p>
           </div>

--- a/frontend/olympus/components/pipeline/PipelineSummaryStrip.tsx
+++ b/frontend/olympus/components/pipeline/PipelineSummaryStrip.tsx
@@ -18,7 +18,7 @@ const DOT_COLOR: Record<RegimeChipColor, string> = {
   red: 'bg-fin-red',
   amber: 'bg-fin-amber',
   blue: 'bg-fin-blue',
-  muted: 'bg-muted',
+  muted: 'bg-border-subtle',
 };
 
 export default function PipelineSummaryStrip({
@@ -29,11 +29,11 @@ export default function PipelineSummaryStrip({
   return (
     <div className="flex gap-3 items-start flex-wrap mt-2.5">
       {/* Digest headline — absorbs "The Read" */}
-      <div className="flex-1 min-w-[230px]" style={{ fontFamily: 'var(--font-serif, Georgia, serif)' }}>
+      <div className="flex-1 min-w-[230px] font-display">
         <span className="block text-[9px] font-bold tracking-[0.14em] uppercase text-fin-blue mb-0.5 font-sans">
           The read
         </span>
-        <span className="text-[14.5px] leading-snug text-foreground">
+        <span className="text-[14.5px] leading-snug text-text-primary">
           {headline ?? 'Loading digest…'}
         </span>
       </div>
@@ -43,19 +43,20 @@ export default function PipelineSummaryStrip({
         {regimeChips.map((chip) => (
           <span
             key={`${chip.label}-${chip.value}`}
-            className="inline-flex items-center gap-1.5 text-[11px] bg-[var(--panel)] border border-border rounded-[7px] px-2 py-1 text-muted whitespace-nowrap"
+            className="inline-flex items-center gap-1.5 text-[11px] bg-bg-secondary border border-border-subtle rounded-[7px] px-2 py-1 text-text-muted whitespace-nowrap"
           >
             <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${DOT_COLOR[chip.color]}`} />
             {chip.label}{' '}
-            <strong className="text-foreground font-semibold">{chip.value}</strong>
+            <strong className="text-text-primary font-semibold">{chip.value}</strong>
           </span>
         ))}
 
         {decision && (
-          <span className="inline-flex items-center gap-1.5 text-[11px] bg-[var(--panel)] border border-border rounded-[7px] px-2 py-1 text-muted whitespace-nowrap">
-            <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-fin-green" />
+          <span className="inline-flex items-center gap-1.5 text-[11px] bg-bg-secondary border border-border-subtle rounded-[7px] px-2 py-1 text-text-muted whitespace-nowrap">
+            {/* Status pip — calm cyan chrome (F5), not fin-green */}
+            <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-fin-blue" />
             Decision{' '}
-            <strong className="text-foreground font-semibold">{decision}</strong>
+            <strong className="text-text-primary font-semibold">{decision}</strong>
           </span>
         )}
       </div>

--- a/frontend/olympus/components/pipeline/useCanvasCamera.test.tsx
+++ b/frontend/olympus/components/pipeline/useCanvasCamera.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeFit, computeCenter } from './useCanvasCamera';
+import { computeFit, computeCenter, computeZoomToward, clampScale } from './useCanvasCamera';
 
 describe('computeFit', () => {
   it('returns scale < 1 when bbox is larger than viewport, fitting both axes', () => {
@@ -38,5 +38,46 @@ describe('computeCenter', () => {
     const result = computeCenter({ x: 100, y: 0, width: 100, height: 48 }, { width: 800, height: 400 }, 0.5);
     // nodeMidX = 150, at scale 0.5: 150 * 0.5 = 75; tx = 400 - 75 = 325
     expect(result.x).toBeCloseTo(325);
+  });
+});
+
+describe('clampScale', () => {
+  it('clamps below the minimum', () => {
+    expect(clampScale(0.1)).toBeCloseTo(0.4);
+  });
+  it('clamps above the maximum', () => {
+    expect(clampScale(10)).toBeCloseTo(2.5);
+  });
+  it('passes through an in-range value', () => {
+    expect(clampScale(1.3)).toBeCloseTo(1.3);
+  });
+});
+
+describe('computeZoomToward', () => {
+  it('keeps the anchor point fixed in screen space', () => {
+    const prev = { x: 0, y: 0, scale: 1 };
+    // World point under the cursor: (originX - x) / scale = 200.
+    const next = computeZoomToward(prev, 2, 200, 100);
+    // After zoom, the same world point must still land under (200,100):
+    // screenX = worldX * scale + x = 200 * 2 + next.x  ⇒ must equal 200.
+    expect(200 * 2 + next.x).toBeCloseTo(200);
+    // worldY = (100 - 0) / 1 = 100; after zoom: 100 * 2 + next.y must equal 100.
+    expect(100 * 2 + next.y).toBeCloseTo(100);
+  });
+
+  it('preserves the world point under the cursor exactly', () => {
+    const prev = { x: 30, y: 10, scale: 1.2 };
+    const originX = 250;
+    const originY = 140;
+    const worldX = (originX - prev.x) / prev.scale;
+    const worldY = (originY - prev.y) / prev.scale;
+    const next = computeZoomToward(prev, 1.8, originX, originY);
+    expect(worldX * next.scale + next.x).toBeCloseTo(originX);
+    expect(worldY * next.scale + next.y).toBeCloseTo(originY);
+  });
+
+  it('clamps the resulting scale', () => {
+    const next = computeZoomToward({ x: 0, y: 0, scale: 2.4 }, 99, 0, 0);
+    expect(next.scale).toBeCloseTo(2.5);
   });
 });

--- a/frontend/olympus/components/pipeline/useCanvasCamera.ts
+++ b/frontend/olympus/components/pipeline/useCanvasCamera.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface Bbox { width: number; height: number; }
 export interface Viewport { width: number; height: number; }
@@ -10,6 +10,8 @@ export interface CameraTransform { x: number; y: number; scale: number; }
 const MIN_SCALE = 0.4;
 const MAX_SCALE = 2.5;
 const PADDING = 30;
+// Idle window after the last wheel event before we treat the gesture as ended.
+const WHEEL_IDLE_MS = 120;
 
 /** Pure helper: compute a transform that fits `bbox` inside `viewport` (centered, scale ≤ 1). */
 export function computeFit(bbox: Bbox, viewport: Viewport): CameraTransform {
@@ -32,113 +34,295 @@ export function computeCenter(rect: NodeRect, viewport: Viewport, scale: number)
   return { x, y, scale };
 }
 
-function clampScale(s: number): number {
+export function clampScale(s: number): number {
   return Math.max(MIN_SCALE, Math.min(MAX_SCALE, s));
 }
 
-type Action =
-  | { type: 'set'; transform: CameraTransform }
-  | { type: 'pan'; dx: number; dy: number }
-  | { type: 'zoom'; newScale: number; originX: number; originY: number };
-
-function reducer(state: CameraTransform, action: Action): CameraTransform {
-  switch (action.type) {
-    case 'set':
-      return action.transform;
-    case 'pan':
-      return { ...state, x: state.x + action.dx, y: state.y + action.dy };
-    case 'zoom': {
-      const s = clampScale(action.newScale);
-      return {
-        scale: s,
-        x: action.originX - (action.originX - state.x) * (s / state.scale),
-        y: action.originY - (action.originY - state.y) * (s / state.scale),
-      };
-    }
-  }
+/**
+ * Pure helper: zoom toward a viewport-relative anchor point. Keeps the world
+ * point under (originX, originY) fixed while changing scale. Unit-tested.
+ */
+export function computeZoomToward(
+  prev: CameraTransform,
+  newScale: number,
+  originX: number,
+  originY: number,
+): CameraTransform {
+  const s = clampScale(newScale);
+  return {
+    scale: s,
+    x: originX - (originX - prev.x) * (s / prev.scale),
+    y: originY - (originY - prev.y) * (s / prev.scale),
+  };
 }
 
 export interface CanvasCameraResult {
+  /**
+   * Latest committed transform. Only `scale` is guaranteed fresh on every
+   * render (synced at interaction-end); x/y track the last committed value and
+   * may lag the live ref mid-gesture. Use the ref + DOM for per-frame reads.
+   */
   transform: CameraTransform;
   zoomIn: () => void;
   zoomOut: () => void;
   fit: (bbox: Bbox, viewport: Viewport) => void;
   centerOn: (rect: NodeRect, viewport: Viewport) => void;
+  /** Attach to the scrolling/transformed layer — its DOM transform is written every frame. */
+  layerRef: React.RefObject<HTMLDivElement | null>;
+  /** Attach to the viewport element — the native wheel + pointer surface. */
+  viewportRef: React.RefObject<HTMLDivElement | null>;
   bind: {
     onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
     onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
     onPointerUp: () => void;
     onPointerCancel: () => void;
-    onWheel: (e: React.WheelEvent<HTMLDivElement>) => void;
   };
 }
 
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+}
+
 export function useCanvasCamera(initialTransform?: Partial<CameraTransform>): CanvasCameraResult {
-  const [transform, dispatch] = useReducer(reducer, {
-    x: 20,
-    y: 10,
-    scale: 1,
-    ...initialTransform,
-  });
+  const initial: CameraTransform = { x: 20, y: 10, scale: 1, ...initialTransform };
+
+  // Live transform — single source of truth, mutated synchronously per event.
+  const transformRef = useRef<CameraTransform>(initial);
+  // `scale` mirrored into React state so callbacks that read transform.scale
+  // (zoomIn/zoomOut/centerOn) and their useCallback deps stay correct. Synced
+  // on interaction-END only, never per-frame. `committed` is the last value
+  // we exposed to React (used for the initial/SSR paint and consumed by callers
+  // that read `transform`); it is intentionally NOT updated per pan frame.
+  const [committed, setCommitted] = useState<CameraTransform>(initial);
+
+  const layerRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
 
   const drag = useRef<{ startX: number; startY: number; startPanX: number; startPanY: number } | null>(null);
-  const vpRef = useRef<HTMLDivElement | null>(null);
+  const rafId = useRef<number | null>(null);
+  const isInteracting = useRef<boolean>(false);
+  const wheelIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Detect prefers-reduced-motion: skip transitions (not via CSS, but DOM reads)
-  const prefersReducedMotion =
-    typeof window !== 'undefined'
-      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      : false;
-  void prefersReducedMotion; // used by callers via CSS class on vp element
+  // ---- DOM writes -------------------------------------------------------
 
-  const fit = useCallback((bbox: Bbox, viewport: Viewport) => {
-    dispatch({ type: 'set', transform: computeFit(bbox, viewport) });
+  const writeTransform = useCallback(() => {
+    rafId.current = null;
+    const el = layerRef.current;
+    if (!el) return;
+    const { x, y, scale } = transformRef.current;
+    el.style.transform = `translate3d(${x}px,${y}px,0) scale(${scale})`;
   }, []);
 
-  const centerOn = useCallback((rect: NodeRect, viewport: Viewport) => {
-    dispatch({ type: 'set', transform: computeCenter(rect, viewport, transform.scale) });
-  }, [transform.scale]);
+  // Coalesce all transform writes into one rAF per frame.
+  const scheduleWrite = useCallback(() => {
+    if (rafId.current !== null) return;
+    rafId.current = requestAnimationFrame(writeTransform);
+  }, [writeTransform]);
 
-  const zoomIn = useCallback(() => {
-    const cx = typeof window !== 'undefined' ? window.innerWidth / 2 : 400;
-    const cy = typeof window !== 'undefined' ? window.innerHeight / 2 : 300;
-    dispatch({ type: 'zoom', newScale: clampScale(transform.scale + 0.12), originX: cx, originY: cy });
-  }, [transform.scale]);
+  const setTransitionEnabled = useCallback((enabled: boolean) => {
+    const el = layerRef.current;
+    if (!el) return;
+    el.style.transition = enabled && !prefersReducedMotion() ? 'transform 150ms ease-out' : 'none';
+  }, []);
 
-  const zoomOut = useCallback(() => {
-    const cx = typeof window !== 'undefined' ? window.innerWidth / 2 : 400;
-    const cy = typeof window !== 'undefined' ? window.innerHeight / 2 : 300;
-    dispatch({ type: 'zoom', newScale: clampScale(transform.scale - 0.12), originX: cx, originY: cy });
-  }, [transform.scale]);
+  // Begin a direct-manipulation gesture: kill the CSS transition so the layer
+  // tracks the pointer/wheel exactly instead of tweening (rubber-banding).
+  const beginInteraction = useCallback(() => {
+    if (isInteracting.current) return;
+    isInteracting.current = true;
+    setTransitionEnabled(false);
+  }, [setTransitionEnabled]);
 
-  const bind = {
-    onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => {
+  // End a gesture: re-enable the transition for subsequent programmatic moves
+  // and sync the committed scale into React state.
+  const endInteraction = useCallback(() => {
+    if (!isInteracting.current) return;
+    isInteracting.current = false;
+    setTransitionEnabled(true);
+    setCommitted({ ...transformRef.current });
+  }, [setTransitionEnabled]);
+
+  // ---- Imperative camera moves (programmatic → keep transition) ---------
+
+  const applyProgrammatic = useCallback(
+    (next: CameraTransform) => {
+      transformRef.current = next;
+      setTransitionEnabled(true);
+      scheduleWrite();
+      setCommitted({ ...next });
+    },
+    [scheduleWrite, setTransitionEnabled],
+  );
+
+  const fit = useCallback(
+    (bbox: Bbox, viewport: Viewport) => {
+      applyProgrammatic(computeFit(bbox, viewport));
+    },
+    [applyProgrammatic],
+  );
+
+  const centerOn = useCallback(
+    (rect: NodeRect, viewport: Viewport) => {
+      applyProgrammatic(computeCenter(rect, viewport, transformRef.current.scale));
+    },
+    [applyProgrammatic],
+  );
+
+  const zoomByButton = useCallback(
+    (delta: number) => {
+      const vp = viewportRef.current;
+      let originX = 400;
+      let originY = 300;
+      if (vp) {
+        const rect = vp.getBoundingClientRect();
+        originX = rect.width / 2;
+        originY = rect.height / 2;
+      }
+      const next = computeZoomToward(
+        transformRef.current,
+        clampScale(transformRef.current.scale + delta),
+        originX,
+        originY,
+      );
+      applyProgrammatic(next);
+    },
+    [applyProgrammatic],
+  );
+
+  const zoomIn = useCallback(() => zoomByButton(0.12), [zoomByButton]);
+  const zoomOut = useCallback(() => zoomByButton(-0.12), [zoomByButton]);
+
+  // ---- Pointer pan ------------------------------------------------------
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
       if ((e.target as HTMLElement).closest('[data-no-pan]')) return;
-      drag.current = { startX: e.clientX, startY: e.clientY, startPanX: transform.x, startPanY: transform.y };
+      drag.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startPanX: transformRef.current.x,
+        startPanY: transformRef.current.y,
+      };
       (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
-      vpRef.current = e.currentTarget as HTMLDivElement;
+      beginInteraction();
     },
-    onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!drag.current) return;
-      dispatch({
-        type: 'pan',
-        dx: e.clientX - drag.current.startX - (transform.x - drag.current.startPanX),
-        dy: e.clientY - drag.current.startY - (transform.y - drag.current.startPanY),
-      });
-    },
-    onPointerUp: () => { drag.current = null; },
-    onPointerCancel: () => { drag.current = null; },
-    onWheel: (e: React.WheelEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-      dispatch({
-        type: 'zoom',
-        newScale: clampScale(transform.scale - e.deltaY * 0.0013),
-        originX: e.clientX - rect.left,
-        originY: e.clientY - rect.top,
-      });
-    },
-  };
+    [beginInteraction],
+  );
 
-  return { transform, zoomIn, zoomOut, fit, centerOn, bind };
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const d = drag.current;
+      if (!d) return;
+      // Set transform absolutely from start + delta — no accumulation, no
+      // stale-closure wobble.
+      transformRef.current = {
+        ...transformRef.current,
+        x: d.startPanX + (e.clientX - d.startX),
+        y: d.startPanY + (e.clientY - d.startY),
+      };
+      scheduleWrite();
+    },
+    [scheduleWrite],
+  );
+
+  const onPointerUp = useCallback(() => {
+    drag.current = null;
+    endInteraction();
+  }, [endInteraction]);
+
+  const onPointerCancel = useCallback(() => {
+    drag.current = null;
+    endInteraction();
+  }, [endInteraction]);
+
+  // Stable bind object so the spread onto the viewport keeps handler identity.
+  const bind = useMemo(
+    () => ({ onPointerDown, onPointerMove, onPointerUp, onPointerCancel }),
+    [onPointerDown, onPointerMove, onPointerUp, onPointerCancel],
+  );
+
+  // ---- Native wheel (passive:false so preventDefault cancels page zoom) --
+
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Normalize deltaMode: line (1) and page (2) → pixels.
+      const factor = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? window.innerHeight : 1;
+      const dx = e.deltaX * factor;
+      const dy = e.deltaY * factor;
+
+      beginInteraction();
+
+      if (e.ctrlKey) {
+        // Trackpad pinch (macOS surfaces it as ctrl+wheel; native default is
+        // page zoom — preventDefault here, coupled with passive:false).
+        e.preventDefault();
+        const rect = vp.getBoundingClientRect();
+        const originX = e.clientX - rect.left;
+        const originY = e.clientY - rect.top;
+        const newScale = clampScale(transformRef.current.scale * Math.exp(-dy * 0.0015));
+        transformRef.current = computeZoomToward(
+          transformRef.current,
+          newScale,
+          originX,
+          originY,
+        );
+      } else {
+        // Two-finger scroll → pan.
+        e.preventDefault();
+        transformRef.current = {
+          ...transformRef.current,
+          x: transformRef.current.x - dx,
+          y: transformRef.current.y - dy,
+        };
+      }
+
+      scheduleWrite();
+
+      // Debounced wheel-idle → treat the gesture as ended.
+      if (wheelIdleTimer.current) clearTimeout(wheelIdleTimer.current);
+      wheelIdleTimer.current = setTimeout(() => {
+        wheelIdleTimer.current = null;
+        endInteraction();
+      }, WHEEL_IDLE_MS);
+    };
+
+    vp.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      // Clean re-subscribe under React 19 StrictMode double-invoke.
+      vp.removeEventListener('wheel', handleWheel);
+    };
+  }, [beginInteraction, endInteraction, scheduleWrite]);
+
+  // Write the initial transform once the layer node mounts, and set the
+  // baseline transition state.
+  useEffect(() => {
+    setTransitionEnabled(true);
+    scheduleWrite();
+    return () => {
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+        rafId.current = null;
+      }
+      if (wheelIdleTimer.current) {
+        clearTimeout(wheelIdleTimer.current);
+        wheelIdleTimer.current = null;
+      }
+    };
+  }, [scheduleWrite, setTransitionEnabled]);
+
+  return {
+    transform: committed,
+    zoomIn,
+    zoomOut,
+    fit,
+    centerOn,
+    layerRef,
+    viewportRef,
+    bind,
+  };
 }

--- a/frontend/olympus/components/sidebar.test.tsx
+++ b/frontend/olympus/components/sidebar.test.tsx
@@ -27,14 +27,14 @@ import Sidebar from './sidebar';
 describe('Sidebar', () => {
   it('renders the four owner destinations', () => {
     const html = renderToStaticMarkup(createElement(Sidebar));
-    for (const label of ['Today', 'Portfolio', 'Pipeline', 'System']) {
+    for (const label of ['Brief', 'Portfolio', 'Pipeline', 'System']) {
       expect(html).toContain(label);
     }
   });
 
   it('pins System last — demoted to the bottom of the nav', () => {
     const html = renderToStaticMarkup(createElement(Sidebar));
-    expect(html.indexOf('System')).toBeGreaterThan(html.indexOf('Today'));
+    expect(html.indexOf('System')).toBeGreaterThan(html.indexOf('Brief'));
     expect(html.indexOf('System')).toBeGreaterThan(html.indexOf('Pipeline'));
   });
 

--- a/frontend/olympus/components/today/move-hero.tsx
+++ b/frontend/olympus/components/today/move-hero.tsx
@@ -6,9 +6,9 @@ import { AsOfBadge } from '@/components/shared/as-of-badge';
 import { TodayActionsPanel } from '@/components/overview/today-actions-panel';
 
 /**
- * The move-led hero — the single full-weight element of the Today page.
+ * The move-led hero — the single full-weight element of the Brief (landing) page.
  *
- * Quiet regime ribbon → "Today" (display serif) + the move (reusing the tested
+ * Quiet regime ribbon → "Brief" (display serif) + the move (reusing the tested
  * TodayActionsPanel, which already renders the empty and all-HOLD states) → a
  * one-line NAV status. The regime accent is localized here ONLY; the page no
  * longer washes regime colour across the whole viewport.
@@ -143,7 +143,7 @@ export function MoveHero({
 
         {/* THE READ — the marquee */}
         <p className="mt-4 text-[11px] font-bold uppercase tracking-widest text-text-muted">
-          Today · {asOf ?? '—'}
+          Brief · {asOf ?? '—'}
         </p>
         <h1 className="font-display text-3xl sm:text-4xl leading-tight tracking-tight mt-1 text-text-primary">
           {headline ?? regime}

--- a/frontend/olympus/lib/nav.test.ts
+++ b/frontend/olympus/lib/nav.test.ts
@@ -4,7 +4,7 @@ import { NAV } from './nav';
 describe('NAV', () => {
   it('is the 4-destination owner spine, in order', () => {
     expect(NAV.map((n) => n.href)).toEqual(['/', '/portfolio', '/pipeline', '/system']);
-    expect(NAV.map((n) => n.label)).toEqual(['Today', 'Portfolio', 'Pipeline', 'System']);
+    expect(NAV.map((n) => n.label)).toEqual(['Brief', 'Portfolio', 'Pipeline', 'System']);
   });
 
   it('demotes only System', () => {

--- a/frontend/olympus/lib/nav.ts
+++ b/frontend/olympus/lib/nav.ts
@@ -15,7 +15,7 @@ export interface NavItem {
  * app bar so they can never drift.
  */
 export const NAV: NavItem[] = [
-  { href: '/', label: 'Today', icon: LayoutDashboard },
+  { href: '/', label: 'Brief', icon: LayoutDashboard },
   { href: '/portfolio', label: 'Portfolio', icon: PieChart },
   { href: '/pipeline', label: 'Pipeline', icon: GitBranch },
   { href: '/system', label: 'System', icon: Activity, demoted: true },

--- a/frontend/olympus/lib/pipeline-graph-data.test.ts
+++ b/frontend/olympus/lib/pipeline-graph-data.test.ts
@@ -15,4 +15,46 @@ describe('buildPipelineDayData', () => {
     expect(d.fanoutCounts['analysts']).toBe(1);
     expect(d.presentKeys.has('digest')).toBe(true);
   });
+
+  it('counts asset-classes by exact-set membership (not a prefix)', () => {
+    const docs = [
+      { document_key: 'bonds' }, { document_key: 'commodities' },
+      { document_key: 'crypto' }, { document_key: 'equity' },
+      { document_key: 'forex' }, { document_key: 'international' },
+      { document_key: 'macro' }, // NOT an asset class
+    ];
+    const d = buildPipelineDayData(docs);
+    expect(d.fanoutCounts['asset-classes']).toBe(6);
+    expect(d.fanoutKeys['asset-classes']).toEqual([
+      'bonds', 'commodities', 'crypto', 'equity', 'forex', 'international',
+    ]);
+  });
+
+  it('collects SORTED fanoutKeys for each fan-out id', () => {
+    const docs = [
+      { document_key: 'analyst/QQQ' }, { document_key: 'analyst/TLT' },
+      { document_key: 'analyst/BITO' },
+      { document_key: 'deliberation/QQQ' },
+      { document_key: 'sector-technology' }, { document_key: 'sector-financials' },
+      { document_key: 'sector-scorecard' }, // excluded from sectors
+      { document_key: 'alt-cta-positioning' }, { document_key: 'alt-sentiment-news' },
+      { document_key: 'inst-hedge-fund-intel' }, { document_key: 'inst-institutional-flows' },
+    ];
+    const d = buildPipelineDayData(docs);
+    expect(d.fanoutKeys['analysts']).toEqual(['analyst/BITO', 'analyst/QQQ', 'analyst/TLT']);
+    expect(d.fanoutKeys['deliberation']).toEqual(['deliberation/QQQ']);
+    expect(d.fanoutKeys['sectors']).toEqual(['sector-financials', 'sector-technology']);
+    expect(d.fanoutKeys['alt-data']).toEqual(['alt-cta-positioning', 'alt-sentiment-news']);
+    expect(d.fanoutKeys['institutional']).toEqual(['inst-hedge-fund-intel', 'inst-institutional-flows']);
+    // counts agree with keys length
+    expect(d.fanoutCounts['analysts']).toBe(3);
+    expect(d.fanoutCounts['sectors']).toBe(2);
+  });
+
+  it('produces empty arrays / undefined counts when a fan-out has no docs', () => {
+    const d = buildPipelineDayData([{ document_key: 'digest' }]);
+    expect(d.fanoutKeys['analysts']).toEqual([]);
+    expect(d.fanoutKeys['asset-classes']).toEqual([]);
+    expect(d.fanoutCounts['analysts']).toBeUndefined();
+  });
 });

--- a/frontend/olympus/lib/pipeline-graph-data.test.ts
+++ b/frontend/olympus/lib/pipeline-graph-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPipelineDayData } from './pipeline-graph-data';
+import { buildPipelineDayData, fanoutIdForKey } from './pipeline-graph-data';
 
 describe('buildPipelineDayData', () => {
   it('counts fan-outs by document_key prefix', () => {
@@ -56,5 +56,23 @@ describe('buildPipelineDayData', () => {
     expect(d.fanoutKeys['analysts']).toEqual([]);
     expect(d.fanoutKeys['asset-classes']).toEqual([]);
     expect(d.fanoutCounts['analysts']).toBeUndefined();
+  });
+});
+
+describe('fanoutIdForKey', () => {
+  it('maps a branch document_key to its owning fan-out id', () => {
+    expect(fanoutIdForKey('analyst/QQQ')).toBe('analysts');
+    expect(fanoutIdForKey('deliberation/TLT')).toBe('deliberation');
+    expect(fanoutIdForKey('sector-technology')).toBe('sectors');
+    expect(fanoutIdForKey('alt-sentiment-news')).toBe('alt-data');
+    expect(fanoutIdForKey('inst-hedge-fund-intel')).toBe('institutional');
+    expect(fanoutIdForKey('crypto')).toBe('asset-classes');
+  });
+
+  it('returns null for non-fan-out keys', () => {
+    expect(fanoutIdForKey('digest')).toBeNull();
+    expect(fanoutIdForKey('pm-direction-memo')).toBeNull();
+    expect(fanoutIdForKey('sector-scorecard')).toBeNull(); // excluded from sectors
+    expect(fanoutIdForKey('macro')).toBeNull(); // not an asset class
   });
 });

--- a/frontend/olympus/lib/pipeline-graph-data.ts
+++ b/frontend/olympus/lib/pipeline-graph-data.ts
@@ -1,21 +1,39 @@
-const PREFIX_COUNTERS: { fanoutId: string; match: (k: string) => boolean }[] = [
+const ASSET_CLASSES = new Set(['bonds', 'commodities', 'crypto', 'equity', 'forex', 'international']);
+
+const FANOUT_MATCHERS: { fanoutId: string; match: (k: string) => boolean }[] = [
   { fanoutId: 'alt-data', match: (k) => k.startsWith('alt-') },
   { fanoutId: 'institutional', match: (k) => k.startsWith('inst-') },
+  { fanoutId: 'asset-classes', match: (k) => ASSET_CLASSES.has(k) },
   { fanoutId: 'sectors', match: (k) => k.startsWith('sector-') && k !== 'sector-scorecard' },
   { fanoutId: 'analysts', match: (k) => k.startsWith('analyst/') },
   { fanoutId: 'deliberation', match: (k) => k.startsWith('deliberation/') },
 ];
 
-export interface PipelineDayData { fanoutCounts: Record<string, number>; presentKeys: Set<string>; }
+export interface PipelineDayData {
+  /** count of present document_keys per fan-out id (= fanoutKeys length; omitted when 0) */
+  fanoutCounts: Record<string, number>;
+  /** sorted list of this day's real document_keys per fan-out id */
+  fanoutKeys: Record<string, string[]>;
+  presentKeys: Set<string>;
+}
 
 export function buildPipelineDayData(docs: { document_key: string }[]): PipelineDayData {
-  const fanoutCounts: Record<string, number> = {};
   const presentKeys = new Set<string>();
+  const fanoutKeys: Record<string, string[]> = {};
+  for (const { fanoutId } of FANOUT_MATCHERS) fanoutKeys[fanoutId] = [];
+
   for (const { document_key } of docs) {
     presentKeys.add(document_key);
-    for (const c of PREFIX_COUNTERS) {
-      if (c.match(document_key)) fanoutCounts[c.fanoutId] = (fanoutCounts[c.fanoutId] ?? 0) + 1;
+    for (const c of FANOUT_MATCHERS) {
+      if (c.match(document_key)) fanoutKeys[c.fanoutId].push(document_key);
     }
   }
-  return { fanoutCounts, presentKeys };
+
+  const fanoutCounts: Record<string, number> = {};
+  for (const { fanoutId } of FANOUT_MATCHERS) {
+    fanoutKeys[fanoutId].sort();
+    if (fanoutKeys[fanoutId].length > 0) fanoutCounts[fanoutId] = fanoutKeys[fanoutId].length;
+  }
+
+  return { fanoutCounts, fanoutKeys, presentKeys };
 }

--- a/frontend/olympus/lib/pipeline-graph-data.ts
+++ b/frontend/olympus/lib/pipeline-graph-data.ts
@@ -17,6 +17,18 @@ export interface PipelineDayData {
   presentKeys: Set<string>;
 }
 
+/**
+ * Map a document_key to the fan-out id it belongs to (e.g. `analyst/QQQ` -> `analysts`,
+ * `sector-tech` -> `sectors`, `bonds` -> `asset-classes`), or null for non-fan-out keys.
+ * Used to auto-expand the owning fan-out when deep-linking straight to a branch node.
+ */
+export function fanoutIdForKey(key: string): string | null {
+  for (const c of FANOUT_MATCHERS) {
+    if (c.match(key)) return c.fanoutId;
+  }
+  return null;
+}
+
 export function buildPipelineDayData(docs: { document_key: string }[]): PipelineDayData {
   const presentKeys = new Set<string>();
   const fanoutKeys: Record<string, string[]> = {};

--- a/frontend/olympus/lib/pipeline-layout.test.ts
+++ b/frontend/olympus/lib/pipeline-layout.test.ts
@@ -3,7 +3,11 @@ import { layoutPipeline } from './pipeline-layout';
 import type { ExpansionState } from './pipeline-layout';
 import type { PipelineDayData } from './pipeline-graph-data';
 
-const emptyDay: PipelineDayData = { fanoutCounts: { sectors: 12 }, presentKeys: new Set<string>() };
+const emptyDay: PipelineDayData = {
+  fanoutCounts: { sectors: 12 },
+  fanoutKeys: {},
+  presentKeys: new Set<string>(),
+};
 const collapsed: ExpansionState = { expandedStages: new Set(), expandedFanouts: new Set() };
 
 describe('layoutPipeline', () => {
@@ -15,7 +19,8 @@ describe('layoutPipeline', () => {
     expect([...xs]).toEqual([...xs].sort((a, b) => a - b)); // strictly increasing order preserved
     expect(new Set(stages.map((n) => n.y)).size).toBe(1);   // one row
   });
-  it('expanding sectors fan-out emits 12 vertical branch nodes', () => {
+
+  it('expanding sectors fan-out (no fanoutKeys) falls back to count-indexed branches with NO documentKey', () => {
     const exp: ExpansionState = {
       expandedStages: new Set(['research']),
       expandedFanouts: new Set(['research:sectors']),
@@ -26,5 +31,61 @@ describe('layoutPipeline', () => {
     const ys = branches.map((n) => n.y);
     expect(new Set(branches.map((n) => n.x)).size).toBe(1); // same column
     expect([...ys]).toEqual([...ys].sort((a, b) => a - b)); // stacked downward
+    expect(branches.every((b) => b.documentKey === undefined)).toBe(true);
+  });
+
+  it('emits one branch per real document_key with entity-suffix labels when fanoutKeys present', () => {
+    const day: PipelineDayData = {
+      fanoutCounts: { analysts: 2, sectors: 2, 'asset-classes': 2 },
+      fanoutKeys: {
+        analysts: ['analyst/QQQ', 'analyst/TLT'],
+        sectors: ['sector-financials', 'sector-technology'],
+        'asset-classes': ['bonds', 'crypto'],
+      },
+      presentKeys: new Set(['analyst/QQQ', 'analyst/TLT', 'sector-financials', 'sector-technology', 'bonds', 'crypto']),
+    };
+    const exp: ExpansionState = {
+      expandedStages: new Set(['research', 'selection']),
+      expandedFanouts: new Set(['research:sectors', 'research:asset-classes', 'selection:analysts']),
+    };
+    const l = layoutPipeline(day, exp);
+
+    const analysts = l.nodes.filter((n) => n.id.startsWith('selection:analysts:'));
+    expect(analysts.map((n) => n.documentKey)).toEqual(['analyst/QQQ', 'analyst/TLT']);
+    expect(analysts.map((n) => n.label)).toEqual(['QQQ', 'TLT']);
+
+    const sectors = l.nodes.filter((n) => n.id.startsWith('research:sectors:'));
+    expect(sectors.map((n) => n.documentKey)).toEqual(['sector-financials', 'sector-technology']);
+    expect(sectors.map((n) => n.label)).toEqual(['financials', 'technology']);
+
+    const assets = l.nodes.filter((n) => n.id.startsWith('research:asset-classes:'));
+    expect(assets.map((n) => n.documentKey)).toEqual(['bonds', 'crypto']);
+    expect(assets.map((n) => n.label)).toEqual(['bonds', 'crypto']);
+  });
+
+  it('leaf sub-steps get documentKey only when the key is present that day', () => {
+    const day: PipelineDayData = {
+      fanoutCounts: {},
+      fanoutKeys: {},
+      presentKeys: new Set(['macro', 'pm-direction-memo', 'commit-run/123', 'commit-run/999']),
+    };
+    const exp: ExpansionState = {
+      expandedStages: new Set(['research', 'synthesis', 'selection', 'decision']),
+      expandedFanouts: new Set(),
+    };
+    const l = layoutPipeline(day, exp);
+    const byId = (id: string) => l.nodes.find((n) => n.id === id);
+
+    expect(byId('research:macro')?.documentKey).toBe('macro');
+    expect(byId('selection:pm-direction')?.documentKey).toBe('pm-direction-memo');
+    // digest absent that day -> no documentKey (golden rule)
+    expect(byId('synthesis:digest')?.documentKey).toBeUndefined();
+    // consolidate maps to sector-scorecard, absent -> undefined
+    expect(byId('synthesis:consolidate')?.documentKey).toBeUndefined();
+    // commit resolves via a present commit-run/* (lexicographically-last default)
+    expect(byId('decision:commit')?.documentKey).toBe('commit-run/999');
+    // thesis/screener never get a key
+    expect(byId('selection:thesis')?.documentKey).toBeUndefined();
+    expect(byId('selection:screener')?.documentKey).toBeUndefined();
   });
 });

--- a/frontend/olympus/lib/pipeline-layout.ts
+++ b/frontend/olympus/lib/pipeline-layout.ts
@@ -15,7 +15,7 @@ export interface LaidOutNode {
   documentKey?: string;
 }
 
-export interface Connector { fromId: string; toId: string; }
+export interface Connector { fromId: string; toId: string; active?: boolean; }
 
 export interface PipelineLayout {
   nodes: LaidOutNode[];
@@ -130,7 +130,9 @@ export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState):
           height: NODE_H,
           documentKey: leafKey,
         });
-        if (prevId) connectors.push({ fromId: prevId, toId: subId });
+        // Sequential connectors inside an expanded stage are "active" (the
+        // expanded stage's own internal flow), so they read in cyan on top.
+        if (prevId) connectors.push({ fromId: prevId, toId: subId, active: true });
         prevId = subId;
         cursorX += NODE_W + GAP_X;
 
@@ -152,7 +154,8 @@ export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState):
                 height: NODE_H,
                 documentKey,
               });
-              connectors.push({ fromId: subId, toId: branchId });
+              // Fan-out branch connectors flow out of an expanded fan-out.
+              connectors.push({ fromId: subId, toId: branchId, active: true });
               if (branchY + NODE_H > maxY) maxY = branchY + NODE_H;
             });
           } else {
@@ -172,7 +175,7 @@ export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState):
                 width: NODE_W,
                 height: NODE_H,
               });
-              connectors.push({ fromId: subId, toId: branchId });
+              connectors.push({ fromId: subId, toId: branchId, active: true });
               if (branchY + NODE_H > maxY) maxY = branchY + NODE_H;
             }
           }

--- a/frontend/olympus/lib/pipeline-layout.ts
+++ b/frontend/olympus/lib/pipeline-layout.ts
@@ -1,6 +1,7 @@
 import { PIPELINE_TOPOLOGY } from './pipeline-topology';
 import type { PipelineStageId } from './pipeline-topology';
 import type { PipelineDayData } from './pipeline-graph-data';
+import { leafDocumentKey } from './pipeline-links';
 
 export interface LaidOutNode {
   id: string;
@@ -33,6 +34,31 @@ const NODE_H = 48;
 const GAP_X = 24;
 const GAP_Y = 12;
 const BASE_Y = 0;
+
+/**
+ * Resolve a leaf sub-step's document_key, honouring the golden rule: only
+ * return a key that is actually present in this day's documents. `commit` is
+ * special-cased — there can be several `commit-run/{run_id}` keys per day, so
+ * we pick the present ones and default to the lexicographically-last.
+ */
+function resolveLeafDocumentKey(subStepId: string, day: PipelineDayData): string | undefined {
+  if (subStepId === 'commit') {
+    const runs = [...day.presentKeys].filter((k) => k.startsWith('commit-run/')).sort();
+    return runs.length > 0 ? runs[runs.length - 1] : undefined;
+  }
+  const key = leafDocumentKey(subStepId);
+  return key && day.presentKeys.has(key) ? key : undefined;
+}
+
+/** Derive the human-readable branch label (entity suffix) from a fan-out document_key. */
+function branchLabel(fanoutId: string, documentKey: string): string {
+  if (fanoutId === 'analysts' || fanoutId === 'deliberation') {
+    return documentKey.split('/')[1] ?? documentKey;
+  }
+  if (fanoutId === 'sectors') return documentKey.replace('sector-', '');
+  // asset-classes are bare names; alt-/inst- keep their full key as the label.
+  return documentKey;
+}
 
 export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState): PipelineLayout {
   const nodes: LaidOutNode[] = [];
@@ -90,6 +116,9 @@ export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState):
         const fanoutExpanded = expansion.expandedFanouts.has(fanoutKey);
         const subX = cursorX;
 
+        // Leaf sub-steps (no fan-out) carry a document_key when it's present today.
+        const leafKey = sub.fanout ? undefined : resolveLeafDocumentKey(sub.id, day);
+
         nodes.push({
           id: subId,
           kind: 'substep',
@@ -99,28 +128,53 @@ export function layoutPipeline(day: PipelineDayData, expansion: ExpansionState):
           y: BASE_Y,
           width: NODE_W,
           height: NODE_H,
+          documentKey: leafKey,
         });
         if (prevId) connectors.push({ fromId: prevId, toId: subId });
         prevId = subId;
         cursorX += NODE_W + GAP_X;
 
         if (sub.fanout && fanoutExpanded) {
-          const count = day.fanoutCounts[sub.fanout.id] ?? sub.fanout.defaultCount;
-          for (let i = 0; i < count; i++) {
-            const branchId = `${stage.id}:${sub.id}:${i}`;
-            const branchY = BASE_Y + (i + 1) * (NODE_H + GAP_Y);
-            nodes.push({
-              id: branchId,
-              kind: 'fanout-branch',
-              stageId: stage.id,
-              label: `${sub.label} ${i + 1}`,
-              x: subX,
-              y: branchY,
-              width: NODE_W,
-              height: NODE_H,
+          const keys = day.fanoutKeys[sub.fanout.id] ?? [];
+          if (keys.length > 0) {
+            // Emit one branch per real document_key, clickable.
+            keys.forEach((documentKey, i) => {
+              const branchId = `${stage.id}:${sub.id}:${i}`;
+              const branchY = BASE_Y + (i + 1) * (NODE_H + GAP_Y);
+              nodes.push({
+                id: branchId,
+                kind: 'fanout-branch',
+                stageId: stage.id,
+                label: branchLabel(sub.fanout!.id, documentKey),
+                x: subX,
+                y: branchY,
+                width: NODE_W,
+                height: NODE_H,
+                documentKey,
+              });
+              connectors.push({ fromId: subId, toId: branchId });
+              if (branchY + NODE_H > maxY) maxY = branchY + NODE_H;
             });
-            connectors.push({ fromId: subId, toId: branchId });
-            if (branchY + NODE_H > maxY) maxY = branchY + NODE_H;
+          } else {
+            // No-data fallback: index-emit placeholder branches with NO documentKey
+            // (renders the shape but is not clickable) so nothing regresses.
+            const count = day.fanoutCounts[sub.fanout.id] ?? sub.fanout.defaultCount;
+            for (let i = 0; i < count; i++) {
+              const branchId = `${stage.id}:${sub.id}:${i}`;
+              const branchY = BASE_Y + (i + 1) * (NODE_H + GAP_Y);
+              nodes.push({
+                id: branchId,
+                kind: 'fanout-branch',
+                stageId: stage.id,
+                label: `${sub.label} ${i + 1}`,
+                x: subX,
+                y: branchY,
+                width: NODE_W,
+                height: NODE_H,
+              });
+              connectors.push({ fromId: subId, toId: branchId });
+              if (branchY + NODE_H > maxY) maxY = branchY + NODE_H;
+            }
           }
         }
       }

--- a/frontend/olympus/lib/pipeline-links.ts
+++ b/frontend/olympus/lib/pipeline-links.ts
@@ -36,6 +36,8 @@ export function parsePipelineParams(sp: URLSearchParams): { date?: string; stage
 /** Map a sub-step id (+ optional branch qualifier) to its document_key. Returns null for unknown sub-steps. */
 export function leafDocumentKey(subStepId: string, branch?: string): string | null {
   switch (subStepId) {
+    case 'macro': return 'macro';
+    case 'consolidate': return 'sector-scorecard';
     case 'digest': return 'digest';
     case 'pm-direction': return 'pm-direction-memo';
     case 'risk-sizing': return 'pm-rebalance';


### PR DESCRIPTION
Addresses PM review of the live Pipeline graph (and renames the landing page). Diagnosed and implemented via adversarially-verified multi-agent workflows.

## Fixes
- **Expansion felt inverted** — "Expand all" seeded an *empty* fan-out set and fan-out parents only showed an expand affordance when live counts loaded (they never did). Now Expand-all seeds every fan-out from `PIPELINE_TOPOLOGY`, and parents always render a chevron + count badge from the static topology, so vertical fan-out expansion is discoverable. (Layout math was already correct.)
- **Clicking a node opened nothing** — `layoutPipeline` never assigned a `documentKey`. Now leaf sub-steps map to real keys under the **golden rule (clickable iff the key is present that day)**; fan-out branches carry per-entity keys (`analyst/{T}`, `deliberation/{T}`, `sector-*`, bare asset-classes) and open the right reused view (analyst review, deliberation with all rounds, digest, rebalance). Deep-linking to a branch (`?node=analyst/QQQ`) now auto-expands its owning fan-out. Selection highlight matches on `documentKey`. `asset-classes` fan-out (bare names) is no longer silently empty.
- **Jittery trackpad pan/zoom** — rAF + ref direct-DOM transform (no per-event React re-render), CSS transition disabled during interaction, native `{passive:false}` wheel listener, `ctrl+wheel` pinch distinguished from two-finger scroll, viewport-anchored button zoom.
- **Harsh black/white** — components used Tailwind classes **absent from the `@theme` block** (so they hit raw UA fallbacks). Swept to canonical suite tokens (`.glass-card`, `border-border-subtle`, cyan `fin-blue` for chrome/active, connectors light only the active path). F5 respected (no `fin-green/red` chrome).
- **Rename** the landing page **Today → Brief** (nav label + command palette + hero eyebrow; scoped to the `/` surface — the FX suite's own "Today" tab and date utils untouched).

## Verification
- **538 vitest tests green** (incl. token-hygiene F5 guard + new `fanoutIdForKey` tests).
- `tsc --noEmit`: no new errors (4 pre-existing baseline in `DecisionQuality.test.tsx` + `security-headers.test.ts`).
- `next build` clean; `/pipeline` static; eslint clean.

## Reviewer note — needs a trackpad pass
Pan/zoom *feel* and the visual restyle can't be verified headlessly. Please scroll/pinch/drag `/pipeline`, expand a fan-out (e.g. Sectors) vertically and a stage horizontally, and click a leaf/branch to confirm the document opens. Validated against live `2026-06-24` (delta day) + `2026-06-23` data.

Fixes #1055
Refs #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvfyP2WatQhVSBS45HPys2