### PR TITLE
chore(digiquant): standardize Supabase env naming to CORE_*/TWELVEX_* (#1090)

### DIFF
--- a/.github/workflows/pipeline-atlas-metrics.yml
+++ b/.github/workflows/pipeline-atlas-metrics.yml
@@ -55,8 +55,11 @@ jobs:
 
       - name: Refresh portfolio_metrics (Sharpe / vol / drawdown / NAV continuity)
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # transition (#1090): legacy names fed from the same secrets until readers migrate
+          SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           # Bind the dispatch input via env (never interpolate ${{ inputs.* }} into run:).
           RUN_DATE: ${{ inputs.date }}
         run: |
@@ -70,8 +73,11 @@ jobs:
         # Run even if metrics refresh failed — the two surfaces are independent.
         if: always()
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # transition (#1090): legacy names fed from the same secrets until readers migrate
+          SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           RUN_DATE: ${{ inputs.date }}
         run: |
           if [ -n "$RUN_DATE" ]; then

--- a/.github/workflows/pipeline-digiquant-backfill.yml
+++ b/.github/workflows/pipeline-digiquant-backfill.yml
@@ -38,8 +38,11 @@ jobs:
     timeout-minutes: 45
 
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # transition (#1090): legacy names fed from the same secrets until readers migrate
+      SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
 
     steps:

--- a/.github/workflows/pipeline-digiquant-prices.yml
+++ b/.github/workflows/pipeline-digiquant-prices.yml
@@ -46,8 +46,11 @@ jobs:
       group: digiquant-prices-intraday
       cancel-in-progress: false
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # transition (#1090): legacy names fed from the same secrets until readers migrate
+      SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -134,8 +137,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # transition (#1090): legacy names fed from the same secrets until readers migrate
+      SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -155,8 +161,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # transition (#1090): legacy names fed from the same secrets until readers migrate
+      SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
       FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pipeline-olympus.yml
+++ b/.github/workflows/pipeline-olympus.yml
@@ -123,8 +123,11 @@ jobs:
 
       - name: Ingest Fed rate-decision odds
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # transition (#1090): legacy names fed from the same secrets until readers migrate
+          SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -o pipefail
@@ -142,8 +145,11 @@ jobs:
 
       - name: Validate AI provider routing
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # transition (#1090): legacy names fed from the same secrets until readers migrate
+          SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           python digiquant/scripts/atlas/validate-providers.py --skip-dry-run
@@ -151,8 +157,11 @@ jobs:
       - name: Run Olympus research pipeline
         id: run
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # transition (#1090): legacy names fed from the same secrets until readers migrate
+          SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
           DIGI_CHECKPOINTER_POSTGRES_URI: ${{ secrets.DIGI_CHECKPOINTER_POSTGRES_URI }}

--- a/digiquant/AGENTS.md
+++ b/digiquant/AGENTS.md
@@ -119,11 +119,11 @@ used by Olympus/Atlas ([`supabase/`](supabase/), `project_id "digiquant-atlas"`)
 datasets already live here; #1064 only **adds** the strategy store
 ([`supabase/migrations/046_strategy_store.sql`](supabase/migrations/046_strategy_store.sql)).
 
-The strategy-store accessor (`digiquant.data.store`, `build_digiquant_client`) resolves
-`SUPABASE_URL_DIGIQUANT` / `SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` and **falls back** to the
-shared `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` — so it needs no extra config today, and a
-future split onto its own project is a config change, not a code change. If you ever set the
-`_DIGIQUANT` vars, they are **GitHub Actions secrets — never commit values**.
+The strategy-store accessor (`digiquant.data.store`, `build_digiquant_client`) resolves the
+standardized `CORE_SUPABASE_URL` / `CORE_SUPABASE_SERVICE_KEY`
+([ADR 0022](../docs/adr/0022-supabase-env-naming-standard.md)), falling back to the legacy
+`*_DIGIQUANT` and shared `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` names. `CORE_SUPABASE_*`
+is a **GitHub org secret** (all repos write `core`) — **never commit values**.
 
 See [`ARCHITECTURE.md` § DigiQuant Data Layer](ARCHITECTURE.md#digiquant-data-layer--strategy-store--shared-data-1064)
 and [`docs/adr/0021-digiquant-supabase-project-topology.md`](../docs/adr/0021-digiquant-supabase-project-topology.md).

--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -932,9 +932,10 @@ already live here; #1064 only **adds** the strategy store. See
 `docs/adr/0021-digiquant-supabase-project-topology.md`.
 
 **Connection.** Accessor `digiquant.data.store` (`build_digiquant_client` + Polars-friendly
-helpers in `strategies.py`). Credentials resolve `SUPABASE_URL_DIGIQUANT` /
-`SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT` and **fall back** to the shared `SUPABASE_URL` /
-`SUPABASE_SERVICE_ROLE_KEY` — one project today, a zero-code split if the store ever
+helpers in `strategies.py`). Credentials resolve the standardized `CORE_SUPABASE_URL` /
+`CORE_SUPABASE_SERVICE_KEY` ([ADR 0022](../docs/adr/0022-supabase-env-naming-standard.md)),
+falling back to the legacy `*_DIGIQUANT` and shared `SUPABASE_URL` /
+`SUPABASE_SERVICE_ROLE_KEY` names — one project today, a zero-code split if the store ever
 graduates onto its own project.
 
 **Strategy store** (added by [`supabase/migrations/046_strategy_store.sql`](supabase/migrations/046_strategy_store.sql))

--- a/digiquant/scripts/atlas/audit_activity_coverage_api.py
+++ b/digiquant/scripts/atlas/audit_activity_coverage_api.py
@@ -38,8 +38,8 @@ def _max_date(sb, table: str, col: str = "date"):
 
 
 def main() -> int:
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         print("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required", file=sys.stderr)
         return 1

--- a/digiquant/scripts/atlas/backfill_context.py
+++ b/digiquant/scripts/atlas/backfill_context.py
@@ -51,8 +51,8 @@ CORE_TICKERS = ["SPY", "QQQ", "IWM", "GLD", "IAU", "BIL", "SHY", "TLT",
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/backfill_execution_prices.py
+++ b/digiquant/scripts/atlas/backfill_execution_prices.py
@@ -38,8 +38,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/backfill_export_state.py
+++ b/digiquant/scripts/atlas/backfill_export_state.py
@@ -41,8 +41,8 @@ DEFAULT_OUT = ROOT / "data" / "backfill-backup"
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/backfill_normalize_schemas.py
+++ b/digiquant/scripts/atlas/backfill_normalize_schemas.py
@@ -91,8 +91,8 @@ SECTOR_ETF_MAP = {
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/backfill_position_events.py
+++ b/digiquant/scripts/atlas/backfill_position_events.py
@@ -42,8 +42,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/backfill_positions_entry_from_events.py
+++ b/digiquant/scripts/atlas/backfill_positions_entry_from_events.py
@@ -41,8 +41,8 @@ from position_entry_from_events import patch_positions_entries_for_date
 def _sb() -> Any:
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/ensure_position_activity_through_today.py
+++ b/digiquant/scripts/atlas/ensure_position_activity_through_today.py
@@ -51,8 +51,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/execute_at_open.py
+++ b/digiquant/scripts/atlas/execute_at_open.py
@@ -28,8 +28,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/fetch_research_library.py
+++ b/digiquant/scripts/atlas/fetch_research_library.py
@@ -47,8 +47,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/fill-entry-prices.py
+++ b/digiquant/scripts/atlas/fill-entry-prices.py
@@ -36,8 +36,8 @@ except ImportError:
 
 
 def get_supabase_client():
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not _HAS_SUPABASE:
         print("❌ supabase-py not installed — pip install supabase", file=sys.stderr)
         sys.exit(1)

--- a/digiquant/scripts/atlas/fold_document_deltas.py
+++ b/digiquant/scripts/atlas/fold_document_deltas.py
@@ -50,8 +50,8 @@ ISO = re.compile(r"\d{4}-\d{2}-\d{2}")
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/format_deliberation_transcripts_chat.py
+++ b/digiquant/scripts/atlas/format_deliberation_transcripts_chat.py
@@ -45,8 +45,8 @@ except ImportError:
 
 
 def _sb():
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise SystemExit("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/materialize_snapshot.py
+++ b/digiquant/scripts/atlas/materialize_snapshot.py
@@ -55,13 +55,13 @@ _SUPABASE_UPSERT_ERRORS = (OSError, ValueError, TypeError, KeyError, RuntimeErro
 def _require_supabase() -> None:
     if not _HAS_SUPABASE:
         raise RuntimeError("Supabase SDK not installed. Run: pip install supabase")
-    if not os.environ.get("SUPABASE_URL") or not os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
+    if not os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL")) or not os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY")):
         raise RuntimeError("Missing SUPABASE_URL and/or SUPABASE_SERVICE_ROLE_KEY in environment.")
 
 
 def _sb():
     _require_supabase()
-    return create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_ROLE_KEY"])
+    return create_client(os.environ.get("CORE_SUPABASE_URL", os.environ["SUPABASE_URL"]), os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ["SUPABASE_SERVICE_ROLE_KEY"]))
 
 
 def _safe_upsert(table: str, row: Dict[str, Any], on_conflict: str) -> None:

--- a/digiquant/scripts/atlas/normalize_supabase_documents.py
+++ b/digiquant/scripts/atlas/normalize_supabase_documents.py
@@ -95,8 +95,8 @@ def _sb():
     if load_dotenv:
         load_dotenv(ROOT / "config" / "supabase.env")
         load_dotenv()
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/pipeline_meta_review.py
+++ b/digiquant/scripts/atlas/pipeline_meta_review.py
@@ -36,8 +36,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/pipeline_review_to_github.py
+++ b/digiquant/scripts/atlas/pipeline_review_to_github.py
@@ -69,8 +69,8 @@ _SEVERITY_TO_LABEL = {
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/publish_document.py
+++ b/digiquant/scripts/atlas/publish_document.py
@@ -38,8 +38,8 @@ ROOT = Path(__file__).parent.parent
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/publish_research.py
+++ b/digiquant/scripts/atlas/publish_research.py
@@ -57,8 +57,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/refresh_performance_metrics.py
+++ b/digiquant/scripts/atlas/refresh_performance_metrics.py
@@ -66,8 +66,8 @@ from position_entry_from_events import patch_positions_entries_for_date
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/repair_supabase_portfolio_data.py
+++ b/digiquant/scripts/atlas/repair_supabase_portfolio_data.py
@@ -41,8 +41,8 @@ ROOT = Path(__file__).parent.parent
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/run_db_first.py
+++ b/digiquant/scripts/atlas/run_db_first.py
@@ -31,8 +31,8 @@ ROOT = Path(__file__).parent.parent
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/sync_positions_from_rebalance.py
+++ b/digiquant/scripts/atlas/sync_positions_from_rebalance.py
@@ -49,8 +49,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/update_tearsheet.py
+++ b/digiquant/scripts/atlas/update_tearsheet.py
@@ -500,8 +500,8 @@ def compute_fx_impact(pj_positions, investor_currency):
 
 def supabase_configured():
     """Check if Supabase credentials are available in environment."""
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     return bool(_HAS_SUPABASE and url and key)
 
 
@@ -509,8 +509,8 @@ def _get_supabase_client():
     """Create a Supabase client using service_role key (write access)."""
     from supabase import create_client
 
-    url = os.environ["SUPABASE_URL"]
-    key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ["SUPABASE_URL"])
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ["SUPABASE_SERVICE_ROLE_KEY"])
     return create_client(url, key)
 
 

--- a/digiquant/scripts/atlas/validate-providers.py
+++ b/digiquant/scripts/atlas/validate-providers.py
@@ -288,8 +288,8 @@ def check_openrouter_web_search() -> bool:
 
 def check_supabase() -> bool:
     print(_bold("\n5. Supabase connectivity + baseline row"))
-    url = os.environ.get("SUPABASE_URL", "").strip()
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL", "")).strip()
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")).strip()
     if not url or not key:
         check("Supabase ping", False, "SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — skipping")
         return False

--- a/digiquant/scripts/atlas/validate_db_first.py
+++ b/digiquant/scripts/atlas/validate_db_first.py
@@ -27,8 +27,8 @@ except ImportError:
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/validate_pipeline_step.py
+++ b/digiquant/scripts/atlas/validate_pipeline_step.py
@@ -76,8 +76,8 @@ STEP_DESCRIPTIONS = {
 def _sb():
     if not _HAS_SB:
         raise RuntimeError("pip install supabase")
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required")
     return create_client(url, key)

--- a/digiquant/scripts/atlas/verify_supabase_canonical.py
+++ b/digiquant/scripts/atlas/verify_supabase_canonical.py
@@ -47,8 +47,8 @@ def main() -> int:
         print("❌ pip install supabase", file=sys.stderr)
         return 2
 
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL"))
+    key = os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY"))
     if not url or not key:
         print("❌ SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required (see config/supabase.env)", file=sys.stderr)
         return 2

--- a/digiquant/src/digiquant/cli/prices.py
+++ b/digiquant/src/digiquant/cli/prices.py
@@ -144,8 +144,10 @@ def fetch_quotes_cmd(
 
     if supabase and not dry_run:
         client = build_supabase_client(
-            os.environ.get("SUPABASE_URL"),
-            os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
+            os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL")),
+            os.environ.get(
+                "CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            ),
         )
         if client is None:
             raise click.ClickException("Supabase credentials not set.")
@@ -211,8 +213,10 @@ def compute_technicals_cmd(
     client = None
     if supabase and not dry_run:
         client = build_supabase_client(
-            os.environ.get("SUPABASE_URL"),
-            os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
+            os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL")),
+            os.environ.get(
+                "CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            ),
         )
         if client is None:
             raise click.ClickException("Supabase credentials not set.")
@@ -398,8 +402,8 @@ def fetch_macro_cmd(
         return
 
     client = build_supabase_client(
-        os.environ.get("SUPABASE_URL"),
-        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
+        os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL")),
+        os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY")),
     )
     if client is None:
         raise click.ClickException("Supabase credentials not set.")
@@ -479,8 +483,8 @@ def sync_calendar_cmd(venues: str, start: str, end: str, dry_run: bool, supabase
         return
 
     client = build_supabase_client(
-        os.environ.get("SUPABASE_URL"),
-        os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
+        os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL")),
+        os.environ.get("CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY")),
     )
     if client is None:
         raise click.ClickException("Supabase credentials not set.")

--- a/digiquant/src/digiquant/data/store/client.py
+++ b/digiquant/src/digiquant/data/store/client.py
@@ -5,11 +5,10 @@ historically used by Olympus/Atlas (`SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`
 repurposed as the suite-wide shared backend (free-tier 2-project limit; see
 ``docs/adr/0021-digiquant-supabase-project-topology.md``).
 
-Credential resolution **prefers** the ``_DIGIQUANT``-suffixed vars and **falls back**
-to the shared ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. Today both resolve to
-the same project, so the store works with zero extra config; if the strategy store
-ever graduates onto its own Supabase project, setting the ``_DIGIQUANT`` vars splits it
-off with no code change.
+Credential resolution uses the standardized ``CORE_SUPABASE_*`` names (#1090) first,
+then the legacy ``_DIGIQUANT``-suffixed vars (#1064), then the original shared
+``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY`` — read-new-fall-back-to-old so a
+half-migrated environment keeps working until the legacy names are dropped.
 """
 
 from __future__ import annotations
@@ -17,10 +16,12 @@ from __future__ import annotations
 import os
 from typing import Any, Protocol  # noqa: ANN401 — SupabaseLike.table returns the driver's dynamic type
 
+CORE_URL_ENV = "CORE_SUPABASE_URL"
+CORE_SERVICE_KEY_ENV = "CORE_SUPABASE_SERVICE_KEY"
 SUPABASE_URL_ENV = "SUPABASE_URL"
 SUPABASE_SERVICE_ROLE_KEY_ENV = "SUPABASE_SERVICE_ROLE_KEY"
-DIGIQUANT_URL_ENV = "SUPABASE_URL_DIGIQUANT"
-DIGIQUANT_SERVICE_ROLE_KEY_ENV = "SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT"
+DIGIQUANT_URL_ENV = "SUPABASE_URL_DIGIQUANT"  # legacy (pre-#1090)
+DIGIQUANT_SERVICE_ROLE_KEY_ENV = "SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT"  # legacy (pre-#1090)
 
 
 class SupabaseLike(Protocol):
@@ -40,14 +41,16 @@ def _first_env(*names: str) -> str | None:
 
 
 def digiquant_credentials() -> tuple[str | None, str | None]:
-    """Return ``(url, service_role_key)`` for the DigiQuant ``core`` project.
+    """Return ``(url, service_key)`` for the DigiQuant ``core`` project.
 
-    Prefers the ``_DIGIQUANT``-suffixed vars; falls back to the shared
-    ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. Blank values normalize to
-    ``None`` so callers get a single, unambiguous "creds missing" signal.
+    Resolution order (#1090): ``CORE_SUPABASE_*`` → legacy ``*_DIGIQUANT`` → original
+    ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. Blank values normalize to ``None``
+    so callers get a single, unambiguous "creds missing" signal.
     """
-    url = _first_env(DIGIQUANT_URL_ENV, SUPABASE_URL_ENV)
-    key = _first_env(DIGIQUANT_SERVICE_ROLE_KEY_ENV, SUPABASE_SERVICE_ROLE_KEY_ENV)
+    url = _first_env(CORE_URL_ENV, DIGIQUANT_URL_ENV, SUPABASE_URL_ENV)
+    key = _first_env(
+        CORE_SERVICE_KEY_ENV, DIGIQUANT_SERVICE_ROLE_KEY_ENV, SUPABASE_SERVICE_ROLE_KEY_ENV
+    )
     return url, key
 
 
@@ -66,6 +69,8 @@ def build_digiquant_client():  # pragma: no cover - thin wrapper over supabase S
 
 
 __all__ = [
+    "CORE_SERVICE_KEY_ENV",
+    "CORE_URL_ENV",
     "DIGIQUANT_SERVICE_ROLE_KEY_ENV",
     "DIGIQUANT_URL_ENV",
     "SUPABASE_SERVICE_ROLE_KEY_ENV",

--- a/digiquant/src/digiquant/olympus/atlas/graph.py
+++ b/digiquant/src/digiquant/olympus/atlas/graph.py
@@ -419,7 +419,9 @@ def _auto_resolve_baseline(run_date: date) -> date | None:
     """
     import os
 
-    if not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_ROLE_KEY"):
+    if not os.getenv("CORE_SUPABASE_URL", os.getenv("SUPABASE_URL")) or not os.getenv(
+        "CORE_SUPABASE_SERVICE_KEY", os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    ):
         return None
 
     from digiquant.olympus.atlas.supabase_io import SupabaseConfig, build_client

--- a/digiquant/src/digiquant/olympus/atlas/supabase_io.py
+++ b/digiquant/src/digiquant/olympus/atlas/supabase_io.py
@@ -149,8 +149,10 @@ class SupabaseConfig:
 
     @classmethod
     def from_env(cls) -> "SupabaseConfig":
-        url = os.environ.get("SUPABASE_URL", "").strip()
-        key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
+        url = os.environ.get("CORE_SUPABASE_URL", os.environ.get("SUPABASE_URL", "")).strip()
+        key = os.environ.get(
+            "CORE_SUPABASE_SERVICE_KEY", os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+        ).strip()
         missing: list[str] = []
         if not url:
             missing.append("SUPABASE_URL")

--- a/docs/adr/0022-supabase-env-naming-standard.md
+++ b/docs/adr/0022-supabase-env-naming-standard.md
@@ -1,0 +1,71 @@
+# ADR 0022: Standardized Supabase Env Naming (`CORE_*` / `TWELVEX_*`)
+
+**Status:** accepted
+**Date:** 2026-06-25
+
+## Context
+
+Supabase connection env vars diverged across the codebase:
+
+- digithings (Olympus/Atlas/prices) wrote to the core project via `SUPABASE_URL` /
+  `SUPABASE_SERVICE_ROLE_KEY`.
+- twelve-x used `SUPABASE_URL` (hardcoded) / `SUPABASE_SERVICE_KEY` (no `ROLE`).
+- [#1064](https://github.com/digithings-ai/digithings/issues/1064) added a third pair,
+  `SUPABASE_URL_DIGIQUANT` / `SUPABASE_SERVICE_ROLE_KEY_DIGIQUANT`, for the strategy store.
+
+With Olympus and twelve-x now distinct Supabase projects ([ADR 0021](0021-digiquant-supabase-project-topology.md))
+and the calendar consolidated into `core` ([#1066](https://github.com/digithings-ai/digithings/issues/1066)),
+a single naming scheme is needed so any repo can reference the shared core project and its
+own project unambiguously. The org-level core secret was renamed in GitHub already, so code
++ workflows must conform.
+
+## Decision
+
+One scheme, `{PROJECT}_SUPABASE_{URL,SERVICE_KEY}` — drop `ROLE`:
+
+| Env var | Scope | Value |
+|---------|-------|-------|
+| `CORE_SUPABASE_URL` | GitHub **org** (all repos) | core/Olympus project URL |
+| `CORE_SUPABASE_SERVICE_KEY` | GitHub **org** (all repos) | core project service-role key |
+| `TWELVEX_SUPABASE_URL` | twelve-x repo only | twelve-x project URL |
+| `TWELVEX_SUPABASE_SERVICE_KEY` | twelve-x repo only | twelve-x project service-role key |
+
+The shared core key is an **org** secret (every repo's pipeline can write `core`); each
+project's own key is a **repo** secret. Frontend `NEXT_PUBLIC_*` anon keys (public, browser)
+are out of scope.
+
+**Transition-safe migration (no pipeline breakage):**
+
+- Code resolves `CORE_SUPABASE_* || <legacy names>` — read-new-fall-back-to-old. The legacy
+  chain is `*_DIGIQUANT` (#1064) then `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`.
+- Workflows set the new env names from the new secrets **and** keep the legacy env names
+  populated from the same secrets, so any not-yet-migrated reader still works.
+- Once every reader is on `CORE_*`, the legacy env names + secrets are dropped (follow-up).
+
+## Consequences
+
+**Positive**
+
+- One predictable scheme across repos; the core key is defined once at the org level.
+- Migration cannot break live pipelines — every reader has a working fallback and the
+  workflows feed both names.
+
+**Negative**
+
+- Temporary redundancy: workflows map one secret to two env names, and code carries a
+  fallback chain, until the cleanup pass removes the legacy names.
+- `digiquant/scripts/atlas/*` (ruff-exempt legacy ops) carry the same inline fallback; they
+  are not lint-enforced, so they're verified by AST-parse + the workflow env.
+
+## Alternatives considered
+
+1. **Keep per-repo names, alias in CI only.** Rejected: the code still reads divergent names;
+   the divergence (and the `ROLE` inconsistency) persists.
+2. **Hard rename with no fallback.** Rejected: any missed reader or unsynced secret breaks a
+   live pipeline run. The fallback chain removes that risk.
+
+## Links
+
+- Implements [#1090](https://github.com/digithings-ai/digithings/issues/1090).
+- Builds on [ADR 0021](0021-digiquant-supabase-project-topology.md) (project topology) and
+  the #1066 calendar consolidation.

--- a/tests/dq/store/test_strategy_store.py
+++ b/tests/dq/store/test_strategy_store.py
@@ -23,6 +23,8 @@ from digiquant.data.store import (
     upsert_tearsheet,
 )
 from digiquant.data.store.client import (
+    CORE_SERVICE_KEY_ENV,
+    CORE_URL_ENV,
     DIGIQUANT_SERVICE_ROLE_KEY_ENV,
     DIGIQUANT_URL_ENV,
     SUPABASE_SERVICE_ROLE_KEY_ENV,
@@ -118,12 +120,25 @@ class FakeClient:
 class TestCredentials:
     def _clear_all(self, mp: pytest.MonkeyPatch) -> None:
         for var in (
+            CORE_URL_ENV,
+            CORE_SERVICE_KEY_ENV,
             DIGIQUANT_URL_ENV,
             DIGIQUANT_SERVICE_ROLE_KEY_ENV,
             SUPABASE_URL_ENV,
             SUPABASE_SERVICE_ROLE_KEY_ENV,
         ):
             mp.delenv(var, raising=False)
+
+    def test_core_vars_take_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#1090: CORE_SUPABASE_* wins over the legacy _DIGIQUANT and SUPABASE_* names."""
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv(SUPABASE_URL_ENV, "https://legacy.supabase.co")
+        monkeypatch.setenv(SUPABASE_SERVICE_ROLE_KEY_ENV, "legacy-key")
+        monkeypatch.setenv(DIGIQUANT_URL_ENV, "https://dq.supabase.co")
+        monkeypatch.setenv(DIGIQUANT_SERVICE_ROLE_KEY_ENV, "dq-key")
+        monkeypatch.setenv(CORE_URL_ENV, "https://core.supabase.co")
+        monkeypatch.setenv(CORE_SERVICE_KEY_ENV, "core-key")
+        assert digiquant_credentials() == ("https://core.supabase.co", "core-key")
 
     def test_digiquant_vars_used_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._clear_all(monkeypatch)


### PR DESCRIPTION
## What

Adopt one Supabase env naming scheme across the codebase — `{PROJECT}_SUPABASE_{URL,SERVICE_KEY}`, dropping `ROLE` — with a **transition-safe** rollout so live pipelines don't break while the GitHub secrets (already renamed) and the twelve-x repo migrate. See [ADR 0022](docs/adr/0022-supabase-env-naming-standard.md).

Refs #1090 (digithings side; the twelve-x own-key rename is a separate confidential-repo change — handed off).

## The standard

| Env var | Scope | Value |
|---------|-------|-------|
| `CORE_SUPABASE_URL` / `CORE_SUPABASE_SERVICE_KEY` | GitHub **org** | core/Olympus project |
| `TWELVEX_SUPABASE_URL` / `TWELVEX_SUPABASE_SERVICE_KEY` | twelve-x repo | twelve-x project |

## Changes (digithings)

- **Code** reads `CORE_SUPABASE_*` and falls back to legacy `*_DIGIQUANT` (#1064) then `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`:
  - Live app: `olympus/atlas/supabase_io.py`, `atlas/graph.py`, `cli/prices.py` (also fixes a `SUPABASE_SERVICE_ROLE_KEY` self-duplicate), `data/store/client.py`.
  - 28 `scripts/atlas/*.py` ops scripts (ruff-exempt legacy) — codemod, AST-verified.
- **Workflows** (`pipeline-olympus`, `-digiquant-prices`, `-atlas-metrics`, `-digiquant-backfill`): set the new `CORE_*` env from the new secrets **and** keep legacy env names populated; every secret ref falls back `secrets.CORE_* || secrets.SUPABASE_*`, so it works whether new or old secrets exist.
- **Docs**: ADR 0022 + ARCHITECTURE/AGENTS notes.

## Transition / cleanup (follow-up)

Pure transition: once every reader **and** the twelve-x repo are on `CORE_*`/`TWELVEX_*`, drop the legacy env mappings + secrets. The twelve-x rename (`SUPABASE_SERVICE_KEY → TWELVEX_SUPABASE_SERVICE_KEY`, hardcoded URL → `TWELVEX_SUPABASE_URL`, with fallback) is handed off separately (confidential repo).

## Verification

- `ruff check digiquant/src` clean; changed src ruff-formatted.
- 1349 digiquant unit tests pass on 3.12 (the only failures are pre-existing pandas-gated files, unrelated — confirmed on clean develop).
- All 4 workflows valid YAML; zero leftover `secrets.SUPABASE_*` refs.
- `make score` → 10/10 across all dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)