### PR TITLE
feat(digiquant): tearsheet schema 1.1 — OHLC price bars + per-trade signal type

### DIFF
--- a/digiquant/ARCHITECTURE.md
+++ b/digiquant/ARCHITECTURE.md
@@ -212,6 +212,13 @@ The BTC/ETH/SOL Slapper tearsheets published on digiquant.io are produced end-to
 
 Structural settings (symbol, capital, sizing, 2018 trade window, precision) live in the **public** `strategies/settings.json`; proprietary indicator calibrations live in the **gitignored** `strategies/calibrations.json` (shape shown in `calibrations.example.json`). The `SlapperConfig.trade_start` gate mirrors Pine's `in_date_range` so warmup uses earlier bars while reported trades match the TradingView window.
 
+**Tearsheet schema 1.1** (`tearsheet_data.SCHEMA_VERSION`) adds two back-compatible fields the renderer can opt into:
+
+- `ohlc_bars: list[OHLCBar]` (`{t,o,h,l,c}`) — full-history candlesticks for the price chart. Note this spans the **entire** price series, while `equity_curve`/`trades` are scoped to the `trade_start` window — the renderer must not assume a shared x-axis. Defaults to `[]`; absent on 1.0 fixtures and on adapter paths with no bars.
+- Per-trade signal type carried in `TradeRecord.entry_label` on the Nautilus path. `SlapperStrategy` records each entry's signal family in a metadata-only side-channel (`_signal_log`, keyed by `(entry_date, direction)`) — pure metadata, never fed back into a trade decision. `generate_tearsheets._entry_label` joins it onto round-trip trades and maps to the Pine display taxonomy (`MR Long`/`Trend Long`/`MR&T Long`/`Reversal Long` + Short variants), matching `scripts/validation/pine_backtest.py`. A join miss falls back to `""`.
+
+Existing published fixtures stay at schema `1.0` (no `ohlc_bars`, blank `entry_label`) until regenerated, so consumers must tolerate both versions.
+
 ---
 
 ## 4. Data Model

--- a/digiquant/scripts/generate_tearsheets.py
+++ b/digiquant/scripts/generate_tearsheets.py
@@ -58,12 +58,48 @@ def _mult(direction: str, entry_price: float, price: float) -> float:
     return 1.0 + (entry_price - price) / entry_price
 
 
+# Signal-type → TradingView-style display label, mirroring the Pine validator's
+# taxonomy (scripts/validation/pine_backtest.py: "MR Long"/"Trend Long"/"MR&T Long",
+# "Reversal Long", + Short variants) so both engines emit the same entry_label strings.
+_SIGNAL_LABELS = {
+    ("mean_reversion", "long"): "MR Long",
+    ("mean_reversion", "short"): "MR Short",
+    ("trend", "long"): "Trend Long",
+    ("trend", "short"): "Trend Short",
+    ("trend+mr", "long"): "MR&T Long",
+    ("trend+mr", "short"): "MR&T Short",
+    ("reversal", "long"): "Reversal Long",
+    ("reversal", "short"): "Reversal Short",
+}
+
+
+def _entry_label(signal_type: str | None, direction: str) -> str:
+    """Map a recorded ``(signal_type, direction)`` to a Pine-style display label.
+
+    Returns "" when the type is missing or unrecognized, so a join miss (e.g. the
+    engine fills an entry on a different bar than the one the strategy recorded)
+    degrades gracefully to a blank label instead of raising.
+    """
+    if not signal_type:
+        return ""
+    return _SIGNAL_LABELS.get((signal_type, direction), "")
+
+
 def _dir_metrics(trades: list[dict], initial: float) -> dict:
     """All/Long/Short performance block from round-trip trades (pnl in quote ccy)."""
     if not trades:
-        return {"trades": 0, "net_profit": 0.0, "net_profit_pct": 0.0, "gross_profit": 0.0,
-                "gross_loss": 0.0, "percent_profitable": 0.0, "profit_factor": None,
-                "avg_trade": 0.0, "wins": 0, "losses": 0}
+        return {
+            "trades": 0,
+            "net_profit": 0.0,
+            "net_profit_pct": 0.0,
+            "gross_profit": 0.0,
+            "gross_loss": 0.0,
+            "percent_profitable": 0.0,
+            "profit_factor": None,
+            "avg_trade": 0.0,
+            "wins": 0,
+            "losses": 0,
+        }
     wins = [t for t in trades if t["pnl"] > 0]
     losses = [t for t in trades if t["pnl"] <= 0]
     gross_profit = sum(t["pnl"] for t in wins)
@@ -84,9 +120,13 @@ def _dir_metrics(trades: list[dict], initial: float) -> dict:
 
 
 def run_nautilus(strategy: str, symbol: str, ohlcv, settings: dict):
-    """Run the Nautilus backtest; return (positions_report_df, bars_list).
+    """Run the Nautilus backtest; return (positions_report_df, bars_list, ohlc_bars, signal_log).
 
     ``bars_list`` is [(date_str, close_float), ...] for the mark-to-market curve.
+    ``ohlc_bars`` is [(date_str, o, h, l, c), ...] for the candlestick chart.
+    ``signal_log`` maps (entry_date, direction) -> signal type recorded by the
+    strategy on entry ("mean_reversion"/"trend"/"trend+mr"/"reversal"); may be
+    empty for strategies that do not populate ``_signal_log``.
     """
     from datetime import datetime, timezone
 
@@ -114,6 +154,12 @@ def run_nautilus(strategy: str, symbol: str, ohlcv, settings: dict):
     closes = ohlcv["close"].to_list()
     vols = ohlcv["volume"].to_list() if "volume" in ohlcv.columns else None
     bars_list = [(str(t)[:10], float(c)) for t, c in zip(ts_vals, closes)]
+    # Full-history OHLC (date, o, h, l, c) for the candlestick chart. Spans the
+    # whole price series, not just the traded window — see run_and_write.
+    ohlc_bars = [
+        (str(t)[:10], float(o), float(h), float(low), float(c))
+        for t, o, h, low, c in zip(ts_vals, opens, highs, lows, closes)
+    ]
 
     price_prec = int(d.get("price_precision", 2))
     size_prec = int(d.get("size_precision", 8))
@@ -126,14 +172,20 @@ def run_nautilus(strategy: str, symbol: str, ohlcv, settings: dict):
         is_inverse=False,
         price_precision=price_prec,
         size_precision=size_prec,
-        price_increment=Price.from_str(f"{10 ** -price_prec:.{price_prec}f}"),
-        size_increment=Quantity.from_str(f"{10 ** -size_prec:.{size_prec}f}"),
+        price_increment=Price.from_str(f"{10**-price_prec:.{price_prec}f}"),
+        size_increment=Quantity.from_str(f"{10**-size_prec:.{size_prec}f}"),
         max_quantity=None,
-        min_quantity=Quantity.from_str(f"{10 ** -size_prec:.{size_prec}f}"),
-        max_notional=None, min_notional=None, max_price=None, min_price=None,
-        margin_init=Decimal("0"), margin_maint=Decimal("0"),
-        maker_fee=Decimal("0"), taker_fee=Decimal("0"),
-        ts_event=0, ts_init=0,
+        min_quantity=Quantity.from_str(f"{10**-size_prec:.{size_prec}f}"),
+        max_notional=None,
+        min_notional=None,
+        max_price=None,
+        min_price=None,
+        margin_init=Decimal("0"),
+        margin_maint=Decimal("0"),
+        maker_fee=Decimal("0"),
+        taker_fee=Decimal("0"),
+        ts_event=0,
+        ts_init=0,
     )
     bar_type = BarType.from_str(f"{symbol}.{venue_name}-{d.get('bar_spec', '1-DAY-LAST')}-EXTERNAL")
 
@@ -167,20 +219,28 @@ def run_nautilus(strategy: str, symbol: str, ohlcv, settings: dict):
 
     engine = BacktestEngine()
     engine.add_venue(
-        venue=Venue(venue_name), oms_type=OmsType.NETTING, account_type=AccountType.MARGIN,
-        base_currency=USD, starting_balances=[Money(d["initial_capital"], USD)],
+        venue=Venue(venue_name),
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.MARGIN,
+        base_currency=USD,
+        starting_balances=[Money(d["initial_capital"], USD)],
     )
     engine.add_instrument(inst)
     engine.add_data(bars)
     strat, _ = get_strategy(
-        strategy_name=strategy, instrument_id=inst.id, bar_type=bar_type,
-        trade_size=Decimal(1), size_pct_equity=float(d["size_pct_equity"]),
+        strategy_name=strategy,
+        instrument_id=inst.id,
+        bar_type=bar_type,
+        trade_size=Decimal(1),
+        size_pct_equity=float(d["size_pct_equity"]),
     )
     engine.add_strategy(strat)
     engine.run()
     positions = engine.trader.generate_positions_report()
+    # Read the strategy's signal-type side-channel BEFORE dispose() tears it down.
+    signal_log = dict(getattr(strat, "_signal_log", {}) or {})
     engine.dispose()
-    return positions, bars_list
+    return positions, bars_list, ohlc_bars, signal_log
 
 
 def trades_from_positions(positions) -> list[dict]:
@@ -189,6 +249,7 @@ def trades_from_positions(positions) -> list[dict]:
     The Nautilus report is read row-wise; missing exits (NaT/NaN) are detected via
     self-inequality, avoiding non-Polars dataframe helpers in DigiQuant code.
     """
+
     def _missing(x) -> bool:
         return x is None or x != x  # NaN/NaT compare unequal to themselves
 
@@ -198,18 +259,22 @@ def trades_from_positions(positions) -> list[dict]:
         direction = "long" if "BUY" in entry else "short"
         ts_close = r.get("ts_closed")
         avg_close = r.get("avg_px_close")
-        rows.append({
-            "direction": direction,
-            "entry_date": str(r.get("ts_opened"))[:10],
-            "entry_price": float(r.get("avg_px_open") or 0.0),
-            "exit_date": "" if _missing(ts_close) else str(ts_close)[:10],
-            "exit_price": None if _missing(avg_close) else float(avg_close),
-        })
+        rows.append(
+            {
+                "direction": direction,
+                "entry_date": str(r.get("ts_opened"))[:10],
+                "entry_price": float(r.get("avg_px_open") or 0.0),
+                "exit_date": "" if _missing(ts_close) else str(ts_close)[:10],
+                "exit_price": None if _missing(avg_close) else float(avg_close),
+            }
+        )
     rows.sort(key=lambda t: t["entry_date"])
     return rows
 
 
-def build_equity_and_trades(trades: list[dict], bars_list, initial_capital: float, trade_start: str):
+def build_equity_and_trades(
+    trades: list[dict], bars_list, initial_capital: float, trade_start: str
+):
     """Walk bars to build a TV-style MTM equity curve and per-trade PnL.
 
     Equity compounds at 100% per position (bankruptcy-floored at 0), matching the
@@ -231,15 +296,31 @@ def build_equity_and_trades(trades: list[dict], bars_list, initial_capital: floa
             ep = pos["trade"]["exit_price"] if pos["trade"]["exit_price"] is not None else close
             equity = max(pos["entry_equity"] * _mult(pos["direction"], pos["entry_price"], ep), 0.0)
             t = pos["trade"]
-            closed.append({**t, "exit_price": ep, "pnl": equity - pos["entry_equity"],
-                           "pnl_pct": (equity / pos["entry_equity"] - 1) * 100 if pos["entry_equity"] else 0.0,
-                           "equity_after": equity})
+            closed.append(
+                {
+                    **t,
+                    "exit_price": ep,
+                    "pnl": equity - pos["entry_equity"],
+                    "pnl_pct": (equity / pos["entry_equity"] - 1) * 100
+                    if pos["entry_equity"]
+                    else 0.0,
+                    "equity_after": equity,
+                }
+            )
             pos = None
         if pos is None and date in entries:
             t = entries[date]
-            pos = {"direction": t["direction"], "entry_price": t["entry_price"],
-                   "entry_equity": equity, "trade": t}
-        mtm = pos["entry_equity"] * _mult(pos["direction"], pos["entry_price"], close) if pos else equity
+            pos = {
+                "direction": t["direction"],
+                "entry_price": t["entry_price"],
+                "entry_equity": equity,
+                "trade": t,
+            }
+        mtm = (
+            pos["entry_equity"] * _mult(pos["direction"], pos["entry_price"], close)
+            if pos
+            else equity
+        )
         equity_curve.append((date, max(mtm, 0.0)))
 
     # Open position at the end → unrealized, listed like TradingView's open trade.
@@ -247,14 +328,23 @@ def build_equity_and_trades(trades: list[dict], bars_list, initial_capital: floa
         last_close = bars_list[-1][1]
         eq = max(pos["entry_equity"] * _mult(pos["direction"], pos["entry_price"], last_close), 0.0)
         t = pos["trade"]
-        closed.append({**t, "exit_date": "", "exit_price": last_close,
-                       "pnl": eq - pos["entry_equity"],
-                       "pnl_pct": (eq / pos["entry_equity"] - 1) * 100 if pos["entry_equity"] else 0.0,
-                       "equity_after": eq, "exit_reason": "open"})
+        closed.append(
+            {
+                **t,
+                "exit_date": "",
+                "exit_price": last_close,
+                "pnl": eq - pos["entry_equity"],
+                "pnl_pct": (eq / pos["entry_equity"] - 1) * 100 if pos["entry_equity"] else 0.0,
+                "equity_after": eq,
+                "exit_reason": "open",
+            }
+        )
     return equity_curve, closed
 
 
-def run_and_write(strategy: str, symbol: str, settings: dict, cache_dir: Path, output_dir: Path) -> dict | None:
+def run_and_write(
+    strategy: str, symbol: str, settings: dict, cache_dir: Path, output_dir: Path
+) -> dict | None:
     from digiquant.data.prices.history_cache import load_cached
     from digiquant.tearsheet_data import from_nautilus_run
 
@@ -268,7 +358,7 @@ def run_and_write(strategy: str, symbol: str, settings: dict, cache_dir: Path, o
     trade_start = d.get("trade_start") or ""
 
     logger.info("Running Nautilus backtest: %s (%s, %d bars)", strategy, symbol, len(ohlcv))
-    positions, bars_list = run_nautilus(strategy, symbol, ohlcv, settings)
+    positions, bars_list, ohlc_bars, signal_log = run_nautilus(strategy, symbol, ohlcv, settings)
     trades = trades_from_positions(positions)
     equity_curve, closed = build_equity_and_trades(trades, bars_list, initial_capital, trade_start)
 
@@ -287,35 +377,69 @@ def run_and_write(strategy: str, symbol: str, settings: dict, cache_dir: Path, o
     window = [t for t in equity_curve]
     period = f"{window[0][0]} → {window[-1][0]}" if window else ""
     summary = {
-        "strategy": strategy, "symbol": symbol, "period": period,
-        "bars": len(window), "initial_capital": initial_capital, "final_equity": final_equity,
-        "net_profit_pct": all_m["net_profit_pct"], "max_drawdown_pct": max_dd,
-        "all": all_m, "long": _dir_metrics(longs, initial_capital),
+        "strategy": strategy,
+        "symbol": symbol,
+        "period": period,
+        "bars": len(window),
+        "initial_capital": initial_capital,
+        "final_equity": final_equity,
+        "net_profit_pct": all_m["net_profit_pct"],
+        "max_drawdown_pct": max_dd,
+        "all": all_m,
+        "long": _dir_metrics(longs, initial_capital),
         "short": _dir_metrics(shorts, initial_capital),
     }
-    trade_dicts = [{**t, "entry_label": t.get("exit_reason", "")} for t in closed]
+    # entry_label carries the per-trade signal type (MR/Trend/MR&T/Reversal),
+    # joined on (entry_date, direction) from the strategy's signal log. Misses
+    # (e.g. a fill recorded on a different bar) fall back to "".
+    trade_dicts = [
+        {
+            **t,
+            "entry_label": _entry_label(
+                signal_log.get((t["entry_date"], t["direction"])), t["direction"]
+            ),
+        }
+        for t in closed
+    ]
 
     td = from_nautilus_run(
-        summary, trade_dicts, equity_curve,
+        summary,
+        trade_dicts,
+        equity_curve,
         data_source=d.get("data_source", "Coinbase daily OHLCV (CCXT)"),
-        notes=[f"NautilusTrader backtest, {settings['strategies'][strategy].get('label', strategy)}; "
-               f"100% equity compounding, trade window from {trade_start}."],
+        ohlc_bars=ohlc_bars,
+        notes=[
+            f"NautilusTrader backtest, {settings['strategies'][strategy].get('label', strategy)}; "
+            f"100% equity compounding, trade window from {trade_start}."
+        ],
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     out_path = output_dir / f"{strategy}.json"
     out_path.write_text(td.to_json())
-    logger.info("  Wrote %s | net %.0f%% | maxDD %.1f%% | PF %.2f | win %.1f%% | %d trades",
-                out_path, td.net_profit_pct, td.max_drawdown_pct,
-                td.profit_factor or 0.0, td.win_rate_pct, td.total_trades)
+    logger.info(
+        "  Wrote %s | net %.0f%% | maxDD %.1f%% | PF %.2f | win %.1f%% | %d trades",
+        out_path,
+        td.net_profit_pct,
+        td.max_drawdown_pct,
+        td.profit_factor or 0.0,
+        td.win_rate_pct,
+        td.total_trades,
+    )
 
     return {
-        "strategy": td.strategy, "symbol": td.symbol, "engine": td.engine,
+        "strategy": td.strategy,
+        "symbol": td.symbol,
+        "engine": td.engine,
         "label": settings["strategies"][strategy].get("label", strategy),
-        "period_start": td.period_start, "period_end": td.period_end,
-        "net_profit_pct": td.net_profit_pct, "max_drawdown_pct": td.max_drawdown_pct,
-        "profit_factor": td.profit_factor, "win_rate_pct": td.win_rate_pct,
-        "total_trades": td.total_trades, "generated_at": td.generated_at,
+        "period_start": td.period_start,
+        "period_end": td.period_end,
+        "net_profit_pct": td.net_profit_pct,
+        "max_drawdown_pct": td.max_drawdown_pct,
+        "profit_factor": td.profit_factor,
+        "win_rate_pct": td.win_rate_pct,
+        "total_trades": td.total_trades,
+        "generated_at": td.generated_at,
         "href": f"/strategies/{td.strategy}",
     }
 
@@ -323,10 +447,16 @@ def run_and_write(strategy: str, symbol: str, settings: dict, cache_dir: Path, o
 def main() -> None:
     settings = load_settings()
     strategies = settings["strategies"]
-    parser = argparse.ArgumentParser(description="Generate Nautilus tearsheet JSONs for digiquant.io")
+    parser = argparse.ArgumentParser(
+        description="Generate Nautilus tearsheet JSONs for digiquant.io"
+    )
     parser.add_argument("--strategy", choices=list(strategies.keys()), help="Run a single strategy")
-    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE, help="OHLCV cache directory")
-    parser.add_argument("--output-dir", type=Path, default=FRONTEND_STRATEGIES, help="Output directory")
+    parser.add_argument(
+        "--cache-dir", type=Path, default=DEFAULT_CACHE, help="OHLCV cache directory"
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=FRONTEND_STRATEGIES, help="Output directory"
+    )
     args = parser.parse_args()
 
     targets = {args.strategy: strategies[args.strategy]} if args.strategy else strategies
@@ -342,7 +472,9 @@ def main() -> None:
     if entries:
         idx_path = args.output_dir / "index.json"
         if args.strategy and idx_path.exists():
-            existing = [e for e in json.loads(idx_path.read_text()) if e["strategy"] != args.strategy]
+            existing = [
+                e for e in json.loads(idx_path.read_text()) if e["strategy"] != args.strategy
+            ]
             entries = existing + entries
         idx_path.write_text(json.dumps(entries, indent=2))
         logger.info("Updated index.json (%d strategies)", len(entries))

--- a/digiquant/src/digiquant/strategies/slapper.py
+++ b/digiquant/src/digiquant/strategies/slapper.py
@@ -16,6 +16,7 @@ Reversal stop (BTC only, use_reversal_stop=True):
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 
@@ -132,17 +133,19 @@ class SlapperStrategy(Strategy):
         self._is_mr_only_entry: bool = False
         self._signal_close_price: float | None = None
 
+        # Per-entry signal-type side-channel for the tearsheet generator. Maps
+        # (entry_date "YYYY-MM-DD", direction "long"/"short") -> signal type, one
+        # of "mean_reversion" / "trend" / "trend+mr" / "reversal". Pure metadata:
+        # it never feeds back into a trade decision, so it cannot change behavior.
+        self._signal_log: dict[tuple[str, str], str] = {}
+
         self._instrument: Instrument | None = None
 
         # Precompute the trade-window threshold in epoch-ns for cheap per-bar gating.
         self._trade_start_ns: int | None = None
         if config.trade_start:
-            from datetime import datetime, timezone
-
             self._trade_start_ns = int(
-                datetime.fromisoformat(config.trade_start)
-                .replace(tzinfo=timezone.utc)
-                .timestamp()
+                datetime.fromisoformat(config.trade_start).replace(tzinfo=timezone.utc).timestamp()
                 * 1_000_000_000
             )
 
@@ -242,9 +245,13 @@ class SlapperStrategy(Strategy):
         # signals from `trade_start` onward (Pine `in_date_range`).
         in_window = self._trade_start_ns is None or bar.ts_event >= self._trade_start_ns
 
+        # Bar date as "YYYY-MM-DD" UTC — the join key the tearsheet generator uses
+        # against the positions report's ts_opened[:10]. Computed once per bar.
+        bar_date = self._bar_date(bar.ts_event)
+
         # ── Reversal stop (BTC Slapper only) ─────────────────────────────────
         if self.config.use_reversal_stop and in_window:
-            self._check_reversal_stop(close)
+            self._check_reversal_stop(close, bar_date)
 
         # ── Entries — close-then-open reversal, pyramiding=0 (Pine parity) ────
         # See rsi_momentum.py:73-108 for the established pattern.
@@ -267,6 +274,13 @@ class SlapperStrategy(Strategy):
             if entered is not None:
                 self._is_mr_only_entry = mr_long and not trend_long
                 self._signal_close_price = close
+                self._signal_log[(bar_date, "long")] = (
+                    "trend+mr"
+                    if mr_long and trend_long
+                    else "trend"
+                    if trend_long
+                    else "mean_reversion"
+                )
 
         elif sell_signal and in_window and self.config.enable_short:
             if self.portfolio.is_flat(self.config.instrument_id):
@@ -280,6 +294,13 @@ class SlapperStrategy(Strategy):
             if entered is not None:
                 self._is_mr_only_entry = mr_short and not trend_short
                 self._signal_close_price = close
+                self._signal_log[(bar_date, "short")] = (
+                    "trend+mr"
+                    if mr_short and trend_short
+                    else "trend"
+                    if trend_short
+                    else "mean_reversion"
+                )
 
         # Reset the mr-only flag only when we are flat AND did not just submit an
         # entry this bar (a fresh entry's fill is still pending, so is_flat() is
@@ -327,11 +348,23 @@ class SlapperStrategy(Strategy):
         )
         self.submit_order(order)
 
-    def _check_reversal_stop(self, close: float) -> None:
+    @staticmethod
+    def _bar_date(ts_event: int) -> str:
+        """Format a bar's epoch-ns ``ts_event`` as a UTC ``YYYY-MM-DD`` date.
+
+        Mirrors the tearsheet generator's ``str(ts_opened)[:10]`` join key so a
+        recorded signal type lines up with the round-trip trade it produced.
+        Integer-divides ns→s (``//``) — float division would exceed 2^53 for
+        ns timestamps and risk a sub-second rounding carry across a day boundary.
+        """
+        return datetime.fromtimestamp(ts_event // 1_000_000_000, tz=timezone.utc).date().isoformat()
+
+    def _check_reversal_stop(self, close: float, bar_date: str) -> None:
         """Reverse position when MR-only entry exceeds drawdown threshold.
 
         Pine closes the losing MR position and immediately enters the opposite
         side (a reversal). We replicate: close, then open the opposite side.
+        ``bar_date`` is used only to tag the reversal entry in ``_signal_log``.
         """
         if not self._is_mr_only_entry or self._signal_close_price is None:
             return
@@ -343,6 +376,7 @@ class SlapperStrategy(Strategy):
             if dd_pct > threshold and self.config.enable_short:
                 self.close_all_positions(self.config.instrument_id)
                 self._enter(OrderSide.SELL, close)
+                self._signal_log[(bar_date, "short")] = "reversal"
                 self._is_mr_only_entry = False  # reversal aligns with trend
 
         elif self.portfolio.is_net_short(self.config.instrument_id) and trend == 1.0:
@@ -350,6 +384,7 @@ class SlapperStrategy(Strategy):
             if dd_pct > threshold and self.config.enable_long:
                 self.close_all_positions(self.config.instrument_id)
                 self._enter(OrderSide.BUY, close)
+                self._signal_log[(bar_date, "long")] = "reversal"
                 self._is_mr_only_entry = False
 
     def on_stop(self) -> None:
@@ -382,6 +417,7 @@ class SlapperStrategy(Strategy):
         self._prev_selected_rsi = None
         self._is_mr_only_entry = False
         self._signal_close_price = None
+        self._signal_log = {}
 
 
 # ─── Settings & calibrations ──────────────────────────────────────────────────

--- a/digiquant/src/digiquant/tearsheet_data.py
+++ b/digiquant/src/digiquant/tearsheet_data.py
@@ -17,7 +17,10 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field
 
-SCHEMA_VERSION = "1.0"
+# 1.1 — added optional ``ohlc_bars`` (price candlesticks) + per-trade signal type
+# carried in ``entry_label`` (MR/Trend/MR&T) on the nautilus path. Back-compatible:
+# 1.0 consumers ignore ``ohlc_bars``; 1.1 fixtures may carry an empty list.
+SCHEMA_VERSION = "1.1"
 
 
 class SeriesPoint(BaseModel):
@@ -25,6 +28,20 @@ class SeriesPoint(BaseModel):
 
     t: str = Field(..., description="ISO date or datetime")
     v: float = Field(..., description="Value at t")
+
+
+class OHLCBar(BaseModel):
+    """One OHLC price bar for the candlestick price chart.
+
+    Single-letter ``t/o/h/l/c`` keys mirror ``SeriesPoint``'s compact ``t/v``
+    style and keep the per-bar JSON small across a multi-year daily series.
+    """
+
+    t: str = Field(..., description="ISO date or datetime")
+    o: float = Field(..., description="Open")
+    h: float = Field(..., description="High")
+    l: float = Field(..., description="Low")  # noqa: E741 — OHLC convention, compact chart key
+    c: float = Field(..., description="Close")
 
 
 class StatBlock(BaseModel):
@@ -98,6 +115,9 @@ class TearsheetData(BaseModel):
     # ── Series + trades ───────────────────────────────────────────────────
     equity_curve: list[SeriesPoint] = Field(default_factory=list)
     drawdown_curve: list[SeriesPoint] = Field(default_factory=list)
+    # Full-history OHLC price bars for the candlestick chart. Defaults to []
+    # for back-compat: 1.0 fixtures (and adapters that have no bars) omit it.
+    ohlc_bars: list[OHLCBar] = Field(default_factory=list)
     trades: list[TradeRecord] = Field(default_factory=list)
 
     notes: list[str] = Field(default_factory=list)
@@ -155,12 +175,15 @@ def _build_tearsheet(
     data_source: str = "",
     generated_at: str | None = None,
     notes: Sequence[str] | None = None,
+    ohlc_bars: Sequence[tuple[str, float, float, float, float]] | None = None,
 ) -> TearsheetData:
     """Shared builder for the summary-based adapters (``from_pine`` / ``from_nautilus_run``).
 
     ``summary`` is a dict with All/Long/Short metric blocks (keys mirroring
     ``pine_backtest.summarize``); ``trades`` is a sequence of per-closed-trade
     mappings; ``equity_curve`` is the ``(date, mark-to-market equity)`` list.
+    ``ohlc_bars`` is an optional ``(date, open, high, low, close)`` list for the
+    candlestick price chart (raw tuples so callers need not import ``OHLCBar``).
     """
     overall = summary.get("all")
     overall_block = _stat_block(overall if isinstance(overall, Mapping) else None)
@@ -214,6 +237,7 @@ def _build_tearsheet(
         short=_stat_block(short_block if isinstance(short_block, Mapping) else None),
         equity_curve=[SeriesPoint(t=ts, v=v) for ts, v in equity_curve],
         drawdown_curve=_drawdown_from_equity(equity_curve, initial_capital),
+        ohlc_bars=[OHLCBar(t=t, o=o, h=h, l=low, c=c) for t, o, h, low, c in (ohlc_bars or [])],
         trades=trade_records,
         notes=list(notes or []),
     )
@@ -227,11 +251,18 @@ def from_pine(
     data_source: str = "",
     generated_at: str | None = None,
     notes: Sequence[str] | None = None,
+    ohlc_bars: Sequence[tuple[str, float, float, float, float]] | None = None,
 ) -> TearsheetData:
     """Adapt the Pine validation backtester output into ``TearsheetData`` (engine=pine)."""
     return _build_tearsheet(
-        summary, trades, equity_curve,
-        engine="pine", data_source=data_source, generated_at=generated_at, notes=notes,
+        summary,
+        trades,
+        equity_curve,
+        engine="pine",
+        data_source=data_source,
+        generated_at=generated_at,
+        notes=notes,
+        ohlc_bars=ohlc_bars,
     )
 
 
@@ -243,13 +274,20 @@ def from_nautilus_run(
     data_source: str = "",
     generated_at: str | None = None,
     notes: Sequence[str] | None = None,
+    ohlc_bars: Sequence[tuple[str, float, float, float, float]] | None = None,
 ) -> TearsheetData:
     """Adapt a NautilusTrader backtest (round-trip positions + MTM equity) into
     ``TearsheetData`` (engine=nautilus). Same summary/trades/equity shape as
     ``from_pine`` so the renderer consumes one schema regardless of engine."""
     return _build_tearsheet(
-        summary, trades, equity_curve,
-        engine="nautilus", data_source=data_source, generated_at=generated_at, notes=notes,
+        summary,
+        trades,
+        equity_curve,
+        engine="nautilus",
+        data_source=data_source,
+        generated_at=generated_at,
+        notes=notes,
+        ohlc_bars=ohlc_bars,
     )
 
 
@@ -324,6 +362,7 @@ def from_nautilus(
 
 __all__ = [
     "SCHEMA_VERSION",
+    "OHLCBar",
     "SeriesPoint",
     "StatBlock",
     "TearsheetData",

--- a/tests/dq/test_tearsheet_data.py
+++ b/tests/dq/test_tearsheet_data.py
@@ -6,18 +6,38 @@ runs in the base (non-Nautilus) test environment.
 
 from __future__ import annotations
 
+import importlib.util
 import json
+from pathlib import Path
 
 import pytest
 
 from digiquant.tearsheet_data import (
     SCHEMA_VERSION,
+    OHLCBar,
     TearsheetData,
     from_nautilus,
+    from_nautilus_run,
     from_pine,
 )
 
 pytestmark = pytest.mark.unit
+
+
+def _load_generator():
+    """Import the (non-package) tearsheet generator script by path.
+
+    Nautilus imports are local to ``run_nautilus``, so importing the module is
+    safe in the base test environment; only ``_entry_label`` is exercised here.
+    """
+    script = (
+        Path(__file__).resolve().parents[2] / "digiquant" / "scripts" / "generate_tearsheets.py"
+    )
+    spec = importlib.util.spec_from_file_location("generate_tearsheets", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _pine_summary() -> dict:
@@ -141,3 +161,61 @@ def test_from_nautilus_duck_types_result() -> None:
     assert ts.net_profit == 500.0
     assert ts.final_equity == pytest.approx(1500.0)  # initial + pnl when no curve
     assert ts.total_trades == 12
+
+
+# ── Schema 1.1: ohlc_bars + signal-type entry_label ──────────────────────────
+
+
+def test_schema_version_is_1_1() -> None:
+    assert SCHEMA_VERSION == "1.1"
+
+
+def test_ohlc_bars_default_empty_and_back_compatible() -> None:
+    # Adapters without OHLC (and 1.0 fixtures) leave ohlc_bars as [].
+    ts = from_pine(_pine_summary(), _pine_trades(), equity_curve=[])
+    assert ts.ohlc_bars == []
+    # A 1.0-style payload (no ohlc_bars key) must still validate.
+    again = TearsheetData.model_validate({"strategy": "x", "symbol": "Y", "generated_at": "t"})
+    assert again.ohlc_bars == []
+
+
+def test_ohlc_bars_roundtrip() -> None:
+    bars = [("2020-01-01", 100.0, 110.0, 95.0, 105.0), ("2020-01-02", 105.0, 120.0, 104.0, 118.0)]
+    ts = from_nautilus_run(
+        _pine_summary(), _pine_trades(), equity_curve=[("2020-01-01", 1000.0)], ohlc_bars=bars
+    )
+    assert len(ts.ohlc_bars) == 2
+    assert ts.ohlc_bars[0] == OHLCBar(t="2020-01-01", o=100.0, h=110.0, l=95.0, c=105.0)
+    payload = json.loads(ts.to_json())
+    assert payload["schema_version"] == "1.1"
+    assert payload["ohlc_bars"][1] == {
+        "t": "2020-01-02",
+        "o": 105.0,
+        "h": 120.0,
+        "l": 104.0,
+        "c": 118.0,
+    }
+    # Re-validate to prove the serialized shape is contract-faithful.
+    again = TearsheetData.model_validate(payload)
+    assert again.ohlc_bars[0].c == 105.0
+
+
+@pytest.mark.parametrize(
+    ("signal_type", "direction", "expected"),
+    [
+        ("mean_reversion", "long", "MR Long"),
+        ("mean_reversion", "short", "MR Short"),
+        ("trend", "long", "Trend Long"),
+        ("trend", "short", "Trend Short"),
+        ("trend+mr", "long", "MR&T Long"),
+        ("trend+mr", "short", "MR&T Short"),
+        ("reversal", "long", "Reversal Long"),
+        ("reversal", "short", "Reversal Short"),
+        (None, "long", ""),  # join miss → blank, no crash
+        ("", "short", ""),  # blank type → blank
+        ("bogus", "long", ""),  # unknown type → blank
+    ],
+)
+def test_entry_label_mirrors_pine_taxonomy(signal_type, direction, expected) -> None:
+    gen = _load_generator()
+    assert gen._entry_label(signal_type, direction) == expected


### PR DESCRIPTION
Backend support for the upcoming tearsheet candlestick price chart.

## Changes
- `tearsheet_data.py`: `SCHEMA_VERSION` 1.0 → **1.1**; new optional `ohlc_bars: list[OHLCBar]` (compact `t/o/h/l/c`) defaulting to `[]` — **back-compatible** (1.0 consumers ignore it). `_build_tearsheet` / `from_pine` / `from_nautilus_run` take raw `(date,o,h,l,c)` tuples so callers needn't import the model.
- `generate_tearsheets.py`: emit OHLC bars for the fixtures.
- `slapper.py`: carry the per-trade signal type (MR / Trend / MR&T) in `entry_label` on the nautilus path.
- `tests/dq/test_tearsheet_data.py`: **19 pass** (incl. new OHLC + back-compat cases).

## Notes
- Ruff-clean, `make score` 10/10, tests pass locally.
- The frontend already carries the matching `OHLCBar`/`ohlc_bars` shape in `types.ts`; the candlestick chart renders once fixtures carry `ohlc_bars`.
- **Manual step (maintainer):** regenerate the published tearsheet fixtures with OHLC to light up candlesticks.
- **Branching:** landed via `task→develop`, consistent with the current digiquant.io effort — `module/digiquant` is 15 commits behind develop, so routing through it risks editing stale code (the scenario CLAUDE.md's 2026-06-17 note warns about). Flagging for the digiquant module owner to confirm.

Fixes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)