### PR TITLE
fix(digibase/notion): split oversized rich_text to Notion's 2000-char cap

### DIFF
--- a/digibase/src/digibase/connectors/notion.py
+++ b/digibase/src/digibase/connectors/notion.py
@@ -908,6 +908,20 @@ def _digest_body_blocks(
     return body
 
 
+# Notion rejects any rich_text element whose text.content exceeds 2000 characters
+# (it 400s the whole children.append batch). A block may hold many rich_text
+# elements, so we SPLIT oversized content across elements rather than truncate —
+# truncating would silently drop body text (e.g. a long LLM-generated heading line).
+_MAX_RICH_TEXT_LEN = 2000
+
+
+def _chunk_content(content: str, limit: int = _MAX_RICH_TEXT_LEN) -> list[str]:
+    """Split a string into <=limit-char pieces, preserving order and full content."""
+    if len(content) <= limit:
+        return [content]
+    return [content[i : i + limit] for i in range(0, len(content), limit)]
+
+
 def _rich_text(text: str) -> list[dict]:
     """Convert a plain text string with **bold** markers to Notion rich_text."""
     # Strip [[wikilinks]] to plain text
@@ -918,13 +932,16 @@ def _rich_text(text: str) -> list[dict]:
     for i, seg in enumerate(segments):
         if not seg:
             continue
-        parts.append(
-            {
-                "type": "text",
-                "text": {"content": seg},
-                "annotations": {"bold": i % 2 == 1},
-            }
-        )
+        bold = i % 2 == 1
+        # Keep each element within Notion's 2000-char cap (long paragraphs/bullets).
+        for piece in _chunk_content(seg):
+            parts.append(
+                {
+                    "type": "text",
+                    "text": {"content": piece},
+                    "annotations": {"bold": bold},
+                }
+            )
     return parts or [{"type": "text", "text": {"content": ""}}]
 
 
@@ -935,10 +952,11 @@ def _paragraph(text: str) -> dict:
 def _heading(text: str, level: int) -> dict:
     t = f"heading_{level}"
     clean = re.sub(r"\[\[([^\]]+)\]\]", r"\1", text)
+    rich = [{"type": "text", "text": {"content": piece}} for piece in _chunk_content(clean)]
     return {
         "object": "block",
         "type": t,
-        t: {"rich_text": [{"type": "text", "text": {"content": clean}}]},
+        t: {"rich_text": rich or [{"type": "text", "text": {"content": ""}}]},
     }
 
 
@@ -960,11 +978,12 @@ def _numbered(text: str) -> dict:
 
 def _code_block(content: str, language: str) -> dict:
     lang = language.strip().lower() or "plain text"
+    rich = [{"type": "text", "text": {"content": piece}} for piece in _chunk_content(content)]
     return {
         "object": "block",
         "type": "code",
         "code": {
-            "rich_text": [{"type": "text", "text": {"content": content}}],
+            "rich_text": rich or [{"type": "text", "text": {"content": ""}}],
             "language": lang,
         },
     }

--- a/tests/db/connectors/test_notion_connector.py
+++ b/tests/db/connectors/test_notion_connector.py
@@ -455,6 +455,49 @@ def test_markdown_to_blocks_skip_title_drops_first_h1():
     assert [b["type"] for b in skipped_blocks] == ["heading_2", "paragraph"]
 
 
+def test_markdown_to_blocks_splits_oversized_rich_text_to_2000():
+    """Notion rejects any rich_text element >2000 chars; long content must be SPLIT
+    across elements (never truncated), so no body text is silently dropped."""
+    long_heading = "H" * 6863           # the real failure mode: an oversized ## line
+    long_para = "P" * 4500              # long plain paragraph
+    long_code = "C" * 5000              # long fenced code block
+    md = "\n".join(
+        ["## " + long_heading, "", long_para, "", "```", long_code, "```"]
+    )
+
+    blocks = markdown_to_blocks(md)
+
+    def _content(block):
+        rt = block[block["type"]]["rich_text"]
+        # Every element stays within the hard cap …
+        assert all(len(seg["text"]["content"]) <= 2000 for seg in rt)
+        # … and concatenating them reproduces the full text (no loss).
+        return "".join(seg["text"]["content"] for seg in rt)
+
+    heading = next(b for b in blocks if b["type"] == "heading_2")
+    assert _content(heading) == long_heading
+    assert len(heading["heading_2"]["rich_text"]) == 4  # ceil(6863/2000)
+
+    para = next(b for b in blocks if b["type"] == "paragraph")
+    assert _content(para) == long_para
+
+    code = next(b for b in blocks if b["type"] == "code")
+    assert _content(code) == long_code
+
+
+def test_markdown_to_blocks_splits_preserve_bold_annotation():
+    """A long **bold** run is split into multiple elements that all stay bold."""
+    md = "**" + ("B" * 4500) + "**"
+
+    para = markdown_to_blocks(md)[0]
+    rt = para["paragraph"]["rich_text"]
+
+    assert len(rt) >= 3
+    assert all(seg["annotations"]["bold"] is True for seg in rt)
+    assert all(len(seg["text"]["content"]) <= 2000 for seg in rt)
+    assert "".join(seg["text"]["content"] for seg in rt) == "B" * 4500
+
+
 def test_write_page_content_uses_public_converter(mock_notion_client):
     """write_page_content still renders bodies (default keeps H1, handles tables)."""
     mock_notion_client.blocks.children.list.return_value = {"results": [], "has_more": False}


### PR DESCRIPTION
Fixes #1093

## Problem
`markdown_to_blocks` builds one rich_text element per heading/paragraph/code block with no length guard. Notion rejects any rich_text element whose `text.content` exceeds **2000 chars** and 400s the entire `children.append` batch — so a single long line silently drops a page's whole body.

Observed in the twelve-x daily run: a 6863-char LLM-generated `## ` heading line →
`body.children[0].heading_2.rich_text[0].text.content.length should be ≤ 2000, instead was 6863`
→ that brief's body never published (and the run still logged `Notion: N` success, masking it).

## Fix
Split content >2000 chars across multiple rich_text elements (a block may hold many) instead of truncating — preserves full text and bold annotations. Covers headings, paragraphs, bullets, numbered items, and code blocks.

## Tests
Two unit tests in `tests/db/connectors/test_notion_connector.py` (6863-char heading, long paragraph, long code, split-bold). `pytest tests/db -m unit` + `ruff check` green.

## Notes
Branched from `298a83e` (the commit twelve-x pins) so the change is minimal and back-portable; `298a83e` is an ancestor of `develop`, so this PR's diff is only the two files. twelve-x bumps its digibase/digillm pins to this commit to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)