### PR TITLE
fix(digiquant): idempotent 047_economic_calendar policy → develop

### DIFF
--- a/digiquant/supabase/migrations/047_economic_calendar.sql
+++ b/digiquant/supabase/migrations/047_economic_calendar.sql
@@ -49,5 +49,8 @@ create index if not exists idx_economic_calendar_country_date
 
 alter table public.economic_calendar enable row level security;
 
+-- drop-if-exists/create so the migration is safely re-runnable (CREATE POLICY has no
+-- IF NOT EXISTS; the policy may already exist where the schema was applied before).
+drop policy if exists economic_calendar_anon_select on public.economic_calendar;
 create policy economic_calendar_anon_select on public.economic_calendar
     for select to anon using (true);


### PR DESCRIPTION
Promotes the 047 RLS-policy idempotency fix (#1105, merged to module via #1107) into develop. Single-file migration fix; completes the db-migrate unblock.

Fixes #1105