### PR TITLE
feat(digiquant-web): round-4 landing polish — hero orb, glow top-edge, merged dual-axis P&L

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -25,6 +25,13 @@
 
 .dq-up { color: var(--up); } .dq-down { color: var(--down); }
 
+/* The shared `.glow` (site.css) drifts vertically (keyframe `translate(…, 2%)`),
+   which leaves a faint un-tinted strip at the very top edge — most visible on
+   subpages and when the auto-hiding nav uncovers the top. Anchor it here in
+   digiquant-web (the shared file also feeds digithings.ai, so we don't touch
+   it) so the page shading always reaches the top border. */
+.glow { animation: none; transform: none; }
+
 /* (Removed in the v7 port: old left-headline hero `.panel`/`.dq-curve`, the
    simulated `.dq-tickerbar` marquee, and the `.dq-mini-flow` teaser. The home is
    now HeroMesh + PipelineScene + StrategySuite — see the "v7 landing" block below.) */

--- a/frontend/digiquant-web/components/landing/HeroGraph.tsx
+++ b/frontend/digiquant-web/components/landing/HeroGraph.tsx
@@ -1,24 +1,19 @@
 "use client";
 /**
- * Reactive "neural net" overlaid on the hero (item 14, v3).
+ * Reactive "neural orb" overlaid on the hero (item 14, v4).
  *
- * A spread-out network that GROWS toward the cursor: as the slow-following head
- * moves, it spawns new nodes with lateral spread and webs them by proximity, so
- * paths grow in the direction of motion while older nodes fade and collapse
- * behind — a living trail. There is no glow here: the single hue is the
- * HeroMesh behind it, which tracks the cursor at the same gradual pace, so the
- * shading trails the net. When the cursor is idle the head wanders gently so the
- * net keeps breathing. pointer-events: none; theme-aware; one static frame under
- * prefers-reduced-motion.
+ * A contained OVAL cluster of interconnected nodes that sits centered on the
+ * shading orb (HeroMesh hue) and tracks the cursor at the same gradual pace, so
+ * the two move together. It is NOT a trail/snake — the cluster holds its shape
+ * and rotates slowly. When the cursor is idle the orb stays where it was and
+ * keeps cycling gently. No glow here (the mesh is the single hue).
+ * pointer-events: none; theme-aware; one static frame under reduced-motion.
  */
 import { useEffect, useRef } from "react";
 
-type Node = { x: number; y: number; born: number };
+type Node = { ang: number; rx: number; ry: number; breathe: number; phase: number };
 
 const PAL_FALLBACK = ["61", "214", "196"];
-const MAX = 70;
-const MAX_AGE = 2600; // ms a node lives before it has fully collapsed
-const DCON = 0.13; // connect radius, normalized to the smaller axis
 
 export function HeroGraph() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -41,15 +36,14 @@ export function HeroGraph() {
     let accent = readAccent();
     let light = document.documentElement.getAttribute("data-theme") === "light";
 
+    const N = 18;
     let W = 0;
     let H = 0;
+    let RX = 0; // oval radii in px (wider than tall)
+    let RY = 0;
     let nodes: Node[] = [];
-    const head = { x: 0.5, y: 0.46 };
-    const target = { x: 0.5, y: 0.46 };
-    const lastSpawn = { x: 0.5, y: 0.46 };
-    let vx = 0;
-    let vy = 0;
-    let lastMove = -1e9;
+    // centre tracks the cursor at the mesh's gradual pace; holds position when idle
+    const c = { x: 0.5, y: 0.46, tx: 0.5, ty: 0.46 };
 
     const rnd = (a: number, b: number) => a + Math.random() * (b - a);
 
@@ -60,89 +54,84 @@ export function HeroGraph() {
       canvas!.width = Math.max(1, Math.round(W * dpr));
       canvas!.height = Math.max(1, Math.round(H * dpr));
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      const m = Math.min(W, H);
+      RX = m * 0.15;
+      RY = m * 0.1;
+      if (nodes.length !== N) {
+        nodes = Array.from({ length: N }, (_, i) => ({
+          ang: (i / N) * Math.PI * 2 + rnd(-0.18, 0.18),
+          // mix of outer-shell and a few inner nodes → an orb, not just a ring
+          rx: i % 4 === 0 ? rnd(0.2, 0.5) : rnd(0.7, 1),
+          ry: i % 4 === 0 ? rnd(0.2, 0.5) : rnd(0.7, 1),
+          breathe: 0.0005 + Math.random() * 0.0007,
+          phase: Math.random() * 6.28,
+        }));
+      }
     }
 
-    function spawn(now: number) {
-      const sp = Math.hypot(vx, vy) || 1e-6;
-      const nx = -vy / sp;
-      const ny = vx / sp; // unit perpendicular to motion → lateral spread
-      const k = Math.min(0.055, Math.max(0.014, sp * 1.6));
-      nodes.push({ x: head.x, y: head.y, born: now });
-      nodes.push({ x: head.x + nx * rnd(0.25, 1) * k, y: head.y + ny * rnd(0.25, 1) * k, born: now });
-      nodes.push({ x: head.x - nx * rnd(0.25, 1) * k, y: head.y - ny * rnd(0.25, 1) * k, born: now });
-      if (nodes.length > MAX) nodes.splice(0, nodes.length - MAX);
-    }
+    function draw(t: number) {
+      // gradual ease toward the cursor (same feel as the mesh); idle → holds
+      c.x += (c.tx - c.x) * 0.045;
+      c.y += (c.ty - c.y) * 0.045;
+      const cx = c.x * W;
+      const cy = c.y * H;
+      const spin = t * 0.00018; // slow global rotation → gentle idle cycling
 
-    const alphaOf = (n: Node, now: number) => {
-      const a = (now - n.born) / MAX_AGE; // 0 (new) .. 1 (dead)
-      const fin = Math.min(1, a / 0.08); // quick fade-in
-      const fout = Math.min(1, (1 - a) / 0.4); // long fade-out (collapse)
-      return Math.max(0, Math.min(fin, fout));
-    };
-
-    function frame(now: number) {
-      // cursor when recently moved, else a slow autonomous wander
-      if (now - lastMove > 700) {
-        target.x = 0.5 + Math.sin(now * 0.00013) * 0.26;
-        target.y = 0.45 + Math.cos(now * 0.00017) * 0.16;
+      const px: number[] = [];
+      const py: number[] = [];
+      for (const n of nodes) {
+        const a = n.ang + spin;
+        const br = 0.9 + 0.1 * Math.sin(t * n.breathe + n.phase);
+        px.push(cx + Math.cos(a) * n.rx * RX * br);
+        py.push(cy + Math.sin(a) * n.ry * RY * br);
       }
-      const px = head.x;
-      const py = head.y;
-      head.x += (target.x - head.x) * 0.04; // slow, gradual tracking (was snappy)
-      head.y += (target.y - head.y) * 0.04;
-      vx = head.x - px;
-      vy = head.y - py;
-      if (Math.hypot(head.x - lastSpawn.x, head.y - lastSpawn.y) > 0.02) {
-        spawn(now);
-        lastSpawn.x = head.x;
-        lastSpawn.y = head.y;
-      }
-      nodes = nodes.filter((n) => now - n.born < MAX_AGE);
 
       ctx!.clearRect(0, 0, W, H);
       const rgb = `${accent[0]},${accent[1]},${accent[2]}`;
       const baseA = light ? 0.6 : 0.72;
+      const DCON = RX * 1.15; // contained webbing within the orb
 
       ctx!.lineWidth = 1;
-      for (let i = 0; i < nodes.length; i++) {
-        const ai = alphaOf(nodes[i], now);
-        if (ai <= 0) continue;
-        for (let j = i + 1; j < nodes.length; j++) {
-          const aj = alphaOf(nodes[j], now);
-          if (aj <= 0) continue;
-          const dx = nodes[i].x - nodes[j].x;
-          const dy = nodes[i].y - nodes[j].y;
-          const d = Math.hypot(dx, dy);
+      for (let i = 0; i < N; i++) {
+        // spoke to centre
+        ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.22})`;
+        ctx!.beginPath();
+        ctx!.moveTo(cx, cy);
+        ctx!.lineTo(px[i], py[i]);
+        ctx!.stroke();
+        for (let j = i + 1; j < N; j++) {
+          const d = Math.hypot(px[i] - px[j], py[i] - py[j]);
           if (d < DCON) {
-            ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.55 * Math.min(ai, aj) * (1 - d / DCON)})`;
+            ctx!.strokeStyle = `rgba(${rgb},${baseA * 0.45 * (1 - d / DCON)})`;
             ctx!.beginPath();
-            ctx!.moveTo(nodes[i].x * W, nodes[i].y * H);
-            ctx!.lineTo(nodes[j].x * W, nodes[j].y * H);
+            ctx!.moveTo(px[i], py[i]);
+            ctx!.lineTo(px[j], py[j]);
             ctx!.stroke();
           }
         }
       }
-      for (const n of nodes) {
-        const a = alphaOf(n, now);
-        if (a <= 0) continue;
-        ctx!.fillStyle = `rgba(${rgb},${baseA * a})`;
+      for (let i = 0; i < N; i++) {
+        ctx!.fillStyle = `rgba(${rgb},${baseA})`;
         ctx!.beginPath();
-        ctx!.arc(n.x * W, n.y * H, 1.5, 0, 7);
+        ctx!.arc(px[i], py[i], 1.5, 0, 7);
         ctx!.fill();
       }
+      ctx!.fillStyle = `rgba(${rgb},${baseA})`;
+      ctx!.beginPath();
+      ctx!.arc(cx, cy, 2.4, 0, 7);
+      ctx!.fill();
     }
 
     let raf = 0;
-    function loop() {
-      frame(performance.now());
+    function loop(t: number) {
+      draw(t);
       raf = requestAnimationFrame(loop);
     }
 
     function onMove(e: MouseEvent) {
       const r = canvas!.getBoundingClientRect();
-      target.x = (e.clientX - r.left) / r.width;
-      target.y = (e.clientY - r.top) / r.height;
-      lastMove = performance.now();
+      c.tx = (e.clientX - r.left) / r.width;
+      c.ty = (e.clientY - r.top) / r.height;
     }
     const onTheme = () => {
       accent = readAccent();
@@ -160,10 +149,7 @@ export function HeroGraph() {
       window.addEventListener("mousemove", onMove, { passive: true });
       raf = requestAnimationFrame(loop);
     } else {
-      // one calm static frame: a small settled net near the centre
-      const t = performance.now() - 500;
-      for (let i = 0; i < 14; i++) nodes.push({ x: 0.5 + rnd(-0.2, 0.2), y: 0.45 + rnd(-0.12, 0.12), born: t });
-      frame(performance.now());
+      draw(0);
     }
 
     return () => {

--- a/frontend/digiquant-web/components/tearsheet/charts.tsx
+++ b/frontend/digiquant-web/components/tearsheet/charts.tsx
@@ -217,3 +217,149 @@ export function SignedBars({ values, height = 220, fmt = fmtCompact }: SignedBar
     </Svg>
   );
 }
+
+/** Scale for the cumulative line in ComboPnl: log dollars (symlog under the hood,
+ * so the zero start and early negative crossings stay finite) or % of initial. */
+export type PnlScale = "log" | "pct";
+
+export interface ComboPnlProps {
+  /** Per-trade P&L in dollars (left axis bars). */
+  pnl: number[];
+  /** Running cumulative P&L points (right axis line); same length / order as pnl. */
+  cumulative: TearsheetPoint[];
+  initialCapital: number;
+  scale: PnlScale;
+  height?: number;
+}
+
+/**
+ * Dual-axis combo: per-trade P&L bars on the LEFT scale (gains up / losses down),
+ * cumulative P&L as a line on its own RIGHT scale. The right scale toggles between
+ * log dollars (symlog — legible across the strategy's many decades of compounding)
+ * and cumulative return as a % of initial capital. Only the left/bars axis draws
+ * gridlines; the right axis contributes labels only.
+ */
+export function ComboPnl({ pnl, cumulative, initialCapital, scale, height = 300 }: ComboPnlProps) {
+  if (!pnl || pnl.length === 0) return <Empty height={height} msg="no trades" />;
+
+  // Wider right gutter than the shared PAD.right (26): this is the only chart with
+  // right-axis labels, and they ("100K", "80000%") need room to sit inside the
+  // 1000-wide viewBox. Local to ComboPnl so the other charts are untouched.
+  const PR = 60;
+  const plotW = W - PAD.left - PR;
+  const plotH = height - PAD.top - PAD.bottom;
+  const n = pnl.length;
+  const slot = plotW / n;
+  const bw = Math.max(0.6, Math.min(slot * 0.7, 16));
+  // Shared x: centre-of-slot, so trade i's bar and its cumulative point align.
+  const xCenter = (i: number) => PAD.left + (i + 0.5) * slot;
+
+  // ---- Left axis: per-trade P&L (linear, zero-anchored). Owns the gridlines. ----
+  let lLo = 0, lHi = 0;
+  for (const v of pnl) {
+    if (v < lLo) lLo = v;
+    if (v > lHi) lHi = v;
+  }
+  if (lLo === lHi) lHi = lLo + 1;
+  const lPad = (lHi - lLo) * 0.08;
+  lLo -= lPad;
+  lHi += lPad;
+  const yLeft = (v: number) => PAD.top + plotH - ((v - lLo) / (lHi - lLo)) * plotH;
+  const zeroY = yLeft(0);
+
+  const gridEls: ReactNode[] = [];
+  niceLinearTicks(lLo, lHi, 4).forEach((tv, i) => {
+    const y = yLeft(tv);
+    gridEls.push(
+      <line key={`g${i}`} x1={PAD.left} y1={y} x2={W - PR} y2={y} className={"ts-grid" + (tv === 0 ? " ts-grid-zero" : "")} />,
+      <text key={`gt${i}`} x={PAD.left - 12} y={y + 5} textAnchor="end" className="ts-axis">{fmtCompact(tv)}</text>,
+    );
+  });
+
+  // ---- Right axis: cumulative line. symlog for "log", linear % for "pct". ----
+  const pct = scale === "pct";
+  const cumScale = makeScale("symlog");
+  // Project a cumulative dollar value to the plotted right-axis quantity.
+  const project = (v: number) => (pct ? (v / initialCapital) * 100 : v);
+  const rScaleF = (v: number) => (pct ? project(v) : cumScale.f(v));
+
+  let rLo = Infinity, rHi = -Infinity;
+  for (const p of cumulative) {
+    const y = rScaleF(p.v);
+    if (y < rLo) rLo = y;
+    if (y > rHi) rHi = y;
+  }
+  // Anchor the right axis at zero too, so the line's baseline reads sensibly.
+  rLo = Math.min(rLo, rScaleF(0));
+  rHi = Math.max(rHi, rScaleF(0));
+  if (rLo === rHi) rHi = rLo + 1;
+  const rPad = (rHi - rLo) * 0.07;
+  rLo -= rPad;
+  rHi += rPad;
+  const yRight = (v: number) => PAD.top + plotH - ((rScaleF(v) - rLo) / (rHi - rLo)) * plotH;
+
+  // Right-axis ticks as {plotted-position, label} pairs. For log we format each
+  // tick from its REAL dollar value (not a round-trip through symlog, which lands
+  // 10^6 just under 1e6 → "1000K"); decadeTicks gives clean decades → "1M".
+  let rTicks: { tp: number; label: string }[];
+  if (pct) {
+    // Compact the % labels (fmtCompact → "20K%", "10M%") so the flagship
+    // strategies' multi-thousand-percent returns stay inside the viewBox — a
+    // raw toFixed(0) emits "20000000%" (9 chars) and overflows the right edge.
+    rTicks = niceLinearTicks(rLo, rHi, 4).map((tv) => ({ tp: tv, label: fmtCompact(tv) + "%" }));
+  } else {
+    const realLo = cumScale.inv(rLo), realHi = cumScale.inv(rHi);
+    rTicks = decadeTicks("symlog", realLo, realHi).map((rv) => ({ tp: cumScale.f(rv), label: fmtCompact(rv) }));
+  }
+  const rightLabels: ReactNode[] = [];
+  rTicks.forEach(({ tp, label }, i) => {
+    const y = PAD.top + plotH - ((tp - rLo) / (rHi - rLo)) * plotH;
+    if (y < PAD.top - 1 || y > PAD.top + plotH + 1) return;
+    rightLabels.push(
+      <text key={`r${i}`} x={W - PR + 12} y={y + 5} textAnchor="start" className="ts-axis">{label}</text>,
+    );
+  });
+
+  // Cumulative line path (right axis), stroked only — no area, so bars stay visible.
+  let line = "";
+  for (let i = 0; i < n; i++) {
+    const v = cumulative[i] ? cumulative[i].v : 0;
+    line += (i ? "L" : "M") + xCenter(i).toFixed(1) + " " + yRight(v).toFixed(1) + " ";
+  }
+
+  // X date labels: first / mid / last trade exit, like TimeSeries.
+  const idxs = [0, Math.floor((n - 1) / 2), n - 1];
+
+  // Legend swatches (reuse existing classes only).
+  const legY = PAD.top - 4;
+
+  return (
+    <Svg height={height}>
+      {gridEls}
+      {pnl.map((v, i) => {
+        const x = PAD.left + i * slot + (slot - bw) / 2;
+        const y = v >= 0 ? yLeft(v) : zeroY;
+        const h = Math.max(0.5, Math.abs(yLeft(v) - zeroY));
+        return (
+          <rect key={i} x={x.toFixed(1)} y={y.toFixed(1)} width={bw.toFixed(1)} height={h.toFixed(1)} className={"ts-bar ts-tone-" + (v >= 0 ? "up" : "down")} />
+        );
+      })}
+      <path d={line} className="ts-line ts-tone-accent" fill="none" />
+      {rightLabels}
+      {idxs.map((i, k) => {
+        const anchor = i === 0 ? "start" : i === n - 1 ? "end" : "middle";
+        const pt = cumulative[i];
+        return (
+          <text key={`x${k}`} x={xCenter(i)} y={height - 10} textAnchor={anchor} className="ts-axis">
+            {(pt && pt.t ? pt.t : "").slice(0, 10)}
+          </text>
+        );
+      })}
+      {/* Legend — which series maps to which axis. */}
+      <rect x={PAD.left} y={legY - 9} width={14} height={9} className="ts-bar ts-tone-up" />
+      <text x={PAD.left + 20} y={legY} textAnchor="start" className="ts-axis">per-trade P&amp;L (L)</text>
+      <line x1={PAD.left + 200} y1={legY - 4} x2={PAD.left + 232} y2={legY - 4} className="ts-line ts-tone-accent" />
+      <text x={PAD.left + 238} y={legY} textAnchor="start" className="ts-axis">cumulative (R)</text>
+    </Svg>
+  );
+}

--- a/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
+++ b/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
@@ -7,7 +7,7 @@
  * P&L), and the trade log. "Download PDF" uses the browser's print-to-PDF.
  */
 import { useEffect, useMemo, useState } from "react";
-import { TimeSeries, SignedBars, type Scale } from "./charts";
+import { TimeSeries, ComboPnl, type Scale, type PnlScale } from "./charts";
 import { fmtCompact, fmtMoney, fmtNum, fmtPct, toneClass } from "./format";
 import { avgTradePct, cagrPct, calmar, tradesPerYear } from "./stats";
 import { type TearsheetBreakdown, type TearsheetData } from "./types";
@@ -60,6 +60,7 @@ export function TearsheetView({ slug }: { slug: string }) {
   const [data, setData] = useState<TearsheetData | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [scale, setScale] = useState<Scale>("log");
+  const [pnlScale, setPnlScale] = useState<PnlScale>("log");
 
   useEffect(() => {
     let alive = true;
@@ -172,16 +173,21 @@ export function TearsheetView({ slug }: { slug: string }) {
         <div className="ts-table-wrap"><Breakdown d={data} /></div>
       </section>
 
-      <div className="ts-grid-2">
-        <section className="ts-panel">
-          <div className="ts-panel-head"><span className="ts-panel-label">Per-trade P&amp;L</span></div>
-          <div className="ts-chart"><SignedBars values={data.trades.map((t) => t.pnl)} height={220} fmt={fmtCompact} /></div>
-        </section>
-        <section className="ts-panel">
-          <div className="ts-panel-head"><span className="ts-panel-label">Cumulative P&amp;L · symlog</span></div>
-          <div className="ts-chart"><TimeSeries points={cumPts} height={220} scale="symlog" tone="accent" zeroBaseline fmt={fmtCompact} /></div>
-        </section>
-      </div>
+      <section className="ts-panel">
+        <div className="ts-panel-head">
+          <span className="ts-panel-label">Trade P&amp;L — per-trade &amp; cumulative</span>
+          <label className="ts-scale">
+            <span>Cumulative</span>
+            <select className="ts-select" value={pnlScale} onChange={(e) => setPnlScale(e.target.value as PnlScale)}>
+              <option value="log">Log $</option>
+              <option value="pct">% of initial</option>
+            </select>
+          </label>
+        </div>
+        <div className="ts-chart">
+          <ComboPnl pnl={data.trades.map((t) => t.pnl)} cumulative={cumPts} initialCapital={data.initial_capital} scale={pnlScale} height={300} />
+        </div>
+      </section>
 
       <section className="ts-panel">
         <div className="ts-panel-head"><span className="ts-panel-label">Trade log</span></div>


### PR DESCRIPTION
Round-4 landing polish for **digiquant.io** — all changes confined to `frontend/digiquant-web/` (no shared `frontend/design`, `frontend/web`, or `frontend/digithings-web` files touched).

## Changes

### 1. Hero "neural orb" (`HeroGraph.tsx`)
A contained **oval** cluster of interconnected nodes that sits centered on the `HeroMesh` shading hue and eases toward the cursor at the mesh's gradual pace, holding position with a slow idle cycle when the cursor is idle — replaces the previous dense "snake"/trail. Reduced-motion renders one static frame.

Verified objectively: fresh-load centroid **(0.50, 0.46)** (on the shading), oval bounding box (wider than tall), and the centroid tracks a driven cursor to its target.

### 2. Top-edge shading gap
The shared `site.css` `.glow` animates `translate(-5%, 2%)`, which left a black strip above the tearsheet shading that drifted on scroll. Anchored locally (`.glow { animation: none; transform: none; }`) so the shading reaches the top border. Shared `site.css` is intentionally left untouched (the same latent drift still exists on digithings.ai — flagged to that team).

### 3. Merged dual-axis P&L chart (`ComboPnl`)
The two side-by-side **Per-trade P&L** and **Cumulative P&L** panels are merged into one dual-axis combo chart:
- **Left axis** — per-trade P&L bars (linear $, zero-anchored, up/down toned), owns the gridlines.
- **Right axis** — cumulative P&L line with a **Log $ / % of initial** toggle for the strategy's heavy compounding. Log uses **symlog** so the zero start / early crossings stay finite.
- Right-axis labels sit in a wider local gutter and are compacted via `fmtCompact` (`"1.0M"`, `"20K%"`, `"10M%"`) so the flagship strategies' multi-million-percent returns stay inside the viewBox.

Verified `overflow = 0` on `sol_slapper` and `btc_slapper` in both scales, both themes, and at 375px mobile (no horizontal overflow).

## Verification
- `make score`: **10/10** all dimensions (Security/Quality/Optimization/Accuracy).
- Production `next build`: green, 12 static pages.
- Both themes + mobile checked in the live preview.

Fixes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)