### PR TITLE
feat(digivault): Supabase-backed architecture vault + embedded docs chat (#1087)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -34,11 +34,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install pyyaml
-        run: python3 -m pip install pyyaml
+      - name: Install lint deps
+        run: python3 -m pip install pyyaml "pydantic>=2"
 
       - name: Check internal markdown links
         run: python3 scripts/check_doc_links.py
+
+      - name: Lint the docs/vision DigiVault vault
+        run: make vault-check
 
       - name: Verify generated files are in sync
         run: python3 scripts/agents_init.py --check

--- a/.github/workflows/sync-architecture-vault.yml
+++ b/.github/workflows/sync-architecture-vault.yml
@@ -1,0 +1,49 @@
+name: sync-architecture-vault
+# Publish the DigiVault-managed docs/vision vault → Supabase public.architecture_notes
+# so the digithings.ai docs chat always reads the current architecture docs. The repo
+# docs are the source of truth; this mirrors them to the DB on every change ("publish
+# on update"). Dogfoods two modules: digivault parses the vault, digibase[supabase]
+# upserts it (on_conflict=vault_path, idempotent).
+#
+# Requires migration 048 (public.architecture_notes) applied first — see db-migrate.yml.
+# On the first main release that adds both 048 and the vault, approve db-migrate before
+# this run (or re-run this via workflow_dispatch once the table exists).
+#
+# Prod-mutating: runs under the `production` environment so it inherits the same
+# required-reviewer gate as db-migrate (CLAUDE.md human gate for shared-DB writes).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/vision/**'
+      - 'scripts/sync_architecture_vault.py'
+      - '.github/workflows/sync-architecture-vault.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency: sync-architecture-vault
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # digivault (core: pydantic + pyyaml) parses the vault; digibase[supabase]
+      # upserts. Installed as regular packages so they shadow the repo-root namespace dirs.
+      - name: Install DigiThings modules
+        run: python3 -m pip install ./digivault "./digibase[supabase]"
+
+      - name: Sync docs/vision → public.architecture_notes
+        env:
+          CORE_SUPABASE_URL: ${{ secrets.CORE_SUPABASE_URL || secrets.SUPABASE_URL }}
+          CORE_SUPABASE_SERVICE_KEY: ${{ secrets.CORE_SUPABASE_SERVICE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: python3 scripts/sync_architecture_vault.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 # Stray npm installs at repo root — always use workspace-scoped installs under frontend/
 /node_modules/
 
+# Cloudflare Pages Functions for digithings.ai are authored under
+# frontend/digithings-web/functions/ and mirrored to a repo-root functions/ by
+# scripts/build-digithings.sh at build time (CF requires functions/ at the project
+# root). The generated copy is a build artifact — never commit it.
+/functions/
+
 .venv/
 .venv-ci/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Digi Ecosystem – common targets (Phase 0+)
 # Use: make build, make test, make test-e2e, make up, make down
 
-.PHONY: build up down test test-unit test-e2e test-baseline doc-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status batch-candidates parse-error hooks-install qr-logo up-observability down-observability atlas-validate
+.PHONY: build up down test test-unit test-e2e test-baseline doc-check vault-check package up-heartbeat up-digichat down-digichat digichat-dev digichat-health stack-local stack-local-stop up-digichat-db down-digichat-db seed-digisearch-local export-edgar-digisearch-dev seed-digisearch-edgar-dev seed-digisearch-edgar-dev-host edgar-digisearch-dev agents-init score score-delta clean-imports find-stale commit pr task new-task status batch-candidates parse-error hooks-install qr-logo up-observability down-observability atlas-validate
 
 build:
 	docker compose build
@@ -35,6 +35,13 @@ test-e2e:
 # Internal markdown links (agent-facing docs). Same check as CI workflow docs.yml.
 doc-check:
 	python3 scripts/check_doc_links.py
+
+# Lint the DigiVault-managed docs/vision vault (wikilinks, frontmatter, taxonomy,
+# orphans) against docs/vision/.digivault.yml. Uses the digivault core (pydantic +
+# pyyaml only); -P keeps cwd off sys.path so the real package under digivault/src
+# loads, not the repo-root namespace dir.
+vault-check:
+	PYTHONPATH=digivault/src python3 -P scripts/check_vault.py
 
 # Regenerate frontend/digithings/assets/qrw.svg from scripts/generate-qr.py.
 # Requires: pip install "qrcode==8.0"

--- a/digiquant/supabase/migrations/048_architecture_notes.sql
+++ b/digiquant/supabase/migrations/048_architecture_notes.sql
@@ -1,0 +1,99 @@
+-- 048_architecture_notes.sql
+--
+-- Run with:  supabase db push   (or apply via MCP against this project).
+--
+-- DigiThings architecture vault — the Supabase-backed twin of the DigiVault-managed
+-- `docs/vision/` Obsidian vault. Mirrors the proven `knowledge_notes` shape (the
+-- DigiQuant financial KB, migration 20260625, #1087) so the same DigiVault store
+-- protocol + MCP read tools serve both vaults. Synced from docs/vision/ on every
+-- push by scripts/sync_architecture_vault.py (DigiVault parses, digibase upserts).
+--
+-- This powers the digithings.ai docs chat: the public Cloudflare Function reads it
+-- with the anon key (anon SELECT below) and searches via search_architecture_notes()
+-- — the vault is the chatbot's ONLY knowledge source, no web search.
+--
+-- ADDITIVE ONLY: one new table + one read function, no FKs to existing objects,
+-- no DROP/ALTER/TRUNCATE of anything else. Idempotent.
+--
+-- RLS: enabled with anon SELECT (public open-core docs — README/ARCHITECTURE/ADRs/
+-- vision, never projects/ which is confidential). Writes via service_role (RLS bypass).
+
+create table if not exists public.architecture_notes (
+    id            bigint generated always as identity primary key,
+    slug          text not null,                       -- note name (filename stem)
+    vault_path    text not null,                       -- path within the vault, no .md
+    title         text not null,
+    note_type     text not null default 'reference',   -- module | moc | concept | reference
+    status        text not null default 'stub',        -- stub | summarized | reviewed
+    tags          text[] not null default '{}',
+    relevance     text[] not null default '{}',        -- module stems that consume/depend on this
+    summary       text not null default '',            -- the note's one-line tagline
+    body_markdown text not null default '',            -- Obsidian markdown body (post-frontmatter)
+    frontmatter   jsonb  not null default '{}'::jsonb,  -- full parsed YAML frontmatter
+    sources       jsonb  not null default '[]'::jsonb,  -- [{title,author,url,kind,accessed}]
+    wikilinks     text[] not null default '{}',        -- outbound [[targets]] for the backlink graph
+    -- Full-text search vector over title + summary + body. knowledge_notes deferred
+    -- pgvector to #1087; a Postgres FTS column is cheap and immediately answer-capable,
+    -- which is exactly what the docs chat needs.
+    fts tsvector generated always as (
+        to_tsvector(
+            'english',
+            coalesce(title, '') || ' ' || coalesce(summary, '') || ' ' || coalesce(body_markdown, '')
+        )
+    ) stored,
+    created_at    timestamptz not null default now(),
+    updated_at    timestamptz not null default now(),
+    constraint architecture_notes_vault_path_key unique (vault_path)
+);
+
+comment on table public.architecture_notes is
+    'DigiThings architecture vault: Obsidian-style notes (frontmatter + markdown body + [[wikilinks]]), DigiVault-managed, synced from docs/vision/ by scripts/sync_architecture_vault.py. anon SELECT for the digithings.ai docs chat; service_role writes. Mirrors knowledge_notes (#1087).';
+
+create index if not exists idx_architecture_notes_fts
+    on public.architecture_notes using gin (fts);
+create index if not exists idx_architecture_notes_tags
+    on public.architecture_notes using gin (tags);
+create index if not exists idx_architecture_notes_note_type
+    on public.architecture_notes (note_type);
+
+alter table public.architecture_notes enable row level security;
+
+-- drop-if-exists/create so the migration is safely re-runnable (CREATE POLICY has no
+-- IF NOT EXISTS; the policy may already exist where the schema was applied before).
+drop policy if exists architecture_notes_anon_select on public.architecture_notes;
+create policy architecture_notes_anon_select on public.architecture_notes
+    for select to anon using (true);
+
+-- Full-text search the docs chat calls via PostgREST RPC with the anon key. SECURITY
+-- INVOKER (default): anon reads through the RLS policy above. websearch_to_tsquery
+-- parses user input safely. match_limit is clamped to [1, 20].
+create or replace function public.search_architecture_notes(query text, match_limit int default 7)
+returns table (
+    vault_path    text,
+    title         text,
+    note_type     text,
+    summary       text,
+    body_markdown text,
+    tags          text[],
+    wikilinks     text[],
+    rank          real
+)
+language sql
+stable
+as $$
+    select
+        n.vault_path,
+        n.title,
+        n.note_type,
+        n.summary,
+        n.body_markdown,
+        n.tags,
+        n.wikilinks,
+        ts_rank(n.fts, websearch_to_tsquery('english', query)) as rank
+    from public.architecture_notes n
+    where n.fts @@ websearch_to_tsquery('english', query)
+    order by rank desc
+    limit greatest(1, least(match_limit, 20));
+$$;
+
+grant execute on function public.search_architecture_notes(text, int) to anon;

--- a/digivault/ARCHITECTURE.md
+++ b/digivault/ARCHITECTURE.md
@@ -30,7 +30,8 @@ extra.
 | `digivault/models.py` | Pydantic v2 result models: `Note`, `LinkRef`, `ValidationIssue`, `LintReport`, `VaultConfig`. |
 | `digivault/frontmatter.py` | Round-trip-safe YAML frontmatter `split` / `dump` / `set_keys` (PyYAML). `split(dump(fm, body)) == (fm, body)`. |
 | `digivault/wikilinks.py` | Parse `[[note]]`/`[[note#h\|alias]]`/`![[embed]]`; `rewrite_target` / `map_targets` rewrite links while skipping code spans/blocks. |
-| `digivault/vault.py` | `Vault` — load a directory, build the note index + link graph + backlinks + tag index; maintenance ops (`create_note`, `rename` with inbound-link rewrite, `set_frontmatter`, `reindex`, `lint`). |
+| `digivault/vault.py` | `Vault` — load a directory (or any store via `Vault.from_sources`), build the note index + link graph + backlinks + tag index; maintenance ops (`create_note`, `rename` with inbound-link rewrite, `set_frontmatter`, `reindex`, `lint`). |
+| `digivault/supabase_store.py` | `SupabaseStore` — read a vault out of Supabase (`architecture_notes`/`knowledge_notes`) and reconstruct it via `Vault.from_sources`; FTS `search` via the `search_architecture_notes` RPC. Optional `[supabase]` extra, lazily imported. |
 | `digivault/path_scopes.py` | DigiKey scope policy: reads need `digivault:read`, writes `digivault:write`. |
 | `digivault/orchestrator_tools.py` | OpenAI-style tool manifest fetched by DigiGraph via `POST /v1/orchestrator_tools`. |
 | `digivault/server.py` | FastAPI app: `/healthz`, `/v1/status`, note CRUD, lint, backlinks, tags, orchestrator endpoints. |
@@ -76,10 +77,14 @@ report = vault.lint()           # -> LintReport(ok, note_count, issues)
 - **Re-read per request.** A documentation vault is small; recomputing the index
   from disk avoids a whole class of cache-coherency bugs. If a large vault ever
   needs it, add an explicit cache behind `reindex`.
-- **Storage = filesystem (v1).** DigiVault owns *how knowledge is organized and
-  traversed* (frontmatter, wikilinks, backlinks, taxonomy); `digistore` (when it
-  ships) owns *where bytes live*. They are complementary — DigiVault would sit
-  above DigiStore, not replace it.
+- **Storage is pluggable (filesystem + Supabase).** DigiVault owns *how knowledge
+  is organized and traversed* (frontmatter, wikilinks, backlinks, taxonomy). The
+  on-disk `Vault(root)` is the default; `Vault.from_sources` builds the same index
+  from any `(rel_path, text)` source, and `supabase_store.SupabaseStore` reads a
+  vault out of Postgres (`architecture_notes` / `knowledge_notes`, #1087) — read-only,
+  reconstructed via `dump_frontmatter`, served to agents through the anon key.
+  `digistore` (when it ships) will own *where bytes live* beneath this; the two
+  remain complementary — DigiVault sits above DigiStore, not replacing it.
 - **Wikilinks, not standard links.** The vault speaks Obsidian `[[...]]`. The
   repo's `scripts/check_doc_links.py` validates only `[text](path)` links, so
   DigiVault owns wikilink validation via `lint` (wired into `make vault-check`

--- a/digivault/pyproject.toml
+++ b/digivault/pyproject.toml
@@ -27,6 +27,9 @@ service = [
     "typer>=0.12",
 ]
 dev = ["pytest>=8", "ruff>=0.8"]
+# Supabase-backed vault store (digivault.supabase_store). Lazily imported — the
+# core stays pydantic+pyyaml-only; this extra adds the DB read/search path.
+supabase = ["supabase>=2"]
 
 [project.scripts]
 digivault = "digivault.cli:app"

--- a/digivault/src/digivault/supabase_store.py
+++ b/digivault/src/digivault/supabase_store.py
@@ -1,0 +1,126 @@
+"""Supabase-backed vault store — read an Obsidian vault persisted in Postgres.
+
+Reconstructs DigiVault notes from a Supabase table (``architecture_notes`` /
+``knowledge_notes`` — Obsidian-shaped rows: ``frontmatter`` jsonb + ``body_markdown``
++ ``wikilinks`` []) and feeds them to :meth:`Vault.from_sources`, so the *same*
+indexing — frontmatter, ``[[wikilinks]]``, backlinks, tags, lint — applies to a
+DB-hosted vault as to an on-disk one (DigiVault store protocol, #1087).
+
+The vault holds public open-core docs: read with the anon key for agents; the
+service role only writes (the sync job). ``supabase`` is imported lazily and lives
+behind the optional ``digivault[supabase]`` extra — ``import digivault`` never loads it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+from digivault import frontmatter as _fm
+from digivault.models import VaultConfig
+from digivault.vault import Vault
+
+DEFAULT_TABLE = "architecture_notes"
+DEFAULT_SEARCH_RPC = "search_architecture_notes"
+
+# Columns needed to reconstruct a note. body+frontmatter round-trip via
+# dump_frontmatter; the Vault re-parses them so tags/wikilinks/backlinks match disk.
+_SELECT = "vault_path,title,frontmatter,body_markdown"
+
+
+class SupabaseClientProtocol(Protocol):
+    """The slice of a ``supabase.Client`` this store uses (lets tests inject a fake)."""
+
+    def table(self, name: str) -> Any: ...
+    def rpc(self, fn: str, params: dict[str, Any]) -> Any: ...
+
+
+class SupabaseStoreError(RuntimeError):
+    """Raised when Supabase credentials are missing or a query fails."""
+
+
+def _rows(response: Any) -> list[dict[str, Any]]:
+    """PostgREST responses expose decoded rows on ``.data``."""
+    return list(getattr(response, "data", None) or [])
+
+
+class SupabaseStore:
+    """Read a DigiVault vault out of a Supabase table.
+
+    Inject a client for tests, or build one from the environment with
+    :meth:`from_env`. Read-only — writes go through the sync job (digibase upsert).
+    """
+
+    def __init__(
+        self,
+        client: SupabaseClientProtocol,
+        *,
+        table: str = DEFAULT_TABLE,
+        search_rpc: str = DEFAULT_SEARCH_RPC,
+    ) -> None:
+        self._client = client
+        self._table = table
+        self._search_rpc = search_rpc
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        table: str = DEFAULT_TABLE,
+        search_rpc: str = DEFAULT_SEARCH_RPC,
+    ) -> SupabaseStore:
+        """Build a store from env credentials (ADR-0022 CORE_* names, with fallbacks).
+
+        Reads prefer the anon key (the vault is anon-readable via RLS); the service
+        role also works for trusted callers (e.g. the self-hosted MCP server).
+        """
+        url = _first_env("CORE_SUPABASE_URL", "SUPABASE_URL")
+        key = _first_env(
+            "CORE_SUPABASE_ANON_KEY",
+            "CORE_SUPABASE_SERVICE_KEY",
+            "SUPABASE_ANON_KEY",
+            "SUPABASE_SERVICE_ROLE_KEY",
+        )
+        if not url or not key:
+            raise SupabaseStoreError(
+                "Supabase not configured: set CORE_SUPABASE_URL + a key "
+                "(CORE_SUPABASE_ANON_KEY or CORE_SUPABASE_SERVICE_KEY)."
+            )
+        try:
+            from supabase import create_client  # lazy: optional [supabase] extra
+        except ImportError as exc:  # pragma: no cover - exercised only without the extra
+            raise SupabaseStoreError(
+                "The 'supabase' package is required: install digivault[supabase]."
+            ) from exc
+        return cls(create_client(url, key), table=table, search_rpc=search_rpc)
+
+    def sources(self) -> list[tuple[str, str]]:
+        """Reconstruct ``(rel_path, markdown_text)`` pairs for :meth:`Vault.from_sources`."""
+        pairs: list[tuple[str, str]] = []
+        for row in _rows(self._client.table(self._table).select(_SELECT).execute()):
+            vault_path = str(row.get("vault_path") or "").strip()
+            if not vault_path:
+                continue
+            frontmatter = dict(row.get("frontmatter") or {})
+            body = str(row.get("body_markdown") or "")
+            pairs.append((f"{vault_path}.md", _fm.dump_frontmatter(frontmatter, body)))
+        return pairs
+
+    def load_vault(self, *, config: VaultConfig | None = None) -> Vault:
+        """Materialize a read-only :class:`Vault` from the table."""
+        return Vault.from_sources(self.sources(), config=config)
+
+    def search(self, query: str, *, limit: int = 7) -> list[dict[str, Any]]:
+        """Full-text search via the ``search_architecture_notes`` RPC (ranked rows)."""
+        response = self._client.rpc(
+            self._search_rpc, {"query": query, "match_limit": limit}
+        ).execute()
+        return _rows(response)
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""

--- a/digivault/src/digivault/supabase_store.py
+++ b/digivault/src/digivault/supabase_store.py
@@ -14,7 +14,7 @@ behind the optional ``digivault[supabase]`` extra — ``import digivault`` never
 from __future__ import annotations
 
 import os
-from typing import Any, Protocol
+from typing import Any, Protocol  # noqa: ANN401 — Supabase client/response shapes are dynamic
 
 from digivault import frontmatter as _fm
 from digivault.models import VaultConfig

--- a/digivault/src/digivault/vault.py
+++ b/digivault/src/digivault/vault.py
@@ -61,7 +61,33 @@ class Vault:
         self.config = self._load_config()
         self._notes: dict[str, Note] = {}
         self._duplicates: dict[str, list[str]] = {}
+        # Populated only for store-backed (read-only) vaults built via from_sources,
+        # where note bodies cannot be re-read from disk. None => filesystem-backed.
+        self._raw_text: dict[str, str] | None = None
         self.reindex()
+
+    @classmethod
+    def from_sources(
+        cls,
+        sources: Iterable[tuple[str, str]],
+        *,
+        config: VaultConfig | None = None,
+    ) -> Vault:
+        """Build a **read-only** vault from ``(rel_path, markdown_text)`` pairs.
+
+        Lets a non-filesystem backend (e.g. the Supabase-backed vault in
+        ``digivault.supabase_store``) reuse the exact same indexing — frontmatter,
+        wikilinks, backlinks, tags, lint — as the on-disk ``Vault``. Writes
+        (``create_note``/``rename``/``set_frontmatter``) raise ``VaultError``.
+        """
+        obj = cls.__new__(cls)
+        obj.root = None  # type: ignore[assignment]  # read-only sentinel; writes guarded
+        obj.config = config or VaultConfig()
+        obj._notes = {}
+        obj._duplicates = {}
+        obj._raw_text = {}
+        obj._build_index(sorted(sources, key=lambda pair: pair[0]))
+        return obj
 
     # ── loading ────────────────────────────────────────────────────────────
     def _load_config(self) -> VaultConfig:
@@ -82,27 +108,37 @@ class Vault:
                 continue
             yield p
 
+    def _iter_sources(self) -> Iterable[tuple[str, str]]:
+        """Yield ``(rel_path, text)`` for every markdown note (filesystem backend)."""
+        for path in self._iter_markdown():
+            rel = path.relative_to(self.root).as_posix()
+            yield rel, path.read_text(encoding="utf-8", errors="replace")
+
     def reindex(self) -> None:
         """Rebuild the note index, link graph, and backlinks from disk."""
+        self._build_index(self._iter_sources())
+
+    def _build_index(self, sources: Iterable[tuple[str, str]]) -> None:
+        """Build the note index, link graph, backlinks, and tag index from sources."""
         notes: dict[str, Note] = {}
         raw_outlinks: dict[str, list] = {}
         duplicates: dict[str, list[str]] = {}
-        for path in self._iter_markdown():
-            text = path.read_text(encoding="utf-8", errors="replace")
+        for rel, text in sources:
             fm, body = _fm.split_frontmatter(text)
-            name = path.stem
-            rel = path.relative_to(self.root).as_posix()
+            name = Path(rel).stem
             if name in notes:
                 # Two notes share a filename stem in different folders. Keep the
                 # first (deterministic via sorted iteration) and surface the
                 # collision through lint instead of silently dropping a note.
                 duplicates.setdefault(name, [notes[name].rel_path]).append(rel)
                 continue
+            if self._raw_text is not None:
+                self._raw_text[name] = text
             links = _wl.parse_links(body)
             raw_outlinks[name] = links
             notes[name] = Note(
                 name=name,
-                rel_path=path.relative_to(self.root).as_posix(),
+                rel_path=rel,
                 title=fm.get("title"),
                 tags=_normalize_tags(fm.get("tags")),
                 aliases=_normalize_aliases(fm.get("aliases")),
@@ -140,9 +176,16 @@ class Vault:
         note = self._notes.get(name)
         if note is None:
             raise VaultError(f"No such note: {name!r}")
+        if self._raw_text is not None:  # store-backed: body lives in the cache, not on disk
+            return self._raw_text[name]
         return (self.root / note.rel_path).read_text(encoding="utf-8", errors="replace")
 
     # ── writes ─────────────────────────────────────────────────────────────
+    def _require_writable(self) -> None:
+        """Read-only (store-backed) vaults from ``from_sources`` cannot be mutated."""
+        if self._raw_text is not None:
+            raise VaultError("read-only (store-backed) vault: writes are not supported")
+
     def _safe_path(self, rel: str) -> Path:
         """Resolve ``rel`` under the vault root, refusing escapes (path traversal)."""
         candidate = (self.root / rel).resolve()
@@ -159,6 +202,7 @@ class Vault:
         subdir: str = "",
     ) -> Note:
         """Create a new note ``<subdir>/<name>.md``. Fails if the name exists."""
+        self._require_writable()
         clean = name.strip()
         if not clean or "/" in clean or clean.startswith("."):
             raise VaultError(f"Invalid note name: {name!r}")
@@ -177,6 +221,7 @@ class Vault:
 
     def set_frontmatter(self, name: str, updates: dict[str, Any]) -> Note:
         """Merge ``updates`` into a note's frontmatter and persist."""
+        self._require_writable()
         note = self._notes.get(name)
         if note is None:
             raise VaultError(f"No such note: {name!r}")
@@ -187,6 +232,7 @@ class Vault:
 
     def rename(self, old_name: str, new_name: str) -> Note:
         """Rename a note and rewrite every inbound ``[[wikilink]]`` to match."""
+        self._require_writable()
         note = self._notes.get(old_name)
         if note is None:
             raise VaultError(f"No such note: {old_name!r}")

--- a/docs/vision/.digivault.yml
+++ b/docs/vision/.digivault.yml
@@ -1,0 +1,28 @@
+# DigiVault manifest for the DigiThings architecture vision vault.
+# Governs required frontmatter, the tag taxonomy, and link integrity.
+# Validated in CI via `make vault-check`.
+required_frontmatter:
+  - title
+  - type
+  - status
+allowed_tags:
+  - moc
+  - core
+  - support
+  - roadmap
+  - orchestration
+  - quant
+  - retrieval
+  - chat
+  - auth
+  - observability
+  - audit
+  - library
+  - llm-routing
+  - web-scraping
+  - devtools
+  - connectors
+  - storage
+  - knowledge-vault
+  - dashboard
+allow_orphans: false

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -1,3 +1,11 @@
+---
+title: DigiThings — Ecosystem Overview
+type: moc
+status: reviewed
+created: 2026-04-19
+tags:
+  - moc
+---
 # DigiThings — Ecosystem Overview
 > A modular AI production platform that assembles the best open-source infrastructure into a pre-wired stack, with proprietary domain expertise layered on top.
 
@@ -113,7 +121,7 @@ The open core is the infrastructure. The proprietary layer is the domain experti
 
 One document per module — positioning, current state, 12-month roadmap, and open vs. proprietary split:
 
-- [DigiGraph](digigraph.md) · [DigiQuant](digiquant.md) · [DigiSearch](digisearch.md) · [DigiChat](digichat.md)
-- [DigiKey](digikey.md) · [DigiSmith](digismith.md) · [DigiClaw](digiclaw.md) · [DigiBase](digibase.md)
-- [DigiLLM](digillm.md) · [DigiFetch](digifetch.md) · [DigiDev](digidev.md) · [Olympus](olympus.md)
-- [DigiLink](digilink.md) · [DigiStore](digistore.md) *(designed, not yet shipped)*
+- [[digigraph|DigiGraph]] · [[digiquant|DigiQuant]] · [[digisearch|DigiSearch]] · [[digichat|DigiChat]]
+- [[digikey|DigiKey]] · [[digismith|DigiSmith]] · [[digiclaw|DigiClaw]] · [[digibase|DigiBase]] · [[digivault|DigiVault]]
+- [[digillm|DigiLLM]] · [[digifetch|DigiFetch]] · [[digidev|DigiDev]] · [[olympus|Olympus]]
+- [[digilink|DigiLink]] · [[digistore|DigiStore]] *(designed, not yet shipped)*

--- a/docs/vision/digibase.md
+++ b/docs/vision/digibase.md
@@ -1,3 +1,18 @@
+---
+title: DigiBase
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - support
+  - library
+relevance:
+  - digigraph
+  - digiquant
+  - digisearch
+  - digismith
+  - digikey
+---
 # DigiBase
 
 > Shared infrastructure library — the utilities every DigiThings service uses, kept minimal and dependency-free.

--- a/docs/vision/digichat.md
+++ b/docs/vision/digichat.md
@@ -1,3 +1,12 @@
+---
+title: DigiChat
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - core
+  - chat
+---
 # DigiChat
 
 > The conversational interface for every DigiThings deployment — your models, your keys, your data.

--- a/docs/vision/digiclaw.md
+++ b/docs/vision/digiclaw.md
@@ -1,3 +1,12 @@
+---
+title: DigiClaw
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - support
+  - audit
+---
 # DigiClaw
 
 > The always-on agent layer — scheduled and continuous AI agents that run the ecosystem autonomously.

--- a/docs/vision/digidev.md
+++ b/docs/vision/digidev.md
@@ -1,3 +1,12 @@
+---
+title: DigiDev
+type: module
+status: reviewed
+created: 2026-06-15
+tags:
+  - support
+  - devtools
+---
 # DigiDev
 > A drop-in agentic-coding workflow kit — structured tasks, a quality gate, guardrails, and connectors to the tools you already use.
 

--- a/docs/vision/digifetch.md
+++ b/docs/vision/digifetch.md
@@ -1,3 +1,13 @@
+---
+title: DigiFetch
+type: module
+status: reviewed
+created: 2026-06-15
+tags:
+  - support
+  - web-scraping
+  - library
+---
 # DigiFetch
 > The shared web-scraping engine — headless-browser lifecycle, composable retry/backoff, and polite rate limiting, as a library with no service coupling.
 

--- a/docs/vision/digigraph.md
+++ b/docs/vision/digigraph.md
@@ -1,3 +1,16 @@
+---
+title: DigiGraph
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - core
+  - orchestration
+relevance:
+  - digiquant
+  - digisearch
+  - digichat
+---
 # DigiGraph
 > The orchestration hub — every agent workflow, tool call, and sub-graph in the DigiThings ecosystem flows through here.
 
@@ -42,7 +55,7 @@ Shipped and in production:
 - JWT authentication via DigiKey
 - Per-IP rate limiting
 - Checkpoint persistence via `DIGI_CHECKPOINTER` (memory / SQLite / Postgres today; migrates to DigiStore once that module ships)
-- LLM routing — model selection, caching, cost controls (LiteLLM today; the in-tree `digigraph.llm` module is superseded by the shared [DigiLLM](digillm.md) library, to which DigiGraph migrates)
+- LLM routing — model selection, caching, cost controls (LiteLLM today; the in-tree `digigraph.llm` module is superseded by the shared [[digillm|DigiLLM]] library, to which DigiGraph migrates)
 - DigiSmith tracing — every workflow tagged with `workflow_id`, `request_id`, `session_id`
 - MCP server — DigiGraph capabilities available as MCP tools for Claude Desktop and similar clients
 - Parallel tool execution

--- a/docs/vision/digikey.md
+++ b/docs/vision/digikey.md
@@ -1,3 +1,17 @@
+---
+title: DigiKey
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - support
+  - auth
+relevance:
+  - digigraph
+  - digiquant
+  - digisearch
+  - digivault
+---
 # DigiKey
 
 > The auth control plane — API keys, JWT issuance, SSO federation, and access scope enforcement for the entire ecosystem.

--- a/docs/vision/digilink.md
+++ b/docs/vision/digilink.md
@@ -1,3 +1,12 @@
+---
+title: DigiLink
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - roadmap
+  - connectors
+---
 # DigiLink
 > Every DigiThings capability, any protocol — the connection layer that eliminates lock-in.
 

--- a/docs/vision/digillm.md
+++ b/docs/vision/digillm.md
@@ -1,3 +1,16 @@
+---
+title: DigiLLM
+type: module
+status: reviewed
+created: 2026-06-15
+tags:
+  - support
+  - llm-routing
+  - library
+relevance:
+  - digigraph
+  - digisearch
+---
 # DigiLLM
 > The single home for LLM client code — provider-agnostic routing, structured output, and tool calling, with no service coupling.
 

--- a/docs/vision/digiquant.md
+++ b/docs/vision/digiquant.md
@@ -1,3 +1,15 @@
+---
+title: DigiQuant
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - core
+  - quant
+relevance:
+  - olympus
+  - digichat
+---
 # DigiQuant
 > The quantitative finance platform — from macro research to deployed trading strategies, powered by AI agents.
 
@@ -68,7 +80,7 @@ Data and state flow across the broader stack:
 - **DigiSearch** indexes finalized research documents for semantic retrieval, so agents can pull relevant research context on demand.
 - **DigiClaw** runs Atlas and Hermes on their daily and weekly schedules autonomously — DigiQuant's scheduled execution layer.
 - **DigiChat** is the user-facing interface for Kairos product mode and for querying Atlas research interactively.
-- **Olympus** (`frontend/olympus`) is the dedicated dashboard for the trio — Atlas's "Morning Read", Hermes's deliberations and risk debate, and portfolio/NAV tracking — and the surface where the human approval gate will be exercised once Hermes ships (see Current state below). See [olympus.md](olympus.md). Atlas, Hermes, and Kairos run inside DigiQuant as `digiquant.olympus` (ADR-0014, ADR-0015).
+- **Olympus** (`frontend/olympus`) is the dedicated dashboard for the trio — Atlas's "Morning Read", Hermes's deliberations and risk debate, and portfolio/NAV tracking — and the surface where the human approval gate will be exercised once Hermes ships (see Current state below). See [[olympus|olympus.md]]. Atlas, Hermes, and Kairos run inside DigiQuant as `digiquant.olympus` (ADR-0014, ADR-0015).
 
 ## Data philosophy
 

--- a/docs/vision/digisearch.md
+++ b/docs/vision/digisearch.md
@@ -1,3 +1,14 @@
+---
+title: DigiSearch
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - core
+  - retrieval
+relevance:
+  - digigraph
+---
 # DigiSearch
 
 > RAG and retrieval for the DigiThings ecosystem — semantic search, hybrid retrieval, and pluggable vector backends.

--- a/docs/vision/digismith.md
+++ b/docs/vision/digismith.md
@@ -1,3 +1,12 @@
+---
+title: DigiSmith
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - support
+  - observability
+---
 # DigiSmith
 
 > Observability for the DigiThings ecosystem — tracing, metrics, and status, without the overhead.

--- a/docs/vision/digistore.md
+++ b/docs/vision/digistore.md
@@ -1,3 +1,14 @@
+---
+title: DigiStore
+type: module
+status: reviewed
+created: 2026-04-19
+tags:
+  - roadmap
+  - storage
+relevance:
+  - digivault
+---
 # DigiStore
 
 > The storage abstraction layer — one interface for every backend, from SQLite to Supabase to S3.

--- a/docs/vision/digivault.md
+++ b/docs/vision/digivault.md
@@ -1,3 +1,14 @@
+---
+title: DigiVault
+type: module
+status: reviewed
+created: 2026-06-15
+tags:
+  - support
+  - knowledge-vault
+relevance:
+  - digigraph
+---
 # DigiVault
 > The knowledge-vault layer — every note, link, and tag in a managed Obsidian-style markdown vault.
 
@@ -32,11 +43,11 @@ backlinks, lint, and create notes. It reuses DigiKey for JWT auth
 
 It is complementary to two other modules:
 
-- **[DigiStore](digistore.md)** owns *where bytes live* (storage backend
+- **[[digistore|DigiStore]]** owns *where bytes live* (storage backend
   abstraction). DigiVault owns *how knowledge is organized and traversed*
   (frontmatter, wikilinks, backlinks, taxonomy). DigiVault would sit above
   DigiStore, not replace it.
-- **[DigiSearch](digisearch.md)** indexes content for semantic retrieval.
+- **[[digisearch|DigiSearch]]** indexes content for semantic retrieval.
   DigiVault can feed it: a managed vault is a clean ingestion source, and
   DigiVault's tags/links add structure DigiSearch can exploit later.
 

--- a/docs/vision/olympus.md
+++ b/docs/vision/olympus.md
@@ -1,3 +1,13 @@
+---
+title: Olympus
+type: module
+status: reviewed
+created: 2026-06-15
+tags:
+  - support
+  - dashboard
+  - quant
+---
 # Olympus
 > The human-facing dashboard for DigiQuant's finance sub-graphs — Atlas research, Hermes deliberation, and Kairos strategy work in one surface.
 

--- a/frontend/digithings-web/.dev.vars.example
+++ b/frontend/digithings-web/.dev.vars.example
@@ -1,0 +1,15 @@
+# Local secrets/config for `wrangler pages dev` (auto-loaded from this directory).
+# Copy to `.dev.vars` (gitignored) and fill in. NEVER commit `.dev.vars`.
+#
+# The /api/chat docs assistant retrieves ONLY from the DigiVault architecture vault
+# hosted in Supabase (public.architecture_notes), then answers via an OpenRouter
+# free-model pool. If any of these are unset, /api/chat returns a clear 503.
+
+# OpenRouter API key — the LLM call. Free-model pool, so a default key works.
+# Get one at https://openrouter.ai/keys.
+OPENROUTER_API_KEY=
+
+# DigiThings core Supabase project (the vault lives here, read via the anon key
+# under the architecture_notes_anon_select RLS policy — read-only, public docs).
+CORE_SUPABASE_URL=
+CORE_SUPABASE_ANON_KEY=

--- a/frontend/digithings-web/.gitignore
+++ b/frontend/digithings-web/.gitignore
@@ -5,3 +5,7 @@
 next-env.d.ts
 *.tsbuildinfo
 .DS_Store
+
+# Cloudflare Pages / wrangler local
+.dev.vars
+/.wrangler/

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -175,3 +175,35 @@ html { scroll-behavior: smooth; }
   .dt-manifest-body { grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr); gap: 1.6rem; align-items: start; }
   .dt-out { margin-top: 0; border-top: 0; border-left: 1px dashed var(--hair); padding: 0.1rem 0 0.4rem 1.6rem; }
 }
+
+/* ---- "ask about the stack" docs chat (StackChat.tsx) — lives in the right
+   .dt-out panel under the `digithings show` output. Terminal-styled, reuses the
+   manifest tokens (--ink/--accent/--hair/--font-mono). Streams /api/chat. ---- */
+.dt-out-show { padding-bottom: 0.2rem; }
+.dtc { margin-top: 0.9rem; padding-top: 0.85rem; border-top: 1px dashed var(--hair); font-family: var(--font-mono); display: flex; flex-direction: column; gap: 0.6rem; }
+.dtc-head { color: var(--ink-mute); font-size: 0.78rem; letter-spacing: 0.02em; }
+.dtc-thread { font-size: 0.82rem; line-height: 1.65; max-height: 248px; overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; }
+.dtc-empty { display: flex; flex-direction: column; gap: 0.7rem; }
+.dtc-empty p { margin: 0; font-size: 0.82rem; line-height: 1.6; }
+.dtc-suggest { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.dtc-chip { font: inherit; font-size: 0.76rem; color: var(--ink-soft); background: color-mix(in srgb, var(--accent) 8%, transparent); border: 1px solid var(--hair); border-radius: 999px; padding: 0.2rem 0.6rem; cursor: pointer; transition: background 0.18s var(--ease), color 0.18s var(--ease); }
+.dtc-chip:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--ink); }
+.dtc-chip:disabled { opacity: 0.5; cursor: default; }
+.dtc-msgs { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+.dtc-msg { display: grid; grid-template-columns: 0.9rem 1fr; gap: 0.45rem; align-items: start; }
+.dtc-who { color: var(--accent); font-weight: 600; user-select: none; }
+.dtc-body { white-space: pre-wrap; word-break: break-word; color: var(--ink-soft); }
+.dtc-user .dtc-body { color: var(--ink); }
+.dtc-error { margin: 0.3rem 0 0; font-size: 0.8rem; color: color-mix(in srgb, #e5484d 80%, var(--ink)); }
+.dtc-form { display: grid; grid-template-columns: 0.9rem 1fr auto; align-items: center; gap: 0.45rem; border: 1px solid var(--hair); border-radius: 9px; padding: 0.4rem 0.55rem; background: color-mix(in srgb, var(--surface) 60%, transparent); }
+.dtc-form:focus-within { border-color: color-mix(in srgb, var(--accent) 55%, var(--hair)); }
+.dtc-input { font: inherit; font-size: 0.84rem; background: transparent; border: 0; color: var(--ink); width: 100%; padding: 0.1rem 0; }
+.dtc-input::placeholder { color: var(--ink-mute); }
+.dtc-input:focus { outline: none; }
+.dtc-input:disabled { opacity: 0.6; }
+.dtc-send { font: inherit; font-size: 0.95rem; line-height: 1; color: var(--accent); background: transparent; border: 0; cursor: pointer; padding: 0.15rem 0.35rem; border-radius: 6px; transition: background 0.18s var(--ease); }
+.dtc-send:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 14%, transparent); }
+.dtc-send:disabled { opacity: 0.4; cursor: default; }
+@media (prefers-reduced-motion: reduce) {
+  .dtc-chip, .dtc-send { transition: none; }
+}

--- a/frontend/digithings-web/components/landing/ModuleManifest.tsx
+++ b/frontend/digithings-web/components/landing/ModuleManifest.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { modules, type ModuleNode } from "@digithings/web";
+import { StackChat } from "./StackChat";
 
 /**
  * Terminal-manifest display of the ten DigiThings modules — a `digithings ps`
@@ -88,26 +89,29 @@ export function ModuleManifest() {
           );
         })}
       </ol>
-      <div className="dt-out" aria-live="polite">
-        {selMod ? (
-          <>
+      <div className="dt-out">
+        <div className="dt-out-show" aria-live="polite">
+          {selMod ? (
+            <>
+              <div className="dt-out-cmd">
+                <span className="dt-mh-prompt">$</span> digithings show{" "}
+                <span className="dt-d">digi</span>
+                <span className="dt-s">{selMod.id.replace(/^digi/, "")}</span>
+              </div>
+              <pre className="dt-out-body">
+                {out.slice(0, shown)}
+                <span className="dt-cur" />
+              </pre>
+            </>
+          ) : (
             <div className="dt-out-cmd">
-              <span className="dt-mh-prompt">$</span> digithings show{" "}
-              <span className="dt-d">digi</span>
-              <span className="dt-s">{selMod.id.replace(/^digi/, "")}</span>
-            </div>
-            <pre className="dt-out-body">
-              {out.slice(0, shown)}
+              <span className="dt-mh-prompt">$</span>{" "}
+              <span className="dt-out-dim">select a module to inspect</span>
               <span className="dt-cur" />
-            </pre>
-          </>
-        ) : (
-          <div className="dt-out-cmd">
-            <span className="dt-mh-prompt">$</span>{" "}
-            <span className="dt-out-dim">select a module to inspect</span>
-            <span className="dt-cur" />
-          </div>
-        )}
+            </div>
+          )}
+        </div>
+        <StackChat />
       </div>
       </div>
     </div>

--- a/frontend/digithings-web/components/landing/StackChat.tsx
+++ b/frontend/digithings-web/components/landing/StackChat.tsx
@@ -1,0 +1,202 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * "Ask about the stack" — a read-only docs Q&A chat that lives in the right-hand
+ * panel of the module manifest, under the `digithings show <module>` output.
+ *
+ * It POSTs the running transcript to the Cloudflare Pages Function at
+ * `/api/chat`, which runs BM25 retrieval over the committed digivault KB and
+ * streams an OpenRouter free-pool completion back as plain-text token deltas.
+ * We render those tokens live. Terminal aesthetic via the existing `.dt-*` /
+ * `.dtc-*` tokens; theme-aware and keyboard accessible. If the deployment has
+ * no OpenRouter key the Function returns a JSON error and we show a friendly
+ * "chat not configured" line instead of a thread.
+ */
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+const SUGGESTIONS = [
+  "What is DigiQuant?",
+  "How does auth work?",
+  "What does Olympus do?",
+];
+
+export function StackChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const threadRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Keep the newest tokens in view as they stream.
+  useEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, busy]);
+
+  // Abort any in-flight stream on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  async function send(question: string) {
+    const q = question.trim();
+    if (!q || busy) return;
+    setError(null);
+    setInput("");
+
+    const next: ChatMessage[] = [...messages, { role: "user", content: q }];
+    // Add an empty assistant turn we append streamed tokens into.
+    setMessages([...next, { role: "assistant", content: "" }]);
+    setBusy(true);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ messages: next }),
+        signal: controller.signal,
+      });
+
+      // Non-streaming JSON => an error path (missing key, rate limit, etc.).
+      const ctype = res.headers.get("content-type") ?? "";
+      if (!res.ok || ctype.includes("application/json")) {
+        let msg = `request failed (${res.status})`;
+        try {
+          const data = await res.json();
+          msg = data.error
+            ? data.error === "chat not configured"
+              ? "chat not configured on this deployment"
+              : String(data.error)
+            : msg;
+        } catch {
+          /* keep generic msg */
+        }
+        // Drop the placeholder assistant turn; surface the error line instead.
+        setMessages(next);
+        setError(msg);
+        return;
+      }
+
+      // Stream plain-text token deltas into the last assistant message.
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("no response stream");
+      const decoder = new TextDecoder();
+      let acc = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        acc += decoder.decode(value, { stream: true });
+        setMessages([...next, { role: "assistant", content: acc }]);
+      }
+      if (!acc.trim()) {
+        setMessages(next);
+        setError("no answer returned — try rephrasing");
+      }
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return;
+      setMessages(next);
+      setError(`network error: ${(e as Error).message}`);
+    } finally {
+      setBusy(false);
+      abortRef.current = null;
+    }
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    void send(input);
+  }
+
+  const empty = messages.length === 0;
+
+  return (
+    <div className="dtc">
+      <div className="dtc-head">
+        <span className="dt-mh-prompt">$</span> digithings ask
+        <span className="dt-out-dim"> · docs Q&amp;A over the digivault</span>
+      </div>
+
+      <div className="dtc-thread" ref={threadRef} aria-live="polite" aria-atomic="false">
+        {empty && !error ? (
+          <div className="dtc-empty">
+            <p className="dt-out-dim">
+              Ask about the stack — modules, ports, auth, orchestration. Answers come
+              only from the published docs.
+            </p>
+            <div className="dtc-suggest">
+              {SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className="dtc-chip"
+                  onClick={() => void send(s)}
+                  disabled={busy}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <ul className="dtc-msgs">
+            {messages.map((m, i) => {
+              const streaming =
+                busy && m.role === "assistant" && i === messages.length - 1;
+              return (
+                <li key={i} className={`dtc-msg dtc-${m.role}`}>
+                  <span className="dtc-who" aria-hidden="true">
+                    {m.role === "user" ? ">" : "·"}
+                  </span>
+                  <span className="dtc-body">
+                    {m.content}
+                    {streaming && <span className="dt-cur" />}
+                    {streaming && !m.content && (
+                      <span className="dt-out-dim">retrieving…</span>
+                    )}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        {error && (
+          <p className="dtc-error" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <form className="dtc-form" onSubmit={onSubmit}>
+        <span className="dt-mh-prompt" aria-hidden="true">
+          $
+        </span>
+        <input
+          className="dtc-input"
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="ask about the stack…"
+          aria-label="Ask about the DigiThings stack"
+          disabled={busy}
+          autoComplete="off"
+          maxLength={500}
+        />
+        <button
+          className="dtc-send"
+          type="submit"
+          disabled={busy || !input.trim()}
+          aria-label="Send question"
+        >
+          {busy ? "…" : "↵"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -1,0 +1,283 @@
+// Cloudflare Pages Function — POST /api/chat
+// "Ask about the stack" docs chat for digithings.ai.
+//
+// The DigiVault-managed architecture vault is the ONLY knowledge source — no web
+// search, no other tools. Retrieval is a Postgres full-text search over the vault
+// hosted in Supabase (public.architecture_notes, synced from docs/vision/ by
+// scripts/sync_architecture_vault.py). We call the search_architecture_notes RPC
+// with the anon key (RLS-gated, read-only), inject the top hits as system context,
+// and stream an OpenRouter free-model-pool completion back as plain-text deltas.
+//
+// Config (Pages env vars):
+//   OPENROUTER_API_KEY      — required; the LLM call. Missing => clear 503.
+//   CORE_SUPABASE_URL       — required; the vault's Supabase project URL.
+//   CORE_SUPABASE_ANON_KEY  — required; anon key (public, RLS-gated read).
+// No service-role key here: the Function only ever reads, through the anon RLS policy.
+
+interface Env {
+  OPENROUTER_API_KEY?: string;
+  CORE_SUPABASE_URL?: string;
+  CORE_SUPABASE_ANON_KEY?: string;
+  // Optional KV for cross-isolate rate limiting; falls back to in-memory (soft).
+  RATE_LIMIT_KV?: {
+    get: (key: string) => Promise<string | null>;
+    put: (key: string, value: string, opts?: { expirationTtl?: number }) => Promise<void>;
+  };
+}
+interface EventContext {
+  request: Request;
+  env: Env;
+  waitUntil?: (p: Promise<unknown>) => void;
+}
+interface ChatMessage {
+  role: "user" | "assistant" | "system";
+  content: string;
+}
+interface VaultHit {
+  vault_path: string;
+  title: string;
+  note_type: string;
+  summary: string;
+  body_markdown: string;
+  tags: string[];
+  wikilinks: string[];
+  rank: number;
+}
+
+// ---- Tunables ----
+const MAX_TURNS = 12; // conversation turns sent upstream
+const MAX_MSG_CHARS = 2000; // cap a single message
+const TOP_K = 6; // vault hits injected as context
+const MAX_NOTE_CHARS = 1500; // truncate each note body — bounds prompt size/cost
+const RATE_LIMIT_MAX = 20;
+const RATE_LIMIT_WINDOW_S = 60;
+
+// OpenRouter FREE-MODEL POOL (models[] fallback routing). `:free` membership churns —
+// verify against https://openrouter.ai/models?max_price=0 before relying in prod.
+const MODEL_POOL = [
+  "meta-llama/llama-3.3-70b-instruct:free",
+  "qwen/qwen-2.5-72b-instruct:free",
+  "google/gemma-2-9b-it:free",
+  "mistralai/mistral-7b-instruct:free",
+];
+
+const SYSTEM_PROMPT =
+  "You are the DigiThings documentation assistant. Answer ONLY from the provided " +
+  "DigiVault context about the open-core agentic stack (DigiGraph, DigiQuant, " +
+  "DigiSearch, DigiChat, DigiKey, DigiSmith, DigiVault, DigiClaw, DigiBase, DigiLLM, " +
+  "DigiFetch, DigiDev, DigiLink, DigiStore, Olympus). Be concise and technical. If the " +
+  "context doesn't cover the question, say so plainly. Never invent features, ports, or APIs.";
+
+function jsonError(message: string, status = 400): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function notConfigured(detail: string): Response {
+  return new Response(JSON.stringify({ error: "chat not configured", detail }), {
+    status: 503,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+// ---- Rate limiting (KV if bound, else best-effort in-memory per-isolate) ----
+const memHits = new Map<string, { count: number; reset: number }>();
+async function rateLimit(env: Env, ip: string): Promise<boolean> {
+  const now = Date.now();
+  if (env.RATE_LIMIT_KV) {
+    const key = `rl:${ip}`;
+    const raw = await env.RATE_LIMIT_KV.get(key);
+    const count = raw ? parseInt(raw, 10) || 0 : 0;
+    if (count >= RATE_LIMIT_MAX) return false;
+    await env.RATE_LIMIT_KV.put(key, String(count + 1), { expirationTtl: RATE_LIMIT_WINDOW_S });
+    return true;
+  }
+  const e = memHits.get(ip);
+  if (!e || now > e.reset) {
+    memHits.set(ip, { count: 1, reset: now + RATE_LIMIT_WINDOW_S * 1000 });
+    return true;
+  }
+  if (e.count >= RATE_LIMIT_MAX) return false;
+  e.count += 1;
+  return true;
+}
+
+// ---- Same-site guard: cheap speed-bump vs cross-site/scripted abuse (Origin is
+// spoofable; the real throttle is KV). Lenient on localhost for wrangler testing. ----
+function sameSiteOK(request: Request): boolean {
+  const reqHost = new URL(request.url).hostname;
+  if (reqHost === "localhost" || reqHost === "127.0.0.1") return true;
+  const origin = request.headers.get("origin");
+  if (!origin) return false; // browsers send Origin on POST; absent => not a page request
+  try {
+    const o = new URL(origin).hostname;
+    return o === reqHost || o.endsWith(".pages.dev");
+  } catch {
+    return false;
+  }
+}
+
+// ---- Retrieval: FTS over the Supabase-hosted vault via the RPC (anon, RLS read) ----
+async function searchVault(env: Env, query: string, k: number): Promise<VaultHit[]> {
+  const base = (env.CORE_SUPABASE_URL ?? "").replace(/\/+$/, "");
+  const key = env.CORE_SUPABASE_ANON_KEY ?? "";
+  const resp = await fetch(`${base}/rest/v1/rpc/search_architecture_notes`, {
+    method: "POST",
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, match_limit: k }),
+  });
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    throw new Error(`vault search ${resp.status}: ${detail.slice(0, 200)}`);
+  }
+  return (await resp.json()) as VaultHit[];
+}
+
+function buildContext(hits: VaultHit[]): string {
+  return hits
+    .map((h) => {
+      const body =
+        h.body_markdown.length > MAX_NOTE_CHARS
+          ? h.body_markdown.slice(0, MAX_NOTE_CHARS) + "\n…(truncated)"
+          : h.body_markdown;
+      return `## ${h.title} (${h.vault_path})\n${body}`;
+    })
+    .join("\n\n---\n\n");
+}
+
+// onRequestPost — Pages Functions route handler for POST /api/chat.
+export async function onRequestPost(ctx: EventContext): Promise<Response> {
+  const { request, env } = ctx;
+
+  // 1. Config gates FIRST — never call upstreams half-configured.
+  if (!env.OPENROUTER_API_KEY) {
+    return notConfigured("OPENROUTER_API_KEY is not set on this deployment.");
+  }
+  if (!env.CORE_SUPABASE_URL || !env.CORE_SUPABASE_ANON_KEY) {
+    return notConfigured("CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY are not set — the vault is unreachable.");
+  }
+
+  // 1b. Same-site guard — reject cross-site / scripted callers before any work.
+  if (!sameSiteOK(request)) return jsonError("forbidden: cross-site requests are not allowed", 403);
+
+  // 2. Rate limit by client IP.
+  const ip = request.headers.get("cf-connecting-ip") ?? "anon";
+  if (!(await rateLimit(env, ip))) return jsonError("rate limit exceeded — slow down a moment", 429);
+
+  // 3. Parse + sanitize body.
+  let body: { messages?: ChatMessage[] };
+  try {
+    body = (await request.json()) as { messages?: ChatMessage[] };
+  } catch {
+    return jsonError("invalid JSON body");
+  }
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  if (messages.length === 0) return jsonError("messages required");
+
+  const clean: ChatMessage[] = messages
+    .filter(
+      (m) => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string",
+    )
+    .slice(-MAX_TURNS)
+    .map((m) => ({ role: m.role, content: m.content.slice(0, MAX_MSG_CHARS) }));
+  const lastUser = [...clean].reverse().find((m) => m.role === "user");
+  if (!lastUser) return jsonError("a user message is required");
+
+  // 4. Retrieve from the vault (the only knowledge source).
+  let context = "";
+  try {
+    context = buildContext(await searchVault(env, lastUser.content, TOP_K));
+  } catch (e) {
+    return jsonError(`vault unavailable: ${(e as Error).message}`, 502);
+  }
+
+  // 5. Compose upstream messages.
+  const upstream: ChatMessage[] = [
+    { role: "system", content: SYSTEM_PROMPT },
+    {
+      role: "system",
+      content:
+        "DigiVault context (answer ONLY from this; cite nothing outside it):\n\n" +
+        (context || "(no relevant documentation found for this question)"),
+    },
+    ...clean,
+  ];
+
+  // 6. Call OpenRouter with the free-model pool + streaming.
+  let orResp: Response;
+  try {
+    orResp = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+        "content-type": "application/json",
+        "HTTP-Referer": "https://digithings.ai",
+        "X-Title": "DigiThings Docs Assistant",
+      },
+      body: JSON.stringify({
+        models: MODEL_POOL,
+        messages: upstream,
+        stream: true,
+        temperature: 0.2,
+        max_tokens: 700,
+      }),
+    });
+  } catch (e) {
+    return jsonError(`upstream request failed: ${(e as Error).message}`, 502);
+  }
+  if (!orResp.ok || !orResp.body) {
+    const detail = await orResp.text().catch(() => "");
+    return jsonError(`model pool error (${orResp.status}): ${detail.slice(0, 300)}`, 502);
+  }
+
+  // 7. Transform OpenRouter SSE → plain-text token stream the browser appends.
+  const reader = orResp.body.getReader();
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buf = "";
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? ""; // keep the trailing partial line
+      for (const line of lines) {
+        const t = line.trim();
+        if (!t.startsWith("data:")) continue;
+        const payload = t.slice(5).trim();
+        if (payload === "[DONE]") {
+          controller.close();
+          return;
+        }
+        try {
+          const json = JSON.parse(payload);
+          const delta: string | undefined = json?.choices?.[0]?.delta?.content;
+          if (delta) controller.enqueue(encoder.encode(delta));
+        } catch {
+          // ignore non-JSON keepalive / ": OPENROUTER PROCESSING" comment frames
+        }
+      }
+    },
+    cancel() {
+      reader.cancel().catch(() => {});
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}

--- a/frontend/digithings-web/wrangler.toml
+++ b/frontend/digithings-web/wrangler.toml
@@ -1,0 +1,26 @@
+# Cloudflare Pages config for digithings.ai.
+#
+# This file lives at the Pages project ROOT (frontend/digithings-web), which is
+# where `functions/` is discovered from. The static site is a Next.js
+# `output: "export"` build; `pages_build_output_dir` points at the export
+# folder. NOTE: the repo's deploy script (scripts/build-digithings.sh) assembles
+# repo-root `dist/` for the production Pages project — see that script's header
+# and the chat README notes for the production root-directory caveat. This
+# wrangler.toml is primarily for LOCAL `wrangler pages dev`, which serves the
+# Next export in `out/` together with the auto-discovered `functions/` dir.
+
+name = "digithings-web"
+compatibility_date = "2024-09-23"
+pages_build_output_dir = "out"
+
+# Secrets (NEVER committed):
+#   OPENROUTER_API_KEY — set via `.dev.vars` locally, or as a Pages project
+#   secret in production (Dashboard → Settings → Environment variables, or
+#   `npx wrangler pages secret put OPENROUTER_API_KEY`).
+
+# Optional: bind a KV namespace for cross-isolate per-IP rate limiting. If this
+# binding is absent the Function falls back to a best-effort in-memory limiter.
+# Uncomment and fill the id after `wrangler kv namespace create RATE_LIMIT_KV`:
+# [[kv_namespaces]]
+# binding = "RATE_LIMIT_KV"
+# id = "<your-kv-namespace-id>"

--- a/scripts/build-digithings.sh
+++ b/scripts/build-digithings.sh
@@ -42,5 +42,16 @@ echo "digithings.ai" > dist/CNAME
 [ -f dist/index.html ] || { echo "ERROR: dist/index.html missing — build did not export" >&2; exit 1; }
 grep -q "dt-manifest" dist/index.html || { echo "ERROR: module manifest missing from home page" >&2; exit 1; }
 
+# Cloudflare Pages Functions live at the PROJECT ROOT (this script's CWD = repo root),
+# NOT inside the static output dir. The /api/chat docs-assistant Function is authored
+# under frontend/digithings-web/functions/; mirror it to a repo-root functions/ so the
+# (repo-root) Pages project compiles it. The chat reads the DigiVault vault from Supabase
+# at runtime (CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY + OPENROUTER_API_KEY as Pages env
+# vars) — no bundled data, so there is nothing to assert in dist/ beyond the export above.
+echo "--- mirroring Pages Functions to repo root ---"
+rm -rf functions
+cp -r frontend/digithings-web/functions functions
+[ -f functions/api/chat.ts ] || { echo "ERROR: chat Function missing from functions/" >&2; exit 1; }
+
 echo "--- dist/ contents ---"
 ls -la dist/

--- a/scripts/check_vault.py
+++ b/scripts/check_vault.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""``make vault-check`` — lint the DigiVault-managed ``docs/vision`` vault.
+
+Validates wikilink integrity, required frontmatter, the tag taxonomy, and orphans
+against ``docs/vision/.digivault.yml`` using the DigiVault core (pydantic + pyyaml
+only — no service extra). Exits non-zero on any issue so CI gates the docs vault,
+matching the DigiVault roadmap ("make vault-check validating wikilinks and
+frontmatter in CI").
+
+Run::
+
+    PYTHONPATH=digivault/src python3 -P scripts/check_vault.py [VAULT_DIR]
+"""
+
+from __future__ import annotations
+
+import sys
+
+from digivault import Vault
+
+DEFAULT_VAULT = "docs/vision"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    vault_dir = args[0] if args else DEFAULT_VAULT
+
+    report = Vault(vault_dir).lint()
+    for issue in report.issues:
+        print(f"{issue.note}: {issue.kind}: {issue.message}", file=sys.stderr)
+
+    status = "OK" if report.ok else "FAIL"
+    print(f"{status}: {vault_dir} — {report.note_count} notes, {len(report.issues)} issue(s)")
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_architecture_vault.py
+++ b/scripts/sync_architecture_vault.py
@@ -31,7 +31,7 @@ import argparse
 import json
 import sys
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any  # noqa: ANN401 — frontmatter/row values are arbitrary YAML/JSON
 
 from digivault import Vault, split_frontmatter
 

--- a/scripts/sync_architecture_vault.py
+++ b/scripts/sync_architecture_vault.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Sync the DigiVault-managed ``docs/vision`` vault → Supabase ``public.architecture_notes``.
+
+Dogfoods two DigiThings modules:
+
+* **digivault** — parses the Obsidian vault (YAML frontmatter, body, ``[[wikilinks]]``)
+  via the core ``Vault`` index. It is the single source of truth for note structure.
+* **digibase[supabase]** — idempotent ``upsert`` keyed on ``vault_path`` (``on_conflict``).
+
+The repo docs stay the source of truth; this publishes them to Supabase so the
+digithings.ai docs chat can read + full-text-search them (migration 048).
+
+Usage
+-----
+Dry-run (no DB, no credentials — verifies the parse/mapping)::
+
+    PYTHONPATH=digivault/src:digibase/src python3 -P scripts/sync_architecture_vault.py --dry-run
+
+Real sync (CI / operator; needs service-role credentials in the environment)::
+
+    python3 scripts/sync_architecture_vault.py
+
+Credentials resolve ``CORE_SUPABASE_URL`` / ``CORE_SUPABASE_SERVICE_KEY`` (ADR-0022),
+falling back to ``SUPABASE_URL`` / ``SUPABASE_SERVICE_ROLE_KEY``. The service key is read
+from the environment only — never hardcoded, never logged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from digivault import Vault, split_frontmatter
+
+DEFAULT_VAULT = "docs/vision"
+DEFAULT_TABLE = "architecture_notes"
+
+
+def _jsonable(value: Any) -> Any:
+    """Round-trip through JSON so YAML dates/tuples become JSON-safe scalars."""
+    return json.loads(json.dumps(value, default=str))
+
+
+def _summary_from_body(body: str) -> str:
+    """The note's tagline — the first Markdown blockquote line under the H1."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(">"):
+            return stripped.lstrip(">").strip()
+    for line in body.splitlines():  # fallback: first non-heading, non-empty line
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def build_rows(vault_dir: str) -> list[dict[str, Any]]:
+    """Parse the vault with DigiVault and map each note to an architecture_notes row."""
+    vault = Vault(vault_dir)
+    rows: list[dict[str, Any]] = []
+    for note in vault.list_notes():
+        frontmatter, body = split_frontmatter(vault.read_text(note.name))
+        vault_path = note.rel_path[:-3] if note.rel_path.endswith(".md") else note.rel_path
+        rows.append(
+            {
+                "slug": note.name,
+                "vault_path": vault_path,
+                "title": note.title or frontmatter.get("title") or note.name,
+                "note_type": str(frontmatter.get("type", "reference")),
+                "status": str(frontmatter.get("status", "stub")),
+                "tags": list(note.tags),
+                "relevance": [str(r) for r in (frontmatter.get("relevance") or [])],
+                "summary": _summary_from_body(body),
+                "body_markdown": body,
+                "frontmatter": _jsonable(frontmatter),
+                "sources": _jsonable(frontmatter.get("sources") or []),
+                "wikilinks": sorted({link.target for link in note.outlinks}),
+            }
+        )
+    return rows
+
+
+def _connector():  # type: ignore[no-untyped-def]
+    """Build a digibase SupabaseConnector, preferring the ADR-0022 CORE_* names."""
+    from digibase.connectors.supabase import (  # noqa: PLC0415 (deferred: optional extra)
+        SupabaseConnector,
+        SupabaseNotConfiguredError,
+    )
+
+    candidates = (
+        ("CORE_SUPABASE_URL", "CORE_SUPABASE_SERVICE_KEY"),
+        ("SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"),
+    )
+    for url_var, key_var in candidates:
+        try:
+            return SupabaseConnector.from_env(url_var=url_var, key_var=key_var)
+        except SupabaseNotConfiguredError:
+            continue
+    raise SystemExit(
+        "No Supabase credentials found. Set CORE_SUPABASE_URL + CORE_SUPABASE_SERVICE_KEY "
+        "(or SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY)."
+    )
+
+
+def _print_dry_run(rows: list[dict[str, Any]]) -> None:
+    """Compact, body-free view so the mapping is easy to eyeball."""
+    preview = [
+        {
+            "vault_path": r["vault_path"],
+            "title": r["title"],
+            "note_type": r["note_type"],
+            "status": r["status"],
+            "tags": r["tags"],
+            "relevance": r["relevance"],
+            "summary": r["summary"],
+            "wikilinks": r["wikilinks"],
+            "body_chars": len(r["body_markdown"]),
+        }
+        for r in rows
+    ]
+    print(json.dumps(preview, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sync docs/vision vault → Supabase.")
+    parser.add_argument("--vault", default=DEFAULT_VAULT, help="Vault root (default: docs/vision).")
+    parser.add_argument("--table", default=DEFAULT_TABLE, help="Target table.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Parse and print rows; no DB connection."
+    )
+    args = parser.parse_args(argv)
+
+    rows = build_rows(args.vault)
+    if not rows:
+        print(f"No notes found in {args.vault}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        _print_dry_run(rows)
+        print(f"\n[dry-run] {len(rows)} notes parsed from {args.vault}", file=sys.stderr)
+        return 0
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    for row in rows:
+        row["updated_at"] = timestamp
+
+    result = _connector().upsert(args.table, rows, on_conflict="vault_path")
+    if not result.success:
+        print(f"Upsert failed: {result.error}", file=sys.stderr)
+        return 1
+    print(f"Synced {result.rows} notes → {args.table}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dv/test_supabase_store.py
+++ b/tests/dv/test_supabase_store.py
@@ -7,7 +7,7 @@ the filesystem Vault, that the resulting vault is read-only, and that search hit
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any  # noqa: ANN401 — fake client mirrors the dynamic supabase client
 
 import pytest
 

--- a/tests/dv/test_supabase_store.py
+++ b/tests/dv/test_supabase_store.py
@@ -1,0 +1,137 @@
+"""Unit tests for the Supabase-backed vault store (digivault.supabase_store).
+
+Deterministic, network-free: a fake client returns canned rows / RPC data. Verifies
+the store reconstructs Notes (frontmatter, tags, wikilinks, backlinks) identically to
+the filesystem Vault, that the resulting vault is read-only, and that search hits the RPC.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from digivault.supabase_store import SupabaseStore, SupabaseStoreError
+from digivault.vault import VaultError
+
+pytestmark = pytest.mark.unit
+
+
+class _Response:
+    def __init__(self, data: list[dict[str, Any]]) -> None:
+        self.data = data
+
+
+class _Query:
+    def __init__(self, data: list[dict[str, Any]]) -> None:
+        self._data = data
+
+    def select(self, *_a: Any, **_k: Any) -> "_Query":
+        return self
+
+    def execute(self) -> _Response:
+        return _Response(self._data)
+
+
+class _FakeClient:
+    """Minimal stand-in satisfying SupabaseClientProtocol."""
+
+    def __init__(self, rows: list[dict[str, Any]], rpc_data: list[dict[str, Any]] | None = None):
+        self._rows = rows
+        self._rpc_data = rpc_data or []
+        self.rpc_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def table(self, _name: str) -> _Query:
+        return _Query(self._rows)
+
+    def rpc(self, fn: str, params: dict[str, Any]) -> _Query:
+        self.rpc_calls.append((fn, params))
+        return _Query(self._rpc_data)
+
+
+_ROWS = [
+    {
+        "vault_path": "digigraph",
+        "title": "DigiGraph",
+        "frontmatter": {
+            "title": "DigiGraph",
+            "type": "module",
+            "status": "reviewed",
+            "tags": ["core", "orchestration"],
+        },
+        "body_markdown": "# DigiGraph\n> hub\n\nOrchestrates [[digisearch|DigiSearch]].",
+    },
+    {
+        "vault_path": "digisearch",
+        "title": "DigiSearch",
+        "frontmatter": {
+            "title": "DigiSearch",
+            "type": "module",
+            "status": "reviewed",
+            "tags": ["core", "retrieval"],
+        },
+        "body_markdown": "# DigiSearch\n> rag pipeline",
+    },
+]
+
+
+def test_reconstructs_notes_with_tags_and_backlinks() -> None:
+    vault = SupabaseStore(_FakeClient(_ROWS)).load_vault()
+
+    assert {n.name for n in vault.list_notes()} == {"digigraph", "digisearch"}
+    digigraph = vault.get_note("digigraph")
+    assert digigraph is not None
+    assert digigraph.title == "DigiGraph"
+    assert set(digigraph.tags) == {"core", "orchestration"}
+    # The [[digisearch]] wikilink resolves into a backlink — same indexing as on disk.
+    assert vault.backlinks("digisearch") == ("digigraph",)
+
+
+def test_read_text_uses_body_cache() -> None:
+    vault = SupabaseStore(_FakeClient(_ROWS)).load_vault()
+    body = vault.read_text("digigraph")
+    assert "Orchestrates" in body and "DigiGraph" in body
+
+
+def test_store_backed_vault_is_read_only() -> None:
+    vault = SupabaseStore(_FakeClient(_ROWS)).load_vault()
+    with pytest.raises(VaultError, match="read-only"):
+        vault.create_note("whatever")
+    with pytest.raises(VaultError, match="read-only"):
+        vault.set_frontmatter("digigraph", {"status": "stub"})
+
+
+def test_lint_runs_on_store_backed_vault() -> None:
+    report = SupabaseStore(_FakeClient(_ROWS)).load_vault().lint()
+    assert report.ok is True
+    assert report.note_count == 2
+
+
+def test_blank_vault_path_rows_are_skipped() -> None:
+    rows = [*_ROWS, {"vault_path": "  ", "title": "junk", "frontmatter": {}, "body_markdown": ""}]
+    vault = SupabaseStore(_FakeClient(rows)).load_vault()
+    assert len(vault.list_notes()) == 2
+
+
+def test_search_calls_rpc_with_query_and_limit() -> None:
+    client = _FakeClient([], rpc_data=[{"vault_path": "digikey", "title": "DigiKey", "rank": 0.9}])
+    results = SupabaseStore(client).search("authentication jwt", limit=3)
+
+    assert results[0]["vault_path"] == "digikey"
+    assert client.rpc_calls == [
+        ("search_architecture_notes", {"query": "authentication jwt", "match_limit": 3})
+    ]
+
+
+def test_from_env_raises_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "CORE_SUPABASE_URL",
+        "SUPABASE_URL",
+        "CORE_SUPABASE_ANON_KEY",
+        "CORE_SUPABASE_SERVICE_KEY",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(SupabaseStoreError, match="not configured"):
+        SupabaseStore.from_env()


### PR DESCRIPTION
## What

Replaces the static, in-repo KB chat prototype with a **DigiVault-managed architecture vault hosted in Supabase**, navigated by the embedded docs chat on digithings.ai. The repo docs stay the source of truth; the chat answers **only** from the vault — no web search, no other sources.

All phases in one PR, per request.

## Phases

- **0 — Vault** (`docs/vision/`): migrated in place to a DigiVault-managed Obsidian vault (YAML frontmatter, `[[wikilinks]]`, `_moc`, `.digivault.yml` manifest). `make vault-check` lints it (wikilinks/frontmatter/taxonomy/orphans) in CI. **16 notes, 0 issues.**
- **1 — Supabase vault + sync**: migration `048_architecture_notes` (mirrors `knowledge_notes` #1087 + a generated `tsvector` FTS column + `search_architecture_notes()` RPC + anon-read RLS). `scripts/sync_architecture_vault.py` publishes the vault → Supabase (DigiVault parses, `digibase[supabase]` upserts on `vault_path`). `sync-architecture-vault.yml` runs it on release (production environment, gated).
- **2 — DigiVault store** (`#1087` core): `Vault` is now storage-pluggable (`Vault.from_sources`); `supabase_store.SupabaseStore` reconstructs notes from `architecture_notes`/`knowledge_notes` and FTS-searches via the RPC. Additive — the filesystem path is unchanged (existing tests green), core stays `pydantic`+`pyyaml`-only (`supabase` is a lazy `[supabase]` extra). **33 DigiVault tests pass.**
- **3 — Embedded chat**: `functions/api/chat.ts` (Cloudflare Pages Function) retrieves via the `search_architecture_notes` RPC (anon key, RLS read-only), truncates context to bound cost, and streams an OpenRouter free-model-pool completion. Config-gated (503 if unset), same-site guard + per-IP rate limit. `StackChat` UI mounted in the module manifest.

## Verification

- `make score` (full diff): **Security 10 / Quality 10 / Optimization 10 / Accuracy 10**.
- DigiVault: 33 unit tests pass; `import digivault` stays FastAPI/Supabase-free (guard); ruff clean.
- `digithings-web` builds + static-exports; `chat.ts` typechecks.
- Migration `048` **applied to the core Supabase** (authorized) and the FTS RPC verified end-to-end (synthetic query ranked correctly, then cleaned).

## Operational notes (before the chat goes live)

1. **Seed the vault**: the 16 notes are seeded via the `digibase` connector — either the `sync-architecture-vault` workflow on the next release, or run locally with the service key:
   `CORE_SUPABASE_URL=… CORE_SUPABASE_SERVICE_KEY=… python scripts/sync_architecture_vault.py` (idempotent).
2. **Pages env vars** for the Function: `OPENROUTER_API_KEY`, `CORE_SUPABASE_URL`, `CORE_SUPABASE_ANON_KEY`.
3. **Bind `RATE_LIMIT_KV`** (see `wrangler.toml`) before public deploy — the in-memory limiter is per-isolate (soft).
4. **Verify the `:free` model slugs** in `chat.ts` are still live (membership churns).

## Scope / follow-ups

`Refs #1087`. Delivers #1087's store protocol + Supabase store + the public chat. **Deferred to follow-ups:** the literal DigiVault **MCP read tools** (`digivault_read_note`/`digivault_search` in `mcp_server.py`) for the self-hosted DigiGraph path, and the **pgvector** semantic-search column. Supersedes the static-KB chat prototype (the rejected `_digivault-kb.json` approach is **not** carried forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
