### PR TITLE
feat(digiquant): shared economic_calendar in core + repoint Olympus events tab (#1066)

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -947,8 +947,14 @@ graduates onto its own project.
 
 **Shared data layer.** `price_history`, `price_technicals`, `trading_calendar`,
 `macro_series_observations` already reside in `core` (no migration needed). `#1065`'s
-cross-project price copy is therefore **superseded**; `#1066` brings the twelve-x
-`economic_calendar` into the shared layer.
+cross-project price copy is therefore **superseded**. `#1066` adds a shared
+`economic_calendar` (migration `047`, mirroring twelve-x's `fx_economic_calendar`
+incl. `event_datetime_utc` + the impact CHECK + unique `external_id`): the twelve-x
+ingest (`fx_calendar/calendar_db.py`) is repointed to write it, and the Olympus
+twelve-x **events tab reads it via the main Olympus client** (`getUpcomingEvents` in
+`frontend/olympus/lib/twelve-x/fetch.ts`) rather than the twelve-x project — the
+other FX research tables stay on `twelveXSupabase`. Cutover is gated: the frontend
+read goes live only once the repointed ingest has populated `core`.
 
 **RLS.** Every strategy-store table RLS-enabled. Public reference + tearsheet tables grant
 `anon SELECT USING (true)`; writers use the service role (RLS bypass). `strategy_calibrations`

--- a/digiquant/supabase/migrations/047_economic_calendar.sql
+++ b/digiquant/supabase/migrations/047_economic_calendar.sql
@@ -1,0 +1,53 @@
+-- 047_economic_calendar.sql
+--
+-- Run with:  supabase db push   (or apply via MCP against this project).
+--
+-- Shared economic calendar for the DigiQuant suite (#1066). The twelve-x FX research
+-- project (separate Supabase project) owns the calendar ingest today, writing its own
+-- `fx_economic_calendar`. The calendar is a repurposable dataset (relevant to any
+-- DigiQuant project), so it belongs in the unified `core` shared data layer. This creates
+-- the shared `economic_calendar` here; twelve-x's ingest is repointed to write it and the
+-- twelve-x frontend is repointed to read it (sibling changes — see ADR 0021 + #1066).
+--
+-- Schema mirrors twelve-x `fx_economic_calendar` EXACTLY (migrations 001 + 002 there) so
+-- the cutover is a table rename, not a reshape: same columns, the impact CHECK, the
+-- UNIQUE(external_id) that `fx_events_snapshot.calendar_external_id` joins to app-side,
+-- and the absolute-instant `event_datetime_utc` the frontend orders by.
+--
+-- ADDITIVE ONLY: one new table, no FKs to existing objects, no DROP/ALTER/TRUNCATE.
+-- NOTE: this project carries a vestigial, unused `fx_economic_calendar` (migration 031,
+-- 0 rows) — a different table; not touched here, flagged for a later drop.
+--
+-- RLS: enabled with anon SELECT (public, non-sensitive macro events); the ingest writes
+-- via the service role (RLS bypass). Idempotent.
+
+create table if not exists public.economic_calendar (
+    id                 bigint generated always as identity primary key,
+    event_date         date not null,
+    event_time         text,
+    country            text not null,
+    event_name         text not null,
+    category           text not null default 'other',
+    impact             text not null default 'medium',
+    actual             text,
+    forecast           text,
+    prior              text,
+    source             text not null default 'trading_economics',
+    external_id        text not null,
+    scraped_at         timestamptz not null default now(),
+    created_at         timestamptz not null default now(),
+    updated_at         timestamptz not null default now(),
+    event_datetime_utc timestamptz,
+    constraint economic_calendar_external_id_key unique (external_id),
+    constraint economic_calendar_impact_check check (impact in ('high', 'medium', 'low'))
+);
+
+create index if not exists idx_economic_calendar_event_date
+    on public.economic_calendar (event_date);
+create index if not exists idx_economic_calendar_country_date
+    on public.economic_calendar (country, event_date);
+
+alter table public.economic_calendar enable row level security;
+
+create policy economic_calendar_anon_select on public.economic_calendar
+    for select to anon using (true);

--- a/frontend/olympus/lib/twelve-x/fetch.ts
+++ b/frontend/olympus/lib/twelve-x/fetch.ts
@@ -12,6 +12,7 @@
  */
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { isTwelveXConfigured, twelveXSupabase } from './supabase';
+import { isSupabaseConfigured, supabase } from '../supabase';
 import { MATRIX_COLUMNS } from './types';
 import type {
   ConfluenceCatalyst,
@@ -67,6 +68,43 @@ async function querySupabase<T>(
       const { data, error } = await queryFn(twelveXSupabase);
       if (error) throw error;
       // No error + no data == empty result, not a failure.
+      if (data == null) return emptyValue;
+      return data;
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries - 1) {
+        await new Promise((r) => setTimeout(r, delayMs * Math.pow(2, attempt)));
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Empty-tolerant query against the MAIN Olympus client (the `core` project), for the
+ * shared `economic_calendar` (#1066). The calendar moved out of the twelve-x project
+ * into `core`'s shared data layer, so it is read via the main client — unlike the other
+ * FX research tables, which stay on `twelveXSupabase`. Same empty == `[]` semantics as
+ * {@link querySupabase} so an empty calendar renders an empty state, not a crash.
+ */
+async function queryMainSupabase<T>(
+  queryFn: (sb: SupabaseClient) => PromiseLike<{ data: T | null; error: unknown }>,
+  {
+    retries = 3,
+    delayMs = 500,
+    emptyValue = [] as unknown as T,
+  }: { retries?: number; delayMs?: number; emptyValue?: T } = {}
+): Promise<T> {
+  if (!isSupabaseConfigured() || !supabase) {
+    throw new Error(
+      'Olympus Supabase is not configured. Set NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+  let lastError: unknown;
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const { data, error } = await queryFn(supabase as unknown as SupabaseClient);
+      if (error) throw error;
       if (data == null) return emptyValue;
       return data;
     } catch (err) {
@@ -319,19 +357,21 @@ export async function getIntelligence(
 }
 
 /**
- * Upcoming macro catalysts from `fx_economic_calendar`: today → +14 days,
+ * Upcoming macro catalysts from the shared `economic_calendar` (core): today → +14 days,
  * ordered by the absolute UTC release instant (NULL release times — all-day rows —
  * sort last, then by event_date). Returns `[]` when unconfigured or none exist.
  */
 export async function getUpcomingEvents(): Promise<FxEconomicCalendarRow[]> {
-  if (!isTwelveXConfigured() || !twelveXSupabase) return [];
+  // #1066: the calendar lives in the shared `core` project now, so it is read via the
+  // MAIN Olympus client (not `twelveXSupabase`), from `economic_calendar`.
+  if (!isSupabaseConfigured() || !supabase) return [];
   const today = new Date();
   const start = today.toISOString().slice(0, 10);
   const horizon = new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000);
   const end = horizon.toISOString().slice(0, 10);
-  const rows = await querySupabase<FxEconomicCalendarRow[]>((sb) =>
+  const rows = await queryMainSupabase<FxEconomicCalendarRow[]>((sb) =>
     sb
-      .from('fx_economic_calendar')
+      .from('economic_calendar')
       .select(
         'id, external_id, event_date, event_time, country, event_name, category, impact, actual, forecast, prior, event_datetime_utc'
       )


### PR DESCRIPTION
## What

Adds the shared **`economic_calendar`** dataset to the unified `core` project and repoints
the Olympus twelve-x **events tab** to read it from `core`. This is the **digithings side**
of #1066.

Refs #1066 (intentionally not `Fixes` — full closure needs the twelve-x ingest repoint + a
post-deploy parity check; see below).

## Changes

- **`supabase/migrations/047_economic_calendar.sql`** — additive: one new table mirroring
  twelve-x's `fx_economic_calendar` **exactly** (the `impact` CHECK `('high','medium','low')`,
  `event_datetime_utc`, `UNIQUE(external_id)` that `fx_events_snapshot.calendar_external_id`
  joins to, the two indexes), RLS enabled + anon SELECT. **Applied to `core`** and verified
  (16 cols, RLS on, anon policy, 0 rows; no existing object touched).
- **`frontend/olympus/lib/twelve-x/fetch.ts`** — `getUpcomingEvents` now reads
  `economic_calendar` via the **main Olympus client** (core *is* the Olympus project, so no
  new env var) instead of `fx_economic_calendar` via `twelveXSupabase`. New empty-tolerant
  `queryMainSupabase` helper. The other FX research tables stay on the twelve-x project — the
  calendar is the one shared dataset.
- **`ARCHITECTURE.md`** — `economic_calendar` in the shared data layer + the gated cutover.

## Cross-repo: AC4 is separate (confidential twelve-x repo)

The calendar **ingest** repoint (`fx_calendar/calendar_db.py` → dual-write `core`) lives in
the confidential twelve-x repo (separate remote) and needs a `core` service-role key as a new
twelve-x secret. It is **not** in this PR; the diff is handed off separately. Once deployed, it
populates `core` (the ingest re-scrapes the same public FairEconomy source on the same forward
window — so an exact one-time DB-copy was unnecessary).

## Cutover gate (deploy ordering)

The frontend read must **not** ship until `core` is populated by the repointed ingest, or the
events tab renders empty. Order: table (done) → twelve-x ingest writes `core` → verify parity
(event counts vs source) → deploy this frontend read.

## Verification

- `make score` → Security 10 / Quality 10 / Optimization 10 / Accuracy 10.
- Migration applied + verified against `core` (additive; existing tables unchanged).
- Frontend: typecheck/lint/test via the `olympus` CI job (node_modules not installed locally).
- Runtime "events view unchanged" verified post-ingest-deploy (when `core` has data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)