### PR TITLE
chore: portable .claude/launch.json (resolve repo root, drop hardcoded home)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,25 +4,25 @@
     {
       "name": "DigiGraph",
       "runtimeExecutable": "/bin/bash",
-      "runtimeArgs": ["-c", "cd /Users/chrisstefan/Code/digithings && set -a; [ -f .env ] && source .env; set +a; export DIGI_PROJECT_CONFIG=./projects/local/config.yaml; export OPENAI_API_BASE=https://ollama.com/v1; [ -n \"$OLLAMA_API_KEY\" ] && export OPENAI_API_KEY=\"$OLLAMA_API_KEY\"; export OLLAMA_MODEL=minimax-m2.7:cloud; export DIGI_ALLOWED_ORIGINS=http://localhost:5174,http://localhost:3000; export DIGIKEY_PUBLIC_KEY_PEM=$(cat ./projects/local/dev_public_key.pem); export DIGIKEY_ISSUER=digikey-local; export DIGIKEY_AUDIENCE=digi-ecosystem; PYTHONPATH=/Users/chrisstefan/Code/digithings/digigraph/src:/Users/chrisstefan/Code/digithings/digiquant/src:/Users/chrisstefan/Code/digithings .venv/bin/python -m uvicorn digigraph.server:app --host 127.0.0.1 --port 18000"],
+      "runtimeArgs": ["-c", "cd \"$(git rev-parse --show-toplevel)\" && set -a; [ -f .env ] && source .env; set +a; export DIGI_PROJECT_CONFIG=./projects/local/config.yaml; export OPENAI_API_BASE=https://ollama.com/v1; [ -n \"$OLLAMA_API_KEY\" ] && export OPENAI_API_KEY=\"$OLLAMA_API_KEY\"; export OLLAMA_MODEL=minimax-m2.7:cloud; export DIGI_ALLOWED_ORIGINS=http://localhost:5174,http://localhost:3000; export DIGIKEY_PUBLIC_KEY_PEM=$(cat ./projects/local/dev_public_key.pem); export DIGIKEY_ISSUER=digikey-local; export DIGIKEY_AUDIENCE=digi-ecosystem; PYTHONPATH=digigraph/src:digiquant/src:. .venv/bin/python -m uvicorn digigraph.server:app --host 127.0.0.1 --port 18000"],
       "port": 18000
     },
     {
       "name": "DigiQuant",
       "runtimeExecutable": "/bin/bash",
-      "runtimeArgs": ["-c", "PYTHONPATH=/Users/chrisstefan/Code/digithings/digiquant/src:/Users/chrisstefan/Code/digithings /Users/chrisstefan/Code/digithings/.venv/bin/python -m uvicorn digiquant.server:app --host 127.0.0.1 --port 18001"],
+      "runtimeArgs": ["-c", "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=digiquant/src:. .venv/bin/python -m uvicorn digiquant.server:app --host 127.0.0.1 --port 18001"],
       "port": 18001
     },
     {
       "name": "DigiSearch",
       "runtimeExecutable": "/bin/bash",
-      "runtimeArgs": ["-c", "PYTHONPATH=/Users/chrisstefan/Code/digithings/digisearch/src:/Users/chrisstefan/Code/digithings /Users/chrisstefan/Code/digithings/.venv/bin/python -m uvicorn digisearch.server:app --host 127.0.0.1 --port 8002"],
+      "runtimeArgs": ["-c", "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=digisearch/src:. .venv/bin/python -m uvicorn digisearch.server:app --host 127.0.0.1 --port 8002"],
       "port": 8002
     },
     {
       "name": "Website",
-      "runtimeExecutable": "/Users/chrisstefan/Code/digithings/.venv/bin/python",
-      "runtimeArgs": ["-m", "http.server", "3000", "--directory", "website"],
+      "runtimeExecutable": "/bin/bash",
+      "runtimeArgs": ["-c", "cd \"$(git rev-parse --show-toplevel)\" && .venv/bin/python -m http.server 3000 --directory website"],
       "port": 3000
     },
     {
@@ -45,8 +45,8 @@
     },
     {
       "name": "demos",
-      "runtimeExecutable": "/Users/chrisstefan/Code/digithings/.venv/bin/python",
-      "runtimeArgs": ["-m", "http.server", "4020", "--directory", "frontend/design/demos/digiquant-landing"],
+      "runtimeExecutable": "/bin/bash",
+      "runtimeArgs": ["-c", "cd \"$(git rev-parse --show-toplevel)\" && .venv/bin/python -m http.server 4020 --directory frontend/design/demos/digiquant-landing"],
       "port": 4020
     }
   ]


### PR DESCRIPTION
The `DigiGraph`/`DigiQuant`/`DigiSearch`/`Website`/`demos` launch configs hardcoded `/Users/chrisstefan/Code/digithings`. On any other machine the `cd` fails and the following relative commands (`cat ./projects/local/dev_public_key.pem`, `.venv/bin/python`) run from the wrong directory and error — which is exactly what broke the dev-server start.

Fix: resolve the repo root dynamically with `cd "$(git rev-parse --show-toplevel)"` and use repo-relative `PYTHONPATH` + `.venv/bin/python`, so the configs work on any clone. The frontend `npm --workspace` configs were already portable and are unchanged.

Note: this only fixes the *paths*. Running the Python services still requires a local `.venv` and the (confidential) `projects/local/` config + dev key, which aren't part of the repo.

`make score` 10/10.

Fixes #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)