### PR TITLE
fix(digiquant): make 047_economic_calendar RLS policy idempotent

### DIFF
--- a/digiquant/supabase/migrations/047_economic_calendar.sql
+++ b/digiquant/supabase/migrations/047_economic_calendar.sql
@@ -49,5 +49,8 @@ create index if not exists idx_economic_calendar_country_date
 
 alter table public.economic_calendar enable row level security;
 
+-- drop-if-exists/create so the migration is safely re-runnable (CREATE POLICY has no
+-- IF NOT EXISTS; the policy may already exist where the schema was applied before).
+drop policy if exists economic_calendar_anon_select on public.economic_calendar;
 create policy economic_calendar_anon_select on public.economic_calendar
     for select to anon using (true);


### PR DESCRIPTION
Guards 047's anon-SELECT policy with `drop policy if exists` (same fix as #1100 for 046). Completes the db-migrate unblock so 047 records and the economic_calendar migration is tracked. `make score` 10/10.

Fixes #1105