### PR TITLE
feat(digiquant-web): v7 chrome on tearsheets + light-mode polish

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -93,6 +93,7 @@
 .ts-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 1.5rem; flex-wrap: wrap; margin-bottom: 2rem; padding-bottom: 1.4rem; border-bottom: 1px solid var(--hair); }
 .ts-back { display: inline-block; color: var(--ink-soft); font-family: var(--font-mono); font-size: 0.8rem; letter-spacing: 0.02em; margin-bottom: 0.9rem; }
 .ts-back:hover { color: var(--accent); }
+.ts-kicker { display: block; font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.45rem; }
 .ts-h1 { font-family: var(--font-sans); font-size: clamp(1.7rem, 3.6vw, 2.6rem); font-weight: 600; letter-spacing: -0.03em; line-height: 1.05; color: var(--ink); margin: 0 0 0.85rem; }
 .ts-meta { display: flex; align-items: center; gap: 0.55rem; flex-wrap: wrap; }
 .ts-meta-text { color: var(--ink-mute); font-size: 0.85rem; font-family: var(--font-mono); }
@@ -101,15 +102,15 @@
 .ts-chip-soft { color: var(--ink-soft); border-color: var(--hair); background: var(--surface); }
 
 .ts-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(186px, 1fr)); gap: 0.9rem; margin-bottom: 1.4rem; }
-.ts-kpi { min-width: 0; border: 1px solid var(--hair); border-radius: var(--r-md); background: var(--surface); padding: 1.1rem 1.2rem; display: flex; flex-direction: column; gap: 0.3rem; }
+.ts-kpi { min-width: 0; border: 1px solid var(--hair); border-radius: var(--r-md); background: linear-gradient(180deg, var(--surface), var(--surface-2)); padding: 1.1rem 1.2rem; display: flex; flex-direction: column; gap: 0.3rem; }
 .ts-kpi-label { font-size: 0.7rem; color: var(--ink-mute); letter-spacing: 0.1em; text-transform: uppercase; font-family: var(--font-mono); }
 .ts-kpi-value { font-family: var(--font-mono); font-size: clamp(1.2rem, 1.05rem + 0.9vw, 1.65rem); font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; color: var(--ink); overflow-wrap: anywhere; }
 .ts-kpi-sub { font-size: 0.76rem; color: var(--ink-mute); overflow-wrap: anywhere; }
 .is-pos { color: var(--up); }
 .is-neg { color: var(--down); }
 
-.ts-panel { border: 1px solid var(--hair); border-radius: var(--r-md); background: var(--surface); padding: 1.25rem 1.3rem 1.35rem; margin-bottom: 1.1rem; }
-.ts-panel-head { display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 1rem; }
+.ts-panel { border: 1px solid var(--hair); border-radius: 16px; background: linear-gradient(180deg, var(--surface), var(--surface-2)); padding: 1.25rem 1.3rem 1.35rem; margin-bottom: 1.1rem; box-shadow: 0 28px 64px -52px rgba(0, 0, 0, 0.55); }
+.ts-panel-head { display: flex; justify-content: space-between; align-items: center; gap: 1rem; margin-bottom: 1.1rem; padding-bottom: 0.7rem; border-bottom: 1px solid var(--hair); }
 .ts-panel-label { font-family: var(--font-mono); font-size: 0.72rem; color: var(--ink-mute); letter-spacing: 0.12em; text-transform: uppercase; }
 .ts-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1.1rem; }
 
@@ -153,11 +154,11 @@
 .ts-notes li::before { content: "·"; position: absolute; left: 0; color: var(--accent); }
 
 .ts-lib-head { text-align: center; max-width: 680px; margin: 0 auto 2.6rem; }
-.ts-lib-head .ts-h1 { margin-top: 0.6rem; }
+.ts-lib-head .ts-h1 { font-family: var(--serif); font-weight: 400; font-size: clamp(2rem, 4.4vw, 3rem); letter-spacing: -0.015em; margin-top: 0.6rem; }
 .ts-lib-lede { color: var(--ink-soft); font-size: 1.02rem; line-height: 1.6; margin: 0.9rem auto 0; }
 .ts-lib-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 1.1rem; }
-.ts-card { display: flex; flex-direction: column; gap: 0.9rem; border: 1px solid var(--hair); border-radius: var(--r-md); background: var(--surface); padding: 1.3rem; transition: transform 0.25s var(--ease), border-color 0.25s var(--ease); }
-.ts-card:hover { border-color: var(--hair-2); transform: translateY(-3px); }
+.ts-card { display: flex; flex-direction: column; gap: 0.9rem; border: 1px solid var(--hair); border-radius: var(--r-md); background: linear-gradient(180deg, var(--surface), var(--surface-2)); padding: 1.3rem; transition: transform 0.25s var(--ease), border-color 0.25s var(--ease), box-shadow 0.25s var(--ease); }
+.ts-card:hover { border-color: color-mix(in srgb, var(--accent) 40%, transparent); transform: translateY(-3px); box-shadow: 0 26px 52px -36px var(--accent); }
 .ts-card-head { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
 .ts-card-name { color: var(--ink); font-family: var(--font-mono); font-size: 1.05rem; letter-spacing: -0.01em; }
 .ts-card-period { color: var(--ink-mute); font-size: 0.78rem; font-family: var(--font-mono); }
@@ -311,7 +312,6 @@
 .dqss-empty { font-family: var(--font-mono); font-size: 0.78rem; color: var(--ink-mute); padding: 2rem 0; text-align: center; }
 .dqss-full { display: inline-block; margin-top: 1rem; font-family: var(--font-mono); font-size: 0.78rem; color: var(--accent); }
 .dqss-full:hover { text-decoration: underline; }
-.dqss-note { font-family: var(--font-mono); font-size: 0.68rem; color: var(--ink-mute); margin-top: 1rem; }
 .dqss .is-pos { color: var(--up); }
 .dqss .is-neg { color: var(--down); }
 @media (max-width: 860px) { .dqss-grid { grid-template-columns: 1fr; } .dqss-right { position: static; margin-top: 1rem; } .dqss-item { min-height: auto; padding: 1.2rem 0; } .dqss-kpis { grid-template-columns: repeat(2, 1fr); } }

--- a/frontend/digiquant-web/components/landing/HeroMesh.tsx
+++ b/frontend/digiquant-web/components/landing/HeroMesh.tsx
@@ -39,7 +39,9 @@ export function HeroMesh({ children }: { children: ReactNode }) {
 
     const readBg = () =>
       getComputedStyle(document.documentElement).getPropertyValue("--bg").trim() || "#0B0C0E";
+    const readLight = () => document.documentElement.getAttribute("data-theme") === "light";
     let bg = readBg();
+    let light = readLight();
 
     let blobs: { c: string; bx: number; by: number; r: number; ph: number; sp: number }[] = [];
     let MW = 0;
@@ -74,7 +76,10 @@ export function HeroMesh({ children }: { children: ReactNode }) {
       ctx!.globalCompositeOperation = "source-over";
       ctx!.fillStyle = bg;
       ctx!.fillRect(0, 0, MW, MH);
-      ctx!.globalCompositeOperation = "lighter";
+      // Additive glow reads beautifully on the dark base; on the near-white
+      // light base "lighter" can't brighten past white, so the mesh vanishes —
+      // fall back to a normal blend (soft teal tint) there.
+      ctx!.globalCompositeOperation = light ? "source-over" : "lighter";
       blobs.forEach((b, i) => {
         let cx = (b.bx + Math.sin(t * b.sp + b.ph) * 0.14 + sn * (i % 2 ? 0.06 : -0.06)) * MW;
         let cy = (b.by + Math.cos(t * b.sp * 1.1 + b.ph) * 0.14 - sn * 0.16) * MH;
@@ -82,7 +87,7 @@ export function HeroMesh({ children }: { children: ReactNode }) {
         cy += (fy * MH - cy) * (0.2 + (i % 2 ? 0.1 : 0));
         const rad = b.r * Math.max(MW, MH) * (0.5 + (i % 2 ? 0.08 : 0));
         const g = ctx!.createRadialGradient(cx, cy, 0, cx, cy, rad);
-        g.addColorStop(0, `rgba(${b.c},${0.5 - sn * 0.18})`);
+        g.addColorStop(0, `rgba(${b.c},${(light ? 0.3 : 0.5) - sn * (light ? 0.1 : 0.18)})`);
         g.addColorStop(1, `rgba(${b.c},0)`);
         ctx!.fillStyle = g;
         ctx!.beginPath();
@@ -114,7 +119,8 @@ export function HeroMesh({ children }: { children: ReactNode }) {
 
     const onThemeChange = () => {
       bg = readBg();
-      drawMesh(performance.now()); // repaint with the new base colour
+      light = readLight();
+      drawMesh(performance.now()); // repaint with the new base colour + blend
     };
     const themeObserver = new MutationObserver(onThemeChange);
     themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -326,11 +326,6 @@ export function StrategySuite() {
             </div>
           </aside>
         </div>
-
-        <p className="dqss-note">
-          // Real NautilusTrader backtests from the strategy library — equity, fills and KPIs are
-          the same data the full tearsheet renders.
-        </p>
       </div>
     </section>
   );

--- a/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
+++ b/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
@@ -95,6 +95,7 @@ export function TearsheetView({ slug }: { slug: string }) {
       <header className="ts-header">
         <div className="ts-header-main">
           <a href="/strategies" className="ts-back">← Strategy library</a>
+          <span className="ts-kicker">// tearsheet</span>
           <h1 className="ts-h1">{data.strategy}</h1>
           <div className="ts-meta">
             <span className="ts-chip">{data.symbol}</span>


### PR DESCRIPTION
Brings the strategy **tearsheet** and **library** surfaces into the v7 landing design language (shipped in #1096) and closes the remaining light-mode gap. Follows up on the locked v7 port.

## What changed
- **Library title → Fraunces serif** so `/strategies` matches the hero and `/pipeline`. Data and numbers stay sans by design (the tearsheet is a data surface).
- **v7 card chrome on tearsheet + library**: KPI cards, panels, and library cards now use a `surface→surface-2` gradient, a card-bar header divider, and a soft accent-tinted shadow — echoing the landing's `.dqss-card` / `.dq-flow-step`. Every value is a `[data-theme]` token, so both themes render with **zero theme-specific branches**.
- **`// tearsheet` editorial kicker** on the detail header (matches the `// strategy library` / hero eyebrow convention).
- **HeroMesh theme-aware compositing**: additive `lighter` blending glows on the dark base but washes out to nothing on the near-white light base — so light mode falls back to a normal blend (soft teal tint). The hero now has presence in both themes.
- **Removed** the redundant NautilusTrader caption from the strategy suite and its dead `.dqss-note` rule.

## Theming note
`default = system` was already live via the shared `themeInitScript` (`@digithings/web`); the only real light-mode gap was the hero mesh, fixed here. **No shared package touched** — all overrides live in `frontend/digiquant-web`.

## Verification
- Screenshotted `/`, `/pipeline`, `/strategies`, `/strategies/[id]` in **both light and dark** — all clean.
- `next build` static export: all 11 routes generated.
- Boundary check: only `frontend/digiquant-web/` changed (nothing under `frontend/web`, `frontend/design`, `frontend/digithings-web`).
- `make score`: Security 10 · Quality 10 · Optimization 10 · Accuracy 10.

## Scope
4 files, +17/−15. Olympus / twelve-x redesign (#843) intentionally out of scope — in-flight on separate branches.

Fixes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)