### PR TITLE
feat(olympus): display serif → Fraunces (v7 house face)

### DIFF
--- a/frontend/olympus/app/globals.css
+++ b/frontend/olympus/app/globals.css
@@ -43,14 +43,14 @@
      next/font family would miss — cf. #684). */
   --font-sans: var(--font-geist-sans), system-ui, -apple-system, sans-serif;
   --font-mono: var(--font-geist-mono), ui-monospace, monospace;
-  --font-display: var(--font-instrument-serif), Georgia, "Times New Roman", serif;
+  --font-display: var(--font-fraunces), Georgia, "Times New Roman", serif;
 }
 
-/* tokens.css declares --font-display: "Instrument Serif" literally under
-   :root[data-theme]; re-declare here (equal specificity, later source) so the
-   next/font-loaded, CSP-safe face is used instead of a name that never ships. */
+/* tokens.css declares --font-display literally under :root[data-theme];
+   re-declare here (equal specificity, later source) so the next/font-loaded,
+   CSP-safe Fraunces face is used instead of a name that never ships. */
 :root[data-theme] {
-  --font-display: var(--font-instrument-serif), Georgia, "Times New Roman", serif;
+  --font-display: var(--font-fraunces), Georgia, "Times New Roman", serif;
 }
 
 /* ── Base ──────────────────────────────────────────────────────────────── */

--- a/frontend/olympus/app/layout.tsx
+++ b/frontend/olympus/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import { ReactNode } from 'react';
-import { Geist, Geist_Mono, Instrument_Serif } from 'next/font/google';
+import { Geist, Geist_Mono, Fraunces } from 'next/font/google';
 import { DashboardProvider } from '@/lib/dashboard-context';
 import { AppShellProvider } from '@/components/app-shell-context';
 import { ThemeProvider } from '@/components/theme-provider';
@@ -24,12 +24,11 @@ const geistMono = Geist_Mono({
   display: 'swap',
 });
 
-// Editorial display serif — the digiquant.io house headline face. Self-hosted by
-// next/font so it satisfies the Olympus CSP (font-src 'self' data:).
-const instrumentSerif = Instrument_Serif({
+// Editorial display serif — the digiquant.io house headline face (Fraunces).
+// Self-hosted by next/font so it satisfies the Olympus CSP (font-src 'self' data:).
+const fraunces = Fraunces({
   subsets: ['latin'],
-  weight: '400',
-  variable: '--font-instrument-serif',
+  variable: '--font-fraunces',
   display: 'swap',
 });
 
@@ -44,11 +43,11 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={instrumentSerif.variable} suppressHydrationWarning>
+    <html lang="en" className={fraunces.variable} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT }} />
       </head>
-      <body className={`qn-blueprint-bg accent-digiquant min-h-screen bg-bg-primary text-text-primary antialiased ${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable}`}>
+      <body className={`qn-blueprint-bg accent-digiquant min-h-screen bg-bg-primary text-text-primary antialiased ${geistSans.variable} ${geistMono.variable} ${fraunces.variable}`}>
         <ThemeProvider>
           <MotionLayer />
           <DashboardProvider>


### PR DESCRIPTION
Aligns Olympus's display serif to the v7 house headline face used on digiquant.io.

- `layout.tsx`: `Instrument_Serif` → `Fraunces` (next/font, self-hosted/CSP-safe; `--font-fraunces`), applied on html + body.
- `globals.css`: `--font-display` references `var(--font-fraunces)` in both the base and `:root[data-theme]` scopes; Geist sans/mono unchanged.

Low-risk font-family swap (same usage slots), no layout/functional changes. Build clean (18 pages), `make score` 10/10.

**Verification:** the in-session headless preview is down (it can no longer render even known-good pages this session), so this is build-verified + parity (Fraunces is the verified digiquant.io face). Please eyeball Olympus headings in a real browser before merge.

**Deferred to a visual-capable session:** Olympus radii → `--r-*` token scale + KPI/panel gradient polish; digichat `data-theme` participation.

Fixes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)