### PR TITLE
Release: develop → main — DigiChat /api/chat 502 fix + signature chat + ESLint/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       digigraph: ${{ steps.filter.outputs.digigraph }}
       digichat: ${{ steps.filter.outputs.digichat }}
       olympus: ${{ steps.filter.outputs.olympus }}
+      web: ${{ steps.filter.outputs.web }}
       score: ${{ steps.filter.outputs.score }}
       e2e_contract: ${{ steps.filter.outputs.e2e_contract }}
       nautilus_smoke: ${{ steps.filter.outputs.nautilus_smoke }}
@@ -86,6 +87,14 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/test-olympus.yml'
+            web:
+              - 'frontend/digithings-web/**'
+              - 'frontend/digiquant-web/**'
+              - 'frontend/web/**'
+              - 'frontend/design/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/test-web.yml'
             score:
               - 'digibase/**'
               - 'digiclaw/**'
@@ -197,6 +206,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.olympus == 'true'
     uses: ./.github/workflows/test-olympus.yml
+
+  web:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    uses: ./.github/workflows/test-web.yml
 
   score:
     needs: changes

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -1,0 +1,35 @@
+name: "Test: web apps"
+
+on:
+  workflow_call:
+
+concurrency:
+  group: web-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      # Install at the monorepo root so npm wires the @digithings/web and
+      # @digithings/design workspace symlinks, then lint each app in-workspace.
+      # No "Install Linux native bindings" step here: these jobs are lint-only
+      # (ESLint is pure JS) and never invoke rolldown / lightningcss / oxide.
+      - name: Install (root workspaces)
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint digithings-web
+        run: npm run lint --workspace digithings-web
+
+      - name: Lint digiquant-web
+        run: npm run lint --workspace digiquant-web

--- a/docs/vision/digichat.md
+++ b/docs/vision/digichat.md
@@ -29,8 +29,8 @@ Examples:
 
 **Two live deployments:**
 
-digithings.ai — platform demo:
-DigiThings own documentation indexed. Free tier: 3 questions with a cheap fast model. BYOK to continue beyond free. Model selector spans OpenAI, Anthropic, Gemini, Ollama. Sample questions displayed to guide exploration ("What does DigiQuant do?"). Goal: let any visitor experience the DigiThings stack directly.
+digithings.ai — platform demo (the flagship public DigiChat):
+DigiThings' own architecture docs are published into a [[digivault]] vault hosted in the core Supabase (the `architecture_notes` table, synced from `docs/vision/`), and DigiChat retrieves from it with full-text search on every turn — answers are grounded in the real docs, never web search. It runs on OpenRouter's free model pool, so visitors can use it with no sign-up; a lightweight per-IP throttle only deters bot floods (the free pool's own account-wide daily quota still applies — a one-time small credit purchase lifts it ~20x). Served at the edge by a Cloudflare Pages Function (`/api/chat`) using the anon, RLS-gated read key, so no secrets ever reach the browser. The bot introduces itself and can explain its own architecture. Bring-your-own-key — paste a provider key for stronger models, forwarded per-request and never stored — is the planned next step. Sample questions guide exploration ("What does DigiGraph orchestrate?"). Goal: let any visitor experience the DigiThings stack directly.
 
 digiquant.io — investment profiling:
 Entry flow powered by a proprietary investment profiling sub-graph. User inputs investment preferences → DigiChat builds and saves an investment profile to DigiStore (user acquisition + personalization). Shows what strategies and allocations could be constructed for their profile. Paywall trigger: "Ready to build your first strategy? Start with Kairos." Free taste → paid conversion.

--- a/frontend/digiquant-web/app/pipeline/page.tsx
+++ b/frontend/digiquant-web/app/pipeline/page.tsx
@@ -32,7 +32,7 @@ export default function PipelinePage() {
         <section className="section">
           <div className="wrap">
             <Reveal className="dq-sechead">
-              <div className="dq-eyebrow">// the pipeline</div>
+              <div className="dq-eyebrow">{"// the pipeline"}</div>
               <h2 className="dq-title">Research in, orders out — in a straight line.</h2>
               <p className="dq-sub">digiquant is not a hub of services routing messages around; it&rsquo;s a linear research workflow. You start in a chat, and each stage hands its output to the next until a strategy is ready to run. Built on the open <a href="https://digiquant.io" style={{ color: "var(--accent)" }}>digiquant</a> stack — itself a module of <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)" }}>the DigiThings platform</a>.</p>
             </Reveal>
@@ -56,7 +56,7 @@ export default function PipelinePage() {
         <section className="section section-alt">
           <div className="wrap">
             <Reveal className="dq-sechead center">
-              <div className="dq-eyebrow">// execution, gated</div>
+              <div className="dq-eyebrow">{"// execution, gated"}</div>
               <h2 className="dq-title">The execution layer climbs a ladder.</h2>
               <p className="dq-sub">Stage 07 in detail: a strategy earns its way to live. Backtest → paper → loopback → live, each rung a human gate. Loopback-only by default.</p>
             </Reveal>
@@ -74,7 +74,7 @@ export default function PipelinePage() {
                 </g>
                 <g transform="translate(421 24)" fill="none" stroke="var(--accent)" strokeWidth="1.4"><rect x="0" y="7" width="18" height="13" rx="1.5" /><path d="M4 7 v-2 a5 5 0 0 1 10 0 v2" /></g>
               </svg>
-              <p className="ladder-cap">// loopback-only by default · human-gated transitions</p>
+              <p className="ladder-cap">{"// loopback-only by default · human-gated transitions"}</p>
             </Reveal>
           </div>
         </section>

--- a/frontend/digiquant-web/app/strategies/page.tsx
+++ b/frontend/digiquant-web/app/strategies/page.tsx
@@ -23,7 +23,7 @@ export default function StrategiesPage() {
         <AmbientMesh />
         <div className="wrap">
           <header className="dq-sechead">
-            <div className="dq-eyebrow">// strategy library</div>
+            <div className="dq-eyebrow">{"// strategy library"}</div>
             <h1 className="dq-title">Three base strategies, fully validated</h1>
             <p className="dq-sub">
               digiquant ships with three reference crypto strategies — one per major asset

--- a/frontend/digiquant-web/components/landing/DqNav.tsx
+++ b/frontend/digiquant-web/components/landing/DqNav.tsx
@@ -9,6 +9,7 @@
  * `ThemeToggle` so it stays consistent with the rest of the design system.
  */
 import { useEffect, useRef } from "react";
+import Link from "next/link";
 import { ThemeToggle } from "@digithings/web";
 import { Brand, DQ_NAV_PRIMARY } from "@/app/_nav";
 import { OlympusMark } from "./OlympusMark";
@@ -45,9 +46,9 @@ export function DqNav() {
   return (
     <header className="dqnav" ref={navRef}>
       <div className="wrap">
-        <a className="brand" href="/" aria-label="digiquant home">
+        <Link className="brand" href="/" aria-label="digiquant home">
           <Brand />
-        </a>
+        </Link>
         <nav className="dqnav-links" aria-label="Primary">
           {DQ_NAV_PRIMARY.map((l) => (
             <a

--- a/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
+++ b/frontend/digiquant-web/components/tearsheet/tearsheet-view.tsx
@@ -8,6 +8,7 @@
  * log. "Download PDF" uses the browser's print-to-PDF.
  */
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import {
   TimeSeries,
   ComboPnl,
@@ -137,8 +138,8 @@ export function TearsheetView({ slug }: { slug: string }) {
     <div>
       <header className="ts-header">
         <div className="ts-header-main">
-          <a href="/strategies" className="ts-back">← Strategy library</a>
-          <span className="ts-kicker">// tearsheet</span>
+          <Link href="/strategies" className="ts-back">← Strategy library</Link>
+          <span className="ts-kicker">{"// tearsheet"}</span>
           <h1 className="ts-h1">{data.strategy}</h1>
           <div className="ts-meta">
             <span className="ts-chip">{data.symbol}</span>

--- a/frontend/digiquant-web/eslint.config.mjs
+++ b/frontend/digiquant-web/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;

--- a/frontend/digiquant-web/package.json
+++ b/frontend/digiquant-web/package.json
@@ -23,6 +23,8 @@
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "eslint": "^9",
+    "eslint-config-next": "16.2.4",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.7",
     "typescript": "^6.0.2"

--- a/frontend/digithings-web/app/_nav.tsx
+++ b/frontend/digithings-web/app/_nav.tsx
@@ -22,7 +22,7 @@ export const DT_NAV: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },
-  { label: "Try Chat", href: "/chat", cta: true },
+  { label: "Ask DigiChat", href: "/chat", cta: true },
 ];
 
 /** v7 nav shape (used by <DigiNav />): wayfinding links on the left of the tail,

--- a/frontend/digithings-web/app/chat/page.tsx
+++ b/frontend/digithings-web/app/chat/page.tsx
@@ -1,73 +1,24 @@
 import type { Metadata } from "next";
-import { Footer, Terminal, Reveal, type TermLine } from "@digithings/web";
-import { DT_FOOTER, DT_FOOTER_META } from "../_nav";
 import { DigiNav } from "@/components/landing/DigiNav";
-import { AmbientMesh } from "@/components/landing/AmbientMesh";
+import { DigiChatSession } from "@/components/DigiChatSession";
 
 export const metadata: Metadata = {
-  title: "DigiChat — digithings",
-  description: "Talk to your stack. DigiChat streams DigiGraph — BYOK, self-hosted, audited.",
+  title: "DigiChat — the DigiThings assistant",
+  description:
+    "Ask DigiChat anything about the DigiThings architecture — grounded in the DigiVault docs, " +
+    "running on a free model pool. No sign-up.",
 };
 
-const SESSION: TermLine[] = [
-  { kind: "cmd", text: "Build me a mean-reversion stat-arb on tech" },
-  { kind: "out", text: "→ routing to DigiQuant + DigiSearch" },
-  { kind: "out", text: "Atlas: researching candidates (NASDAQ tech, 90d)" },
-  { kind: "out", text: "→ scaffold: pairs-mean-reversion · sector=tech" },
-  { kind: "arrow", text: "→ backtest queued · tear sheet on completion" },
-  { kind: "gap" },
-  { kind: "cmd", text: "Show me the Sharpe by year" },
-  { kind: "out", text: "→ 2021: 1.12   2022: 0.87   2023: 1.44   2024: 1.31" },
-];
-
-const FEATURES = [
-  ["byok", "Your keys, your models", "Paste any Anthropic / OpenAI / LiteLLM key — forwarded per-request, never stored."],
-  ["streams digigraph", "Full orchestration surface", "Every message routes through the LangGraph supervisor; tools and sub-graphs on every turn."],
-  ["audit on", "Immutable logs, zero raw PII", "DigiSmith correlation IDs on every span; PII redacted before logs hit disk."],
-  ["self-hosted", "One compose file", "Runs on your laptop, a VM, or Kubernetes — the same Docker profile."],
-];
-
+// The /chat route is the full-screen signature DigiChat experience. The marketing
+// that used to live here (hero + canned transcript + feature cards) now streams as
+// the bot's own self-introduction inside DigiChatSession — the chat IS the pitch.
 export default function ChatPage() {
   return (
     <>
       <DigiNav />
-      <main className="dq-subpage">
-        <AmbientMesh />
-        <section className="hero center">
-          <div className="wrap">
-            <Reveal as="p" className="eyebrow"><span className="prompt">$</span> digichat · streams digigraph</Reveal>
-            <Reveal as="h1" className="hero-title" delay={0.05} >Talk to your <em>stack.</em></Reveal>
-            <Reveal as="p" className="hero-lede" delay={0.1}>Ask questions, run research, explore your data — with your keys, your models, and full audit on every response.</Reveal>
-            <Reveal className="hero-actions" delay={0.15}>
-              <a className="btn btn-primary" href="https://github.com/digithings-ai/digithings" target="_blank" rel="noopener noreferrer">Self-host on GitHub <span aria-hidden="true">→</span></a>
-              <a className="btn btn-ghost" href="/">Back to the stack</a>
-            </Reveal>
-          </div>
-        </section>
-
-        <section className="section">
-          <div className="wrap">
-            <div className="grid" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(230px, 1fr))" }}>
-              {FEATURES.map(([tag, h, p]) => (
-                <Reveal key={h} className="card">
-                  <div className="card-top"><span className="tier core">{tag}</span></div>
-                  <h3>{h}</h3><p className="card-body">{p}</p>
-                </Reveal>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="section section-alt">
-          <div className="wrap">
-            <Reveal className="section-head center"><span className="kicker">// example session</span><h2>What a turn looks like.</h2><p>Illustrative only — numbers are not real data.</p></Reveal>
-            <div style={{ maxWidth: 760, margin: "0 auto" }}>
-              <Terminal title="chat.digithings.ai" lines={SESSION} />
-            </div>
-          </div>
-        </section>
+      <main className="dc-page">
+        <DigiChatSession />
       </main>
-      <Footer links={DT_FOOTER} meta={DT_FOOTER_META} />
     </>
   );
 }

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -138,7 +138,7 @@ html { scroll-behavior: smooth; }
 .dt-manifest-body { display: grid; grid-template-columns: 1fr; }
 .dt-manifest-head { color: var(--ink-mute); font-size: 0.8rem; letter-spacing: 0.02em; margin-bottom: 0.7rem; }
 .dt-mh-prompt { color: var(--accent); }
-.dt-manifest-rows { list-style: none; margin: 0; padding: 0; }
+.dt-manifest-rows { list-style: none; margin: 0; padding: 0; max-height: clamp(220px, 40vh, 380px); overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; min-height: 0; }
 .dt-mrow { animation: dt-mrow-in 0.5s var(--ease) both; }
 @keyframes dt-mrow-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 .dt-mrow-link { width: 100%; text-align: left; background: transparent; border: 0; cursor: pointer; font: inherit; display: grid; grid-template-columns: 12px minmax(108px, 132px) 58px 1fr; align-items: center; gap: 0.55rem 0.85rem; padding: 0.4rem 0.55rem; border-radius: 8px; color: var(--ink-soft); transition: background 0.18s var(--ease); }
@@ -156,7 +156,7 @@ html { scroll-behavior: smooth; }
 .dt-out { margin-top: 0.6rem; padding: 0.75rem 0.55rem 0.3rem; border-top: 1px dashed var(--hair); }
 .dt-out-cmd { color: var(--ink-mute); font-size: 0.84rem; }
 .dt-out-dim { color: var(--ink-mute); }
-.dt-out-body { margin: 0.55rem 0 0; white-space: pre-wrap; word-break: break-word; font-family: var(--font-mono); font-size: 0.84rem; line-height: 1.7; color: var(--ink-soft); }
+.dt-out-body { margin: 0.55rem 0 0; white-space: pre-wrap; word-break: break-word; font-family: var(--font-mono); font-size: 0.84rem; line-height: 1.7; color: var(--ink-soft); max-height: clamp(180px, 34vh, 320px); overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; }
 .dt-out-body .dt-d { color: var(--ink); }
 .dt-cur { display: inline-block; width: 7px; height: 14px; background: var(--accent); vertical-align: -2px; animation: dt-bl 1.1s steps(1) infinite; }
 @keyframes dt-bl { 50% { opacity: 0; } }
@@ -176,12 +176,65 @@ html { scroll-behavior: smooth; }
   .dt-out { margin-top: 0; border-top: 0; border-left: 1px dashed var(--hair); padding: 0.1rem 0 0.4rem 1.6rem; }
 }
 
-/* ---- "ask about the stack" docs chat (StackChat.tsx) — lives in the right
-   .dt-out panel under the `digithings show` output. Terminal-styled, reuses the
-   manifest tokens (--ink/--accent/--hair/--font-mono). Streams /api/chat. ---- */
+/* ---- "ask about the stack" quick-ask (StackChat.tsx) — docked full-width BELOW
+   the manifest body (no longer inside the right column, which used to let the chat
+   grow the card past the page). Compact + capped; follow-ups escalate to /chat.
+   Terminal-styled, reuses the manifest tokens. Streams /api/chat. ---- */
 .dt-out-show { padding-bottom: 0.2rem; }
 .dtc { margin-top: 0.9rem; padding-top: 0.85rem; border-top: 1px dashed var(--hair); font-family: var(--font-mono); display: flex; flex-direction: column; gap: 0.6rem; }
-.dtc-head { color: var(--ink-mute); font-size: 0.78rem; letter-spacing: 0.02em; }
+.dtc-head { display: flex; align-items: center; flex-wrap: wrap; gap: 0.2rem 0.4rem; color: var(--ink-mute); font-size: 0.78rem; letter-spacing: 0.02em; }
+.dtc-open { margin-left: auto; font: inherit; font-size: 0.74rem; color: var(--accent); background: transparent; border: 0; cursor: pointer; padding: 0.1rem 0.35rem; border-radius: 6px; transition: background 0.18s var(--ease); }
+.dtc-open:hover { background: color-mix(in srgb, var(--accent) 13%, transparent); }
+.dtc-escalate { margin: 0; font-size: 0.76rem; line-height: 1.5; }
+.dtc-escalate strong { color: var(--accent); font-weight: 500; }
+
+/* ---- DigiChat identity: the "Ask DigiChat" nav CTA + the two-tone wordmark ---- */
+.dt-askcta { display: inline-flex; align-items: center; gap: 0.4rem; }
+.dt-askcta svg { flex: none; }
+.dc-wordmark { font-family: var(--font-mono); font-weight: 500; letter-spacing: -0.01em; }
+.dc-wordmark .dc-wm-d { color: var(--ink); }
+.dc-wordmark .dc-wm-s { color: var(--accent); }
+
+/* ---- DigiChat signature page (/chat) — full-screen terminal chat. Theme-aware
+   via tokens; reuses .dt-cur (cursor), .dtc-chip (suggestions), .dtc-error. ---- */
+.dc-page { min-height: 100vh; padding: calc(var(--dq-nav-h, 62px) + 1.1rem) clamp(0.7rem, 3vw, 1.4rem) clamp(0.9rem, 3vw, 1.4rem); display: flex; }
+.dc-session { width: 100%; max-width: 920px; margin: 0 auto; display: flex; flex-direction: column; height: calc(100vh - var(--dq-nav-h, 62px) - 2.2rem); min-height: 440px; font-family: var(--font-mono); background: color-mix(in srgb, var(--surface) 70%, transparent); border: 1px solid var(--hair); border-radius: 16px; overflow: hidden; }
+.dc-bar { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; padding: 0.7rem 0.95rem; border-bottom: 1px solid var(--hair); color: var(--ink-mute); font-size: 0.82rem; }
+.dc-bar > svg { color: var(--accent); flex: none; }
+.dc-bar-meta { color: var(--ink-mute); }
+.dc-bar-model { margin-left: auto; font-size: 0.74rem; color: var(--ink-soft); border: 1px solid var(--hair); border-radius: 7px; padding: 0.15rem 0.5rem; }
+.dc-thread { flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; padding: 1.1rem 0.95rem; display: flex; flex-direction: column; gap: 1rem; }
+.dc-msg { position: relative; display: grid; grid-template-columns: 1rem minmax(0, 1fr); gap: 0.6rem; align-items: start; font-size: 0.9rem; line-height: 1.7; }
+.dc-who { color: var(--accent); font-weight: 600; user-select: none; }
+.dc-user .dc-who { color: var(--ink-mute); }
+.dc-body { min-width: 0; color: var(--ink-soft); word-break: break-word; }
+.dc-user .dc-body, .dc-intro .dc-body { color: var(--ink); white-space: pre-wrap; }
+.dc-intro .dc-body { color: var(--ink-soft); }
+.dc-md-p { margin: 0 0 0.7rem; }
+.dc-md-p:last-child { margin-bottom: 0; }
+.dc-body a { color: var(--accent); text-underline-offset: 2px; }
+.dc-code-inline { font-family: var(--font-mono); font-size: 0.85em; background: color-mix(in srgb, var(--ink) 9%, transparent); border-radius: 5px; padding: 0.05rem 0.3rem; }
+.dc-code-block { position: relative; margin: 0.6rem 0; }
+.dc-code-block pre { margin: 0; background: color-mix(in srgb, var(--ink) 7%, transparent); border: 1px solid var(--hair); border-radius: 9px; padding: 0.7rem 0.8rem; overflow-x: auto; }
+.dc-code-block code { font-family: var(--font-mono); font-size: 0.82rem; color: var(--ink); white-space: pre; }
+.dc-code-copy, .dc-msg-copy { font: inherit; font-size: 0.7rem; color: var(--ink-mute); background: color-mix(in srgb, var(--surface) 80%, transparent); border: 1px solid var(--hair); border-radius: 6px; padding: 0.12rem 0.4rem; cursor: pointer; opacity: 0; transition: opacity 0.15s var(--ease); }
+.dc-code-copy { position: absolute; top: 0.4rem; right: 0.4rem; }
+.dc-msg-copy { position: absolute; top: 0; right: 0; }
+.dc-code-block:hover .dc-code-copy, .dc-msg:hover .dc-msg-copy, .dc-code-copy:focus-visible, .dc-msg-copy:focus-visible { opacity: 1; }
+.dc-suggest { display: flex; flex-wrap: wrap; gap: 0.45rem; padding-left: 1.6rem; }
+.dc-form { display: grid; grid-template-columns: 0.9rem minmax(0, 1fr) auto; align-items: end; gap: 0.5rem; padding: 0.6rem 0.7rem; border-top: 1px solid var(--hair); background: color-mix(in srgb, var(--surface) 50%, transparent); }
+.dc-form .dt-mh-prompt { padding-bottom: 0.5rem; }
+.dc-textarea { font: inherit; font-size: 0.9rem; line-height: 1.5; background: transparent; border: 0; color: var(--ink); width: 100%; resize: none; max-height: 140px; padding: 0.4rem 0; }
+.dc-textarea::placeholder { color: var(--ink-mute); }
+.dc-textarea:focus { outline: none; }
+.dc-send, .dc-stop { font: inherit; align-self: stretch; color: var(--accent); background: transparent; border: 1px solid var(--hair); border-radius: 8px; cursor: pointer; padding: 0.3rem 0.65rem; transition: background 0.18s var(--ease); }
+.dc-send { font-size: 1rem; }
+.dc-stop { font-size: 0.8rem; color: var(--ink-soft); }
+.dc-send:hover:not(:disabled), .dc-stop:hover { background: color-mix(in srgb, var(--accent) 13%, transparent); }
+.dc-send:disabled { opacity: 0.4; cursor: default; }
+@media (prefers-reduced-motion: reduce) {
+  .dc-code-copy, .dc-msg-copy, .dc-send, .dc-stop { transition: none; }
+}
 .dtc-thread { font-size: 0.82rem; line-height: 1.65; max-height: 248px; overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; }
 .dtc-empty { display: flex; flex-direction: column; gap: 0.7rem; }
 .dtc-empty p { margin: 0; font-size: 0.82rem; line-height: 1.6; }

--- a/frontend/digithings-web/app/page.tsx
+++ b/frontend/digithings-web/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
             Self-hosted, BYOK, audit-on by default. No vendor lock-in, no opaque pipelines.
           </p>
           <div className="dqhero-cta">
-            <a className="btn btn-primary" href="/#architecture">
+            <a className="btn btn-primary" href="#architecture">
               Explore the platform <span aria-hidden="true">→</span>
             </a>
           </div>
@@ -40,7 +40,7 @@ export default function Home() {
         <section className="section" id="architecture">
           <div className="wrap">
             <Reveal className="section-head center">
-              <span className="kicker">// the architecture</span>
+              <span className="kicker">{"// the architecture"}</span>
               <h2>Ten modules, wired into one.</h2>
               <p>A supervisor at the centre routes every request to the right module — chat, quant research, or retrieval. Each one self-hosted, audited, and swappable.</p>
             </Reveal>
@@ -50,7 +50,7 @@ export default function Home() {
 
         <section className="section section-alt" id="principles">
           <div className="wrap">
-            <Reveal className="section-head"><span className="kicker">// why digithings</span><h2>Four properties of every module.</h2></Reveal>
+            <Reveal className="section-head"><span className="kicker">{"// why digithings"}</span><h2>Four properties of every module.</h2></Reveal>
             <div className="principles">
               <Reveal className="principle"><span className="principle-num">01</span><h3>Self-hosted by default</h3><p>One docker-compose file runs the whole stack on a laptop, a VM, or a cluster.</p></Reveal>
               <Reveal className="principle"><span className="principle-num">02</span><h3>BYOK, every request</h3><p>Anthropic, OpenAI, or any LiteLLM-compatible key — forwarded per-request, never stored.</p></Reveal>

--- a/frontend/digithings-web/components/DigiChatMark.tsx
+++ b/frontend/digithings-web/components/DigiChatMark.tsx
@@ -1,0 +1,54 @@
+/**
+ * DigiChatMark — the DigiChat logo: a CLI prompt (`>_`) inside a chat bubble.
+ * The "prompt bubble" direction — chat × terminal, DigiChat's signature mark.
+ *
+ * Draws in `currentColor` so it sits on any surface (the accent-on-dark nav CTA,
+ * the chat title bar, a favicon tile). Decorative by default (`aria-hidden`); pass
+ * a `title` to make it a labelled standalone image for screen readers.
+ */
+export function DigiChatMark({ size = 18, title }: { size?: number; title?: string }) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      fill="none"
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+    >
+      {title ? <title>{title}</title> : null}
+      <rect x="5" y="8" width="46" height="33" rx="10" stroke="currentColor" strokeWidth="2.6" />
+      <path
+        d="M17 41 L17 50 L28 41"
+        stroke="currentColor"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16 18 L23 24.5 L16 31"
+        stroke="currentColor"
+        strokeWidth="2.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <rect x="27" y="29" width="12" height="2.6" rx="1.3" fill="currentColor" />
+    </svg>
+  );
+}
+
+/**
+ * DigiChatWordmark — the two-tone lockup: `digi` in ink, `chat` in the accent,
+ * with an optional blinking cursor block. Mono, theme-aware. Used in the chat
+ * title bar and anywhere the full name is set in the terminal voice.
+ */
+export function DigiChatWordmark({ cursor = false }: { cursor?: boolean }) {
+  return (
+    <span className="dc-wordmark">
+      <span className="dc-wm-d">digi</span>
+      <span className="dc-wm-s">chat</span>
+      {cursor ? <span className="dt-cur" aria-hidden="true" /> : null}
+    </span>
+  );
+}

--- a/frontend/digithings-web/components/DigiChatSession.tsx
+++ b/frontend/digithings-web/components/DigiChatSession.tsx
@@ -41,7 +41,9 @@ export function DigiChatSession() {
   const threadRef = useRef<HTMLDivElement>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
-  // Resume a landing handoff, else type out the self-intro.
+  // Resume a landing handoff, else type out the self-intro. The intro reveal drives
+  // `intro` as an animation, so synchronous setState in the effect body is intentional.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     const h = readAndClearHandoff();
     if (h && h.messages.length) {
@@ -64,6 +66,7 @@ export function DigiChatSession() {
     return () => window.clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Keep the newest content in view as it streams.
   useEffect(() => {

--- a/frontend/digithings-web/components/DigiChatSession.tsx
+++ b/frontend/digithings-web/components/DigiChatSession.tsx
@@ -1,0 +1,201 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { useStackChat } from "@/lib/useStackChat";
+import { readAndClearHandoff } from "@/lib/chatHandoff";
+import { MiniMarkdown } from "@/lib/miniMarkdown";
+import { CopyButton } from "@/lib/CopyButton";
+import { DigiChatMark, DigiChatWordmark } from "@/components/DigiChatMark";
+
+/**
+ * DigiChatSession — the full-screen signature DigiChat experience on `/chat`.
+ * A terminal-skinned chat with the features you expect from a real one (markdown,
+ * copy code, multi-line input, stop), on the shared `useStackChat` engine.
+ *
+ * It opens with a streamed self-introduction (client-side, display-only — never
+ * sent upstream, so it's instant, free, and always on-message) that doubles as the
+ * page's marketing. If the visitor arrived from the landing quick-ask, it resumes
+ * that session via the cross-tab handoff (see `chatHandoff`).
+ *
+ * Theme-aware via the design tokens (not hardcoded dark), consistent with the
+ * module manifest.
+ */
+const INTRO = `Hi — I'm DigiChat, the assistant for the DigiThings stack.
+
+I answer questions about the architecture: how the modules fit together, how the system is built, and how it runs. Ask me anything — DigiGraph orchestration, DigiQuant backtests, auth in DigiKey, retrieval in DigiSearch — the lot.
+
+A bit about me: I'm grounded in DigiVault, a self-hosted, Obsidian-style vault in the cloud, and I search it before every answer, so I cite the real docs instead of guessing. I run on OpenRouter's free model pool — no sign-up, no key needed. For heavier use or stronger models, bring-your-own-key is coming soon.
+
+Where should we start?`;
+
+const SUGGESTIONS = [
+  "What does DigiGraph orchestrate?",
+  "How does auth work?",
+  "How are you built?",
+  "What can I do with DigiQuant?",
+];
+
+export function DigiChatSession() {
+  const { messages, busy, error, send, stop, seed } = useStackChat();
+  const [input, setInput] = useState("");
+  const [intro, setIntro] = useState(""); // typed-out self-introduction
+  const threadRef = useRef<HTMLDivElement>(null);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // Resume a landing handoff, else type out the self-intro.
+  useEffect(() => {
+    const h = readAndClearHandoff();
+    if (h && h.messages.length) {
+      seed(h.messages);
+      setIntro(INTRO); // show intro instantly above a resumed thread
+      if (h.pending) void send(h.pending);
+      return;
+    }
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setIntro(INTRO);
+      return;
+    }
+    let i = 0;
+    const step = Math.max(2, Math.ceil(INTRO.length / 110)); // ~1.8s regardless of length
+    const id = window.setInterval(() => {
+      i += step;
+      setIntro(INTRO.slice(0, i));
+      if (i >= INTRO.length) window.clearInterval(id);
+    }, 16);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the newest content in view as it streams.
+  useEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, busy, intro]);
+
+  function submit(question: string) {
+    const q = question.trim();
+    if (!q || busy) return;
+    void send(q);
+    setInput("");
+    if (taRef.current) taRef.current.style.height = "auto";
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit(input);
+    }
+  }
+
+  const introDone = intro.length >= INTRO.length;
+
+  return (
+    <section className="dc-session" aria-label="DigiChat">
+      <div className="dc-bar">
+        <DigiChatMark size={18} />
+        <DigiChatWordmark />
+        <span className="dc-bar-meta">· flagship assistant · vault-grounded</span>
+        <span className="dc-bar-model">model: free pool</span>
+      </div>
+
+      <div className="dc-thread" ref={threadRef} aria-live="polite" aria-atomic="false">
+        <div className="dc-msg dc-assistant dc-intro" aria-live="off">
+          <span className="dc-who" aria-hidden="true">
+            ·
+          </span>
+          <div className="dc-body">
+            {intro}
+            {!introDone && <span className="dt-cur" />}
+          </div>
+        </div>
+
+        {introDone && messages.length === 0 && (
+          <div className="dc-suggest">
+            {SUGGESTIONS.map((s) => (
+              <button
+                key={s}
+                type="button"
+                className="dtc-chip"
+                onClick={() => submit(s)}
+                disabled={busy}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {messages.map((m, i) => {
+          const streaming = busy && m.role === "assistant" && i === messages.length - 1;
+          return (
+            <div key={i} className={`dc-msg dc-${m.role}`}>
+              <span className="dc-who" aria-hidden="true">
+                {m.role === "user" ? ">" : "·"}
+              </span>
+              <div className="dc-body">
+                {m.role === "assistant" ? (
+                  <>
+                    <MiniMarkdown text={m.content} />
+                    {streaming && <span className="dt-cur" />}
+                    {streaming && !m.content && <span className="dt-out-dim">retrieving…</span>}
+                  </>
+                ) : (
+                  m.content
+                )}
+              </div>
+              {m.role === "assistant" && !streaming && m.content && (
+                <CopyButton text={m.content} className="dc-msg-copy" ariaLabel="Copy answer" />
+              )}
+            </div>
+          );
+        })}
+
+        {error && (
+          <p className="dtc-error" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <form
+        className="dc-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit(input);
+        }}
+      >
+        <span className="dt-mh-prompt" aria-hidden="true">
+          $
+        </span>
+        <textarea
+          ref={taRef}
+          className="dc-textarea"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            e.target.style.height = "auto";
+            e.target.style.height = `${Math.min(140, e.target.scrollHeight)}px`;
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="ask digichat anything…   (enter to send · shift+enter for a new line)"
+          aria-label="Ask DigiChat"
+          rows={1}
+          maxLength={2000}
+        />
+        {busy ? (
+          <button type="button" className="dc-stop" onClick={stop} aria-label="Stop generating">
+            stop
+          </button>
+        ) : (
+          <button
+            type="submit"
+            className="dc-send"
+            disabled={!input.trim()}
+            aria-label="Send message"
+          >
+            ↵
+          </button>
+        )}
+      </form>
+    </section>
+  );
+}

--- a/frontend/digithings-web/components/landing/DigiNav.tsx
+++ b/frontend/digithings-web/components/landing/DigiNav.tsx
@@ -15,6 +15,7 @@
  * a theme toggle + a GitHub icon button + the existing "Try Chat" primary CTA.
  */
 import { useEffect, useRef } from "react";
+import Link from "next/link";
 import { ThemeToggle } from "@digithings/web";
 import { Brand, DT_NAV_PRIMARY } from "@/app/_nav";
 import { DigiChatMark } from "@/components/DigiChatMark";
@@ -51,9 +52,9 @@ export function DigiNav() {
   return (
     <header className="dqnav" ref={navRef}>
       <div className="wrap">
-        <a className="brand" href="/" aria-label="digithings home">
+        <Link className="brand" href="/" aria-label="digithings home">
           <Brand />
-        </a>
+        </Link>
         <nav className="dqnav-links" aria-label="Primary">
           {DT_NAV_PRIMARY.map((l) => (
             <a
@@ -78,10 +79,10 @@ export function DigiNav() {
           >
             <GitHubGlyph />
           </a>
-          <a className="btn btn-primary btn-sm dt-askcta" href="/chat" aria-label="Ask DigiChat">
+          <Link className="btn btn-primary btn-sm dt-askcta" href="/chat" aria-label="Ask DigiChat">
             <DigiChatMark size={16} />
             Ask DigiChat
-          </a>
+          </Link>
         </div>
       </div>
     </header>

--- a/frontend/digithings-web/components/landing/DigiNav.tsx
+++ b/frontend/digithings-web/components/landing/DigiNav.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useRef } from "react";
 import { ThemeToggle } from "@digithings/web";
 import { Brand, DT_NAV_PRIMARY } from "@/app/_nav";
+import { DigiChatMark } from "@/components/DigiChatMark";
 
 // GitHub glyph rendered locally (the shared NavLink type carries no icon field).
 function GitHubGlyph() {
@@ -77,8 +78,9 @@ export function DigiNav() {
           >
             <GitHubGlyph />
           </a>
-          <a className="btn btn-primary btn-sm" href="/chat">
-            Try Chat
+          <a className="btn btn-primary btn-sm dt-askcta" href="/chat" aria-label="Ask DigiChat">
+            <DigiChatMark size={16} />
+            Ask DigiChat
           </a>
         </div>
       </div>

--- a/frontend/digithings-web/components/landing/ModuleManifest.tsx
+++ b/frontend/digithings-web/components/landing/ModuleManifest.tsx
@@ -111,9 +111,9 @@ export function ModuleManifest() {
             </div>
           )}
         </div>
-        <StackChat />
       </div>
       </div>
+      <StackChat />
     </div>
   );
 }

--- a/frontend/digithings-web/components/landing/ModuleManifest.tsx
+++ b/frontend/digithings-web/components/landing/ModuleManifest.tsx
@@ -29,6 +29,9 @@ export function ModuleManifest() {
   const selMod = sel ? rows.find((m) => m.id === sel) ?? null : null;
   const out = selMod ? buildOutput(selMod) : "";
 
+  // The summary types out character-by-character: this effect resets and then drives
+  // `shown` as an animation, so synchronous setState in the effect body is intentional.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!selMod) {
       setShown(0);
@@ -52,6 +55,7 @@ export function ModuleManifest() {
     return () => window.clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sel]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return (
     <div className="dt-manifest" aria-label="DigiThings module manifest">

--- a/frontend/digithings-web/components/landing/StackChat.tsx
+++ b/frontend/digithings-web/components/landing/StackChat.tsx
@@ -1,38 +1,26 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import { useStackChat } from "@/lib/useStackChat";
+import { writeHandoff } from "@/lib/chatHandoff";
 
 /**
- * "Ask about the stack" — a read-only docs Q&A chat that lives in the right-hand
- * panel of the module manifest, under the `digithings show <module>` output.
+ * "Ask about the stack" — the compact, single-shot quick-ask that lives in the
+ * module manifest. It answers ONE question inline over the DigiVault docs (via the
+ * shared `useStackChat` engine — no web search), then hands off: once a question
+ * has been answered, the next one escalates to the full-screen DigiChat page,
+ * carrying the transcript across tabs (see `writeHandoff`). This keeps the landing
+ * terminal bounded — the inline thread is capped and the real session lives on
+ * `/chat` — instead of growing the panel past the page (the old behaviour).
  *
- * It POSTs the running transcript to the Cloudflare Pages Function at
- * `/api/chat`, which full-text-searches the DigiVault architecture vault hosted
- * in Supabase (the chat's only knowledge source — no web search) and streams an
- * OpenRouter free-pool completion back as plain-text token deltas. We render
- * those tokens live. Terminal aesthetic via the existing `.dt-*` / `.dtc-*`
- * tokens; theme-aware and keyboard accessible. If the deployment isn't
- * configured the Function returns a JSON error and we show a friendly
- * "chat not configured" line instead of a thread.
+ * Terminal aesthetic via the shared `.dt-*` / `.dtc-*` tokens; theme-aware and
+ * keyboard accessible. Errors render as a friendly line, not a thrown thread.
  */
-
-interface ChatMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-const SUGGESTIONS = [
-  "What is DigiQuant?",
-  "How does auth work?",
-  "What does Olympus do?",
-];
+const SUGGESTIONS = ["What is DigiQuant?", "How does auth work?", "What does Olympus do?"];
 
 export function StackChat() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const { messages, busy, error, send } = useStackChat();
   const [input, setInput] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const threadRef = useRef<HTMLDivElement>(null);
-  const abortRef = useRef<AbortController | null>(null);
 
   // Keep the newest tokens in view as they stream.
   useEffect(() => {
@@ -40,96 +28,46 @@ export function StackChat() {
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages, busy]);
 
-  // Abort any in-flight stream on unmount.
-  useEffect(() => () => abortRef.current?.abort(), []);
+  const empty = messages.length === 0;
+  // After the first completed exchange, a new question opens the full session.
+  const escalateNext = messages.length >= 2 && !busy;
 
-  async function send(question: string) {
+  function openFull(pending: string) {
+    writeHandoff(messages, pending);
+    window.open("/chat", "_blank", "noopener,noreferrer");
+  }
+
+  function submit(question: string) {
     const q = question.trim();
     if (!q || busy) return;
-    setError(null);
+    if (escalateNext) openFull(q);
+    else void send(q);
     setInput("");
-
-    const next: ChatMessage[] = [...messages, { role: "user", content: q }];
-    // Add an empty assistant turn we append streamed tokens into.
-    setMessages([...next, { role: "assistant", content: "" }]);
-    setBusy(true);
-
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      const res = await fetch("/api/chat", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ messages: next }),
-        signal: controller.signal,
-      });
-
-      // Non-streaming JSON => an error path (missing key, rate limit, etc.).
-      const ctype = res.headers.get("content-type") ?? "";
-      if (!res.ok || ctype.includes("application/json")) {
-        let msg = `request failed (${res.status})`;
-        try {
-          const data = await res.json();
-          msg = data.error
-            ? data.error === "chat not configured"
-              ? "chat not configured on this deployment"
-              : String(data.error)
-            : msg;
-        } catch {
-          /* keep generic msg */
-        }
-        // Drop the placeholder assistant turn; surface the error line instead.
-        setMessages(next);
-        setError(msg);
-        return;
-      }
-
-      // Stream plain-text token deltas into the last assistant message.
-      const reader = res.body?.getReader();
-      if (!reader) throw new Error("no response stream");
-      const decoder = new TextDecoder();
-      let acc = "";
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        acc += decoder.decode(value, { stream: true });
-        setMessages([...next, { role: "assistant", content: acc }]);
-      }
-      if (!acc.trim()) {
-        setMessages(next);
-        setError("no answer returned — try rephrasing");
-      }
-    } catch (e) {
-      if ((e as Error).name === "AbortError") return;
-      setMessages(next);
-      setError(`network error: ${(e as Error).message}`);
-    } finally {
-      setBusy(false);
-      abortRef.current = null;
-    }
   }
 
   function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    void send(input);
+    submit(input);
   }
-
-  const empty = messages.length === 0;
 
   return (
     <div className="dtc">
       <div className="dtc-head">
         <span className="dt-mh-prompt">$</span> digithings ask
-        <span className="dt-out-dim"> · docs Q&amp;A over the digivault</span>
+        <span className="dt-out-dim"> · quick question over the digivault</span>
+        {!empty && (
+          <button type="button" className="dtc-open" onClick={() => openFull("")}>
+            open in digichat <span aria-hidden="true">↗</span>
+          </button>
+        )}
       </div>
 
       <div className="dtc-thread" ref={threadRef} aria-live="polite" aria-atomic="false">
         {empty && !error ? (
           <div className="dtc-empty">
             <p className="dt-out-dim">
-              Ask about the stack — modules, ports, auth, orchestration. Answers come
-              only from the published docs.
+              Ask one quick question about the stack — answers come only from the published
+              docs. Follow-ups open a full session in DigiChat.
             </p>
             <div className="dtc-suggest">
               {SUGGESTIONS.map((s) => (
@@ -137,7 +75,7 @@ export function StackChat() {
                   key={s}
                   type="button"
                   className="dtc-chip"
-                  onClick={() => void send(s)}
+                  onClick={() => submit(s)}
                   disabled={busy}
                 >
                   {s}
@@ -148,8 +86,7 @@ export function StackChat() {
         ) : (
           <ul className="dtc-msgs">
             {messages.map((m, i) => {
-              const streaming =
-                busy && m.role === "assistant" && i === messages.length - 1;
+              const streaming = busy && m.role === "assistant" && i === messages.length - 1;
               return (
                 <li key={i} className={`dtc-msg dtc-${m.role}`}>
                   <span className="dtc-who" aria-hidden="true">
@@ -158,9 +95,7 @@ export function StackChat() {
                   <span className="dtc-body">
                     {m.content}
                     {streaming && <span className="dt-cur" />}
-                    {streaming && !m.content && (
-                      <span className="dt-out-dim">retrieving…</span>
-                    )}
+                    {streaming && !m.content && <span className="dt-out-dim">retrieving…</span>}
                   </span>
                 </li>
               );
@@ -174,6 +109,12 @@ export function StackChat() {
         )}
       </div>
 
+      {escalateNext && (
+        <p className="dtc-escalate dt-out-dim">
+          More questions? Your next one opens a full session in <strong>DigiChat</strong>.
+        </p>
+      )}
+
       <form className="dtc-form" onSubmit={onSubmit}>
         <span className="dt-mh-prompt" aria-hidden="true">
           $
@@ -183,8 +124,8 @@ export function StackChat() {
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="ask about the stack…"
-          aria-label="Ask about the DigiThings stack"
+          placeholder={escalateNext ? "ask a follow-up in digichat…" : "ask one quick question…"}
+          aria-label="Ask one quick question about the DigiThings stack"
           disabled={busy}
           autoComplete="off"
           maxLength={500}
@@ -193,9 +134,9 @@ export function StackChat() {
           className="dtc-send"
           type="submit"
           disabled={busy || !input.trim()}
-          aria-label="Send question"
+          aria-label={escalateNext ? "Open follow-up in DigiChat" : "Send question"}
         >
-          {busy ? "…" : "↵"}
+          {busy ? "…" : escalateNext ? "↗" : "↵"}
         </button>
       </form>
     </div>

--- a/frontend/digithings-web/eslint.config.mjs
+++ b/frontend/digithings-web/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  // Override default ignores of eslint-config-next.
+  globalIgnores([
+    // Default ignores of eslint-config-next:
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+  ]),
+]);
+
+export default eslintConfig;

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -54,14 +54,15 @@ const MAX_NOTE_CHARS = 1500; // truncate each note body — bounds prompt size/c
 const RATE_LIMIT_MAX = 60;
 const RATE_LIMIT_WINDOW_S = 60;
 
-// OpenRouter FREE-MODEL POOL (models[] fallback routing). `:free` membership churns —
-// verify against https://openrouter.ai/models?max_price=0 before relying in prod.
-const MODEL_POOL = [
-  "meta-llama/llama-3.3-70b-instruct:free",
-  "qwen/qwen-2.5-72b-instruct:free",
-  "google/gemma-2-9b-it:free",
-  "mistralai/mistral-7b-instruct:free",
-];
+// OpenRouter FREE-MODEL routing. We target the Free Models Router (`openrouter/free`): one
+// identifier that auto-selects from OpenRouter's LIVE free pool and capability-filters per request,
+// so it never goes stale as `:free` membership churns (the old hardcoded pool had gone 3/4 dead —
+// only llama-3.3-70b survived). If you ever want an explicit fallback chain instead, send a
+// `models: [...]` array of verified-current `:free` IDs (e.g. "meta-llama/llama-3.3-70b-instruct:free",
+// "openai/gpt-oss-120b:free", "google/gemma-4-31b-it:free") — but that reintroduces the churn upkeep.
+// NB free-tier limits are ACCOUNT-WIDE: 20 req/min, and 50 requests/DAY unless the account has ever
+// purchased >= $10 of credits (one-time, permanent -> 1000/day). https://openrouter.ai/openrouter/free
+const MODEL = "openrouter/free";
 
 const SYSTEM_PROMPT =
   "You are the DigiThings documentation assistant. Answer ONLY from the provided " +
@@ -237,7 +238,7 @@ export async function onRequestPost(ctx: EventContext): Promise<Response> {
         "X-Title": "DigiThings Docs Assistant",
       },
       body: JSON.stringify({
-        models: MODEL_POOL,
+        model: MODEL,
         messages: upstream,
         stream: true,
         temperature: 0.2,

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -134,19 +134,41 @@ function sameSiteOK(request: Request): boolean {
   }
 }
 
+// Upstream fetch deadlines. Without these, a hung Supabase/OpenRouter call makes the Worker
+// wait until Cloudflare kills it with an opaque raw 502; with them, a slow/hung upstream
+// surfaces as our own clean JSON error instead. OpenRouter's free pool can be slow to start,
+// so its budget is generous — but the timer is cleared the instant the response resolves, so
+// a streaming body is never cut mid-stream.
+const VAULT_TIMEOUT_MS = 10_000;
+const OPENROUTER_TIMEOUT_MS = 30_000;
+
+async function fetchWithTimeout(url: string, init: RequestInit, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer); // response resolved (or threw) — no late abort of an open stream
+  }
+}
+
 // ---- Retrieval: FTS over the Supabase-hosted vault via the RPC (anon, RLS read) ----
 async function searchVault(env: Env, query: string, k: number): Promise<VaultHit[]> {
   const base = (env.CORE_SUPABASE_URL ?? "").replace(/\/+$/, "");
   const key = env.CORE_SUPABASE_ANON_KEY ?? "";
-  const resp = await fetch(`${base}/rest/v1/rpc/search_architecture_notes`, {
-    method: "POST",
-    headers: {
-      apikey: key,
-      Authorization: `Bearer ${key}`,
-      "content-type": "application/json",
+  const resp = await fetchWithTimeout(
+    `${base}/rest/v1/rpc/search_architecture_notes`,
+    {
+      method: "POST",
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query, match_limit: k }),
     },
-    body: JSON.stringify({ query, match_limit: k }),
-  });
+    VAULT_TIMEOUT_MS,
+  );
   if (!resp.ok) {
     const detail = await resp.text().catch(() => "");
     throw new Error(`vault search ${resp.status}: ${detail.slice(0, 200)}`);
@@ -166,8 +188,19 @@ function buildContext(hits: VaultHit[]): string {
     .join("\n\n---\n\n");
 }
 
-// onRequestPost — Pages Functions route handler for POST /api/chat.
+// onRequestPost — Pages Functions route handler for POST /api/chat. A top-level guard turns
+// ANY unhandled throw into our JSON 500 (readable in the browser Network tab) instead of an
+// opaque Cloudflare raw 502 — so the endpoint can never fail silently at the edge.
 export async function onRequestPost(ctx: EventContext): Promise<Response> {
+  try {
+    return await handleChat(ctx);
+  } catch (e) {
+    console.error("chat handler crashed:", (e as Error).stack ?? (e as Error).message);
+    return jsonError("chat failed unexpectedly — please retry", 500);
+  }
+}
+
+async function handleChat(ctx: EventContext): Promise<Response> {
   const { request, env } = ctx;
 
   // 1. Config gates FIRST — never call upstreams half-configured.
@@ -229,22 +262,26 @@ export async function onRequestPost(ctx: EventContext): Promise<Response> {
   // 6. Call OpenRouter with the free-model pool + streaming.
   let orResp: Response;
   try {
-    orResp = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
-        "content-type": "application/json",
-        "HTTP-Referer": "https://digithings.ai",
-        "X-Title": "DigiThings Docs Assistant",
+    orResp = await fetchWithTimeout(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+          "content-type": "application/json",
+          "HTTP-Referer": "https://digithings.ai",
+          "X-Title": "DigiThings Docs Assistant",
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          messages: upstream,
+          stream: true,
+          temperature: 0.2,
+          max_tokens: 700,
+        }),
       },
-      body: JSON.stringify({
-        model: MODEL,
-        messages: upstream,
-        stream: true,
-        temperature: 0.2,
-        max_tokens: 700,
-      }),
-    });
+      OPENROUTER_TIMEOUT_MS,
+    );
   } catch (e) {
     console.error("openrouter request failed:", (e as Error).message);
     return jsonError("upstream temporarily unavailable", 502);

--- a/frontend/digithings-web/lib/CopyButton.tsx
+++ b/frontend/digithings-web/lib/CopyButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useState } from "react";
+
+/**
+ * CopyButton — a tiny "copy / copied" button shared by the chat's code blocks and
+ * per-message copy affordances. Write-only clipboard access (no read), with a
+ * 1.2s confirmation flip and a no-op rejection handler for blocked clipboards.
+ */
+export function CopyButton({
+  text,
+  className,
+  ariaLabel,
+}: {
+  text: string;
+  className?: string;
+  ariaLabel: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className={className}
+      aria-label={ariaLabel}
+      onClick={() =>
+        navigator.clipboard?.writeText(text).then(
+          () => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
+          },
+          () => {},
+        )
+      }
+    >
+      {copied ? "copied" : "copy"}
+    </button>
+  );
+}

--- a/frontend/digithings-web/lib/chatHandoff.ts
+++ b/frontend/digithings-web/lib/chatHandoff.ts
@@ -1,0 +1,53 @@
+"use client";
+import type { ChatMessage } from "./useStackChat";
+
+/**
+ * Cross-tab handoff for escalating the landing quick-ask into the full DigiChat
+ * page. When the inline quick-ask hits a follow-up, it stashes the running
+ * transcript plus the new question here and opens `/chat` in a new tab; the page
+ * reads-and-clears this on mount and resumes the session.
+ *
+ * Uses `localStorage`, NOT `sessionStorage`: a `window.open`'d tab gets a fresh
+ * session storage, so the handoff would silently vanish. localStorage is shared
+ * across tabs of the same origin. We keep nothing in the URL (privacy: user text
+ * never lands in a query string or history) and read-and-clear immediately so the
+ * payload is one-shot and doesn't leak into a later visit. Stale payloads (a tab
+ * never opened) self-expire after a few minutes.
+ */
+const KEY = "digichat:handoff";
+const MAX_AGE_MS = 5 * 60 * 1000;
+
+export interface ChatHandoff {
+  messages: ChatMessage[];
+  pending: string;
+  ts: number;
+}
+
+export function writeHandoff(messages: ChatMessage[], pending: string): void {
+  try {
+    const payload: ChatHandoff = { messages, pending: pending.trim(), ts: Date.now() };
+    localStorage.setItem(KEY, JSON.stringify(payload));
+  } catch {
+    /* storage blocked (private mode / quota) — escalation just opens a fresh chat */
+  }
+}
+
+/** Read the handoff once and remove it. Returns null if absent, malformed, or stale. */
+export function readAndClearHandoff(): ChatHandoff | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    localStorage.removeItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ChatHandoff;
+    if (!parsed || typeof parsed.ts !== "number" || Date.now() - parsed.ts > MAX_AGE_MS) return null;
+    if (typeof parsed.pending !== "string" || !Array.isArray(parsed.messages)) return null;
+    // Validate per-element shape before this payload is seeded, rendered, and POSTed.
+    const wellFormed = parsed.messages.every(
+      (m) => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string",
+    );
+    if (!wellFormed) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/digithings-web/lib/miniMarkdown.tsx
+++ b/frontend/digithings-web/lib/miniMarkdown.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { Fragment, type ReactNode } from "react";
+import { CopyButton } from "./CopyButton";
+
+/**
+ * MiniMarkdown — a deliberately minimal, XSS-safe Markdown renderer for streamed
+ * model output. It builds React nodes directly and NEVER uses
+ * `dangerouslySetInnerHTML`, so model text (which is attacker-influenceable via
+ * prompt injection) can't inject markup — React escapes every text node. We
+ * support only what a docs answer needs:
+ *
+ *   - fenced ```code``` blocks (with a copy button)
+ *   - `inline code`
+ *   - **bold**
+ *   - [links](https://…) — http/https only; anything else stays literal text
+ *   - line breaks
+ *
+ * Not full GFM (no raw HTML, images, tables) — that's the point: a tight, audited
+ * surface keeps the Security gate green without a sanitizer dependency. Parsing uses
+ * `String.matchAll` (no stateful `RegExp.exec` loop).
+ */
+
+// Inline spans within a single text segment. Text is auto-escaped by React.
+function renderInline(text: string, keyBase: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const re = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\(https?:\/\/[^\s)]+\))/g;
+  let last = 0;
+  let k = 0;
+  for (const m of text.matchAll(re)) {
+    const idx = m.index ?? 0;
+    if (idx > last) nodes.push(<Fragment key={`${keyBase}-${k++}`}>{text.slice(last, idx)}</Fragment>);
+    const tok = m[0];
+    if (tok.startsWith("`")) {
+      nodes.push(
+        <code key={`${keyBase}-${k++}`} className="dc-code-inline">
+          {tok.slice(1, -1)}
+        </code>,
+      );
+    } else if (tok.startsWith("**")) {
+      nodes.push(<strong key={`${keyBase}-${k++}`}>{tok.slice(2, -2)}</strong>);
+    } else {
+      const lm = tok.match(/^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)$/);
+      if (lm) {
+        nodes.push(
+          <a key={`${keyBase}-${k++}`} href={lm[2]} target="_blank" rel="noopener noreferrer">
+            {lm[1]}
+          </a>,
+        );
+      } else {
+        nodes.push(<Fragment key={`${keyBase}-${k++}`}>{tok}</Fragment>);
+      }
+    }
+    last = idx + tok.length;
+  }
+  if (last < text.length) nodes.push(<Fragment key={`${keyBase}-${k++}`}>{text.slice(last)}</Fragment>);
+  return nodes;
+}
+
+// A text block: paragraphs split on blank lines, single newlines become <br>.
+function renderTextBlock(text: string, keyBase: string): ReactNode[] {
+  return text.split(/\n{2,}/).map((para, pi) => (
+    <p className="dc-md-p" key={`${keyBase}-p${pi}`}>
+      {para.split("\n").map((line, li) => (
+        <Fragment key={`${keyBase}-p${pi}-l${li}`}>
+          {li > 0 && <br />}
+          {renderInline(line, `${keyBase}-p${pi}-l${li}`)}
+        </Fragment>
+      ))}
+    </p>
+  ));
+}
+
+function CodeBlock({ code }: { code: string }) {
+  return (
+    <div className="dc-code-block">
+      <CopyButton text={code} className="dc-code-copy" ariaLabel="Copy code" />
+      <pre>
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function MiniMarkdown({ text }: { text: string }) {
+  const parts: ReactNode[] = [];
+  const re = /```[\w-]*\n?([\s\S]*?)```/g;
+  let last = 0;
+  let k = 0;
+  for (const m of text.matchAll(re)) {
+    const idx = m.index ?? 0;
+    const seg = text.slice(last, idx).trim();
+    if (seg) parts.push(...renderTextBlock(seg, `seg${k++}`));
+    parts.push(<CodeBlock key={`code${k++}`} code={m[1].replace(/\n$/, "")} />);
+    last = idx + m[0].length;
+  }
+  const tail = text.slice(last).trim();
+  if (tail) parts.push(...renderTextBlock(tail, `seg${k++}`));
+  return <>{parts}</>;
+}

--- a/frontend/digithings-web/lib/useStackChat.ts
+++ b/frontend/digithings-web/lib/useStackChat.ts
@@ -1,0 +1,142 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * useStackChat — the shared chat engine behind both the landing quick-ask
+ * (StackChat) and the full-screen DigiChat page. Render-agnostic: it owns the
+ * transcript, streaming, abort, and error state, but emits no UI — each surface
+ * draws its own (compact terminal bar vs. full session).
+ *
+ * It POSTs the running transcript to the Cloudflare Pages Function at
+ * `/api/chat`, which full-text-searches the DigiVault architecture vault in
+ * Supabase and streams an OpenRouter completion back as plain-text token deltas.
+ * A non-streaming JSON response is the error path (missing key, rate limit, …).
+ *
+ * Latest transcript is mirrored in a ref so `send` stays stable and never reads a
+ * stale closure — important when the DigiChat page seeds a handoff transcript and
+ * immediately sends a pending question on mount.
+ */
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface UseStackChat {
+  messages: ChatMessage[];
+  busy: boolean;
+  error: string | null;
+  /** Append a user turn and stream the assistant reply. No-op while busy or empty. */
+  send: (question: string) => Promise<void>;
+  /** Abort the in-flight stream and keep whatever streamed so far. */
+  stop: () => void;
+  /** Clear the transcript and any error. */
+  reset: () => void;
+  /** Replace the transcript wholesale (used by the cross-tab handoff). */
+  seed: (messages: ChatMessage[]) => void;
+}
+
+export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
+  const [messages, setMessages] = useState<ChatMessage[]>(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const messagesRef = useRef<ChatMessage[]>(initial);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Single funnel for transcript writes so the ref and state never diverge.
+  const apply = useCallback((next: ChatMessage[]) => {
+    messagesRef.current = next;
+    setMessages(next);
+  }, []);
+
+  // Abort any in-flight stream on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const send = useCallback(
+    async (question: string) => {
+      const q = question.trim();
+      if (!q || abortRef.current) return; // abortRef set === a stream is in flight
+      setError(null);
+
+      const base: ChatMessage[] = [...messagesRef.current, { role: "user", content: q }];
+      apply([...base, { role: "assistant", content: "" }]); // placeholder we stream into
+      setBusy(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+      try {
+        const res = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ messages: base }),
+          signal: controller.signal,
+        });
+
+        // Non-streaming JSON => an error path (missing key, rate limit, etc.).
+        const ctype = res.headers.get("content-type") ?? "";
+        if (!res.ok || ctype.includes("application/json")) {
+          let msg = `request failed (${res.status})`;
+          try {
+            const data = await res.json();
+            msg = data.error
+              ? data.error === "chat not configured"
+                ? "chat not configured on this deployment"
+                : String(data.error)
+              : msg;
+          } catch {
+            /* keep generic msg */
+          }
+          apply(base); // drop the placeholder; surface the error line instead
+          setError(msg);
+          return;
+        }
+
+        const reader = res.body?.getReader();
+        if (!reader) throw new Error("no response stream");
+        const decoder = new TextDecoder();
+        let acc = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          acc += decoder.decode(value, { stream: true });
+          apply([...base, { role: "assistant", content: acc }]);
+        }
+        if (!acc.trim()) {
+          apply(base);
+          setError("no answer returned — try rephrasing");
+        }
+      } catch (e) {
+        if ((e as Error).name === "AbortError") return; // keep partial text
+        apply([...messagesRef.current.slice(0, -1)]); // drop the empty placeholder
+        setError(`network error: ${(e as Error).message}`);
+      } finally {
+        setBusy(false);
+        abortRef.current = null;
+      }
+    },
+    [apply],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setBusy(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    apply([]);
+    setError(null);
+    setBusy(false);
+  }, [apply]);
+
+  const seed = useCallback(
+    (next: ChatMessage[]) => {
+      setError(null);
+      apply(next);
+    },
+    [apply],
+  );
+
+  return { messages, busy, error, send, stop, reset, seed };
+}

--- a/frontend/digithings-web/package.json
+++ b/frontend/digithings-web/package.json
@@ -23,6 +23,8 @@
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "eslint": "^9",
+    "eslint-config-next": "16.2.4",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.7",
     "typescript": "^6.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,38 @@
         "@types/node": "^25.5.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "eslint": "^9",
+        "eslint-config-next": "16.2.4",
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.7",
         "typescript": "^6.0.2"
+      }
+    },
+    "frontend/digiquant-web/node_modules/eslint-config-next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
+      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.2.4",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "frontend/digithings-web": {
@@ -162,9 +191,38 @@
         "@types/node": "^25.5.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "eslint": "^9",
+        "eslint-config-next": "16.2.4",
         "postcss": "^8.5.4",
         "tailwindcss": "^4.1.7",
         "typescript": "^6.0.2"
+      }
+    },
+    "frontend/digithings-web/node_modules/eslint-config-next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
+      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.2.4",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "frontend/olympus": {
@@ -10348,6 +10406,111 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/scripts/ci_paths.yaml
+++ b/scripts/ci_paths.yaml
@@ -56,6 +56,15 @@ olympus:
   - package-lock.json
   - .github/workflows/olympus-test.yml
 
+web:
+  - frontend/digithings-web/**
+  - frontend/digiquant-web/**
+  - frontend/web/**
+  - frontend/design/**
+  - package.json
+  - package-lock.json
+  - .github/workflows/test-web.yml
+
 score:
   - digibase/**
   - digiclaw/**

--- a/scripts/copilot_pr_suites.py
+++ b/scripts/copilot_pr_suites.py
@@ -27,6 +27,11 @@ SUITE_TEST_COMMANDS: dict[str, list[str]] = {
     "digigraph": ["python -m pytest tests/dg/ -m unit -v --tb=short"],
     "digichat": ["npm ci", "npm run test --workspace digichat"],
     "olympus": ["npm ci", "npm run test --workspace olympus"],
+    "web": [
+        "npm ci",
+        "npm run lint --workspace digithings-web",
+        "npm run lint --workspace digiquant-web",
+    ],
     "atlas_graph": [
         "python -m pytest tests/dq/atlas/ tests/dq/hermes/ -m unit -v --tb=short",
     ],
@@ -137,7 +142,7 @@ def run_suite_commands(suites: list[str], *, changed: list[str]) -> int:
     if targets:
         subprocess.run(["python", "-m", "ruff", "check", *targets], cwd=REPO_ROOT, check=True)
 
-    if "digichat" in suites or "olympus" in suites:
+    if "digichat" in suites or "olympus" in suites or "web" in suites:
         subprocess.run(["npm", "ci"], cwd=REPO_ROOT, check=True)
 
     for suite in suites:


### PR DESCRIPTION
Promotes #1148 to production. This is the only delta on `develop` since the last promotion (#1146).

## What ships
- **Fixes the live `/api/chat` 502.** `openrouter/free` Free Models Router (the hardcoded `:free` pool had gone 3/4 dead) + never-raw-502 hardening: a top-level try/catch and `AbortController` deadlines on both upstream fetches, so the Worker returns our clean JSON instead of Cloudflare's opaque 502. The endpoint can no longer fail silently at the edge.
- **DigiChat signature chat** (digithings.ai) — fixed-height module terminal (the overflow fix), inline quick-ask that escalates to a full session, a full-screen `/chat` page with a streamed self-introduction + XSS-safe markdown, and the "Ask DigiChat" nav CTA.
- **ESLint v9 flat config + `web / lint` CI** for digithings-web + digiquant-web (lint was broken repo-wide).

## Triggered on merge to main
- Cloudflare Pages rebuilds **digithings.ai** (deploys the chat fix → clears the live 502) and **digiquant.io**.
- `db-migrate` — no new migrations, idempotent no-op.
- `sync-architecture-vault` — re-syncs the updated `digichat` vault note.

## Verified on #1148
- pr-reviewer **Ship** (10/10/10/10) + security-reviewer **Pass** (9/10, no secret leak).
- CI **CLEAN**: `web/lint`, both site builds, CodeQL, `score`, `gitleaks`, tests all green.

## Post-deploy smoke test
`POST https://digithings.ai/api/chat` — a streamed answer = fully live; any remaining failure now returns a **readable JSON error** in the Network tab (no more opaque raw 502), so it's self-diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
