### PR TITLE
feat(digiquant-web): subpage consistency (ambient mesh + serif headers) + nav 'Olympus' rename

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -267,8 +267,16 @@
   .dqnav-cta .btn-ghost { display: none; }
 }
 
-/* push subpage content (no full-bleed hero) clear of the fixed nav */
-.dq-subpage { padding-top: var(--dq-nav-h); }
+/* push subpage content (no full-bleed hero) clear of the fixed nav; relative so
+   the ambient mesh can anchor to the top band without covering the footer */
+.dq-subpage { padding-top: var(--dq-nav-h); position: relative; }
+/* subtle teal mesh backdrop carried over from the hero (AmbientMesh canvas) */
+.dq-ambient { position: absolute; top: 0; left: 0; width: 100%; height: 86svh; z-index: 0; pointer-events: none; filter: blur(54px) saturate(1.12); }
+/* subpage section header — the main page's serif eyebrow/title/sub pattern,
+   without .section-head's `h2` rule (which forces 600-weight sans over .dq-title) */
+.dq-sechead { max-width: 56ch; margin-bottom: clamp(2.5rem, 5vw, 4rem); }
+.dq-sechead.center { margin-inline: auto; text-align: center; }
+.dq-sechead.center .dq-title, .dq-sechead.center .dq-sub { margin-inline: auto; }
 
 /* ---- HERO: animated mesh-gradient, scroll-reactive ---- */
 .dqhero { position: relative; min-height: 100svh; display: flex; align-items: center; justify-content: center; text-align: center; overflow: hidden; }

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -32,7 +32,7 @@ export default function Home() {
           </p>
           <div className="dqhero-cta">
             <a className="btn btn-primary" href="/olympus/">
-              Open Olympus
+              Olympus
             </a>
           </div>
         </HeroMesh>
@@ -51,7 +51,7 @@ export default function Home() {
             </p>
             <div className="dqcta-actions">
               <a className="btn btn-primary" href="/olympus/">
-                Open Olympus
+                Olympus
               </a>
             </div>
           </Reveal>

--- a/frontend/digiquant-web/app/pipeline/page.tsx
+++ b/frontend/digiquant-web/app/pipeline/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Footer, Reveal } from "@digithings/web";
 import { DQ_FOOTER, DQ_FOOTER_META } from "../_nav";
 import { DqNav } from "@/components/landing/DqNav";
+import { AmbientMesh } from "@/components/landing/AmbientMesh";
 
 export const metadata: Metadata = {
   title: "Pipeline — digiquant",
@@ -27,12 +28,13 @@ export default function PipelinePage() {
     <>
       <DqNav />
       <main className="dq-subpage">
+        <AmbientMesh />
         <section className="section">
           <div className="wrap">
-            <Reveal className="section-head">
-              <span className="kicker">// the pipeline</span>
-              <h2 className="hero-title" style={{ fontSize: "clamp(2.2rem,5vw,3.4rem)", margin: ".4rem 0 .8rem" }}>Research in, orders out — in a straight line.</h2>
-              <p>digiquant is not a hub of services routing messages around; it&rsquo;s a linear research workflow. You start in a chat, and each stage hands its output to the next until a strategy is ready to run. Built on the open <a href="https://digiquant.io" style={{ color: "var(--accent)" }}>digiquant</a> stack — itself a module of <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)" }}>the DigiThings platform</a>.</p>
+            <Reveal className="dq-sechead">
+              <div className="dq-eyebrow">// the pipeline</div>
+              <h2 className="dq-title">Research in, orders out — in a straight line.</h2>
+              <p className="dq-sub">digiquant is not a hub of services routing messages around; it&rsquo;s a linear research workflow. You start in a chat, and each stage hands its output to the next until a strategy is ready to run. Built on the open <a href="https://digiquant.io" style={{ color: "var(--accent)" }}>digiquant</a> stack — itself a module of <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)" }}>the DigiThings platform</a>.</p>
             </Reveal>
 
             <Reveal>
@@ -53,7 +55,11 @@ export default function PipelinePage() {
 
         <section className="section section-alt">
           <div className="wrap">
-            <Reveal className="section-head center"><span className="kicker">// execution, gated</span><h2>The execution layer climbs a ladder.</h2><p>Stage 07 in detail: a strategy earns its way to live. Backtest → paper → loopback → live, each rung a human gate. Loopback-only by default.</p></Reveal>
+            <Reveal className="dq-sechead center">
+              <div className="dq-eyebrow">// execution, gated</div>
+              <h2 className="dq-title">The execution layer climbs a ladder.</h2>
+              <p className="dq-sub">Stage 07 in detail: a strategy earns its way to live. Backtest → paper → loopback → live, each rung a human gate. Loopback-only by default.</p>
+            </Reveal>
             <Reveal className="ladder">
               <svg viewBox="0 0 520 280" preserveAspectRatio="xMidYMid meet">
                 <g stroke="var(--hair)" strokeWidth="1"><line x1="0" y1="250" x2="520" y2="250" /></g>

--- a/frontend/digiquant-web/app/pricing/page.tsx
+++ b/frontend/digiquant-web/app/pricing/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Footer, Reveal } from "@digithings/web";
 import { DQ_FOOTER, DQ_FOOTER_META } from "../_nav";
 import { DqNav } from "@/components/landing/DqNav";
+import { AmbientMesh } from "@/components/landing/AmbientMesh";
 
 export const metadata: Metadata = {
   title: "Pricing — digiquant",
@@ -32,6 +33,7 @@ export default function PricingPage() {
     <>
       <DqNav />
       <main className="dq-subpage">
+        <AmbientMesh />
         <section className="section">
           <div className="wrap">
             <Reveal>

--- a/frontend/digiquant-web/app/strategies/page.tsx
+++ b/frontend/digiquant-web/app/strategies/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Footer } from "@digithings/web";
 import { DQ_FOOTER, DQ_FOOTER_META } from "../_nav";
 import { DqNav } from "@/components/landing/DqNav";
+import { AmbientMesh } from "@/components/landing/AmbientMesh";
 import { StrategyCard } from "@/components/tearsheet/strategy-card";
 import { type StrategyIndexEntry } from "@/components/tearsheet/types";
 import index from "@/public/strategies/index.json";
@@ -18,12 +19,13 @@ export default function StrategiesPage() {
   return (
     <>
       <DqNav />
-      <main className="ts-page dq-subpage">
+      <main className="dq-subpage">
+        <AmbientMesh />
         <div className="wrap">
-          <header className="ts-lib-head">
-            <span className="kicker">// strategy library</span>
-            <h1 className="ts-h1">Three base strategies, fully validated</h1>
-            <p className="ts-lib-lede">
+          <header className="dq-sechead">
+            <div className="dq-eyebrow">// strategy library</div>
+            <h1 className="dq-title">Three base strategies, fully validated</h1>
+            <p className="dq-sub">
               digiquant ships with three reference crypto strategies — one per major asset
               (BTC, ETH, SOL) — as starting points you can fork, re-optimize, and extend. Each is
               run through the backtest engine and rendered as an interactive

--- a/frontend/digiquant-web/components/landing/AmbientMesh.tsx
+++ b/frontend/digiquant-web/components/landing/AmbientMesh.tsx
@@ -1,0 +1,118 @@
+"use client";
+/**
+ * Subtle ambient mesh backdrop for the subpages (pipeline / strategies / pricing).
+ *
+ * The same teal blob family as the hero's HeroMesh, but quieter and pinned to the
+ * top of the page, so the brand hue carries onto the subpages without a full hero.
+ * Rendered as an `absolute` canvas inside a `position: relative` `.dq-subpage`, so
+ * it only covers the top band (never paints over the footer). It paints over the
+ * page's `--bg`; content lives in `.wrap` (z-index 1) and stays above it.
+ * Theme-aware (additive glow on dark, soft tint on light) and renders one static
+ * frame under prefers-reduced-motion.
+ */
+import { useEffect, useRef } from "react";
+
+const rnd = (a: number, b: number) => a + Math.random() * (b - a);
+const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v));
+
+// teal accent family — a quieter subset of HeroMesh's PAL
+const PAL = ["61,214,196", "38,120,110", "63,185,132"];
+
+export function AmbientMesh() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const readLight = () => document.documentElement.getAttribute("data-theme") === "light";
+    let light = readLight();
+
+    let W = 0;
+    let H = 0;
+    let blobs: { c: string; bx: number; by: number; r: number; ph: number; sp: number }[] = [];
+
+    function init() {
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+      W = canvas!.clientWidth;
+      H = canvas!.clientHeight;
+      canvas!.width = Math.max(1, Math.round(W * dpr));
+      canvas!.height = Math.max(1, Math.round(H * dpr));
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      // blobs biased to the upper band so the hue concentrates behind the header
+      blobs = PAL.map((c) => ({
+        c,
+        bx: rnd(0.25, 0.75),
+        by: rnd(0.16, 0.42),
+        r: rnd(0.5, 0.85),
+        ph: Math.random() * 6.28,
+        sp: rnd(0.0001, 0.00022),
+      }));
+    }
+
+    let tfx = 0.5;
+    let fx = 0.5;
+
+    function draw(t: number) {
+      fx += (tfx - fx) * 0.04; // gentle, slower than the hero
+      ctx!.clearRect(0, 0, W, H);
+      // additive glow on dark; on the near-white light base "lighter" can't
+      // brighten past white, so fall back to a normal soft teal tint.
+      ctx!.globalCompositeOperation = light ? "source-over" : "lighter";
+      blobs.forEach((b, i) => {
+        let cx = (b.bx + Math.sin(t * b.sp + b.ph) * 0.1) * W;
+        const cy = (b.by + Math.cos(t * b.sp * 1.1 + b.ph) * 0.08) * H;
+        cx += (fx * W - cx) * (i % 2 ? 0.12 : 0.06);
+        const rad = b.r * Math.max(W, H) * 0.5;
+        const g = ctx!.createRadialGradient(cx, cy, 0, cx, cy, rad);
+        g.addColorStop(0, `rgba(${b.c},${light ? 0.16 : 0.22})`);
+        g.addColorStop(1, `rgba(${b.c},0)`);
+        ctx!.fillStyle = g;
+        ctx!.beginPath();
+        ctx!.arc(cx, cy, rad, 0, 7);
+        ctx!.fill();
+      });
+    }
+
+    let raf = 0;
+    function loop(t: number) {
+      draw(t);
+      raf = requestAnimationFrame(loop);
+    }
+
+    function onMove(e: MouseEvent) {
+      tfx = clamp(e.clientX / window.innerWidth, 0, 1);
+    }
+    const onTheme = () => {
+      light = readLight();
+      draw(performance.now());
+    };
+    const obs = new MutationObserver(onTheme);
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+    const onResize = () => {
+      init();
+      draw(performance.now());
+    };
+
+    init();
+    draw(performance.now()); // always paint one frame (static fallback)
+    window.addEventListener("resize", onResize, { passive: true });
+
+    const animate = !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (animate) {
+      window.addEventListener("mousemove", onMove, { passive: true });
+      raf = requestAnimationFrame(loop);
+    }
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("mousemove", onMove);
+      obs.disconnect();
+    };
+  }, []);
+
+  return <canvas className="dq-ambient" ref={canvasRef} aria-hidden="true" />;
+}

--- a/frontend/digiquant-web/components/landing/DqNav.tsx
+++ b/frontend/digiquant-web/components/landing/DqNav.tsx
@@ -74,7 +74,7 @@ export function DqNav() {
           </a>
           <a className="btn btn-primary btn-sm dqnav-olympus" href="/olympus/">
             <OlympusMark size={17} />
-            <span>Open Olympus</span>
+            <span>Olympus</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Makes the **Pipeline / Strategies / Pricing** subpages feel like the main landing page, per design review. All changes confined to `frontend/digiquant-web/`.

## Changes

### Ambient mesh backdrop (`AmbientMesh.tsx`)
A quieter, top-anchored sibling of the hero's `HeroMesh` — same teal blob family, ~half the alpha, no neural graph. Rendered as an `absolute` canvas inside the now-`relative` `.dq-subpage`, so it carries the brand hue onto the subpages **without a full hero** and never paints over the footer (it only covers the top `86svh` band; `.wrap` content sits above it at `z-index: 1`). Theme-aware (additive glow on dark, soft tint on light) and renders one static frame under `prefers-reduced-motion`. Mounted on all three subpages.

### Header typography consistency
- **Pipeline** used `.kicker` / `.hero-title` with inline font-size overrides; **Strategies** used `.ts-h1` (the *sans* tearsheet heading) and `.ts-lib-lede`. Both now use the main page's serif `.dq-eyebrow` / `.dq-title` / `.dq-sub` pattern via a new `.dq-sechead` wrapper.
- `.dq-sechead` deliberately omits the shared `.section-head h2` rule, which (at higher specificity) was forcing 600-weight **sans** over `.dq-title`.

### Strategies offset
Dropped the redundant `.ts-page` class on the library page — it stacked an extra top-offset on top of `.dq-subpage`, pushing the header away from the nav. Card grid keeps `.ts-card` / `.ts-lib-grid`.

### Nav rename
`Open Olympus` → `Olympus` on the nav CTA and both home-page CTAs (hero + closing).

## Verification
- Preview, pipeline (light + dark) and strategies: serif titles (Fraunces 400, confirmed the `.section-head h2` override no longer applies), ambient hue behind the header, single nav offset, "Olympus" label.
- `make score`: **10/10** all dimensions.
- Production `next build`: green, 12 static pages.

Fixes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)