### PR TITLE
feat(hermes): mark-to-market weights + rebalancing cadence (#955 backend)

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/preflight.py
@@ -38,15 +38,21 @@ from digiquant.olympus.atlas.supabase_io import (
     prior_book_current_weights,
     query_institutional_absence_streak,
     query_macro_series_freshness,
+    query_price_deltas,
     query_price_technicals_freshness,
     upsert_onchain_cohort_positioning,
 )
 from digiquant.olympus.hermes.candidates import holdings_from_prior_book
+from digiquant.olympus.hermes.turnover import mark_to_market_weights
 
 # decision_log may be empty or not yet migrated — do not fail the rest of preflight.
 _SUPABASE_READ_ERRORS = (OSError, RuntimeError, ValueError, TypeError, KeyError)
 
 logger = logging.getLogger(__name__)
+
+
+def _is_cash_ticker(ticker: str) -> bool:
+    return str(ticker).strip().upper() == "CASH"
 
 
 @dataclass(frozen=True)
@@ -319,7 +325,16 @@ def _hydrate_config(
     }
     current_weights = prior_book_current_weights(prior_book)
     if current_weights:
-        preferences["current_weights"] = current_weights
+        # Mark-to-market (#955): drift prior weights by price moves since the last run so
+        # the H8 no-trade band compares against the actual current book, not stale targets.
+        held = tuple(t for t in current_weights if not _is_cash_ticker(t))
+        try:
+            deltas = (
+                query_price_deltas(client=client, tickers=held, run_date=run_date) if held else {}
+            )
+        except _SUPABASE_READ_ERRORS:
+            deltas = {}
+        preferences["current_weights"] = mark_to_market_weights(current_weights, deltas)
 
     hydrated = AtlasConfigBundle(
         watchlist=list(config.watchlist),

--- a/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/phase7e_risk_sizing.py
@@ -27,7 +27,7 @@ from digiquant.olympus.hermes.payloads import analyst_payloads, deliberation_sum
 from digiquant.olympus.hermes.risk_controls import BreakerConfig, breaker_scale_from_nav_history
 from digiquant.olympus.hermes.sector_map import asset_class, sector_bucket
 from digiquant.olympus.hermes.sizing import SizingCaps, TickerRisk, size_portfolio
-from digiquant.olympus.hermes.turnover import apply_turnover_to_sized_book
+from digiquant.olympus.hermes.turnover import apply_rebalancing_cadence
 
 logger = logging.getLogger(__name__)
 
@@ -296,17 +296,19 @@ def _build_sized_book(
         return None
 
     sized = {p.ticker: p.target_pct for p in result.positions}
+    # current_weights is already mark-to-market drifted in preflight (#955). The cadence
+    # dispatcher rebalances through the no-trade band on a permitted day, else holds the
+    # drifted book (only PM direction changes trade).
     current_weights = dict(state.config.preferences.get("current_weights") or {})
-    if isinstance(current_weights, dict):
-        sized = apply_turnover_to_sized_book(
-            sized,
-            current_weights={
-                str(k): float(v) for k, v in current_weights.items() if _opt_float(v) is not None
-            },
-            prior_book=list(state.prior_context.prior_book),
-            preferences=dict(state.config.preferences),
-            run_date=state.run_date,
-        )
+    sized = apply_rebalancing_cadence(
+        sized,
+        current_weights={
+            str(k): float(v) for k, v in current_weights.items() if _opt_float(v) is not None
+        },
+        prior_book=list(state.prior_context.prior_book),
+        preferences=dict(state.config.preferences),
+        run_date=state.run_date,
+    )
     updated: RebalancePayload = {
         "recommended_portfolio": [
             {"ticker": ticker, "target_pct": round(weight, 4)} for ticker, weight in sized.items()

--- a/digiquant/src/digiquant/olympus/hermes/turnover.py
+++ b/digiquant/src/digiquant/olympus/hermes/turnover.py
@@ -1,9 +1,18 @@
-"""Deterministic turnover / min-hold discipline for Hermes rebalance (#859 Phase D)."""
+"""Deterministic turnover / min-hold discipline for Hermes rebalance (#859 Phase D).
+
+Also hosts the mark-to-market drift + rebalancing-cadence logic (#955): the sizer's
+no-trade band must compare today's targets against the *drifted* current book, and a
+configurable cadence controls how often a calendar rebalance is allowed.
+"""
 
 from __future__ import annotations
 
 from datetime import date, datetime
 from typing import Any  # noqa  # scored-lint suppression: entry_date coercion
+
+# Cadence values read from config preferences (``preferences["rebalancing_cadence"]``),
+# sourced from portfolio.json ``constraints`` during preflight. Default "daily".
+_VALID_CADENCES = frozenset({"daily", "weekly", "monthly", "none"})
 
 
 def _parse_entry_date(value: Any) -> date | None:
@@ -19,6 +28,124 @@ def _parse_entry_date(value: Any) -> date | None:
 
 def _is_cash(ticker: str) -> bool:
     return ticker.strip().upper() == "CASH"
+
+
+def mark_to_market_weights(
+    weights: dict[str, float],
+    deltas: dict[str, float],
+) -> dict[str, float]:
+    """Drift ``weights`` by per-ticker returns since the last run, renormalized (#955).
+
+    Each non-cash position's value moves by ``deltas[ticker]`` (a fractional return,
+    e.g. ``0.03`` for +3%); CASH does not drift. Weights are renormalized to the prior
+    gross so the book still sums to the same total — a position bought at 15% that
+    rallies 3% in a day becomes ~15.4% and cash's *share* shrinks accordingly. Pure: no
+    I/O. Returns the input unchanged when it is empty or the drifted total is degenerate.
+    """
+    if not weights:
+        return dict(weights)
+    drifted: dict[str, float] = {}
+    for ticker, weight in weights.items():
+        if _is_cash(ticker):
+            drifted[ticker] = weight
+        else:
+            drifted[ticker] = weight * (1.0 + float(deltas.get(ticker, 0.0)))
+    total = sum(drifted.values())
+    prior_total = sum(weights.values())
+    if total <= 0 or prior_total <= 0:
+        return dict(weights)
+    scale = prior_total / total
+    return {ticker: round(value * scale, 6) for ticker, value in drifted.items()}
+
+
+def should_rebalance_today(
+    cadence: str,
+    run_date: date,
+    preferences: dict[str, Any] | None = None,
+) -> bool:
+    """Whether a calendar rebalance is permitted on ``run_date`` for ``cadence`` (#955).
+
+    - ``daily`` → always rebalance (band still suppresses churn).
+    - ``weekly`` → on the configured weekday (``rebalance_weekday``, 0=Mon, default Mon).
+    - ``monthly`` → on the configured day-of-month (``rebalance_day_of_month``, default 1);
+      anchors above 28 are capped to 28 so the day exists in every month (no true
+      last-day / month-end firing — day 31 fires on the 28th).
+    - ``none`` → never auto-rebalance (drift held; only PM direction changes trade).
+
+    Unknown cadence values fall back to ``daily`` (safe: matches prior behavior).
+    """
+    prefs = preferences or {}
+    normalized = str(cadence or "daily").strip().lower()
+    if normalized not in _VALID_CADENCES:
+        normalized = "daily"
+    if normalized == "daily":
+        return True
+    if normalized == "none":
+        return False
+    if normalized == "weekly":
+        anchor = int(prefs.get("rebalance_weekday") or 0)
+        return run_date.weekday() == max(0, min(6, anchor))
+    # monthly
+    anchor = int(prefs.get("rebalance_day_of_month") or 1)
+    anchor = max(1, min(28, anchor))  # 28 is the safe upper bound across all months
+    return run_date.day == anchor
+
+
+def hold_drifted_book(
+    sized: dict[str, float],
+    *,
+    current_weights: dict[str, float],
+) -> dict[str, float]:
+    """Non-rebalance-day book: hold drifted weights; honor PM direction changes only (#955).
+
+    On a day the cadence does not permit a calendar rebalance, a continuing held
+    position keeps its drifted current weight (no trade) — magnitude trims/adds wait
+    for the next scheduled rebalance. PM *direction* decisions are still honored
+    immediately: a target of 0 exits the name, and a name with no current weight is a
+    new entry booked at its sized target. This is the "weights drift; rebalance only on
+    an explicit decision" behavior the configured cadence asks for.
+    """
+    if not current_weights:
+        return sized
+    out: dict[str, float] = {}
+    for ticker, target in sized.items():
+        if _is_cash(ticker):
+            continue
+        current = float(current_weights.get(ticker, 0.0))
+        if target <= 0:
+            continue  # PM exit → drop to flat (residual becomes cash)
+        if current <= 0:
+            out[ticker] = target  # new entry → book at target
+        else:
+            out[ticker] = current  # continuing position → hold drifted weight
+    return out
+
+
+def apply_rebalancing_cadence(
+    sized: dict[str, float],
+    *,
+    current_weights: dict[str, float],
+    prior_book: list[dict[str, Any]],
+    preferences: dict[str, Any],
+    run_date: date,
+) -> dict[str, float]:
+    """Dispatch sizing through the rebalancing cadence (#955).
+
+    On a permitted rebalance day, apply the normal no-trade band
+    (:func:`apply_turnover_to_sized_book`). Otherwise hold the drifted book
+    (:func:`hold_drifted_book`). ``current_weights`` must already be mark-to-market
+    drifted (see :func:`mark_to_market_weights`).
+    """
+    cadence = str(preferences.get("rebalancing_cadence") or "daily")
+    if should_rebalance_today(cadence, run_date, preferences):
+        return apply_turnover_to_sized_book(
+            sized,
+            current_weights=current_weights,
+            prior_book=prior_book,
+            preferences=preferences,
+            run_date=run_date,
+        )
+    return hold_drifted_book(sized, current_weights=current_weights)
 
 
 def apply_turnover_to_sized_book(

--- a/tests/dq/atlas/test_preflight.py
+++ b/tests/dq/atlas/test_preflight.py
@@ -175,6 +175,39 @@ class TestPreflight:
         assert out["config"].preferences["current_weights"] == {"SHY": 30.0, "CASH": 70.0}
         assert out["prior_context"].prior_book[0]["ticker"] == "SHY"
 
+    def test_preflight_marks_current_weights_to_market(self) -> None:
+        # #955: with price history showing SHY +10% since the last run, the hydrated
+        # current_weights must reflect the drifted book, not the raw prior 30/70.
+        run_date = date(2026, 6, 19)
+        client = FakeSupabaseClient(
+            canned_reads={
+                "daily_snapshots": [],
+                "documents": [],
+                "price_technicals": [{"date": "2026-06-18", "ticker": "SHY"}],
+                "macro_series_observations": [{"obs_date": "2026-06-18"}],
+                "positions": [
+                    {"date": "2026-06-18", "ticker": "SHY", "weight_pct": 30},
+                    {"date": "2026-06-18", "ticker": "CASH", "weight_pct": 70},
+                ],
+                "price_history": [
+                    {"date": "2026-06-17", "ticker": "SHY", "close": 100.0},
+                    {"date": "2026-06-18", "ticker": "SHY", "close": 110.0},  # +10%
+                ],
+            }
+        )
+        deps = PreflightDeps(
+            client=client,
+            config_loader=lambda: AtlasConfigBundle(watchlist=["SHY"]),
+        )
+        out = build_preflight_node(deps)(
+            AtlasResearchState(run_type="delta", run_date=run_date, baseline_date=date(2026, 6, 17))
+        )
+        weights = out["config"].preferences["current_weights"]
+        # SHY value 30*1.10=33 vs CASH 70, NAV 103 → SHY ~32.04%, CASH ~67.96%.
+        assert weights["SHY"] == pytest.approx(33.0 / 103.0 * 100.0, abs=1e-2)
+        assert weights["CASH"] == pytest.approx(70.0 / 103.0 * 100.0, abs=1e-2)
+        assert weights["SHY"] > 30.0  # drifted up from the raw prior weight
+
     def test_preflight_loads_continuity_sidecars(self) -> None:
         run_date = date(2026, 6, 19)
         client = FakeSupabaseClient(

--- a/tests/dq/hermes/test_rebalancing_cadence.py
+++ b/tests/dq/hermes/test_rebalancing_cadence.py
@@ -1,0 +1,148 @@
+"""Mark-to-market drift + rebalancing cadence (#955).
+
+Covers the two backend pieces: drifting the prior book to actual current weights
+before the no-trade band runs, and the daily/weekly/monthly/none cadence gate.
+Persistence of drifted weights to ``positions`` + the dashboard (scope items 4-5)
+are deferred — they need an ``actual_pct`` schema decision (tracked separately).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from digiquant.olympus.hermes.turnover import (
+    apply_rebalancing_cadence,
+    hold_drifted_book,
+    mark_to_market_weights,
+    should_rebalance_today,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestMarkToMarketWeights:
+    def test_rally_increases_weight_and_shrinks_cash_share(self) -> None:
+        # SPY 80%, CASH 20%; SPY +10% → value 88 vs cash 20, NAV 108.
+        out = mark_to_market_weights({"SPY": 80.0, "CASH": 20.0}, {"SPY": 0.10})
+        assert out["SPY"] == pytest.approx(88.0 / 108.0 * 100.0, abs=1e-3)
+        assert out["CASH"] == pytest.approx(20.0 / 108.0 * 100.0, abs=1e-3)
+        assert sum(out.values()) == pytest.approx(100.0, abs=1e-3)
+
+    def test_cash_does_not_drift(self) -> None:
+        out = mark_to_market_weights({"CASH": 100.0}, {"CASH": 0.5})
+        assert out["CASH"] == pytest.approx(100.0)
+
+    def test_no_deltas_is_identity(self) -> None:
+        weights = {"SPY": 60.0, "TLT": 40.0}
+        assert mark_to_market_weights(weights, {}) == pytest.approx(weights)
+
+    def test_renormalizes_to_prior_gross(self) -> None:
+        # Prior gross 90 (10% implicit cash gap); drift must preserve that gross.
+        out = mark_to_market_weights({"SPY": 50.0, "TLT": 40.0}, {"SPY": 0.20, "TLT": -0.10})
+        assert sum(out.values()) == pytest.approx(90.0, abs=1e-3)
+
+    def test_empty_is_identity(self) -> None:
+        assert mark_to_market_weights({}, {"SPY": 0.1}) == {}
+
+    def test_degenerate_total_falls_back_to_input(self) -> None:
+        # A -100% delta zeroes the only position → degenerate; return input unchanged.
+        weights = {"SPY": 100.0}
+        assert mark_to_market_weights(weights, {"SPY": -1.0}) == weights
+
+
+class TestShouldRebalanceToday:
+    _MON = date(2026, 6, 22)  # Monday
+    _WED = date(2026, 6, 24)  # Wednesday
+
+    def test_daily_always_true(self) -> None:
+        assert should_rebalance_today("daily", self._WED) is True
+
+    def test_none_always_false(self) -> None:
+        assert should_rebalance_today("none", self._MON) is False
+
+    def test_weekly_fires_on_anchor_weekday(self) -> None:
+        assert should_rebalance_today("weekly", self._MON) is True  # default Monday
+        assert should_rebalance_today("weekly", self._WED) is False
+
+    def test_weekly_respects_configured_weekday(self) -> None:
+        prefs = {"rebalance_weekday": 2}  # Wednesday
+        assert should_rebalance_today("weekly", self._WED, prefs) is True
+        assert should_rebalance_today("weekly", self._MON, prefs) is False
+
+    def test_monthly_fires_on_anchor_day(self) -> None:
+        assert should_rebalance_today("monthly", date(2026, 6, 1)) is True  # default day 1
+        assert should_rebalance_today("monthly", date(2026, 6, 15)) is False
+
+    def test_monthly_respects_configured_day(self) -> None:
+        prefs = {"rebalance_day_of_month": 15}
+        assert should_rebalance_today("monthly", date(2026, 6, 15), prefs) is True
+
+    def test_monthly_anchor_above_28_is_clamped_to_28(self) -> None:
+        # Anchors above 28 fire on the 28th (no true month-end firing) — documented clamp.
+        prefs = {"rebalance_day_of_month": 31}
+        assert should_rebalance_today("monthly", date(2026, 6, 28), prefs) is True
+        assert should_rebalance_today("monthly", date(2026, 6, 30), prefs) is False
+
+    def test_unknown_cadence_falls_back_to_daily(self) -> None:
+        assert should_rebalance_today("fortnightly", self._WED) is True
+
+
+class TestHoldDriftedBook:
+    def test_continuing_position_holds_drifted_weight(self) -> None:
+        # Sizer wants to trim SPY 30→25, but on a hold day it keeps the drifted 30.
+        out = hold_drifted_book({"SPY": 25.0}, current_weights={"SPY": 30.0})
+        assert out["SPY"] == 30.0
+
+    def test_pm_exit_is_honored(self) -> None:
+        out = hold_drifted_book({"SPY": 0.0}, current_weights={"SPY": 30.0})
+        assert "SPY" not in out
+
+    def test_new_entry_booked_at_target(self) -> None:
+        out = hold_drifted_book({"NVDA": 12.0}, current_weights={"SPY": 30.0})
+        assert out["NVDA"] == 12.0
+
+    def test_empty_current_weights_is_passthrough(self) -> None:
+        assert hold_drifted_book({"SPY": 25.0}, current_weights={}) == {"SPY": 25.0}
+
+    def test_cash_dropped_from_book(self) -> None:
+        out = hold_drifted_book({"CASH": 20.0, "SPY": 80.0}, current_weights={"SPY": 75.0})
+        assert "CASH" not in out
+        assert out["SPY"] == 75.0
+
+
+class TestApplyRebalancingCadence:
+    _RUN = date(2026, 6, 24)  # Wednesday
+
+    def test_rebalance_day_applies_no_trade_band(self) -> None:
+        # daily → rebalance path; a 10pp move exceeds the band → trade to target.
+        out = apply_rebalancing_cadence(
+            {"SPY": 40.0},
+            current_weights={"SPY": 30.0},
+            prior_book=[{"ticker": "SPY", "entry_date": "2026-01-01"}],
+            preferences={"rebalancing_cadence": "daily"},
+            run_date=self._RUN,
+        )
+        assert out["SPY"] == 40.0  # rebalanced to target
+
+    def test_hold_day_holds_drifted_weight(self) -> None:
+        # none → hold path; the same 10pp move is held at the drifted current weight.
+        out = apply_rebalancing_cadence(
+            {"SPY": 40.0},
+            current_weights={"SPY": 30.0},
+            prior_book=[{"ticker": "SPY", "entry_date": "2026-01-01"}],
+            preferences={"rebalancing_cadence": "none"},
+            run_date=self._RUN,
+        )
+        assert out["SPY"] == 30.0  # held, not rebalanced
+
+    def test_default_cadence_is_daily(self) -> None:
+        out = apply_rebalancing_cadence(
+            {"SPY": 40.0},
+            current_weights={"SPY": 30.0},
+            prior_book=[{"ticker": "SPY", "entry_date": "2026-01-01"}],
+            preferences={},  # no cadence set → daily
+            run_date=self._RUN,
+        )
+        assert out["SPY"] == 40.0


### PR DESCRIPTION
## Summary

Implements the **backend** pieces of #955 (scope items 1–3). Does **not** close #955 — the persistence + dashboard pieces (4–5) are deferred (see below).

**1. Mark-to-market weight drift.** Preflight now drifts the prior book's weights by price moves since the last run (`query_price_deltas`) before populating `preferences["current_weights"]`. The H8 no-trade band therefore compares today's targets against the *actual drifted book*, not stale prior targets — a 15% position that rallied 3% is now seen as ~15.4%, and over a quiet hold the drift no longer goes unnoticed. New pure helper `turnover.mark_to_market_weights` (renormalizes to prior gross; CASH held flat).

**2. Configurable rebalancing cadence.** `turnover.should_rebalance_today` reads `preferences["rebalancing_cadence"]` ∈ `{daily, weekly, monthly, none}` (default `daily` = prior behavior), with `rebalance_weekday` / `rebalance_day_of_month` anchors (month anchor capped at 28).

**3. Cadence-aware sizing.** `phase7e` dispatches through `apply_rebalancing_cadence`: on a permitted rebalance day the existing no-trade band runs; otherwise `hold_drifted_book` holds drifted weights for continuing positions while still honoring PM **direction** changes (exits → 0, new entries). Composes with the #934 band — no double-suppression.

## Deferred to a #955 follow-up (documented on the issue)
- **Piece 4** — persist a separate `actual_pct` (drifted) column on `positions`.
- **Piece 5** — dashboard target-vs-actual columns.

Both need a `positions` schema change on the **same table** as the paused #1044 and adjacent to the human-gated DB arc (#1064/#1065), so they're held for that decision rather than taken autonomously. On a non-rebalance day the committed book already equals the drifted weights (a consequence of `hold_drifted_book`), so `positions` reflects reality today — only the explicit target-vs-actual split needs the new column.

## Test plan
- [x] `pytest -m unit tests/dq/atlas/ tests/dq/hermes/` → **921 passed** on Python 3.12 (verified locally)
- [x] `ruff check` + `ruff format --check` on changed files → clean
- [x] `make score` → Security 10, Quality 10, Optimization 10, Accuracy 10
- New tests: 22 cadence/MTM unit tests + 1 preflight MTM integration test

Refs #955 (backend only — issue stays open for the persistence/dashboard follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)