### PR TITLE
chore(ci): enforce path-filter drift check; reconcile ci_paths.yaml (Fixes #1152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,9 @@ jobs:
           pip install -e "./digikey[dev]"
           pip install cryptography ruff polars tabulate pyyaml pytest openai httpx
 
+      - name: CI path filters in sync (ci.yml ⇄ ci_paths.yaml)
+        run: python scripts/generate_ci_path_filters.py --check
+
       - name: Validate model routing (config only)
         run: python scripts/validate_model_routing.py --routing
 

--- a/scripts/ci_paths.yaml
+++ b/scripts/ci_paths.yaml
@@ -1,60 +1,61 @@
 # Single source of truth for CI path filters (dorny/paths-filter in ci.yml).
 # Regenerate embedded block: python3 scripts/generate_ci_path_filters.py
-# Drift check: python3 scripts/generate_ci_path_filters.py --check
+# Drift check (enforced in CI by the ruff-and-scripts job):
+#   python3 scripts/generate_ci_path_filters.py --check
 
 digibase:
   - digibase/**
   - tests/db/**
-  - .github/workflows/digibase-test.yml
+  - .github/workflows/test-digibase.yml
 
 digikey:
   - digikey/**
   - tests/dk/**
-  - .github/workflows/digikey-test.yml
+  - .github/workflows/test-digikey.yml
 
 digismith:
   - digismith/**
   - tests/dsm/**
-  - .github/workflows/digismith-test.yml
+  - .github/workflows/test-digismith.yml
 
 digivault:
   - digivault/**
   - tests/dv/**
-  - .github/workflows/digivault-test.yml
+  - .github/workflows/test-digivault.yml
 
 digiclaw:
   - digiclaw/**
   - tests/dc/**
-  - .github/workflows/digiclaw-test.yml
+  - .github/workflows/test-digiclaw.yml
 
 digiquant:
   - digiquant/**
   - tests/dq/**
-  - .github/workflows/digiquant-test.yml
+  - .github/workflows/test-digiquant.yml
 
 digisearch:
   - digisearch/**
   - tests/ds/**
-  - .github/workflows/digisearch-test.yml
+  - .github/workflows/test-digisearch.yml
 
 digigraph:
   - digigraph/**
   - tests/dg/**
-  - .github/workflows/digigraph-test.yml
+  - .github/workflows/test-digigraph.yml
 
 digichat:
   - frontend/digichat/**
   - frontend/design/**
   - package.json
   - package-lock.json
-  - .github/workflows/digichat-test.yml
+  - .github/workflows/test-digichat.yml
 
 olympus:
   - frontend/olympus/**
   - frontend/design/**
   - package.json
   - package-lock.json
-  - .github/workflows/olympus-test.yml
+  - .github/workflows/test-olympus.yml
 
 score:
   - digibase/**
@@ -70,19 +71,19 @@ score:
   - tests/**
   - agents.yml
   - agents/**
-  - .github/workflows/score-pr.yml
+  - .github/workflows/test-score.yml
 
 e2e_contract:
   - tests/test_e2e.py
   - tests/test_e2e_contract.py
   - docker-compose.yml
   - digikey/**
-  - .github/workflows/e2e.yml
+  - .github/workflows/test-e2e.yml
 
 nautilus_smoke:
   - digiquant/**
   - tests/dq/test_nautilus_runner.py
-  - .github/workflows/nautilus-smoke.yml
+  - .github/workflows/test-nautilus.yml
 
 atlas_graph:
   - digiquant/src/digiquant/olympus/atlas/**
@@ -90,9 +91,11 @@ atlas_graph:
   - digiquant/supabase/**
   - tests/dq/atlas/**
   - digiquant/src/digiquant/olympus/hermes/**
+  - digiquant/src/digiquant/olympus/learning/**
   - tests/dq/hermes/**
-  - .github/workflows/atlas-graph-ci.yml
-  - .github/workflows/atlas-*.yml
+  - tests/dq/learning/**
+  - .github/workflows/test-atlas-graph.yml
+  - .github/workflows/pipeline-olympus.yml
 
 ruff_and_scripts:
   - digibase/**
@@ -118,4 +121,4 @@ compose:
 pip_audit:
   - "**/pyproject.toml"
   - pip-audit-ignore.txt
-  - .github/workflows/pip-audit.yml
+  - .github/workflows/security-pip-audit.yml


### PR DESCRIPTION
## What & why

`scripts/ci_paths.yaml` — the declared single source of truth for the `dorny/paths-filter` block in `.github/workflows/ci.yml` — had **drifted** from the live embedded block, and **nothing enforced the existing drift check**, so the two were diverging silently.

`python3 scripts/generate_ci_path_filters.py --check` exited **1** on `develop`. The drift was not cosmetic: `ci_paths.yaml` carried workflow filenames that **don't exist on disk**, and a `paths-filter` watching a non-existent workflow never triggers its job — so the gating was quietly degrading.

## Changes

**1. Reconcile `scripts/ci_paths.yaml` → live ci.yml block** (direction matters — see below):
- 10× `*-test.yml` → `test-*.yml` (e.g. `digibase-test.yml` → `test-digibase.yml`)
- `score-pr.yml` → `test-score.yml`, `e2e.yml` → `test-e2e.yml`, `nautilus-smoke.yml` → `test-nautilus.yml`, `pip-audit.yml` → `security-pip-audit.yml`
- `atlas_graph`: add missing `learning` sub-graph paths (`digiquant/src/digiquant/olympus/learning/**`, `tests/dq/learning/**`); correct `atlas-graph-ci.yml`/`atlas-*.yml` → `test-atlas-graph.yml` + `pipeline-olympus.yml`

**2. Enforce the check in CI** — add one step to the `ruff-and-scripts` job:
```yaml
- name: CI path filters in sync (ci.yml ⇄ ci_paths.yaml)
  run: python scripts/generate_ci_path_filters.py --check
```
That job's path filter already watches `scripts/**`, `.github/workflows/ci.yml`, and `scripts/ci_paths.yaml`, so any future edit to either side triggers it and fails on drift.

## Reconciliation direction (important)

The generator's name and the `ci_paths.yaml` header *imply* `ci_paths.yaml` is authoritative and ci.yml is generated from it — but **reality was inverted**. The embedded ci.yml block is the hand-maintained, correct version: it references workflows that actually exist and includes the later-added `learning` paths. So reconciliation flows **ci.yml → ci_paths.yaml**. Running the generator's *write* mode against the old source would have **corrupted** the live filters; with the source reconciled, write mode is idempotent again (footgun closed).

## Verification

- `--check` observed in **both** states: exit **1** when drifted (on develop), exit **0** after reconciliation — proves the check discriminates, not just that it's green now.
- ci.yml diff is **only** the 3-line step; the filter block is byte-for-byte unchanged; ci.yml parses as valid YAML.
- All 17 workflow filenames now referenced in `ci_paths.yaml` exist on disk.
- `make score` — Security 10, Quality 10, Optimization 10, Accuracy 10 (all ≥ threshold).
- Self-test: this PR touches both `ci.yml` and `ci_paths.yaml`, so it triggers `ruff-and-scripts` and exercises the new check against itself.

## Note for maintainers — required status check

This makes the check **run** on relevant PRs, which is what the task asked for. It does **not** by itself make a red `ruff-and-scripts` **block merge** — that requires adding it to `develop`'s required status checks in branch protection (not changeable from this PR). Caveat: path-filtered conditional jobs are awkward as required checks (a skipped `if:` job can wedge PRs), so whether to add it to the required set is a maintainer judgment call.

Fixes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
