### PR TITLE
feat(hermes): prior-deliberation carry loader + MCP query_data (#925)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -800,6 +800,7 @@ flowchart LR
 | `latest_segments` | `documents` | `load_prior_context` | own segment + declared extras only (#696) | full segment body by `document_key` |
 | `prior_book` / `current_weights` | `positions` | `load_prior_book` | PM + risk: weights + held names | entry prices via `positions` tool |
 | `prior_analyst_by_ticker` | `documents` (`analyst/*`) | `load_prior_analyst_summaries` | slim excerpt for **held** tickers | full analyst payload by key |
+| `prior_deliberation_by_ticker` | `documents` (`deliberation/*`) | `load_prior_deliberation_summaries` | slim carry (net_stance, conviction_delta, conclusion excerpt) for **held** tickers; injected as H6 `prior_deliberation` (#925) | full transcript by `document_key` |
 | `active_theses` | `theses` | `load_active_theses_rows` | H1–H3 + H7 PM | thesis history via `theses` tool |
 | `portfolio_performance` | `nav_history` + `portfolio_metrics` | `load_portfolio_performance_snapshot` | latest NAV + metrics pointer | full NAV series via `nav_history` tool |
 | `decision_lessons` | `decision_log` | `fetch_recent_lessons` | PM `past_context` (bounded) | older lessons via `decision_log` query |

--- a/digiquant/src/digiquant/mcp_server.py
+++ b/digiquant/src/digiquant/mcp_server.py
@@ -179,6 +179,48 @@ def create_mcp_server() -> Any:
             return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
         return json.dumps(result, default=str)
 
+    @mcp.tool()
+    def digiquant_query_data(
+        table: str,
+        columns: str = "*",
+        eq: dict[str, Any] | None = None,
+        gte: dict[str, Any] | None = None,
+        lte: dict[str, Any] | None = None,
+        order: str | None = None,
+        desc: bool = True,
+        limit: int = 50,
+    ) -> str:
+        """Read rows from a whitelisted Olympus table (JSON).
+
+        Exposes the same read-only, table-scoped reader the in-process Hermes
+        agents use, so external agents (DigiChat / Kairos) can fetch the paper
+        book and market data by key (#925). Allowed tables: ``positions``,
+        ``nav_history``, ``theses``, ``thesis_vehicles``, ``position_events``,
+        ``portfolio_metrics``, ``price_history``, ``price_technicals``,
+        ``macro_series_observations``, ``trading_calendar``. Operator-internal
+        telemetry (decision_log, diagnostics) is deliberately NOT readable.
+        ``limit`` is capped server-side. Returns ``{"error": ...}`` on failure.
+        """
+        from digiquant.olympus.atlas.data.queries import query_data
+        from digiquant.olympus.atlas.supabase_io import SupabaseConfig, build_client
+
+        try:
+            client = build_client(SupabaseConfig.from_env())
+            result = query_data(
+                client=client,
+                table=table,
+                columns=columns,
+                eq=eq,
+                gte=gte,
+                lte=lte,
+                order=order,
+                desc=desc,
+                limit=limit,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface as JSON to the caller, never crash
+            return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+        return json.dumps(result, default=str)
+
     # ── Slapper tearsheet pipeline (price → Nautilus backtest → TradingView parity) ──
     # These wrap the repo's pipeline scripts so the whole flow is MCP-discoverable.
     # Paths are resolved relative to this package (editable/source checkout).
@@ -226,11 +268,19 @@ def create_mcp_server() -> Any:
                 if not bars:
                     out[ticker] = {"error": "no data"}
                     continue
-                df = bars_to_polars(bars, ticker).unique(subset=["timestamp"], keep="last").sort("timestamp")
+                df = (
+                    bars_to_polars(bars, ticker)
+                    .unique(subset=["timestamp"], keep="last")
+                    .sort("timestamp")
+                )
                 path = cache / f"{ticker}.csv"
                 df.write_csv(path)
-                out[ticker] = {"bars": len(df), "first": df["timestamp"][0],
-                               "last": df["timestamp"][-1], "path": str(path)}
+                out[ticker] = {
+                    "bars": len(df),
+                    "first": df["timestamp"][0],
+                    "last": df["timestamp"][-1],
+                    "path": str(path),
+                }
             except Exception as exc:  # noqa: BLE001 — surface per-symbol, never crash
                 out[ticker] = {"error": f"{type(exc).__name__}: {exc}"}
         return json.dumps(out, indent=2, default=str)
@@ -259,8 +309,9 @@ def create_mcp_server() -> Any:
 
         settings = gt.load_settings()
         cache = Path(cache_dir) if cache_dir else gt.DEFAULT_CACHE
-        targets = ({strategy: settings["strategies"][strategy]} if strategy
-                   else settings["strategies"])
+        targets = (
+            {strategy: settings["strategies"][strategy]} if strategy else settings["strategies"]
+        )
         results = []
         for strat, cfg in targets.items():
             entry = gt.run_and_write(strat, cfg["symbol"], settings, cache, gt.FRONTEND_STRATEGIES)
@@ -289,7 +340,9 @@ def create_mcp_server() -> Any:
         except ImportError as exc:
             return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
         try:
-            return json.dumps(compare(strategy, ohlcv_csv, tv_export_csv, start_date), indent=2, default=str)
+            return json.dumps(
+                compare(strategy, ohlcv_csv, tv_export_csv, start_date), indent=2, default=str
+            )
         except Exception as exc:  # noqa: BLE001 — surface as JSON to the caller
             return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 

--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -34,6 +34,7 @@ from digiquant.olympus.atlas.supabase_io import (
     load_prior_analyst_summaries,
     load_prior_book,
     load_prior_context,
+    load_prior_deliberation_summaries,
     load_portfolio_performance_snapshot,
     prior_book_current_weights,
     query_institutional_absence_streak,
@@ -366,6 +367,12 @@ def build_preflight_node(deps: PreflightDeps) -> Callable[[AtlasResearchState], 
         except _SUPABASE_READ_ERRORS:
             prior_analyst = {}
         try:
+            prior_deliberation = load_prior_deliberation_summaries(
+                deps.client, state.run_date, held_tickers
+            )
+        except _SUPABASE_READ_ERRORS:
+            prior_deliberation = {}
+        try:
             active_theses = load_active_theses_rows(deps.client, state.run_date)
         except _SUPABASE_READ_ERRORS:
             active_theses = []
@@ -381,6 +388,7 @@ def build_preflight_node(deps: PreflightDeps) -> Callable[[AtlasResearchState], 
             decision_lessons=lessons,
             prior_book=prior_book,
             prior_analyst_by_ticker=prior_analyst,
+            prior_deliberation_by_ticker=prior_deliberation,
             portfolio_performance=portfolio_performance,
         )
 

--- a/digiquant/src/digiquant/olympus/atlas/state.py
+++ b/digiquant/src/digiquant/olympus/atlas/state.py
@@ -231,6 +231,16 @@ class PriorContext(BaseModel):
             "fetch via ``query_data`` when the excerpt is insufficient (#859)."
         ),
     )
+    prior_deliberation_by_ticker: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description=(
+            "Slim prior ``deliberation/{ticker}`` summaries for held names — date, "
+            "document_key, net_stance, conviction_delta, converged, conclusion_excerpt. "
+            "The full transcript stays in Supabase (excluded from ``latest_segments``); H6 "
+            "injects this slim carry into the PM↔analyst loop's ``prior_deliberation`` "
+            "phase_input (#925)."
+        ),
+    )
     portfolio_performance: dict[str, Any] = Field(
         default_factory=dict,
         description=(

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -404,6 +404,22 @@ def _slim_analyst_summary(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _slim_deliberation_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract PM-relevant fields from a published ``deliberation/{ticker}`` payload.
+
+    Drops the full ``transcript`` (the bulk of the doc) — the carry is a slim
+    excerpt, not the full debate dump.
+    """
+    body = payload.get("body") if isinstance(payload.get("body"), dict) else payload
+    conclusion = str(body.get("conclusion") or "").strip()
+    return {
+        "net_stance": body.get("net_stance"),
+        "conviction_delta": body.get("conviction_delta"),
+        "converged": body.get("converged"),
+        "conclusion_excerpt": conclusion[:400],
+    }
+
+
 def load_prior_analyst_summaries(
     client: SupabaseClient,
     run_date: date,
@@ -440,6 +456,51 @@ def load_prior_analyst_summaries(
         if ticker in out:
             continue
         slim = _slim_analyst_summary(row.get("payload") or {})
+        out[ticker] = {
+            "date": row.get("date"),
+            "document_key": key,
+            **slim,
+        }
+    return out
+
+
+def load_prior_deliberation_summaries(
+    client: SupabaseClient,
+    run_date: date,
+    tickers: list[str] | tuple[str, ...],
+    *,
+    lookback_days: int = 30,
+) -> dict[str, dict[str, Any]]:
+    """Latest prior ``deliberation/{ticker}`` slim summary per held ticker.
+
+    Mirrors :func:`load_prior_analyst_summaries`. Returns ``{ticker: {date,
+    document_key, net_stance, conviction_delta, converged, conclusion_excerpt}}``.
+    Empty when ``tickers`` is empty or no prior deliberation docs exist.
+    """
+    from datetime import timedelta
+
+    if not tickers:
+        return {}
+    keys = [f"deliberation/{t}" for t in tickers]
+    floor = (run_date - timedelta(days=lookback_days)).isoformat()
+    resp = (
+        client.table("documents")
+        .select("date, document_key, payload")
+        .in_("document_key", list(keys))
+        .gte("date", floor)
+        .lt("date", run_date.isoformat())
+        .order("date", desc=True)
+        .execute()
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for row in getattr(resp, "data", None) or []:
+        key = str(row.get("document_key") or "")
+        if not key.startswith("deliberation/"):
+            continue
+        ticker = key.split("/", 1)[1]
+        if ticker in out:
+            continue
+        slim = _slim_deliberation_summary(row.get("payload") or {})
         out[ticker] = {
             "date": row.get("date"),
             "document_key": key,

--- a/digiquant/src/digiquant/olympus/hermes/phases/h6_deliberation.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h6_deliberation.py
@@ -71,6 +71,13 @@ def deliberation_min_rounds() -> int:
 
 
 def _prior_deliberation_summary(state: HermesState, ticker: str) -> dict[str, Any] | None:
+    # Preferred: slim carry hydrated in preflight (#925). ``deliberation/*`` is excluded
+    # from ``latest_segments`` so the full transcript never bloats every node — the slim
+    # summary lives in ``prior_deliberation_by_ticker`` instead.
+    slim = state.prior_context.prior_deliberation_by_ticker.get(ticker)
+    if isinstance(slim, dict) and slim:
+        return dict(slim)
+    # Fallback for callers that still stash a full payload in latest_segments.
     row = state.prior_context.latest_segments.get(f"deliberation/{ticker}")
     if not isinstance(row, dict):
         return None
@@ -269,7 +276,14 @@ def _h6_node_factory(ticker: str):
                 carried = DeliberationSummary(
                     ticker=ticker,
                     converged=True,
-                    conclusion=str(prior.get("conclusion") or prior.get("bull_thesis") or ""),
+                    # Slim carry (#925) stores conclusion under ``conclusion_excerpt``;
+                    # the full-payload fallback uses ``conclusion`` / ``bull_thesis``.
+                    conclusion=str(
+                        prior.get("conclusion_excerpt")
+                        or prior.get("conclusion")
+                        or prior.get("bull_thesis")
+                        or ""
+                    ),
                     net_stance=prior.get("net_stance", "neutral"),  # type: ignore[arg-type]
                     conviction_delta=int(prior.get("conviction_delta") or 0),
                     transcript=[],

--- a/digiquant/src/digiquant/olympus/hermes/ticker_fingerprint.py
+++ b/digiquant/src/digiquant/olympus/hermes/ticker_fingerprint.py
@@ -79,5 +79,11 @@ def deliberation_skip_signal(
     )
     if signal is None or signal.mode != "quiet":
         return False
+    # A prior deliberation must exist to carry. ``deliberation/*`` is excluded from
+    # latest_segments (#925), so read the slim carry hydrated in preflight; fall back
+    # to latest_segments for any caller that still stashes a full payload there.
+    slim = state.prior_context.prior_deliberation_by_ticker.get(ticker)
+    if isinstance(slim, dict) and slim:
+        return True
     row = state.prior_context.latest_segments.get(f"deliberation/{ticker}")
     return isinstance(row, dict) and bool(row.get("payload"))

--- a/tests/dq/atlas/test_supabase_io.py
+++ b/tests/dq/atlas/test_supabase_io.py
@@ -16,6 +16,7 @@ from digiquant.olympus.atlas.supabase_io import (
     load_prior_analyst_summaries,
     load_prior_book,
     load_prior_context,
+    load_prior_deliberation_summaries,
     load_portfolio_performance_snapshot,
     prior_book_current_weights,
     publish_daily_snapshot,
@@ -449,6 +450,45 @@ class TestContinuityLoaders:
         assert out["SHY"]["date"] == "2026-06-18"
         assert out["SHY"]["conviction_score"] == 2
         assert "yields peaked" in out["SHY"]["thesis_excerpt"]
+
+    def test_load_prior_deliberation_summaries_latest_per_ticker(self) -> None:
+        docs = [
+            {
+                "date": "2026-06-17",
+                "document_key": "deliberation/SHY",
+                "payload": {
+                    "net_stance": "neutral",
+                    "conviction_delta": 0,
+                    "converged": True,
+                    "conclusion": "Hold; duration anchor intact.",
+                    "transcript": [{"role": "pm", "text": "x" * 5000}],
+                },
+            },
+            {
+                "date": "2026-06-18",
+                "document_key": "deliberation/SHY",
+                "payload": {
+                    "net_stance": "bearish",
+                    "conviction_delta": -1,
+                    "converged": True,
+                    "conclusion": "Trim into strength; yields peaked.",
+                    "transcript": [{"role": "pm", "text": "y" * 5000}],
+                },
+            },
+        ]
+        client = FakeSupabaseClient(canned_reads={"documents": docs})
+        out = load_prior_deliberation_summaries(client, date(2026, 6, 19), ["SHY"])
+        assert out["SHY"]["date"] == "2026-06-18"  # latest wins
+        assert out["SHY"]["net_stance"] == "bearish"
+        assert out["SHY"]["conviction_delta"] == -1
+        assert out["SHY"]["converged"] is True
+        assert "yields peaked" in out["SHY"]["conclusion_excerpt"]
+        # The bulky transcript must NOT survive the slim (carry is excerpt-only).
+        assert "transcript" not in out["SHY"]
+
+    def test_load_prior_deliberation_summaries_empty_tickers(self) -> None:
+        client = FakeSupabaseClient(canned_reads={"documents": []})
+        assert load_prior_deliberation_summaries(client, date(2026, 6, 19), []) == {}
 
     def test_load_active_theses_rows_excludes_terminal(self) -> None:
         rows = [

--- a/tests/dq/hermes/test_deliberation_skip.py
+++ b/tests/dq/hermes/test_deliberation_skip.py
@@ -87,3 +87,66 @@ class TestDeliberationSkip:
         summary = final.phase_hermes.deliberation_summaries["AAPL"]
         assert summary["carried"] is True
         assert summary["conclusion"] == "prior agreement"
+
+    def test_slim_carry_path_preserves_conclusion(self) -> None:
+        """#925: the slim ``prior_deliberation_by_ticker`` carry (conclusion_excerpt)
+        must land in the carried summary's ``conclusion`` — not an empty string."""
+        news_hash = news_hash_for_ticker(
+            AtlasResearchState(
+                run_type="delta",
+                run_date=date(2026, 6, 20),
+                config=AtlasConfigBundle(watchlist=["AAPL"]),
+            ),
+            "AAPL",
+        )
+        state = AtlasResearchState(
+            run_type="delta",
+            run_date=date(2026, 6, 20),
+            config=AtlasConfigBundle(watchlist=["AAPL"]),
+            prior_context=PriorContext(
+                prior_analyst_by_ticker={
+                    "AAPL": {
+                        "date": "2026-06-19",
+                        "stance": "hold",
+                        "conviction_score": 1,
+                        "fingerprint_news_hash": news_hash,
+                    }
+                },
+                # No latest_segments entry — only the slim carry from preflight.
+                prior_deliberation_by_ticker={
+                    "AAPL": {
+                        "date": "2026-06-19",
+                        "net_stance": "neutral",
+                        "conviction_delta": 0,
+                        "converged": True,
+                        "conclusion_excerpt": "trim into strength; yields peaked",
+                    }
+                },
+            ),
+            price_deltas={"AAPL": 0.001},
+        )
+        state.phase_hermes = PhaseHermesState(
+            focus_roster=[FocusRosterEntry(ticker="AAPL", roster_reason="held")],
+            asset_analysts={
+                "AAPL": {
+                    "ticker": "AAPL",
+                    "conviction_score": 1,
+                    "stance": "hold",
+                    "thesis": "unchanged",
+                    "risks": "",
+                    "sources": [],
+                }
+            },
+        )
+        compiled = build_pipeline(
+            AtlasResearchState, [build_h6_deliberation(["AAPL"], held={"AAPL"})]
+        )
+        with patch(
+            "digigraph.graph.research_agent.completion_text",
+            side_effect=AssertionError("skip path must not call LLM"),
+        ):
+            result = compiled.invoke(state)
+        final = AtlasResearchState.model_validate(result)
+        summary = final.phase_hermes.deliberation_summaries["AAPL"]
+        assert summary["carried"] is True
+        assert summary["conclusion"] == "trim into strength; yields peaked"

--- a/tests/dq/hermes/test_ticker_fingerprint.py
+++ b/tests/dq/hermes/test_ticker_fingerprint.py
@@ -76,3 +76,27 @@ class TestTickerFingerprint:
             price_deltas={"AAPL": 0.001},
         )
         assert deliberation_skip_signal(state, "AAPL", analyst_stance="hold") is False
+
+    def test_deliberation_skip_fires_with_slim_carry(self) -> None:
+        """#925: a quiet held name with a slim prior-deliberation carry can skip H6."""
+        news = news_hash_for_ticker(
+            AtlasResearchState(
+                run_type="delta",
+                run_date=date(2026, 6, 20),
+                config=AtlasConfigBundle(watchlist=["AAPL"]),
+            ),
+            "AAPL",
+        )
+        state = AtlasResearchState(
+            run_type="delta",
+            run_date=date(2026, 6, 20),
+            config=AtlasConfigBundle(watchlist=["AAPL"]),
+            prior_context=PriorContext(
+                prior_analyst_by_ticker={"AAPL": {"stance": "hold", "fingerprint_news_hash": news}},
+                prior_deliberation_by_ticker={
+                    "AAPL": {"net_stance": "neutral", "conviction_delta": 0, "converged": True}
+                },
+            ),
+            price_deltas={"AAPL": 0.001},
+        )
+        assert deliberation_skip_signal(state, "AAPL", analyst_stance="hold") is True

--- a/tests/dq/test_mcp_data_tools.py
+++ b/tests/dq/test_mcp_data_tools.py
@@ -7,14 +7,41 @@ pytest.importorskip("mcp.server.fastmcp")
 from digiquant.mcp_server import create_mcp_server  # noqa: E402
 
 
-@pytest.mark.unit
-def test_data_tools_registered():
-    server = create_mcp_server()
+def _tool_names(server) -> set[str]:
     # Prefer a public accessor; fall back to FastMCP's internal manager across versions.
     if hasattr(server, "list_tools_sync"):
         tools = server.list_tools_sync()
     else:
         tools = server._tool_manager.list_tools()
-    names = {t.name for t in tools}
+    return {t.name for t in tools}
+
+
+@pytest.mark.unit
+def test_data_tools_registered():
+    names = _tool_names(create_mcp_server())
     assert "digiquant_get_price_technicals" in names, f"missing data tool; got {sorted(names)}"
     assert "digiquant_get_macro_series" in names, f"missing data tool; got {sorted(names)}"
+
+
+@pytest.mark.unit
+def test_query_data_tool_registered():
+    """#925: external agents can fetch the paper book + market data via query_data."""
+    names = _tool_names(create_mcp_server())
+    assert "digiquant_query_data" in names, f"missing query_data tool; got {sorted(names)}"
+
+
+@pytest.mark.unit
+def test_query_data_inherits_in_process_allowlist():
+    """The MCP wrapper reuses the same table allowlist as the in-process agents.
+
+    The book tables the issue names (positions/nav_history/theses) are readable;
+    operator-internal telemetry stays unreadable. ``documents`` is intentionally
+    NOT added here — exposing every published doc externally is a separate
+    security decision (human gate), out of scope for this wiring.
+    """
+    from digiquant.olympus.atlas.data.queries import ALLOWED_READ_TABLES
+
+    for table in ("positions", "nav_history", "theses"):
+        assert table in ALLOWED_READ_TABLES
+    for blocked in ("decision_log", "atlas_run_diagnostics", "documents"):
+        assert blocked not in ALLOWED_READ_TABLES


### PR DESCRIPTION
## Summary

Closes the remaining #859 continuity gaps for Hermes.

**1. Prior deliberation carry (AC1)** — `load_prior_deliberation_summaries` + `_slim_deliberation_summary` in `supabase_io.py` (mirrors the analyst-summary loader directly above them), a new `PriorContext.prior_deliberation_by_ticker` field, and preflight wiring. `deliberation/*` is excluded from `latest_segments`, so the old `_prior_deliberation_summary()` always returned `None` (dead carry). H6 now reads the slim field (full transcript dropped) and falls back to `latest_segments`.

**2. MCP `query_data` (AC2)** — `digiquant_query_data` tool in `mcp_server.py` wraps the in-process `query_data` reader with the **same** table allowlist, so external agents (DigiChat / Kairos) can fetch `positions` / `nav_history` / `theses` / market data by key. `documents` stays excluded — exposing every published doc externally is a separate security decision (human gate).

**3. Triage skip (AC3)** — `deliberation_skip_signal` had the same `latest_segments` bug; now reads the slim carry. Also fixed the H6 carried-summary build to read `conclusion_excerpt` (the slim key) so the skip path produces a non-empty `conclusion` instead of `""`.

**4. Tests (AC4)** — loader latest-per-ticker + empty cases, MCP tool registration + allowlist inheritance, triage gate fires on the slim carry, and a slim-carry regression test pinning the `conclusion_excerpt` fix.

Updates the Day-over-day continuity contract table in `digiquant/ARCHITECTURE.md`.

## Test plan

- [x] `pytest -m unit tests/dq/atlas/ tests/dq/hermes/ tests/dq/test_mcp_data_tools.py` → **905 passed** on Python 3.12 (verified locally in a 3.12 venv)
- [x] `ruff check` + `ruff format --check` on all changed files → clean
- [x] `make score` → Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] `make doc-check` → OK

Fixes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)