### PR TITLE
release: develop → main — idempotent 047 migration (completes db-migrate unblock)

### DIFF
--- a/digiquant/supabase/migrations/047_economic_calendar.sql
+++ b/digiquant/supabase/migrations/047_economic_calendar.sql
@@ -49,5 +49,8 @@ create index if not exists idx_economic_calendar_country_date
 
 alter table public.economic_calendar enable row level security;
 
+-- drop-if-exists/create so the migration is safely re-runnable (CREATE POLICY has no
+-- IF NOT EXISTS; the policy may already exist where the schema was applied before).
+drop policy if exists economic_calendar_anon_select on public.economic_calendar;
 create policy economic_calendar_anon_select on public.economic_calendar
     for select to anon using (true);


### PR DESCRIPTION
**Production release.** Promotes the `047_economic_calendar.sql` idempotency fix to `main`, re-running `db-migrate`. With both 046 (#1100, already on main) and 047 (#1105) now idempotent, db-migrate should record both cleanly — 047 is the last migration above baseline.

Ships only the single migration fix since the last release (#1104):
- `fix(digiquant): make 047_economic_calendar RLS policy idempotent` (#1105)

Re-running `db-migrate` to green is the point of this release. `make score` 10/10.

Resolves #1105