### PR TITLE
feat(digiquant-web): tearsheet charts interactivity — scale buttons, synced zoom, returns matrix

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -141,6 +141,29 @@
 .ts-scale { display: inline-flex; align-items: center; gap: 0.5rem; font-family: var(--font-mono); font-size: 0.7rem; color: var(--ink-mute); letter-spacing: 0.08em; text-transform: uppercase; }
 .ts-select { background: var(--surface-2); border: 1px solid var(--hair); color: var(--ink); font-family: var(--font-mono); font-size: 0.78rem; padding: 0.2rem 0.5rem; border-radius: var(--r-sm); }
 
+/* Panel-head tool cluster: hint + Reset + scale/period toggles. */
+.ts-panel-tools { display: inline-flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; justify-content: flex-end; }
+.ts-hint { font-family: var(--font-mono); font-size: 0.66rem; color: var(--ink-mute); letter-spacing: 0.04em; opacity: 0.8; }
+.ts-reset { font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); background: var(--accent-weak); border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent); border-radius: var(--r-sm); padding: 0.2rem 0.55rem; cursor: pointer; transition: background 0.18s var(--ease); }
+.ts-reset:hover { background: color-mix(in srgb, var(--accent) 24%, transparent); }
+
+/* Segmented toggle (Linear/Log, Log $/%, Monthly/Quarterly/Annual). */
+.ts-seg { display: inline-flex; border: 1px solid var(--hair); border-radius: var(--r-sm); overflow: hidden; background: var(--surface-2); }
+.ts-seg-btn { font-family: var(--font-mono); font-size: 0.74rem; color: var(--ink-mute); background: transparent; border: none; border-left: 1px solid var(--hair); padding: 0.22rem 0.62rem; cursor: pointer; transition: color 0.18s var(--ease), background 0.18s var(--ease); }
+.ts-seg-btn:first-child { border-left: none; }
+.ts-seg-btn:hover { color: var(--ink); }
+.ts-seg-btn.is-active { color: var(--accent); background: var(--accent-weak); }
+
+/* Returns matrix — CSS-grid calendar heatmap of period returns. */
+.ts-matrix { display: grid; gap: 2px; font-family: var(--font-mono); font-size: 0.74rem; }
+.ts-matrix-corner { background: transparent; }
+.ts-matrix-head { color: var(--ink-mute); font-size: 0.66rem; letter-spacing: 0.06em; text-transform: uppercase; text-align: center; padding: 0.3rem 0.2rem; }
+.ts-matrix-year-head { color: var(--ink-soft); }
+.ts-matrix-rowlabel { color: var(--ink-soft); font-size: 0.72rem; display: flex; align-items: center; padding: 0 0.5rem 0 0.1rem; white-space: nowrap; }
+.ts-matrix-cell { color: var(--ink); text-align: center; padding: 0.4rem 0.25rem; border-radius: var(--r-sm); border: 1px solid var(--hair); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ts-matrix-cell.is-empty { color: var(--ink-mute); border-style: dashed; opacity: 0.5; }
+.ts-matrix-year { font-weight: 600; border-color: var(--hair-2); }
+
 .ts-table-wrap { width: 100%; overflow-x: auto; }
 .ts-table-scroll { max-height: 520px; overflow-y: auto; }
 .ts-table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
@@ -184,7 +207,7 @@
   @page { margin: 0; }
   html, body { background: var(--bg) !important; }
   body { -webkit-print-color-adjust: exact; print-color-adjust: exact; color-adjust: exact; }
-  .grain, .glow, .site-nav, .dqnav, .footer, .ts-header-actions, .ts-back, .ts-scale, .nav-toggle, .theme-toggle { display: none !important; }
+  .grain, .glow, .site-nav, .dqnav, .footer, .ts-header-actions, .ts-back, .ts-scale, .ts-panel-tools, .ts-seg, .ts-reset, .ts-hint, .nav-toggle, .theme-toggle { display: none !important; }
   /* drop the fixed-nav offset in print (nav is hidden). No !important: source
      order lets .ts-page's 14mm top inset (below) win on the tearsheet PDF. */
   .dq-subpage { padding-top: 0; }

--- a/frontend/digiquant-web/components/tearsheet/charts.tsx
+++ b/frontend/digiquant-web/components/tearsheet/charts.tsx
@@ -6,8 +6,8 @@
  * (theme-aware via [data-theme]). Supports linear / log / symlog y scales —
  * symlog handles series that cross zero (cumulative P&L).
  */
-import { type ReactNode } from "react";
-import { fmtCompact } from "./format";
+import { type ReactNode, useEffect, useRef } from "react";
+import { fmtCompact, fmtPct } from "./format";
 import { type TearsheetPoint } from "./types";
 
 const W = 1000;
@@ -15,6 +15,135 @@ const PAD = { top: 18, right: 26, bottom: 36, left: 84 };
 
 export type Scale = "linear" | "log" | "symlog";
 export type Tone = "accent" | "up" | "down";
+
+/** A normalized x-domain window (fractions 0..1 over a chart's full date span). */
+export interface ViewWindow {
+  lo: number;
+  hi: number;
+}
+/** Smallest allowed window (2% of the span) — keeps zoom from collapsing. */
+const MIN_VIEW = 0.02;
+
+function clampView(lo: number, hi: number): ViewWindow {
+  let l = Math.max(0, Math.min(lo, 1));
+  let h = Math.max(0, Math.min(hi, 1));
+  if (h - l < MIN_VIEW) {
+    // Re-expand around the window centre, then re-clamp into [0,1].
+    const mid = (l + h) / 2;
+    l = Math.max(0, mid - MIN_VIEW / 2);
+    h = Math.min(1, l + MIN_VIEW);
+    l = Math.max(0, h - MIN_VIEW);
+  }
+  return { lo: l, hi: h };
+}
+
+/**
+ * Generic segmented-button toggle. Real <button>s with aria-pressed inside a
+ * labelled group — accessible, theme-aware (active = accent). Used for the equity
+ * scale, the cumulative-P&L scale, and the returns-matrix period selector.
+ */
+export function SegToggle<T extends string>({
+  value,
+  options,
+  onChange,
+  label,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+  label: string;
+}) {
+  return (
+    <div className="ts-seg" role="group" aria-label={label}>
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          className={"ts-seg-btn" + (o.value === value ? " is-active" : "")}
+          aria-pressed={o.value === value}
+          onClick={() => onChange(o.value)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Translate a pointer event over a `viewBox 0 0 1000 H` SVG into a fraction
+ * (0..1) across the chart's *plot area* (i.e. inside the left/right insets).
+ * `padRight` differs per chart (ComboPnl uses a wider gutter), so callers pass it.
+ */
+function plotFraction(clientX: number, target: Element, padRight: number): number {
+  const rect = target.getBoundingClientRect();
+  if (rect.width === 0) return 0.5;
+  // Fraction across the full 1000-unit viewBox width, then into plot coords.
+  const x = ((clientX - rect.left) / rect.width) * W; // viewBox x
+  const plotW = W - PAD.left - padRight;
+  return Math.max(0, Math.min(1, (x - PAD.left) / plotW));
+}
+
+/** What a view-controlled chart needs to drive zoom/pan; null ⇒ static chart. */
+interface ViewControl {
+  /** plot-area right inset (differs per chart). */
+  padRight: number;
+  /** wheel zoom, centred on cursor clientX, against the chart's own width. */
+  onWheel: (clientX: number, deltaY: number, target: Element) => void;
+  onMouseDown: (e: React.MouseEvent<SVGSVGElement>) => void;
+  onDoubleClick: () => void;
+}
+
+/**
+ * Build the shared wheel / drag / double-click control for a ViewWindow. Returns
+ * null (static chart) when not view-controlled, so the same component renders
+ * statically wherever `view`/`onView` are omitted.
+ */
+function viewHandlers(
+  view: ViewWindow | undefined,
+  onView: ((v: ViewWindow) => void) | undefined,
+  padRight: number,
+): ViewControl | null {
+  if (!view || !onView) return null;
+  const { lo, hi } = view;
+
+  const onWheel = (clientX: number, deltaY: number, target: Element) => {
+    const span = hi - lo;
+    const cursor = lo + plotFraction(clientX, target, padRight) * span;
+    // Wheel up (deltaY < 0) zooms in; down zooms out. Centred on the cursor.
+    const factor = Math.exp(deltaY * 0.0015);
+    const nlo = cursor - (cursor - lo) * factor;
+    const nhi = cursor + (hi - cursor) * factor;
+    onView(clampView(nlo, nhi));
+  };
+
+  const onMouseDown = (e: React.MouseEvent<SVGSVGElement>) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const span = hi - lo;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const plotPxW = rect.width * ((W - PAD.left - padRight) / W);
+    const move = (me: MouseEvent) => {
+      if (plotPxW === 0) return;
+      // Drag right ⇒ window shifts left (content follows the cursor). Clamp the
+      // shift so the window TRANSLATES (keeps its width) against the [0,1] edges
+      // instead of narrowing — true pan, not zoom, at the boundary.
+      let dFrac = ((me.clientX - startX) / plotPxW) * span;
+      dFrac = Math.max(hi - 1, Math.min(lo, dFrac));
+      onView(clampView(lo - dFrac, hi - dFrac));
+    };
+    const up = () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+  };
+
+  const onDoubleClick = () => onView({ lo: 0, hi: 1 });
+
+  return { padRight, onWheel, onMouseDown, onDoubleClick };
+}
 
 function makeScale(kind: Scale) {
   if (kind === "log") {
@@ -63,13 +192,38 @@ function decadeTicks(kind: Scale, realLo: number, realHi: number): number[] {
   return ticks.length ? ticks : [realLo, realHi];
 }
 
-function Svg({ height, children }: { height: number; children: ReactNode }) {
+function Svg({
+  height,
+  children,
+  control,
+}: {
+  height: number;
+  children: ReactNode;
+  control?: ViewControl | null;
+}) {
+  const ref = useRef<SVGSVGElement>(null);
+  // Attach wheel natively (non-passive) so preventDefault actually blocks page
+  // scroll — React's synthetic onWheel is passive and cannot.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !control) return;
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      control.onWheel(e.clientX, e.deltaY, el);
+    };
+    el.addEventListener("wheel", handler, { passive: false });
+    return () => el.removeEventListener("wheel", handler);
+  }, [control]);
+
   return (
     <svg
+      ref={ref}
       viewBox={`0 0 ${W} ${height}`}
       preserveAspectRatio="xMidYMid meet"
-      className="ts-svg"
+      className={"ts-svg" + (control ? " is-interactive" : "")}
       role="img"
+      onMouseDown={control ? control.onMouseDown : undefined}
+      onDoubleClick={control ? control.onDoubleClick : undefined}
     >
       {children}
     </svg>
@@ -93,12 +247,56 @@ export interface TimeSeriesProps {
   tone?: Tone;
   fmt?: (v: number) => string;
   zeroBaseline?: boolean;
+  /** Shared normalized x-window (date span fraction). Omit ⇒ full range, static. */
+  view?: ViewWindow;
+  /** Notified on wheel-zoom / drag-pan / double-click reset. */
+  onView?: (v: ViewWindow) => void;
+  /** Full date span [firstISO, lastISO] for the *whole* series; defaults to the
+   *  series' own endpoints. Pass the shared span so every chart maps the same
+   *  fraction to the same calendar window even if point counts differ. */
+  fullSpan?: [string, string];
+}
+
+/**
+ * Slice points to a normalized fraction window over a shared date span. The
+ * fraction is mapped to a calendar window [t(lo), t(hi)] (linear in time across
+ * the span), then points whose date falls inside are kept — so two series that
+ * share a span stay locked to the same calendar window regardless of sampling.
+ */
+function sliceByView(
+  points: TearsheetPoint[],
+  view: ViewWindow | undefined,
+  fullSpan: [string, string] | undefined,
+): TearsheetPoint[] {
+  if (!view || (view.lo <= 0 && view.hi >= 1) || points.length === 0) return points;
+  const t0 = new Date((fullSpan ? fullSpan[0] : points[0].t)).getTime();
+  const t1 = new Date((fullSpan ? fullSpan[1] : points[points.length - 1].t)).getTime();
+  const span = t1 - t0;
+  if (span <= 0) return points;
+  const loT = t0 + view.lo * span;
+  const hiT = t0 + view.hi * span;
+  const out = points.filter((p) => {
+    const t = new Date(p.t).getTime();
+    return t >= loT && t <= hiT;
+  });
+  // Guarantee at least a couple of points so the path/area still draws.
+  if (out.length >= 2) return out;
+  const mid = (loT + hiT) / 2;
+  let nearest = 0;
+  for (let i = 1; i < points.length; i++) {
+    if (Math.abs(new Date(points[i].t).getTime() - mid) < Math.abs(new Date(points[nearest].t).getTime() - mid)) nearest = i;
+  }
+  return points.slice(Math.max(0, nearest - 1), Math.min(points.length, nearest + 1));
 }
 
 /** Time-series area/line chart. */
-export function TimeSeries({ points, height = 320, scale: scaleKind = "linear", tone = "accent", fmt = fmtCompact, zeroBaseline = false }: TimeSeriesProps) {
-  if (!points || points.length === 0) return <Empty height={height} msg="no data" />;
+export function TimeSeries({ points: allPoints, height = 320, scale: scaleKind = "linear", tone = "accent", fmt = fmtCompact, zeroBaseline = false, view, onView, fullSpan }: TimeSeriesProps) {
+  if (!allPoints || allPoints.length === 0) return <Empty height={height} msg="no data" />;
 
+  // Visible slice — the y-domain re-derives from the slice below, so x-zoom
+  // intentionally auto-rescales the y-axis to the window's range.
+  const points = sliceByView(allPoints, view, fullSpan);
+  const control = viewHandlers(view, onView, PAD.right);
   const scale = makeScale(scaleKind);
   const plotW = W - PAD.left - PAD.right;
   const plotH = height - PAD.top - PAD.bottom;
@@ -149,7 +347,7 @@ export function TimeSeries({ points, height = 320, scale: scaleKind = "linear", 
   const idxs = [0, Math.floor((n - 1) / 2), n - 1];
 
   return (
-    <Svg height={height}>
+    <Svg height={height} control={control}>
       {gridEls}
       <path d={area} className={"ts-area ts-tone-" + tone} />
       <path d={line} className={"ts-line ts-tone-" + tone} fill="none" />
@@ -223,13 +421,20 @@ export function SignedBars({ values, height = 220, fmt = fmtCompact }: SignedBar
 export type PnlScale = "log" | "pct";
 
 export interface ComboPnlProps {
-  /** Per-trade P&L in dollars (left axis bars). */
+  /** Per-trade P&L in dollars (left axis bars), in trade order. */
   pnl: number[];
-  /** Running cumulative P&L points (right axis line); same length / order as pnl. */
+  /** GLOBAL running cumulative P&L points (right axis line); same length / order
+   *  as pnl, with `t` = each trade's exit date. */
   cumulative: TearsheetPoint[];
   initialCapital: number;
   scale: PnlScale;
   height?: number;
+  /** Shared normalized x-window (date span fraction). Omit ⇒ full range, static. */
+  view?: ViewWindow;
+  onView?: (v: ViewWindow) => void;
+  /** Shared full date span [firstISO, lastISO] — the equity-curve span, so the
+   *  combo's trade window locks to the same calendar window as the line charts. */
+  fullSpan?: [string, string];
 }
 
 /**
@@ -238,9 +443,45 @@ export interface ComboPnlProps {
  * log dollars (symlog — legible across the strategy's many decades of compounding)
  * and cumulative return as a % of initial capital. Only the left/bars axis draws
  * gridlines; the right axis contributes labels only.
+ *
+ * When a `view` window is supplied, trades are filtered by their exit date to the
+ * shared calendar window. The cumulative line keeps the GLOBAL running total at
+ * each surviving index (not a window-local re-zero), so the line preserves its
+ * real height and continuity within the window — it will only start at zero when
+ * the window includes the very first trade.
  */
-export function ComboPnl({ pnl, cumulative, initialCapital, scale, height = 300 }: ComboPnlProps) {
-  if (!pnl || pnl.length === 0) return <Empty height={height} msg="no trades" />;
+export function ComboPnl({ pnl: allPnl, cumulative: allCumulative, initialCapital, scale, height = 300, view, onView, fullSpan }: ComboPnlProps) {
+  if (!allPnl || allPnl.length === 0) return <Empty height={height} msg="no trades" />;
+
+  // Filter trades to the shared window by exit date (cumulative[i].t). The
+  // surviving cumulative values stay on the GLOBAL running total — documented above.
+  let pnl = allPnl;
+  let cumulative = allCumulative;
+  if (view && !(view.lo <= 0 && view.hi >= 1)) {
+    const t0 = new Date((fullSpan ? fullSpan[0] : (allCumulative[0]?.t ?? ""))).getTime();
+    const t1 = new Date((fullSpan ? fullSpan[1] : (allCumulative[allCumulative.length - 1]?.t ?? ""))).getTime();
+    const span = t1 - t0;
+    if (span > 0) {
+      const loT = t0 + view.lo * span;
+      const hiT = t0 + view.hi * span;
+      const keepPnl: number[] = [];
+      const keepCum: TearsheetPoint[] = [];
+      allCumulative.forEach((p, i) => {
+        const t = new Date(p.t).getTime();
+        if (t >= loT && t <= hiT) {
+          keepPnl.push(allPnl[i]);
+          keepCum.push(p);
+        }
+      });
+      if (keepCum.length > 0) {
+        pnl = keepPnl;
+        cumulative = keepCum;
+      }
+    }
+  }
+
+  const control = viewHandlers(view, onView, 60 /* PR below */);
+  if (!pnl || pnl.length === 0) return <Empty height={height} msg="no trades in window" />;
 
   // Wider right gutter than the shared PAD.right (26): this is the only chart with
   // right-axis labels, and they ("100K", "80000%") need room to sit inside the
@@ -334,7 +575,7 @@ export function ComboPnl({ pnl, cumulative, initialCapital, scale, height = 300 
   const legY = PAD.top - 4;
 
   return (
-    <Svg height={height}>
+    <Svg height={height} control={control}>
       {gridEls}
       {pnl.map((v, i) => {
         const x = PAD.left + i * slot + (slot - bw) / 2;
@@ -361,5 +602,187 @@ export function ComboPnl({ pnl, cumulative, initialCapital, scale, height = 300 
       <line x1={PAD.left + 200} y1={legY - 4} x2={PAD.left + 232} y2={legY - 4} className="ts-line ts-tone-accent" />
       <text x={PAD.left + 238} y={legY} textAnchor="start" className="ts-axis">cumulative (R)</text>
     </Svg>
+  );
+}
+
+// ----------------------------- Returns matrix ------------------------------
+
+export type ReturnsPeriod = "monthly" | "quarterly" | "annual";
+
+const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const QUARTER_LABELS = ["Q1", "Q2", "Q3", "Q4"];
+
+/** A single rendered cell: the period return % (or null = no data in that slot). */
+interface MatrixCell {
+  ret: number | null;
+}
+interface MatrixRow {
+  year: number;
+  cells: MatrixCell[]; // one per column for the granularity
+  yearRet: number | null; // trailing "Year" column (compounded)
+}
+
+/** Number of columns per granularity (the trailing Year column is separate). */
+function colCount(period: ReturnsPeriod): number {
+  return period === "monthly" ? 12 : period === "quarterly" ? 4 : 1;
+}
+
+/**
+ * Reduce an equity curve to period-over-period returns. The "close" of a period
+ * is its last sampled equity; the return is close / prevClose − 1, chained across
+ * periods (so a flat-but-missing month inherits the previous close). The baseline
+ * before the very first sampled period is the opening equity (equity_curve[0].v ≈
+ * initial capital). Empty period slots stay null. The Year column compounds the
+ * year's own first-to-last ratio (independent of granularity).
+ */
+function buildReturnsRows(points: TearsheetPoint[], period: ReturnsPeriod): MatrixRow[] {
+  if (!points || points.length === 0) return [];
+  const cols = colCount(period);
+  const slotOf = (m: number) => (period === "monthly" ? m : period === "quarterly" ? Math.floor(m / 3) : 0);
+
+  // Last sampled equity per (year, slot), plus per-year first/last for the Year col.
+  const lastInSlot = new Map<string, number>(); // `${year}:${slot}` -> equity
+  const yearFirst = new Map<number, number>();
+  const yearLast = new Map<number, number>();
+  let minYear = Infinity, maxYear = -Infinity;
+
+  for (const p of points) {
+    const d = new Date(p.t);
+    const year = d.getUTCFullYear();
+    const month = d.getUTCMonth();
+    const slot = slotOf(month);
+    lastInSlot.set(`${year}:${slot}`, p.v); // later points overwrite ⇒ last wins
+    if (!yearFirst.has(year)) yearFirst.set(year, p.v);
+    yearLast.set(year, p.v);
+    if (year < minYear) minYear = year;
+    if (year > maxYear) maxYear = year;
+  }
+  if (!Number.isFinite(minYear)) return [];
+
+  const opening = points[0].v;
+  const rows: MatrixRow[] = [];
+  // prevClose chains across the *whole* timeline so a gap inherits the last close.
+  let prevClose = opening;
+
+  for (let year = minYear; year <= maxYear; year++) {
+    const cells: MatrixCell[] = [];
+    for (let s = 0; s < cols; s++) {
+      const close = lastInSlot.get(`${year}:${s}`);
+      if (close === undefined) {
+        cells.push({ ret: null }); // no data in this period
+      } else {
+        const ret = prevClose > 0 ? (close / prevClose - 1) * 100 : null;
+        cells.push({ ret });
+        prevClose = close;
+      }
+    }
+    // Year column: compound the year's own first→last ratio against the close
+    // carried into the year (so the first year reflects growth from `opening`).
+    const last = yearLast.get(year);
+    const yearRet = last !== undefined && prevCloseAtYearStart(year, minYear, opening, yearLast) > 0
+      ? (last / prevCloseAtYearStart(year, minYear, opening, yearLast) - 1) * 100
+      : null;
+    rows.push({ year, cells, yearRet });
+  }
+  return rows;
+}
+
+/** Equity carried into `year`: the prior year's last close, or the opening for the
+ *  first year. Keeps the Year column consistent with the chained cell logic. */
+function prevCloseAtYearStart(year: number, minYear: number, opening: number, yearLast: Map<number, number>): number {
+  if (year === minYear) return opening;
+  // Walk back to the most recent prior year that actually has data.
+  for (let y = year - 1; y >= minYear; y--) {
+    const v = yearLast.get(y);
+    if (v !== undefined) return v;
+  }
+  return opening;
+}
+
+/** Inline cell background: tone-coloured with alpha scaled by |return| relative to
+ *  the granularity's max-abs (small floor so non-zero cells are always visible). */
+function cellBg(ret: number | null, maxAbs: number): string {
+  if (ret === null) return "transparent";
+  if (ret === 0) return "transparent";
+  const tone = ret > 0 ? "var(--up)" : "var(--down)";
+  const mag = maxAbs > 0 ? Math.abs(ret) / maxAbs : 0;
+  // 14%..72% alpha — readable text stays legible, strong months stand out.
+  const pct = Math.round(14 + Math.min(1, mag) * 58);
+  return `color-mix(in srgb, ${tone} ${pct}%, transparent)`;
+}
+
+/** Compact cell % — sheds decimals as magnitude grows so wide crypto returns
+ *  (hundreds / thousands of %) fit the narrow grid cells without truncation. */
+function fmtCellPct(v: number | null): string {
+  if (v === null) return "";
+  const a = Math.abs(v);
+  if (a >= 1000) return fmtCompact(v) + "%"; // e.g. "1.3K%"
+  if (a >= 100) return v.toFixed(0) + "%"; // e.g. "683%"
+  return v.toFixed(1) + "%"; // e.g. "25.7%"
+}
+
+/**
+ * Calendar heatmap of period returns derived from the equity curve. Rows = years,
+ * columns = months / quarters / a single annual cell, plus a trailing compounded
+ * "Year" column. Pure CSS-grid table (no SVG) so it reflows and scrolls on mobile.
+ */
+export function ReturnsMatrix({ points, period }: { points: TearsheetPoint[]; period: ReturnsPeriod }) {
+  const rows = buildReturnsRows(points, period);
+  if (rows.length === 0) return <div className="ts-status">no data</div>;
+
+  const cols = colCount(period);
+  const labels = period === "monthly" ? MONTH_LABELS : period === "quarterly" ? QUARTER_LABELS : ["Year"];
+  // For the annual granularity the single column already IS the year return, so we
+  // suppress the duplicate trailing Year column.
+  const showYearCol = period !== "annual";
+
+  // Max-abs across all rendered cell returns (incl. the Year column) for alpha scale.
+  let maxAbs = 0;
+  for (const r of rows) {
+    for (const c of r.cells) if (c.ret !== null) maxAbs = Math.max(maxAbs, Math.abs(c.ret));
+    if (showYearCol && r.yearRet !== null) maxAbs = Math.max(maxAbs, Math.abs(r.yearRet));
+  }
+
+  const totalCols = 1 + cols + (showYearCol ? 1 : 0); // year-label + data + Year
+  const gridTemplate = `minmax(2.6rem, auto) repeat(${cols + (showYearCol ? 1 : 0)}, minmax(0, 1fr))`;
+
+  const fmtCell = (v: number | null) => fmtCellPct(v);
+
+  return (
+    <div className="ts-table-wrap">
+      <div className="ts-matrix" style={{ gridTemplateColumns: gridTemplate, minWidth: totalCols > 6 ? "640px" : undefined }} role="table" aria-label={`${period} returns`}>
+        <div className="ts-matrix-corner" role="columnheader" />
+        {labels.map((l) => (
+          <div key={l} className="ts-matrix-head" role="columnheader">{l}</div>
+        ))}
+        {showYearCol ? <div className="ts-matrix-head ts-matrix-year-head" role="columnheader">Year</div> : null}
+        {rows.map((r) => (
+          <div key={r.year} className="ts-matrix-row" role="row" style={{ display: "contents" }}>
+            <div className="ts-matrix-rowlabel" role="rowheader">{r.year}</div>
+            {r.cells.map((c, i) => (
+              <div
+                key={i}
+                className={"ts-matrix-cell" + (c.ret === null ? " is-empty" : "")}
+                style={{ background: cellBg(c.ret, maxAbs) }}
+                role="cell"
+                title={c.ret === null ? "no data" : `${labels[i]} ${r.year}: ${fmtPct(c.ret)}`}
+              >
+                {fmtCell(c.ret)}
+              </div>
+            ))}
+            {showYearCol ? (
+              <div
+                className={"ts-matrix-cell ts-matrix-year" + (r.yearRet === null ? " is-empty" : "")}
+                style={{ background: cellBg(r.yearRet, maxAbs) }}
+                role="cell"
+                title={r.yearRet === null ? "no data" : `${r.year} total: ${fmtPct(r.yearRet)}`}
+              >
+                {fmtCell(r.yearRet)}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
+++ b/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
@@ -3,11 +3,21 @@
  * Renders a strategy tearsheet from the unified TearsheetData JSON. Fetches
  * /strategies/<slug>.json at runtime (keeps the large series out of the static
  * HTML), then renders KPIs, the All/Long/Short breakdown, theme-aware SVG charts
- * (equity with a log/linear/symlog toggle, drawdown, per-trade and cumulative
- * P&L), and the trade log. "Download PDF" uses the browser's print-to-PDF.
+ * (equity with a log/linear scale toggle, drawdown, per-trade and cumulative
+ * P&L — all sharing one zoom/pan time window), a returns heatmap, and the trade
+ * log. "Download PDF" uses the browser's print-to-PDF.
  */
 import { useEffect, useMemo, useState } from "react";
-import { TimeSeries, ComboPnl, type Scale, type PnlScale } from "./charts";
+import {
+  TimeSeries,
+  ComboPnl,
+  ReturnsMatrix,
+  SegToggle,
+  type Scale,
+  type PnlScale,
+  type ReturnsPeriod,
+  type ViewWindow,
+} from "./charts";
 import { fmtCompact, fmtMoney, fmtNum, fmtPct, toneClass } from "./format";
 import { avgTradePct, cagrPct, calmar, tradesPerYear } from "./stats";
 import { type TearsheetBreakdown, type TearsheetData } from "./types";
@@ -61,6 +71,9 @@ export function TearsheetView({ slug }: { slug: string }) {
   const [err, setErr] = useState<string | null>(null);
   const [scale, setScale] = useState<Scale>("log");
   const [pnlScale, setPnlScale] = useState<PnlScale>("log");
+  const [period, setPeriod] = useState<ReturnsPeriod>("monthly");
+  // One shared x-window (date-span fraction) drives all three time-series charts.
+  const [view, setView] = useState<ViewWindow>({ lo: 0, hi: 1 });
 
   useEffect(() => {
     let alive = true;
@@ -83,6 +96,15 @@ export function TearsheetView({ slug }: { slug: string }) {
     return data.trades.map((t) => { cum += t.pnl; return { t: t.exit_date, v: cum }; });
   }, [data]);
 
+  // Canonical full date span — the equity curve endpoints. Passed to every
+  // time-series chart so the shared {lo,hi} fraction maps to the SAME calendar
+  // window everywhere (equity, drawdown, and the combo's trade filter), even
+  // though the series sample at different cadences.
+  const fullSpan = useMemo<[string, string] | undefined>(() => {
+    if (!data || data.equity_curve.length === 0) return undefined;
+    return [data.equity_curve[0].t, data.equity_curve[data.equity_curve.length - 1].t];
+  }, [data]);
+
   // Mean per-trade return — more representative than a dollar average, which is
   // dominated by late compounding trades.
   const avgTrade = useMemo(() => avgTradePct(data ? data.trades.map((t) => t.pnl_pct) : []), [data]);
@@ -94,6 +116,15 @@ export function TearsheetView({ slug }: { slug: string }) {
   // Calmar fallback when a Sharpe ratio is not available.
   const cagr = cagrPct(data.initial_capital, data.final_equity, data.period_start, data.period_end);
   const hasSharpe = data.sharpe_ratio !== null && data.sharpe_ratio !== undefined;
+
+  // Zoom/pan chrome: a Reset appears once the window is narrowed from full range.
+  const zoomed = view.lo > 0 || view.hi < 1;
+  const resetView = () => setView({ lo: 0, hi: 1 });
+  const ResetBtn = zoomed ? (
+    <button type="button" className="ts-reset" onClick={resetView} aria-label="Reset zoom to full range">
+      Reset
+    </button>
+  ) : null;
 
   const notes = [
     ...(data.data_source ? [`Data source: ${data.data_source}`] : []),
@@ -147,24 +178,35 @@ export function TearsheetView({ slug }: { slug: string }) {
       <section className="ts-panel">
         <div className="ts-panel-head">
           <span className="ts-panel-label">Equity curve</span>
-          <label className="ts-scale">
-            <span>Scale</span>
-            <select className="ts-select" value={scale} onChange={(e) => setScale(e.target.value as Scale)}>
-              <option value="log">Log</option>
-              <option value="linear">Linear</option>
-              <option value="symlog">Symlog</option>
-            </select>
-          </label>
+          <div className="ts-panel-tools">
+            <span className="ts-hint">scroll to zoom · drag to pan</span>
+            {ResetBtn}
+            <label className="ts-scale">
+              <span>Scale</span>
+              <SegToggle
+                label="Equity curve scale"
+                value={scale}
+                onChange={setScale}
+                options={[
+                  { value: "linear", label: "Linear" },
+                  { value: "log", label: "Log" },
+                ]}
+              />
+            </label>
+          </div>
         </div>
         <div className="ts-chart">
-          <TimeSeries points={data.equity_curve} height={340} scale={scale} tone="accent" fmt={fmtCompact} />
+          <TimeSeries points={data.equity_curve} height={340} scale={scale} tone="accent" fmt={fmtCompact} view={view} onView={setView} fullSpan={fullSpan} />
         </div>
       </section>
 
       <section className="ts-panel">
-        <div className="ts-panel-head"><span className="ts-panel-label">Drawdown (underwater)</span></div>
+        <div className="ts-panel-head">
+          <span className="ts-panel-label">Drawdown (underwater)</span>
+          {ResetBtn}
+        </div>
         <div className="ts-chart">
-          <TimeSeries points={data.drawdown_curve} height={220} scale="linear" tone="down" zeroBaseline fmt={(v) => v.toFixed(0) + "%"} />
+          <TimeSeries points={data.drawdown_curve} height={220} scale="linear" tone="down" zeroBaseline fmt={(v) => v.toFixed(0) + "%"} view={view} onView={setView} fullSpan={fullSpan} />
         </div>
       </section>
 
@@ -176,17 +218,45 @@ export function TearsheetView({ slug }: { slug: string }) {
       <section className="ts-panel">
         <div className="ts-panel-head">
           <span className="ts-panel-label">Trade P&amp;L — per-trade &amp; cumulative</span>
-          <label className="ts-scale">
-            <span>Cumulative</span>
-            <select className="ts-select" value={pnlScale} onChange={(e) => setPnlScale(e.target.value as PnlScale)}>
-              <option value="log">Log $</option>
-              <option value="pct">% of initial</option>
-            </select>
-          </label>
+          <div className="ts-panel-tools">
+            {ResetBtn}
+            <label className="ts-scale">
+              <span>Cumulative</span>
+              <SegToggle
+                label="Cumulative P&L scale"
+                value={pnlScale}
+                onChange={setPnlScale}
+                options={[
+                  { value: "log", label: "Log $" },
+                  { value: "pct", label: "%" },
+                ]}
+              />
+            </label>
+          </div>
         </div>
         <div className="ts-chart">
-          <ComboPnl pnl={data.trades.map((t) => t.pnl)} cumulative={cumPts} initialCapital={data.initial_capital} scale={pnlScale} height={300} />
+          <ComboPnl pnl={data.trades.map((t) => t.pnl)} cumulative={cumPts} initialCapital={data.initial_capital} scale={pnlScale} height={300} view={view} onView={setView} fullSpan={fullSpan} />
         </div>
+      </section>
+
+      <section className="ts-panel">
+        <div className="ts-panel-head">
+          <span className="ts-panel-label">Returns</span>
+          <label className="ts-scale">
+            <span>Period</span>
+            <SegToggle
+              label="Returns matrix period"
+              value={period}
+              onChange={setPeriod}
+              options={[
+                { value: "monthly", label: "Monthly" },
+                { value: "quarterly", label: "Quarterly" },
+                { value: "annual", label: "Annual" },
+              ]}
+            />
+          </label>
+        </div>
+        <ReturnsMatrix points={data.equity_curve} period={period} />
       </section>
 
       <section className="ts-panel">


### PR DESCRIPTION
Tearsheet chart enhancements per design review. All in `frontend/digiquant-web/`.

## 1. Scale controls → segmented buttons (Symlog dropped)
A reusable `SegToggle` (real `<button>`s, `aria-pressed`, `role="group"`) replaces the `<select>` dropdowns. Equity curve = **Linear / Log** only — Symlog removed from the UI (kept in `makeScale` for `ComboPnl`'s internal cumulative axis). ComboPnl = **Log $ / %**. Zero `<select>` remain.

## 2. Synchronized zoom / pan
One shared `{lo, hi}` date window in `tearsheet-view` drives **equity, drawdown, and the combo P&L** together:
- **Wheel** = cursor-centred zoom · **horizontal drag** = pan (width-preserving against the [0,1] edges) · **double-click** + a **Reset** button (appears when zoomed) = clear. Min window 2%.
- Zoom/pan on any chart re-windows all of them by the same calendar range. The equity-curve span is canonical; the two line charts map the same `[t0+lo·span, t0+hi·span]` window, and the combo filters trades by `exit_date` (keeping the global cumulative clipped to the window for continuity).

## 3. Returns matrix
A CSS-grid heatmap of period returns derived from the equity curve: years × **Jan–Dec / Q1–Q4 / Annual** (via the same `SegToggle`), plus a compounded **Year** column. Cells are green/red by sign with alpha scaled by magnitude; empty periods render blank.

## Verification (live, both themes, 375px)
- 3 segmented groups, **0** dropdowns; Symlog gone.
- Wheel-zoom on equity re-windows equity **and** drawdown to the identical range, the combo filters to the same window, and Reset appears.
- Matrix math compounds across months to the Year column (e.g. sol 2023 ≈ 2.7K%).
- `make score`: **10/10**. Production `next build` green (12 static pages).

Known minor caveats (from implementation): heatmap alpha is normalised per-granularity (a runaway month can flatten the scale); combo wheel-zoom centring is approximate since its x-axis is trade-indexed (cross-chart sync is exact). Pre-existing `data-theme` hydration warning is unrelated.

Fixes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)