### PR TITLE
feat(digiquant-web): landing round 3 — growing neural net, single hue, informative metrics

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -286,7 +286,11 @@
 /* ---- PIPELINE: scroll-pinned, one continuous horizontal Olympus track ---- */
 .dqp-scrolly { position: relative; height: 480vh; background: var(--bg); }
 .dqp-pin { position: sticky; top: 0; height: 100svh; display: flex; align-items: center; overflow: hidden; border-top: 1px solid var(--hair); }
-.dqp-pin .wrap { width: 100%; }
+.dqp-pin .wrap { width: 100%; position: relative; z-index: 1; }
+/* kinetic 3D Olympus mark behind the scene — opacity + scale driven by scroll
+   progress in PipelineScene (rotateX gives the laid-back 3D read). */
+.dqp-logo-bg { position: absolute; inset: 0; z-index: 0; display: grid; place-items: center; pointer-events: none; color: var(--accent); opacity: 0; transform: perspective(900px) rotateX(20deg) scale(0.82); transform-origin: 50% 55%; }
+.dqp-logo-bg .olympus-mark { width: min(74vw, 640px); height: auto; filter: drop-shadow(0 24px 70px color-mix(in srgb, var(--accent) 45%, transparent)); }
 .dqp-scene-head { text-align: center; margin-bottom: clamp(1.4rem, 4vw, 2.6rem); }
 .dqp-olympus { display: inline-flex; align-items: center; gap: 0.55rem; font-family: var(--font-mono); font-size: 0.7rem; letter-spacing: 0.16em; text-transform: uppercase; color: var(--accent); }
 .dqp-olympus svg { width: 22px; height: 22px; fill: none; stroke: var(--accent); stroke-width: 1.6; stroke-linejoin: round; stroke-linecap: round; filter: drop-shadow(0 0 8px var(--accent-weak)); }
@@ -354,13 +358,14 @@
 .dqss-full:hover { text-decoration: underline; }
 .dqss .is-pos { color: var(--up); }
 .dqss .is-neg { color: var(--down); }
-/* mobile: pin the tearsheet card to the top (order -1) and let the strategy
-   descriptions scroll underneath it, driving the swap — the single-column
-   `position: static` version had no working scrollytelling. */
+/* mobile: the tearsheet card sits at the TOP of the section (order -1) but is
+   NOT pinned — a sticky card let the descriptions scroll behind it, which read
+   as unpolished. Static keeps the card and the description list in clean,
+   non-overlapping stacking order; tapping a strategy updates the card. */
 @media (max-width: 860px) {
   .dqss-grid { grid-template-columns: 1fr; }
-  .dqss-right { position: sticky; top: calc(var(--dq-nav-h) + 0.6rem); order: -1; margin-bottom: 1.2rem; }
-  .dqss-item { min-height: 56vh; padding: 1rem 0; }
+  .dqss-right { position: static; order: -1; margin-bottom: 1.4rem; }
+  .dqss-item { min-height: auto; padding: 1rem 0; }
   .dqss-kpis { grid-template-columns: repeat(2, 1fr); }
 }
 

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -34,14 +34,6 @@ export default function Home() {
             <a className="btn btn-primary" href="/olympus/">
               Open Olympus
             </a>
-            <a
-              className="btn btn-ghost"
-              href="https://github.com/digithings-ai"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View on GitHub ↗
-            </a>
           </div>
         </HeroMesh>
 
@@ -58,15 +50,7 @@ export default function Home() {
               signal and the market. The core is open — the edge is yours.
             </p>
             <div className="dqcta-actions">
-              <a
-                className="btn btn-primary"
-                href="https://github.com/digithings-ai"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View on GitHub ↗
-              </a>
-              <a className="btn btn-ghost" href="/olympus/">
+              <a className="btn btn-primary" href="/olympus/">
                 Open Olympus
               </a>
             </div>

--- a/frontend/digiquant-web/components/landing/HeroGraph.tsx
+++ b/frontend/digiquant-web/components/landing/HeroGraph.tsx
@@ -1,20 +1,24 @@
 "use client";
 /**
- * Reactive "neural mass" overlaid on the hero (item 14).
+ * Reactive "neural net" overlaid on the hero (item 14, v3).
  *
- * A single dense core of interconnected nodes — a living neural graph — that
- * eases toward the cursor and, while moving, stretches and scales along the
- * direction of motion (with a teal hue that expands with it). At rest it settles
- * into a compact, slowly-breathing mass near the centre. Layered above the mesh
- * veil, below the headline (pointer-events: none). Theme-aware (teal accent,
- * re-read on a data-theme change) and motion-safe: under prefers-reduced-motion
- * it paints one calm static frame at the centre.
+ * A spread-out network that GROWS toward the cursor: as the slow-following head
+ * moves, it spawns new nodes with lateral spread and webs them by proximity, so
+ * paths grow in the direction of motion while older nodes fade and collapse
+ * behind — a living trail. There is no glow here: the single hue is the
+ * HeroMesh behind it, which tracks the cursor at the same gradual pace, so the
+ * shading trails the net. When the cursor is idle the head wanders gently so the
+ * net keeps breathing. pointer-events: none; theme-aware; one static frame under
+ * prefers-reduced-motion.
  */
 import { useEffect, useRef } from "react";
 
-type Node = { ang: number; rad: number; spin: number; breathe: number; phase: number };
+type Node = { x: number; y: number; born: number };
 
 const PAL_FALLBACK = ["61", "214", "196"];
+const MAX = 70;
+const MAX_AGE = 2600; // ms a node lives before it has fully collapsed
+const DCON = 0.13; // connect radius, normalized to the smaller axis
 
 export function HeroGraph() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -37,14 +41,17 @@ export function HeroGraph() {
     let accent = readAccent();
     let light = document.documentElement.getAttribute("data-theme") === "light";
 
-    const N = 22;
     let W = 0;
     let H = 0;
-    let R = 0; // base mass radius in px (scales with viewport)
     let nodes: Node[] = [];
+    const head = { x: 0.5, y: 0.46 };
+    const target = { x: 0.5, y: 0.46 };
+    const lastSpawn = { x: 0.5, y: 0.46 };
+    let vx = 0;
+    let vy = 0;
+    let lastMove = -1e9;
 
-    // core eases toward the cursor; velocity drives the directional stretch
-    const core = { x: 0.5, y: 0.46, tx: 0.5, ty: 0.46, vx: 0, vy: 0 };
+    const rnd = (a: number, b: number) => a + Math.random() * (b - a);
 
     function init() {
       const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
@@ -53,135 +60,110 @@ export function HeroGraph() {
       canvas!.width = Math.max(1, Math.round(W * dpr));
       canvas!.height = Math.max(1, Math.round(H * dpr));
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
-      R = Math.min(W, H) * 0.17;
-      if (nodes.length !== N) {
-        nodes = Array.from({ length: N }, (_, i) => ({
-          // a denser core (small radius) ringed by a looser shell
-          ang: (i / N) * Math.PI * 2 + Math.random() * 0.5,
-          rad: (i % 3 === 0 ? 0.25 : 0.6 + Math.random() * 0.55),
-          spin: (Math.random() - 0.5) * 0.0009,
-          breathe: 0.0006 + Math.random() * 0.0008,
-          phase: Math.random() * 6.28,
-        }));
-      }
     }
 
-    function draw(t: number) {
-      ctx!.clearRect(0, 0, W, H);
+    function spawn(now: number) {
+      const sp = Math.hypot(vx, vy) || 1e-6;
+      const nx = -vy / sp;
+      const ny = vx / sp; // unit perpendicular to motion → lateral spread
+      const k = Math.min(0.055, Math.max(0.014, sp * 1.6));
+      nodes.push({ x: head.x, y: head.y, born: now });
+      nodes.push({ x: head.x + nx * rnd(0.25, 1) * k, y: head.y + ny * rnd(0.25, 1) * k, born: now });
+      nodes.push({ x: head.x - nx * rnd(0.25, 1) * k, y: head.y - ny * rnd(0.25, 1) * k, born: now });
+      if (nodes.length > MAX) nodes.splice(0, nodes.length - MAX);
+    }
 
-      const prevx = core.x;
-      const prevy = core.y;
-      core.x += (core.tx - core.x) * 0.07;
-      core.y += (core.ty - core.y) * 0.07;
-      // smoothed velocity (normalized units/frame)
-      core.vx = core.vx * 0.8 + (core.x - prevx) * 0.2;
-      core.vy = core.vy * 0.8 + (core.y - prevy) * 0.2;
-      const speed = Math.hypot(core.vx, core.vy);
-      const dirAng = Math.atan2(core.vy, core.vx);
-      // stretch along motion, gentle squash across it; scale the whole mass up a touch
-      const stretch = Math.min(speed * 26, 1.5);
-      const along = 1 + stretch;
-      const across = 1 / (1 + stretch * 0.35);
-      const scale = 1 + Math.min(speed * 10, 0.5);
-      const cos = Math.cos(dirAng);
-      const sin = Math.sin(dirAng);
+    const alphaOf = (n: Node, now: number) => {
+      const a = (now - n.born) / MAX_AGE; // 0 (new) .. 1 (dead)
+      const fin = Math.min(1, a / 0.08); // quick fade-in
+      const fout = Math.min(1, (1 - a) / 0.4); // long fade-out (collapse)
+      return Math.max(0, Math.min(fin, fout));
+    };
 
-      const cx = core.x * W;
-      const cy = core.y * H;
-      const rgb = `${accent[0]},${accent[1]},${accent[2]}`;
-      const baseA = light ? 0.62 : 0.7;
-
-      // positions of each node, anisotropically stretched in the motion direction
-      const px: number[] = [];
-      const py: number[] = [];
-      for (const n of nodes) {
-        const a = n.ang + t * n.spin;
-        const r = n.rad * R * scale * (0.85 + 0.15 * Math.sin(t * n.breathe + n.phase));
-        // offset in mass-local axes (ox along motion, oy across)
-        let ox = Math.cos(a) * r;
-        let oy = Math.sin(a) * r;
-        ox *= along;
-        oy *= across;
-        // rotate local axes into the motion direction
-        px.push(cx + ox * cos - oy * sin);
-        py.push(cy + ox * sin + oy * cos);
+    function frame(now: number) {
+      // cursor when recently moved, else a slow autonomous wander
+      if (now - lastMove > 700) {
+        target.x = 0.5 + Math.sin(now * 0.00013) * 0.26;
+        target.y = 0.45 + Math.cos(now * 0.00017) * 0.16;
       }
+      const px = head.x;
+      const py = head.y;
+      head.x += (target.x - head.x) * 0.04; // slow, gradual tracking (was snappy)
+      head.y += (target.y - head.y) * 0.04;
+      vx = head.x - px;
+      vy = head.y - py;
+      if (Math.hypot(head.x - lastSpawn.x, head.y - lastSpawn.y) > 0.02) {
+        spawn(now);
+        lastSpawn.x = head.x;
+        lastSpawn.y = head.y;
+      }
+      nodes = nodes.filter((n) => now - n.born < MAX_AGE);
 
-      // hue: a soft radial glow centred on the mass, expanding with motion
-      const glowR = R * scale * (1.7 + stretch * 0.6);
-      const g = ctx!.createRadialGradient(cx, cy, 0, cx, cy, glowR);
-      g.addColorStop(0, `rgba(${rgb},${light ? 0.2 : 0.22})`);
-      g.addColorStop(1, `rgba(${rgb},0)`);
-      ctx!.fillStyle = g;
-      ctx!.beginPath();
-      ctx!.arc(cx, cy, glowR, 0, 7);
-      ctx!.fill();
+      ctx!.clearRect(0, 0, W, H);
+      const rgb = `${accent[0]},${accent[1]},${accent[2]}`;
+      const baseA = light ? 0.6 : 0.72;
 
-      // edges: each node to the core, plus near-neighbour webbing → a neural mass
       ctx!.lineWidth = 1;
-      for (let i = 0; i < N; i++) {
-        ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.32})`;
-        ctx!.beginPath();
-        ctx!.moveTo(cx, cy);
-        ctx!.lineTo(px[i], py[i]);
-        ctx!.stroke();
-        for (let j = i + 1; j < N; j++) {
-          const d = Math.hypot(px[i] - px[j], py[i] - py[j]);
-          if (d < R * 0.95) {
-            ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.5 * (1 - d / (R * 0.95))})`;
+      for (let i = 0; i < nodes.length; i++) {
+        const ai = alphaOf(nodes[i], now);
+        if (ai <= 0) continue;
+        for (let j = i + 1; j < nodes.length; j++) {
+          const aj = alphaOf(nodes[j], now);
+          if (aj <= 0) continue;
+          const dx = nodes[i].x - nodes[j].x;
+          const dy = nodes[i].y - nodes[j].y;
+          const d = Math.hypot(dx, dy);
+          if (d < DCON) {
+            ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.55 * Math.min(ai, aj) * (1 - d / DCON)})`;
             ctx!.beginPath();
-            ctx!.moveTo(px[i], py[i]);
-            ctx!.lineTo(px[j], py[j]);
+            ctx!.moveTo(nodes[i].x * W, nodes[i].y * H);
+            ctx!.lineTo(nodes[j].x * W, nodes[j].y * H);
             ctx!.stroke();
           }
         }
       }
-
-      // nodes
-      for (let i = 0; i < N; i++) {
-        ctx!.fillStyle = `rgba(${rgb},${baseA})`;
+      for (const n of nodes) {
+        const a = alphaOf(n, now);
+        if (a <= 0) continue;
+        ctx!.fillStyle = `rgba(${rgb},${baseA * a})`;
         ctx!.beginPath();
-        ctx!.arc(px[i], py[i], 1.6, 0, 7);
+        ctx!.arc(n.x * W, n.y * H, 1.5, 0, 7);
         ctx!.fill();
       }
-      // bright core
-      ctx!.fillStyle = `rgba(${rgb},${baseA})`;
-      ctx!.beginPath();
-      ctx!.arc(cx, cy, 2.6, 0, 7);
-      ctx!.fill();
     }
 
     let raf = 0;
-    function loop(t: number) {
-      draw(t);
+    function loop() {
+      frame(performance.now());
       raf = requestAnimationFrame(loop);
     }
 
     function onMove(e: MouseEvent) {
       const r = canvas!.getBoundingClientRect();
-      core.tx = (e.clientX - r.left) / r.width;
-      core.ty = (e.clientY - r.top) / r.height;
+      target.x = (e.clientX - r.left) / r.width;
+      target.y = (e.clientY - r.top) / r.height;
+      lastMove = performance.now();
     }
     const onTheme = () => {
       accent = readAccent();
       light = document.documentElement.getAttribute("data-theme") === "light";
-      draw(performance.now());
     };
     const obs = new MutationObserver(onTheme);
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
-    const onResize = () => {
-      init();
-      draw(performance.now());
-    };
+    const onResize = () => init();
 
     init();
-    draw(performance.now());
     window.addEventListener("resize", onResize, { passive: true });
 
     const animate = !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (animate) {
       window.addEventListener("mousemove", onMove, { passive: true });
       raf = requestAnimationFrame(loop);
+    } else {
+      // one calm static frame: a small settled net near the centre
+      const t = performance.now() - 500;
+      for (let i = 0; i < 14; i++) nodes.push({ x: 0.5 + rnd(-0.2, 0.2), y: 0.45 + rnd(-0.12, 0.12), born: t });
+      frame(performance.now());
     }
 
     return () => {

--- a/frontend/digiquant-web/components/landing/PipelineScene.tsx
+++ b/frontend/digiquant-web/components/landing/PipelineScene.tsx
@@ -75,6 +75,7 @@ export function PipelineScene() {
   const stepsRef = useRef<HTMLDivElement>(null);
   const railFillRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
+  const logoBgRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const scrolly = scrollyRef.current;
@@ -86,6 +87,7 @@ export function PipelineScene() {
     const cards = Array.from(steps.children) as HTMLElement[];
     const nodes = Array.from(scrolly.querySelectorAll<HTMLElement>(".dqp-node"));
     const heads = Array.from(scrolly.querySelectorAll<HTMLElement>(".dqp-ehead"));
+    const logoBg = logoBgRef.current;
 
     let vw = 0;
     let sw = 0;
@@ -137,6 +139,12 @@ export function PipelineScene() {
       const total = scrolly!.offsetHeight - window.innerHeight;
       gp = clamp(-rect.top / (total || 1), 0, 1);
       railFill!.style.width = gp * 100 + "%";
+      // kinetic 3D Olympus mark behind the scene — fades in then keeps growing
+      if (logoBg) {
+        const lt = document.documentElement.getAttribute("data-theme") === "light";
+        logoBg.style.opacity = String(clamp(gp / 0.12, 0, 1) * (lt ? 0.1 : 0.16));
+        logoBg.style.transform = `perspective(900px) rotateX(20deg) scale(${0.82 + gp * 0.5})`;
+      }
       const cf = frontierCf(gp);
       // centre the current/highlighted card in the track (was left-of-centre)
       targetPan = clamp(cf * sw + sw * 0.5 - vw * 0.5, 0, maxPan);
@@ -205,13 +213,15 @@ export function PipelineScene() {
   return (
     <section className="dqp-scrolly" id="pipeline" ref={scrollyRef}>
       <div className="dqp-pin">
+        <div className="dqp-logo-bg" aria-hidden="true" ref={logoBgRef}>
+          <OlympusMark size={560} />
+        </div>
         <div className="wrap">
           <div className="dqp-scene-head">
             <div className="dqp-olympus">
-              <OlympusMark size={22} />
               <span>Olympus · research → portfolio → execution</span>
             </div>
-            <div className="dqp-scene-title">Every fill begins as evidence.</div>
+            <div className="dqp-scene-title">A hedge fund in a box.</div>
           </div>
 
           <div className="dqp-rail">

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -12,6 +12,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { fmtMoney, fmtNum, fmtPct } from "@/components/tearsheet/format";
+import { avgTradePct, cagrPctFromGrowth } from "@/components/tearsheet/stats";
 import { type StrategyIndexEntry, type TearsheetData } from "@/components/tearsheet/types";
 import index from "@/public/strategies/index.json";
 
@@ -179,9 +180,13 @@ export function StrategySuite() {
     setActiveId(id);
   };
 
+  // Lead with annualized + risk/frequency; total net profit % on a multi-year
+  // compounded backtest ("+27M%") is uninformative. Avg trade needs the loaded
+  // tearsheet JSON (no per-trade data on the index entry) — "—" until it arrives.
+  const cagr = cagrPctFromGrowth(entry.net_profit_pct, entry.period_start, entry.period_end);
   const kpis: [string, string, string][] = [
-    ["Net profit", signed(entry.net_profit_pct), "is-pos"],
-    ["Profit factor", fmtNum(entry.profit_factor, 2), ""],
+    ["Annualized", signed(cagr), "is-pos"],
+    ["Avg trade", data ? signed(avgTradePct(data.trades.map((t) => t.pnl_pct))) : "—", ""],
     ["Win rate", fmtPct(entry.win_rate_pct), ""],
     ["Max DD", fmtPct(entry.max_drawdown_pct), "is-neg"],
   ];

--- a/frontend/digiquant-web/components/tearsheet/stats.ts
+++ b/frontend/digiquant-web/components/tearsheet/stats.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure, derived performance statistics shared by the strategy-suite cards and
+ * the full tearsheet. Total net profit % on a multi-year compounded backtest is
+ * uninformative ("+27M%"); these helpers normalize it to annualized, risk-adjusted
+ * and frequency terms that compare across strategies and horizons.
+ *
+ * All functions are pure and side-effect free. Percentages are expressed as
+ * whole-number percents (e.g. 12.5 == 12.5%), matching the rest of the schema.
+ */
+
+const MS_PER_YEAR = 365.25 * 24 * 3600 * 1000;
+
+/** Fractional years between two ISO dates ("YYYY-MM-DD"). Floored at 1e-9 to keep
+ *  it strictly positive so it is always safe as a divisor / root exponent. */
+export function yearsBetween(startISO: string, endISO: string): number {
+  const ms = new Date(endISO).getTime() - new Date(startISO).getTime();
+  return Math.max(ms / MS_PER_YEAR, 1e-9);
+}
+
+/** Annualized return (CAGR %) implied by a total net-profit %, for the index cards
+ *  (no capital fields). growth = 1 + netProfitPct/100; 0 if growth is non-positive. */
+export function cagrPctFromGrowth(netProfitPct: number, startISO: string, endISO: string): number {
+  const growth = 1 + netProfitPct / 100;
+  if (growth <= 0) return 0;
+  const years = yearsBetween(startISO, endISO);
+  return (Math.pow(growth, 1 / years) - 1) * 100;
+}
+
+/** Annualized return (CAGR %) from initial and final capital, for the detail page. */
+export function cagrPct(initial: number, final: number, startISO: string, endISO: string): number {
+  if (initial <= 0 || final <= 0) return 0;
+  const years = yearsBetween(startISO, endISO);
+  return (Math.pow(final / initial, 1 / years) - 1) * 100;
+}
+
+/** Average number of closed trades per year — a frequency / turnover signal. */
+export function tradesPerYear(totalTrades: number, startISO: string, endISO: string): number {
+  return totalTrades / yearsBetween(startISO, endISO);
+}
+
+/** Mean per-trade return (%); 0 for an empty set. More representative than a
+ *  dollar average, which is dominated by late compounding trades. */
+export function avgTradePct(pnlPcts: number[]): number {
+  if (pnlPcts.length === 0) return 0;
+  return pnlPcts.reduce((sum, p) => sum + p, 0) / pnlPcts.length;
+}
+
+/** Calmar ratio: annualized return over the (positive) magnitude of max drawdown.
+ *  `maxDrawdownPct` is negative in the schema; 0 if drawdown is ~flat. */
+export function calmar(cagrPctValue: number, maxDrawdownPct: number): number {
+  return Math.abs(maxDrawdownPct) < 1e-9 ? 0 : cagrPctValue / Math.abs(maxDrawdownPct);
+}

--- a/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
+++ b/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { TimeSeries, SignedBars, type Scale } from "./charts";
 import { fmtCompact, fmtMoney, fmtNum, fmtPct, toneClass } from "./format";
+import { avgTradePct, cagrPct, calmar, tradesPerYear } from "./stats";
 import { type TearsheetBreakdown, type TearsheetData } from "./types";
 
 function Kpi({ label, value, sub }: { label: string; value: React.ReactNode; sub?: string }) {
@@ -83,13 +84,15 @@ export function TearsheetView({ slug }: { slug: string }) {
 
   // Mean per-trade return — more representative than a dollar average, which is
   // dominated by late compounding trades.
-  const avgTradePct = useMemo(
-    () => (data && data.trades.length ? data.trades.reduce((s, t) => s + t.pnl_pct, 0) / data.trades.length : 0),
-    [data],
-  );
+  const avgTrade = useMemo(() => avgTradePct(data ? data.trades.map((t) => t.pnl_pct) : []), [data]);
 
   if (err) return <p className="ts-status ts-status-error">{err}</p>;
   if (!data) return <p className="ts-status">Loading tearsheet…</p>;
+
+  // Annualized return — computed once and reused for the headline KPI and the
+  // Calmar fallback when a Sharpe ratio is not available.
+  const cagr = cagrPct(data.initial_capital, data.final_equity, data.period_start, data.period_end);
+  const hasSharpe = data.sharpe_ratio !== null && data.sharpe_ratio !== undefined;
 
   const notes = [
     ...(data.data_source ? [`Data source: ${data.data_source}`] : []),
@@ -126,14 +129,18 @@ export function TearsheetView({ slug }: { slug: string }) {
       </header>
 
       <section className="ts-kpis" aria-label="Headline metrics">
-        <Kpi label="Net profit" value={<Toned v={data.net_profit_pct}>{fmtPct(data.net_profit_pct)}</Toned>} sub={`${fmtMoney(data.initial_capital)} → ${fmtMoney(data.final_equity)}`} />
+        <Kpi label="Annualized (CAGR)" value={<Toned v={cagr}>{fmtPct(cagr)}</Toned>} sub="compound annual growth" />
+        {hasSharpe ? (
+          <Kpi label="Risk-adjusted" value={fmtNum(data.sharpe_ratio, 2)} sub="Sharpe · annualized" />
+        ) : (
+          <Kpi label="Risk-adjusted" value={fmtNum(calmar(cagr, data.max_drawdown_pct), 2)} sub="Calmar · CAGR / max DD" />
+        )}
+        <Kpi label="Avg trade" value={<Toned v={avgTrade}>{fmtPct(avgTrade)}</Toned>} sub="per closed trade" />
+        <Kpi label="Trades / year" value={fmtNum(tradesPerYear(data.total_trades, data.period_start, data.period_end), 1)} sub={`${data.total_trades} total`} />
         <Kpi label="Max drawdown" value={<span className="is-neg">{fmtPct(data.max_drawdown_pct)}</span>} sub="mark-to-market" />
-        <Kpi label="Profit factor" value={fmtNum(data.profit_factor, 2)} sub="gross win / gross loss" />
         <Kpi label="Win rate" value={fmtPct(data.win_rate_pct)} sub={`${data.total_trades} trades`} />
-        <Kpi label="Avg trade" value={<Toned v={avgTradePct}>{fmtPct(avgTradePct)}</Toned>} sub="per closed trade" />
-        {data.sharpe_ratio !== null && data.sharpe_ratio !== undefined ? (
-          <Kpi label="Sharpe" value={fmtNum(data.sharpe_ratio, 2)} sub="annualized" />
-        ) : null}
+        <Kpi label="Profit factor" value={fmtNum(data.profit_factor, 2)} sub="gross win / gross loss" />
+        <Kpi label="Total return" value={<Toned v={data.net_profit_pct}>{fmtPct(data.net_profit_pct)}</Toned>} sub={`${fmtMoney(data.initial_capital)} → ${fmtMoney(data.final_equity)}`} />
       </section>
 
       <section className="ts-panel">


### PR DESCRIPTION
Design-review round 3 on digiquant.io. All in `frontend/digiquant-web/`. Follows #1115.

## Hero
- **Growing neural net**: replaced the center-mass with a spread-out net that **grows new nodes/paths toward the cursor** and lets **older nodes fade/collapse** behind — a living trail.
- **One shading**: removed the graph's own glow; the `HeroMesh` mesh is now the single hue.
- **Slower tracking** — the head follows the cursor at the gradual mesh pace (was snappy).

## Metrics (the not-very-telling "+27M%" total is demoted)
- `stats.ts` (pure): CAGR, trades/year, Calmar.
- **Tearsheet** leads with **Annualized (CAGR)** → **Risk-adjusted** (Sharpe, else Calmar) → **Avg trade %** → **Trades/year**, then Max DD / Win rate / Profit factor, with **Total return last**. (SOL: 267.8%/yr · Calmar 4.58 · 22.1%/trade · 9.2 trades/yr.)
- **Suite cards** lead with **Annualized** + **Avg trade**.

## Pipeline
- **Kinetic 3D Olympus mark** in the background — scales + fades in on scroll (rotateX perspective, teal).
- Removed the logo from the eyebrow; retitled **"Every fill begins as evidence." → "A hedge fund in a box."**

## Other
- **Removed the in-page GitHub button** (hero + open-source section) — GitHub stays in the top bar + footer only.
- **Mobile**: the strategy tearsheet card is no longer sticky (descriptions were scrolling behind it); it sits at the top, non-overlapping.

## Verification
Both themes + mobile verified; static export builds all 12 routes; `make score` 10/10; only `frontend/digiquant-web/` touched.

Fixes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)