### PR TITLE
feat(digiquant): add strategy store to the unified DigiQuant "core" backend (#1064)

### DIFF
--- a/digiquant/AGENTS.md
+++ b/digiquant/AGENTS.md
@@ -110,6 +110,26 @@ When touching `digiquant/src/digiquant/olympus/`:
 
 ---
 
+## DigiQuant Supabase backend — `core` (#1064)
+
+The DigiQuant shared backend is the **`core`** Supabase project — the project historically
+used by Olympus/Atlas ([`supabase/`](supabase/), `project_id "digiquant-atlas"`), repurposed
+(renamed `core`) as the suite-wide backend. It is **not** a separate project: the free-tier
+2-project limit is taken by Olympus + the confidential **twelve-x** project. The shared market
+datasets already live here; #1064 only **adds** the strategy store
+([`supabase/migrations/046_strategy_store.sql`](supabase/migrations/046_strategy_store.sql)).
+
+The strategy-store accessor (`digiquant.data.store`, `build_digiquant_client`) resolves
+`SUPABASE_URL_DIGIQUANT` / `SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` and **falls back** to the
+shared `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` — so it needs no extra config today, and a
+future split onto its own project is a config change, not a code change. If you ever set the
+`_DIGIQUANT` vars, they are **GitHub Actions secrets — never commit values**.
+
+See [`ARCHITECTURE.md` § DigiQuant Data Layer](ARCHITECTURE.md#digiquant-data-layer--strategy-store--shared-data-1064)
+and [`docs/adr/0021-digiquant-supabase-project-topology.md`](../docs/adr/0021-digiquant-supabase-project-topology.md).
+
+---
+
 ## More
 
 Extension patterns, anti-patterns, and integration boundaries live in [`ARCHITECTURE.md`](ARCHITECTURE.md). Update that doc when changing interfaces or behavior.

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -444,6 +444,8 @@ Strategy registrations are ephemeral — they exist only in the process memory o
 
 The in-process backtest job table (`_backtest_jobs`) has a documented 5-minute TTL but no active cleanup task. Jobs accumulate until the process restarts.
 
+The DigiQuant strategy store (#1064; see [§ DigiQuant Data Layer](#digiquant-data-layer--strategy-store--shared-data-1064)) now provides the durable substrate for per-strategy config, fitted calibration, trades, tearsheets, and live signals. Wiring `service_run_backtest` / the Slapper recompute job to persist canonical run records there (strategy git sha, params hash, data fingerprint) is the remaining step toward reproducible `run_id`s — tracked by #1067/#1068.
+
 ---
 
 ## 8. Performance Analysis
@@ -917,6 +919,42 @@ near-duplicate sector skills were collapsed into one templated
 
 See `docs/adr/0009-atlas-supabase-persistence.md` for the persistence
 decision and `docs/adr/0015-atlas-vs-hermes.md` for the engine split.
+
+## DigiQuant Data Layer — Strategy Store + Shared Data (#1064)
+
+The DigiQuant shared backend is the **`core`** Supabase project — the project historically
+used by Olympus/Atlas (`config.toml project_id "digiquant-atlas"`, rooted at
+`digiquant/supabase/`), repurposed (renamed `core`) as the suite-wide backend rather than a
+separate project, because the `digiquant.io` org is free-tier (2-project limit) and both
+slots are taken (Olympus + the confidential twelve-x). The shared market datasets
+(`price_history`, `price_technicals`, `trading_calendar`, `macro_series_observations`)
+already live here; #1064 only **adds** the strategy store. See
+`docs/adr/0021-digiquant-supabase-project-topology.md`.
+
+**Connection.** Accessor `digiquant.data.store` (`build_digiquant_client` + Polars-friendly
+helpers in `strategies.py`). Credentials resolve `SUPABASE_URL_DIGIQUANT` /
+`SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` and **fall back** to the shared `SUPABASE_URL` /
+`SUPABASE_SERVICE_ROLE_KEY` — one project today, a zero-code split if the store ever
+graduates onto its own project.
+
+**Strategy store** (added by [`supabase/migrations/046_strategy_store.sql`](supabase/migrations/046_strategy_store.sql))
+
+- `strategies` — `id`, `symbol`, `label`, `engine`, `config` jsonb, `enabled`, `version`. Public-readable.
+- `strategy_calibrations` — **private** 1:1 sidecar holding fitted `calibration` jsonb. Service-role-only.
+- `strategy_trades` — executed trade history (entry/exit ts, side, prices, qty, pnl, return_pct).
+- `strategy_tearsheets` — latest tearsheet payload per strategy (`metrics`, `equity_curve`, `as_of`).
+- `strategy_signals` — current state per strategy (`position` long/flat/short, `last_signal_date`, `last_price`).
+
+**Shared data layer.** `price_history`, `price_technicals`, `trading_calendar`,
+`macro_series_observations` already reside in `core` (no migration needed). `#1065`'s
+cross-project price copy is therefore **superseded**; `#1066` brings the twelve-x
+`economic_calendar` into the shared layer.
+
+**RLS.** Every strategy-store table RLS-enabled. Public reference + tearsheet tables grant
+`anon SELECT USING (true)`; writers use the service role (RLS bypass). `strategy_calibrations`
+has no anon policy — anon reads return an empty set (not a permission error) while the service
+role keeps full access (mirrors the `atlas_run_diagnostics` idiom, migration 033). Run
+`get_advisors(type="security")` after applying; expect zero `rls_disabled_in_public` findings.
 
 ## DigiSearch Integration (#199)
 

--- a/digiquant/src/digiquant/data/store/__init__.py
+++ b/digiquant/src/digiquant/data/store/__init__.py
@@ -1,0 +1,46 @@
+"""DigiQuant strategy store + shared-data-layer accessor (#1064).
+
+Thin, Polars-friendly helpers over the dedicated DigiQuant Supabase project,
+separate from the Olympus/Atlas project. See
+``docs/adr/0021-digiquant-supabase-project-topology.md``.
+"""
+
+from __future__ import annotations
+
+from digiquant.data.store.client import (
+    DIGIQUANT_SERVICE_ROLE_KEY_ENV,
+    DIGIQUANT_URL_ENV,
+    SupabaseLike,
+    build_digiquant_client,
+    digiquant_credentials,
+)
+from digiquant.data.store.strategies import (
+    PUBLIC_STRATEGY_COLUMNS,
+    WriteResult,
+    read_calibration,
+    read_signals,
+    read_strategies,
+    record_trades,
+    upsert_calibration,
+    upsert_signal,
+    upsert_strategies,
+    upsert_tearsheet,
+)
+
+__all__ = [
+    "DIGIQUANT_SERVICE_ROLE_KEY_ENV",
+    "DIGIQUANT_URL_ENV",
+    "PUBLIC_STRATEGY_COLUMNS",
+    "SupabaseLike",
+    "WriteResult",
+    "build_digiquant_client",
+    "digiquant_credentials",
+    "read_calibration",
+    "read_signals",
+    "read_strategies",
+    "record_trades",
+    "upsert_calibration",
+    "upsert_signal",
+    "upsert_strategies",
+    "upsert_tearsheet",
+]

--- a/digiquant/src/digiquant/data/store/client.py
+++ b/digiquant/src/digiquant/data/store/client.py
@@ -1,0 +1,76 @@
+"""Thin client factory for the DigiQuant strategy store (#1064).
+
+The strategy store lives in the unified DigiQuant **"core"** project — the project
+historically used by Olympus/Atlas (`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`),
+repurposed as the suite-wide shared backend (free-tier 2-project limit; see
+``docs/adr/0021-digiquant-supabase-project-topology.md``).
+
+Credential resolution **prefers** the ``_DIGIQUANT``-suffixed vars and **falls back**
+to the shared ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. Today both resolve to
+the same project, so the store works with zero extra config; if the strategy store
+ever graduates onto its own Supabase project, setting the ``_DIGIQUANT`` vars splits it
+off with no code change.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol  # noqa: ANN401 — SupabaseLike.table returns the driver's dynamic type
+
+SUPABASE_URL_ENV = "SUPABASE_URL"
+SUPABASE_SERVICE_ROLE_KEY_ENV = "SUPABASE_SERVICE_ROLE_KEY"
+DIGIQUANT_URL_ENV = "SUPABASE_URL_DIGIQUANT"
+DIGIQUANT_SERVICE_ROLE_KEY_ENV = "SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT"
+
+
+class SupabaseLike(Protocol):
+    """Structural type matching both ``supabase.Client`` and test fakes."""
+
+    def table(self, name: str) -> Any:  # pragma: no cover - protocol
+        ...
+
+
+def _first_env(*names: str) -> str | None:
+    """Return the first env var that is set to a non-blank value, else ``None``."""
+    for name in names:
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def digiquant_credentials() -> tuple[str | None, str | None]:
+    """Return ``(url, service_role_key)`` for the DigiQuant ``core`` project.
+
+    Prefers the ``_DIGIQUANT``-suffixed vars; falls back to the shared
+    ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. Blank values normalize to
+    ``None`` so callers get a single, unambiguous "creds missing" signal.
+    """
+    url = _first_env(DIGIQUANT_URL_ENV, SUPABASE_URL_ENV)
+    key = _first_env(DIGIQUANT_SERVICE_ROLE_KEY_ENV, SUPABASE_SERVICE_ROLE_KEY_ENV)
+    return url, key
+
+
+def build_digiquant_client():  # pragma: no cover - thin wrapper over supabase SDK
+    """Build a service-role client for the DigiQuant ``core`` project.
+
+    Returns ``None`` when either credential is missing (matches the legacy
+    ``build_supabase_client`` contract so callers can fail soft).
+    """
+    url, key = digiquant_credentials()
+    if not url or not key:
+        return None
+    from supabase import create_client  # type: ignore[import-not-found]
+
+    return create_client(url, key)
+
+
+__all__ = [
+    "DIGIQUANT_SERVICE_ROLE_KEY_ENV",
+    "DIGIQUANT_URL_ENV",
+    "SUPABASE_SERVICE_ROLE_KEY_ENV",
+    "SUPABASE_URL_ENV",
+    "SupabaseLike",
+    "build_digiquant_client",
+    "digiquant_credentials",
+]

--- a/digiquant/src/digiquant/data/store/strategies.py
+++ b/digiquant/src/digiquant/data/store/strategies.py
@@ -1,0 +1,220 @@
+"""Polars-friendly accessor for the DigiQuant strategy store (#1064).
+
+Read/write helpers over the dedicated DigiQuant Supabase project (see
+:mod:`digiquant.data.store.client`). Writers use the service role (which bypasses
+RLS); public read helpers project only the non-sensitive columns. Fitted
+calibration params live in the private ``strategy_calibrations`` sidecar and are
+reachable only via the service-role helpers here — never exposed to anon.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any  # noqa: ANN401 — JSONB payloads and driver rows are dynamic at the DB boundary
+
+import polars as pl
+
+from digibase.audit import redact_mapping
+
+from digiquant.data.prices._utils import call_with_retry as _call_with_retry
+from digiquant.data.store.client import SupabaseLike
+
+# Non-sensitive ``strategies`` columns — safe to expose / project on public reads.
+# Deliberately excludes anything from the private ``strategy_calibrations`` sidecar.
+PUBLIC_STRATEGY_COLUMNS: tuple[str, ...] = (
+    "id",
+    "symbol",
+    "label",
+    "engine",
+    "config",
+    "enabled",
+    "version",
+    "created_at",
+    "updated_at",
+)
+
+DEFAULT_CHUNK = 500
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    table: str
+    rows: int
+
+
+def _chunks(rows: list[dict[str, Any]], chunk: int):
+    for i in range(0, len(rows), chunk):
+        yield rows[i : i + chunk]
+
+
+def _iso(value: Any) -> Any:
+    """Coerce date/datetime to an ISO string for PostgREST; pass through otherwise."""
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def _emit_audit(table: str, rows: int, operation: str) -> None:
+    """Redacted audit hook (no row bodies — payloads may carry licensed data)."""
+    redact_mapping({"table": table, "rows": rows, "operation": operation})
+
+
+def _write(
+    client: SupabaseLike,
+    table: str,
+    rows: list[dict[str, Any]],
+    *,
+    op: str = "upsert",
+    chunk: int = DEFAULT_CHUNK,
+) -> WriteResult:
+    """Chunked ``upsert``/``insert`` with retry + a redacted audit record.
+
+    Empty ``rows`` is a no-op. Each chunk is a blocking PostgREST round-trip
+    wrapped in :func:`call_with_retry`; ``op`` selects the PostgREST verb.
+    """
+    if not rows:
+        return WriteResult(table=table, rows=0)
+    total = 0
+    for batch in _chunks(rows, chunk):
+        _call_with_retry(lambda b=batch: getattr(client.table(table), op)(b).execute())
+        total += len(batch)
+    _emit_audit(table, total, op)
+    return WriteResult(table=table, rows=total)
+
+
+# ─── Strategies (public) ──────────────────────────────────────────────────────
+
+
+def upsert_strategies(
+    client: SupabaseLike,
+    rows: list[dict[str, Any]],
+    *,
+    chunk: int = DEFAULT_CHUNK,
+) -> WriteResult:
+    """Upsert ``strategies`` rows (keyed on ``id``)."""
+    return _write(client, "strategies", rows, op="upsert", chunk=chunk)
+
+
+def read_strategies(client: SupabaseLike, *, enabled_only: bool = False) -> pl.DataFrame:
+    """Read the public ``strategies`` columns into a Polars frame."""
+    query = client.table("strategies").select(",".join(PUBLIC_STRATEGY_COLUMNS))
+    if enabled_only:
+        query = query.eq("enabled", True)
+    resp = query.execute()
+    return pl.DataFrame(resp.data or [])
+
+
+# ─── Calibrations (private sidecar — service-role only) ─────────────────────────
+
+
+def upsert_calibration(
+    client: SupabaseLike,
+    strategy_id: str,
+    calibration: dict[str, Any],
+    *,
+    as_of: Any | None = None,
+) -> WriteResult:
+    """Write the private fitted calibration for a strategy (service-role only)."""
+    row: dict[str, Any] = {"strategy_id": strategy_id, "calibration": calibration}
+    if as_of is not None:
+        row["as_of"] = _iso(as_of)
+    return _write(client, "strategy_calibrations", [row], op="upsert")
+
+
+def read_calibration(client: SupabaseLike, strategy_id: str) -> dict[str, Any] | None:
+    """Read a strategy's private calibration (requires the service-role client)."""
+    resp = (
+        client.table("strategy_calibrations")
+        .select("calibration")
+        .eq("strategy_id", strategy_id)
+        .limit(1)
+        .execute()
+    )
+    rows = resp.data or []
+    return rows[0].get("calibration") if rows else None
+
+
+# ─── Signals + tearsheets (public) ──────────────────────────────────────────────
+
+
+def upsert_signal(
+    client: SupabaseLike,
+    *,
+    strategy_id: str,
+    position: str,
+    as_of: Any,
+    last_signal_date: Any | None = None,
+    last_price: float | None = None,
+) -> WriteResult:
+    """Upsert the current signal/state for a strategy (one row per strategy)."""
+    row: dict[str, Any] = {
+        "strategy_id": strategy_id,
+        "position": position,
+        "as_of": _iso(as_of),
+    }
+    if last_signal_date is not None:
+        row["last_signal_date"] = _iso(last_signal_date)
+    if last_price is not None:
+        row["last_price"] = last_price
+    return _write(client, "strategy_signals", [row], op="upsert")
+
+
+def read_signals(client: SupabaseLike) -> pl.DataFrame:
+    """Read all current strategy signals into a Polars frame."""
+    resp = client.table("strategy_signals").select("*").execute()
+    return pl.DataFrame(resp.data or [])
+
+
+def upsert_tearsheet(
+    client: SupabaseLike,
+    *,
+    strategy_id: str,
+    metrics: dict[str, Any],
+    as_of: Any,
+    equity_curve: Any | None = None,
+) -> WriteResult:
+    """Upsert the latest tearsheet payload for a strategy (one row per strategy)."""
+    row: dict[str, Any] = {
+        "strategy_id": strategy_id,
+        "metrics": metrics,
+        "as_of": _iso(as_of),
+    }
+    if equity_curve is not None:
+        row["equity_curve"] = equity_curve
+    return _write(client, "strategy_tearsheets", [row], op="upsert")
+
+
+# ─── Trades ─────────────────────────────────────────────────────────────────────
+
+
+def _coerce_trade(row: dict[str, Any]) -> dict[str, Any]:
+    """Copy a trade row, ISO-coercing the entry/exit timestamps when present."""
+    out = dict(row)
+    for key in ("entry_ts", "exit_ts"):
+        if key in out:
+            out[key] = _iso(out[key])
+    return out
+
+
+def record_trades(
+    client: SupabaseLike,
+    rows: list[dict[str, Any]],
+    *,
+    chunk: int = DEFAULT_CHUNK,
+) -> WriteResult:
+    """Insert executed-trade rows for one or more strategies."""
+    payload = [_coerce_trade(r) for r in rows]
+    return _write(client, "strategy_trades", payload, op="insert", chunk=chunk)
+
+
+__all__ = [
+    "DEFAULT_CHUNK",
+    "PUBLIC_STRATEGY_COLUMNS",
+    "WriteResult",
+    "read_calibration",
+    "read_signals",
+    "read_strategies",
+    "record_trades",
+    "upsert_calibration",
+    "upsert_signal",
+    "upsert_strategies",
+    "upsert_tearsheet",
+]

--- a/digiquant/supabase/SCHEMA.md
+++ b/digiquant/supabase/SCHEMA.md
@@ -75,6 +75,21 @@ erDiagram
 | `analyst_coverage` | `(date, ticker)` | Daily denormalized analyst ↔ ticker index. |
 | `deep_dive_triggers` | `(id BIGSERIAL)` | Audit trail of every recess- or delta-watch- or manually- forced deep-dive. |
 
+### Strategy store — new in migration 046 (#1064)
+
+This project is the unified DigiQuant **`core`** backend (Supabase display name `core`;
+local alias still `project_id "digiquant-atlas"`). Migration 046 adds the strategy store
+(additive only — no existing table touched). See
+[`docs/adr/0021-digiquant-supabase-project-topology.md`](../../docs/adr/0021-digiquant-supabase-project-topology.md).
+
+| Table | PK | Purpose |
+|-------|----|---------|
+| `strategies` | `(id)` | One row per strategy: `symbol`, `label`, `engine`, `config` jsonb, `enabled`, `version`. Public-readable. |
+| `strategy_calibrations` | `(strategy_id)` | **Private** 1:1 sidecar; fitted `calibration` jsonb. FK → `strategies (id)`. Service-role-only (see RLS exception). |
+| `strategy_trades` | `(id BIGINT)` | Executed trade history; FK → `strategies (id)`. Indexed `(strategy_id, entry_ts DESC)`. |
+| `strategy_tearsheets` | `(strategy_id)` | Latest tearsheet payload (`metrics` jsonb, `equity_curve` jsonb, `as_of`). |
+| `strategy_signals` | `(strategy_id)` | Current state: `position` (long/flat/short), `last_signal_date`, `last_price`, `as_of`. |
+
 ## RLS (consistent across all tables above)
 
 - Every table has `ENABLE ROW LEVEL SECURITY`.
@@ -83,6 +98,10 @@ erDiagram
 - Writes: require the Supabase `service_role` key. Supabase grants
   service_role bypass at the GRANT layer, so there is no explicit
   `service_role` policy on any Atlas table.
+- **Exception — `strategy_calibrations` (migration 046):** RLS enabled with **no**
+  anon policy, so anon reads return an empty set (not an error) while the service
+  role keeps full access. The fitted calibration is private; mirrors the
+  `atlas_run_diagnostics` idiom (migration 033).
 
 ## Dead / deprecated
 

--- a/digiquant/supabase/migrations/046_strategy_store.sql
+++ b/digiquant/supabase/migrations/046_strategy_store.sql
@@ -1,0 +1,100 @@
+-- 046_strategy_store.sql
+--
+-- Run with:  supabase db push   (or apply via MCP against this project).
+--
+-- DigiQuant strategy store (#1064). This project — historically the Olympus/Atlas
+-- DB (config.toml project_id "digiquant-atlas") — is being repurposed as the unified
+-- DigiQuant shared backend (Supabase display name "core"), beside the dedicated
+-- "twelve-x" project. The shared market datasets (price_history / price_technicals /
+-- trading_calendar / macro_series_observations) already live here, so #1064 reduces to
+-- ADDING the strategy store. See docs/adr/0021-digiquant-supabase-project-topology.md.
+--
+-- ADDITIVE ONLY: this migration creates new tables whose only foreign keys point at
+-- each other. It does NOT touch any existing table, policy, column, or row — no DROP,
+-- no ALTER, no TRUNCATE. (#1065's cross-project price copy is obviated: prices already
+-- live here.)
+--
+-- RLS: every new table RLS-enabled. The public reference + tearsheet tables grant anon
+-- SELECT; server-side writers use the service role (which bypasses RLS). The private
+-- strategy_calibrations sidecar gets NO anon policy — with RLS enabled and zero policies
+-- anon reads return an empty result set (not a permission error) while the service role
+-- keeps full access, mirroring the atlas_run_diagnostics idiom (migration 033). Idempotent.
+
+create table if not exists public.strategies (
+    id          text primary key,
+    symbol      text not null,
+    label       text,
+    engine      text not null,
+    config      jsonb not null default '{}'::jsonb,
+    enabled     boolean not null default true,
+    version     integer not null default 1,
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+-- Private 1:1 sidecar for fitted calibration params (service-role-only; see RLS below).
+create table if not exists public.strategy_calibrations (
+    strategy_id text primary key references public.strategies (id) on delete cascade,
+    calibration jsonb not null default '{}'::jsonb,
+    as_of       timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+create table if not exists public.strategy_trades (
+    id          bigint generated always as identity primary key,
+    strategy_id text not null references public.strategies (id) on delete cascade,
+    entry_ts    timestamptz,
+    exit_ts     timestamptz,
+    side        text,
+    entry_price numeric,
+    exit_price  numeric,
+    qty         numeric,
+    pnl         numeric,
+    return_pct  numeric,
+    created_at  timestamptz not null default now()
+);
+create index if not exists idx_strategy_trades_strategy_entry
+    on public.strategy_trades (strategy_id, entry_ts desc);
+
+-- Latest computed tearsheet payload per strategy (one row per strategy).
+create table if not exists public.strategy_tearsheets (
+    strategy_id  text primary key references public.strategies (id) on delete cascade,
+    metrics      jsonb not null default '{}'::jsonb,
+    equity_curve jsonb,
+    as_of        timestamptz not null,
+    updated_at   timestamptz not null default now()
+);
+
+-- Current signal/state per strategy (one row per strategy).
+create table if not exists public.strategy_signals (
+    strategy_id      text primary key references public.strategies (id) on delete cascade,
+    position         text not null default 'flat' check (position in ('long', 'flat', 'short')),
+    last_signal_date date,
+    last_price       numeric,
+    as_of            timestamptz not null,
+    updated_at       timestamptz not null default now()
+);
+
+-- ── Row-level security ──────────────────────────────────────────────────────────
+
+alter table public.strategies            enable row level security;
+alter table public.strategy_calibrations enable row level security;
+alter table public.strategy_trades       enable row level security;
+alter table public.strategy_tearsheets   enable row level security;
+alter table public.strategy_signals      enable row level security;
+
+-- Public reference + tearsheet tables: anon may SELECT; service role writes (RLS bypass).
+create policy strategies_anon_select on public.strategies
+    for select to anon using (true);
+
+create policy strategy_trades_anon_select on public.strategy_trades
+    for select to anon using (true);
+
+create policy strategy_tearsheets_anon_select on public.strategy_tearsheets
+    for select to anon using (true);
+
+create policy strategy_signals_anon_select on public.strategy_signals
+    for select to anon using (true);
+
+-- strategy_calibrations: PRIVATE. RLS enabled, NO anon policy → anon reads return an
+-- empty result set; the service role keeps full access. Do not add an anon policy here.

--- a/docs/adr/0021-digiquant-supabase-project-topology.md
+++ b/docs/adr/0021-digiquant-supabase-project-topology.md
@@ -1,0 +1,92 @@
+# ADR 0021: DigiQuant Supabase Topology — Consolidate the Shared Backend into the "core" Project
+
+**Status:** accepted
+**Date:** 2026-06-25
+
+## Context
+
+Epic [#1063](https://github.com/digithings-ai/digithings/issues/1063) introduces a
+**strategy store** (per-strategy config, fitted calibration, executed trades, tearsheets,
+live signals) to back DB-driven live tearsheets ([#1069](https://github.com/digithings-ai/digithings/issues/1069)),
+and treats the market datasets (`price_history`, `price_technicals`, `trading_calendar`,
+`economic_calendar`) as a **shared DigiQuant data layer** repurposable across the suite
+(Olympus, twelve-x, the Slapper book).
+
+[#1064](https://github.com/digithings-ai/digithings/issues/1064)'s first acceptance
+criterion originally read *"new Supabase project, separate from the Olympus project."* On
+inspection that is not feasible: the `digiquant.io` Supabase org is on the **free tier
+(2-project limit)** and both slots are used — the Olympus/Atlas project (`project_id
+"digiquant-atlas"`) and the **twelve-x** project (kept separate; it holds confidential
+data). A third dedicated project cannot be provisioned without a paid upgrade.
+
+Two facts make consolidation the pragmatic choice rather than a compromise:
+
+- The shared market data **already lives in the Olympus project** (`price_history` 555k+
+  rows, `price_technicals`, `trading_calendar`, `macro_series_observations`). It was never
+  elsewhere — so the "shared data layer" already exists there.
+- The strategy store is **net-new**: its tables reference only each other, so adding them
+  to that project touches nothing that exists.
+
+## Decision
+
+**Repurpose the existing Olympus/Atlas project as the unified DigiQuant shared backend,
+renamed `core`** (Supabase display name; `config.toml` keeps the stable local alias
+`project_id "digiquant-atlas"`). twelve-x stays a separate project.
+
+- **Add** the strategy store via an **additive-only** migration in this project's existing
+  sequence: [`digiquant/supabase/migrations/046_strategy_store.sql`](../../digiquant/supabase/migrations/046_strategy_store.sql)
+  — `CREATE TABLE IF NOT EXISTS` + `CREATE POLICY` on the five new tables, with **no**
+  `DROP`/`ALTER`/`TRUNCATE` and zero references to existing objects.
+- **No data migration.** The market datasets already reside here; nothing is moved or
+  copied. This obviates [#1065](https://github.com/digithings-ai/digithings/issues/1065)'s
+  cross-project copy (superseded — there are no longer two projects to copy between).
+- **Logical separation preserved in code.** The accessor
+  ([`digiquant.data.store`](../../digiquant/src/digiquant/data/store/)) resolves
+  `SUPABASE_URL_DIGIQUANT` / `SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` and **falls back** to the
+  shared `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`. Today both resolve to `core`; if the
+  store ever graduates onto its own project (post free-tier), setting the `_DIGIQUANT` vars
+  splits it off with **zero code change**.
+- **RLS.** Public reference + tearsheet tables grant `anon SELECT`; the private
+  `strategy_calibrations` sidecar gets no anon policy (RLS-on, zero-policy → empty reads for
+  anon, full access for the service role; the migration-033 idiom).
+
+## Consequences
+
+**Positive**
+
+- Works within the free tier — no new billing, no new CI connection, no data movement, and
+  the riskiest epic step (#1065's price copy) disappears.
+- The accessor's env-var indirection keeps the separation *design* intact: a future split is
+  a config change, not a refactor.
+- The prod touch is minimal and provably safe: new empty tables only.
+
+**Negative**
+
+- The strategy store and Olympus operational data share one project — one blast radius, one
+  credential set, one RLS surface. The privacy boundaries (`strategy_calibrations`
+  service-role-only; per-table RLS) are within-project rather than cross-project.
+- `config.toml`'s `project_id` (`digiquant-atlas`) no longer matches the Supabase display
+  name (`core`). The alias is kept for historical continuity (ADR-0011/0014 reference it);
+  the mismatch is documented here and in `SCHEMA.md`.
+
+## Alternatives considered
+
+1. **A dedicated third Supabase project** (the original #1064 wording). Rejected: blocked by
+   the free-tier 2-project limit; would require a paid upgrade. This was the initial plan
+   until the constraint surfaced.
+2. **Drop twelve-x to free a slot for a dedicated DigiQuant project.** Rejected: twelve-x
+   holds confidential data and is a deliberately separate project.
+3. **A separate Postgres schema inside `core`** (e.g. `strategy.*`). Rejected as needless:
+   `public` + per-table RLS already gives the isolation the strategy store needs, and a
+   second schema complicates PostgREST exposure and the accessor for no gain at this scale.
+
+## Links
+
+- Epic: [#1063](https://github.com/digithings-ai/digithings/issues/1063).
+- Implements [#1064](https://github.com/digithings-ai/digithings/issues/1064); supersedes the
+  cross-project copy in [#1065](https://github.com/digithings-ai/digithings/issues/1065);
+  consumed by [#1066](https://github.com/digithings-ai/digithings/issues/1066),
+  [#1069](https://github.com/digithings-ai/digithings/issues/1069).
+- Migration: [`digiquant/supabase/migrations/046_strategy_store.sql`](../../digiquant/supabase/migrations/046_strategy_store.sql).
+- Accessor: [`digiquant/src/digiquant/data/store/`](../../digiquant/src/digiquant/data/store/).
+- RLS idiom precedent: [migration 033](../../digiquant/supabase/migrations/033_revoke_anon_run_diagnostics.sql).

--- a/tests/dq/store/test_strategy_store.py
+++ b/tests/dq/store/test_strategy_store.py
@@ -1,0 +1,284 @@
+"""Unit tests for the DigiQuant strategy store accessor (#1064)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any  # noqa: ANN401 — fake client mirrors the driver's dynamic surface
+
+import polars as pl
+import pytest
+
+from digiquant.data.store import (
+    PUBLIC_STRATEGY_COLUMNS,
+    build_digiquant_client,
+    digiquant_credentials,
+    read_calibration,
+    read_signals,
+    read_strategies,
+    record_trades,
+    upsert_calibration,
+    upsert_signal,
+    upsert_strategies,
+    upsert_tearsheet,
+)
+from digiquant.data.store.client import (
+    DIGIQUANT_SERVICE_ROLE_KEY_ENV,
+    DIGIQUANT_URL_ENV,
+    SUPABASE_SERVICE_ROLE_KEY_ENV,
+    SUPABASE_URL_ENV,
+)
+
+
+# ─── Fake Supabase client (records selects; honors eq/limit; upsert/insert) ──────
+
+
+@dataclass
+class _Resp:
+    data: list[dict[str, Any]]
+
+
+@dataclass
+class _Query:
+    table_name: str
+    store: dict[str, list[dict[str, Any]]]
+    selects: list[str]
+    _filters: list[tuple[str, Any]] = field(default_factory=list)
+    _limit: int | None = None
+    _pending: list[dict[str, Any]] | None = None
+    _op: str | None = None
+
+    def select(self, cols: str) -> "_Query":
+        self.selects.append(cols)
+        return self
+
+    def eq(self, col: str, val: Any) -> "_Query":
+        self._filters.append((col, val))
+        return self
+
+    def limit(self, n: int) -> "_Query":
+        self._limit = n
+        return self
+
+    def upsert(self, row: Any) -> "_Query":
+        rows = row if isinstance(row, list) else [row]
+        self._pending = [dict(r) for r in rows]
+        self._op = "upsert"
+        return self
+
+    def insert(self, rows: Any) -> "_Query":
+        items = rows if isinstance(rows, list) else [rows]
+        self._pending = [dict(r) for r in items]
+        self._op = "insert"
+        return self
+
+    @staticmethod
+    def _pk(row: dict[str, Any]) -> tuple[str, Any] | None:
+        for key in ("strategy_id", "id"):
+            if key in row:
+                return key, row[key]
+        return None
+
+    def execute(self) -> _Resp:
+        table = self.store.setdefault(self.table_name, [])
+        if self._pending is not None:
+            if self._op == "upsert":
+                for row in self._pending:
+                    pk = self._pk(row)
+                    existing = (
+                        next((r for r in table if r.get(pk[0]) == pk[1]), None) if pk else None
+                    )
+                    if existing is not None:
+                        existing.update(row)
+                    else:
+                        table.append(row)
+            else:  # insert
+                table.extend(self._pending)
+            return _Resp(data=list(self._pending))
+
+        rows = [r for r in table if all(r.get(c) == v for c, v in self._filters)]
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return _Resp(data=rows)
+
+
+@dataclass
+class FakeClient:
+    store: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    selects: list[str] = field(default_factory=list)
+
+    def table(self, name: str) -> _Query:
+        return _Query(table_name=name, store=self.store, selects=self.selects)
+
+
+# ─── Credentials / client factory ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCredentials:
+    def _clear_all(self, mp: pytest.MonkeyPatch) -> None:
+        for var in (
+            DIGIQUANT_URL_ENV,
+            DIGIQUANT_SERVICE_ROLE_KEY_ENV,
+            SUPABASE_URL_ENV,
+            SUPABASE_SERVICE_ROLE_KEY_ENV,
+        ):
+            mp.delenv(var, raising=False)
+
+    def test_digiquant_vars_used_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv(DIGIQUANT_URL_ENV, "https://dq.supabase.co")
+        monkeypatch.setenv(DIGIQUANT_SERVICE_ROLE_KEY_ENV, "dq-key")
+        assert digiquant_credentials() == ("https://dq.supabase.co", "dq-key")
+
+    def test_falls_back_to_shared_supabase_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One project today: the store reuses SUPABASE_URL when _DIGIQUANT is unset."""
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv(SUPABASE_URL_ENV, "https://core.supabase.co")
+        monkeypatch.setenv(SUPABASE_SERVICE_ROLE_KEY_ENV, "core-key")
+        assert digiquant_credentials() == ("https://core.supabase.co", "core-key")
+
+    def test_digiquant_vars_take_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv(SUPABASE_URL_ENV, "https://core.supabase.co")
+        monkeypatch.setenv(SUPABASE_SERVICE_ROLE_KEY_ENV, "core-key")
+        monkeypatch.setenv(DIGIQUANT_URL_ENV, "https://dq.supabase.co")
+        monkeypatch.setenv(DIGIQUANT_SERVICE_ROLE_KEY_ENV, "dq-key")
+        assert digiquant_credentials() == ("https://dq.supabase.co", "dq-key")
+
+    def test_blank_values_normalize_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv(DIGIQUANT_URL_ENV, "   ")
+        assert digiquant_credentials() == (None, None)
+
+    def test_build_client_returns_none_without_creds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear_all(monkeypatch)
+        assert build_digiquant_client() is None
+
+
+# ─── Strategies (public) ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestStrategies:
+    def test_upsert_then_read_roundtrip(self) -> None:
+        client = FakeClient()
+        upsert_strategies(
+            client,
+            [
+                {"id": "slapper-btc", "symbol": "BTC-USD", "engine": "slapper", "enabled": True},
+                {"id": "ema-eth", "symbol": "ETH-USD", "engine": "ema_cross", "enabled": False},
+            ],
+        )
+        df = read_strategies(client)
+        assert isinstance(df, pl.DataFrame)
+        assert set(df["id"].to_list()) == {"slapper-btc", "ema-eth"}
+
+    def test_read_enabled_only_filters(self) -> None:
+        client = FakeClient()
+        upsert_strategies(
+            client,
+            [
+                {"id": "a", "symbol": "BTC-USD", "engine": "slapper", "enabled": True},
+                {"id": "b", "symbol": "ETH-USD", "engine": "slapper", "enabled": False},
+            ],
+        )
+        df = read_strategies(client, enabled_only=True)
+        assert df["id"].to_list() == ["a"]
+
+    def test_public_read_never_projects_calibration(self) -> None:
+        """Security: the public strategies projection must not include calibration."""
+        assert "calibration" not in PUBLIC_STRATEGY_COLUMNS
+        client = FakeClient()
+        read_strategies(client)
+        # The select string handed to the client carries only non-sensitive columns.
+        assert client.selects, "read_strategies must issue a projected select"
+        assert all("calibration" not in sel for sel in client.selects)
+
+    def test_empty_read_returns_empty_frame(self) -> None:
+        df = read_strategies(FakeClient())
+        assert isinstance(df, pl.DataFrame)
+        assert df.height == 0
+
+
+# ─── Calibrations (private sidecar) ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCalibrations:
+    def test_upsert_and_read_calibration(self) -> None:
+        client = FakeClient()
+        upsert_calibration(
+            client, "slapper-btc", {"lookback": 20, "z": 1.5}, as_of=datetime(2026, 6, 25, 12)
+        )
+        assert read_calibration(client, "slapper-btc") == {"lookback": 20, "z": 1.5}
+
+    def test_read_missing_calibration_is_none(self) -> None:
+        assert read_calibration(FakeClient(), "nope") is None
+
+    def test_calibration_written_to_private_table(self) -> None:
+        client = FakeClient()
+        upsert_calibration(client, "s1", {"k": 1})
+        # Lands in the private sidecar, not on the public strategies table.
+        assert "strategy_calibrations" in client.store
+        assert "strategies" not in client.store
+
+
+# ─── Signals / tearsheets / trades ─────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSignalsTearsheetsTrades:
+    def test_upsert_signal_is_idempotent_per_strategy(self) -> None:
+        client = FakeClient()
+        upsert_signal(client, strategy_id="s1", position="long", as_of=datetime(2026, 6, 25))
+        upsert_signal(
+            client,
+            strategy_id="s1",
+            position="flat",
+            as_of=datetime(2026, 6, 26),
+            last_signal_date=date(2026, 6, 26),
+            last_price=101.5,
+        )
+        df = read_signals(client)
+        assert df.height == 1
+        row = df.row(0, named=True)
+        assert row["position"] == "flat"
+        assert row["last_price"] == 101.5
+
+    def test_upsert_tearsheet(self) -> None:
+        client = FakeClient()
+        upsert_tearsheet(
+            client,
+            strategy_id="s1",
+            metrics={"sharpe": 1.2},
+            as_of=datetime(2026, 6, 25),
+            equity_curve=[1.0, 1.1],
+        )
+        stored = client.store["strategy_tearsheets"][0]
+        assert stored["metrics"] == {"sharpe": 1.2}
+        assert stored["equity_curve"] == [1.0, 1.1]
+
+    def test_record_trades_appends_and_isoformats_timestamps(self) -> None:
+        client = FakeClient()
+        result = record_trades(
+            client,
+            [
+                {
+                    "strategy_id": "s1",
+                    "entry_ts": datetime(2026, 6, 1, 9, 30),
+                    "exit_ts": datetime(2026, 6, 2, 16, 0),
+                    "side": "long",
+                    "pnl": 12.0,
+                }
+            ],
+        )
+        assert result.rows == 1
+        stored = client.store["strategy_trades"][0]
+        assert stored["entry_ts"] == "2026-06-01T09:30:00"
+        assert stored["exit_ts"] == "2026-06-02T16:00:00"
+
+    def test_record_trades_empty_is_noop(self) -> None:
+        client = FakeClient()
+        assert record_trades(client, []).rows == 0
+        assert client.store == {}


### PR DESCRIPTION
## What

Adds the **DigiQuant strategy store** to the suite-wide shared Supabase backend, and
documents the topology decision behind it.

Fixes #1064

## The topology pivot (consolidation, not a new project)

#1064 originally called for a *new, dedicated* Supabase project. That's not feasible: the
`digiquant.io` org is **free-tier (2-project limit)** and both slots are taken — the
Olympus/Atlas project and the confidential **twelve-x** project. So we **repurpose the
existing Olympus/Atlas project as the unified DigiQuant `core` backend** (renamed; the
shared market data — `price_history`/`technicals`/`trading_calendar`/`macro` — already
lives there) and **additively add the strategy store**. Rationale + alternatives in
[ADR 0021](docs/adr/0021-digiquant-supabase-project-topology.md).

Consequences:
- **#1065 is superseded** — the cross-project price copy is obviated (prices already live in `core`). Not closed by this PR.
- `economic_calendar` is **deferred to #1066** (the project already has an empty `fx_economic_calendar`; #1066 reconciles).

## Changes

- **`supabase/migrations/046_strategy_store.sql`** — additive-only: `CREATE TABLE IF NOT EXISTS` + `CREATE POLICY` for `strategies`, the private `strategy_calibrations` sidecar, `strategy_trades`, `strategy_tearsheets`, `strategy_signals`. **No `DROP`/`ALTER`/`TRUNCATE`** and zero references to existing objects (the only `ALTER`s are `ENABLE ROW LEVEL SECURITY` on the 5 new tables).
- **`data/store/`** accessor — `build_digiquant_client` resolves `SUPABASE_URL_DIGIQUANT` and **falls back** to the shared `SUPABASE_URL`, so the store works today with zero extra config and a future split onto its own project needs zero code change. Polars-friendly read/write helpers.
- **Docs** — ADR 0021, `ARCHITECTURE.md` + `AGENTS.md` data-layer sections, `supabase/SCHEMA.md` strategy-store inventory.
- **16 unit tests** (`tests/dq/store/`, covered by `test-digiquant.yml`).

## RLS model

Public reference + tearsheet tables grant `anon SELECT`; writers use the service role
(RLS bypass). `strategy_calibrations` is **service-role-only** (RLS enabled, no anon
policy — anon reads return empty, not an error; the migration-033 idiom).

## Applied + verified against the live `core` project

The migration has been **applied** (human-gated; the project holds positions/theses/checkpoints):
- ✅ 5 new tables created, all `rls_enabled=true`, 0 rows.
- ✅ Policies: 4 public tables have `*_anon_select`; `strategy_calibrations` has 0 policies (intended private state).
- ✅ Existing tables untouched (identical row counts).
- ✅ `get_advisors(security)`: **zero `rls_disabled_in_public`**. The one new finding is an INFO `rls_enabled_no_policy` on `strategy_calibrations` — the intended private sidecar (same lint `atlas_run_diagnostics` carries).

## Scoring

`make score` → Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

## Follow-ups (not blocking)

- Rename the Supabase project display name Olympus → `core` (cosmetic dashboard action; doesn't change `project_ref`).
- `SUPABASE_URL_DIGIQUANT` / `SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` GitHub secrets are only needed if/when the store is split onto its own project; the `SUPABASE_URL` fallback covers today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)