### PR TITLE
Promote: agentic digivault chat fix to production (#1154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,9 @@ jobs:
           pip install -e "./digikey[dev]"
           pip install cryptography ruff polars tabulate pyyaml pytest openai httpx
 
+      - name: CI path filters in sync (ci.yml ⇄ ci_paths.yaml)
+        run: python scripts/generate_ci_path_filters.py --check
+
       - name: Validate model routing (config only)
         run: python scripts/validate_model_routing.py --routing
 

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -1,15 +1,21 @@
 // Cloudflare Pages Function — POST /api/chat
-// "Ask about the stack" docs chat for digithings.ai.
+// digichat: the agentic "ask about the stack" assistant for digithings.ai.
 //
-// The DigiVault-managed architecture vault is the ONLY knowledge source — no web
-// search, no other tools. Retrieval is a Postgres full-text search over the vault
-// hosted in Supabase (public.architecture_notes, synced from docs/vision/ by
-// scripts/sync_architecture_vault.py). We call the search_architecture_notes RPC
-// with the anon key (RLS-gated, read-only), inject the top hits as system context,
-// and stream an OpenRouter free-model-pool completion back as plain-text deltas.
+// AGENTIC, not forced-RAG. The model drives the conversation and has exactly ONE tool —
+// search_digivault — which full-text-searches the digivault (the only knowledge source about
+// digithings). The model calls the tool when it needs facts about the stack, and answers casual
+// chat directly without it. Retrieval is a Postgres FTS over the vault hosted in Supabase
+// (public.architecture_notes, synced from docs/vision/ by scripts/sync_architecture_vault.py),
+// queried with the anon key (RLS-gated, read-only). The local digivault MCP server is loopback
+// only and unreachable from Cloudflare's edge, so the tool reads the same vault content from its
+// public Supabase mirror.
+//
+// Every OpenRouter call is awaited inside handleChat (stream=false), so the top-level try/catch +
+// fetchWithTimeout cover all failure modes and the endpoint returns proper HTTP status codes —
+// it can never fail with an opaque raw Cloudflare 502, and there is no post-return stream to drop.
 //
 // Config (Pages env vars):
-//   OPENROUTER_API_KEY      — required; the LLM call. Missing => clear 503.
+//   OPENROUTER_API_KEY      — required; the LLM calls. Missing => clear 503.
 //   CORE_SUPABASE_URL       — required; the vault's Supabase project URL.
 //   CORE_SUPABASE_ANON_KEY  — required; anon key (public, RLS-gated read).
 // No service-role key here: the Function only ever reads, through the anon RLS policy.
@@ -29,9 +35,32 @@ interface EventContext {
   env: Env;
   waitUntil?: (p: Promise<unknown>) => void;
 }
+// A single inbound chat turn from the browser.
 interface ChatMessage {
   role: "user" | "assistant" | "system";
   content: string;
+}
+// OpenAI-shape tool call (as OpenRouter returns it on message.tool_calls).
+interface ToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+// A message in the agentic conversation we send upstream — a superset of ChatMessage that also
+// carries an assistant turn's tool_calls and the role:"tool" results that answer them.
+interface ConvoMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+}
+// The (stream=false) chat-completions response shape we read.
+interface ChatCompletionResponse {
+  choices?: Array<{
+    message?: { role?: string; content?: string | null; tool_calls?: ToolCall[] };
+    finish_reason?: string;
+  }>;
+  error?: { message?: string };
 }
 interface VaultHit {
   vault_path: string;
@@ -47,33 +76,71 @@ interface VaultHit {
 // ---- Tunables ----
 const MAX_TURNS = 12; // conversation turns sent upstream
 const MAX_MSG_CHARS = 2000; // cap a single message
-const TOP_K = 6; // vault hits injected as context
-const MAX_NOTE_CHARS = 1500; // truncate each note body — bounds prompt size/cost
-// Generous per-IP cap: humans never approach it; it only blunts bot floods. The chat runs
-// on OpenRouter FREE models (no cost), so this deters spam rather than rationing real use.
+const TOP_K = 4; // vault hits returned to the model per tool call (small — free models, small ctx)
+const MAX_NOTE_CHARS = 1200; // truncate each note body — bounds the tool-result payload size
+const MAX_TOOL_ROUNDS = 3; // model⇄tool round trips before we stop (bounds worst-case latency)
+// Generous per-IP cap: humans never approach it; it only blunts bot floods. The chat runs on
+// OpenRouter FREE models (no cost), so this deters spam rather than rationing real use.
 const RATE_LIMIT_MAX = 60;
 const RATE_LIMIT_WINDOW_S = 60;
 
-// OpenRouter FREE-MODEL routing via the `models[]` fallback array — OpenRouter tries them in
-// order, advancing to the next on error. We pin verified-current `:free` IDs led by the
-// long-lived, reliable meta-llama/llama-3.3-70b-instruct:free. (The `openrouter/free` router
-// returned HTTP 200 with an *empty* stream in prod — no usable content — so we don't rely on it.)
-// `:free` membership churns; if these go stale, the SSE error-frame surfacing in the transform
-// below makes the failure visible instead of silently empty. NB free-tier limits are ACCOUNT-WIDE:
-// 20 req/min, and 50 req/DAY unless the account has ever purchased >= $10 of credits (permanent
-// -> 1000/day) — verify the deployment's key is on the funded account if you see rate errors.
+// OpenRouter FREE-MODEL pool via the `models[]` fallback array — OpenRouter tries them in order,
+// advancing to the next on error. These are led by tool-calling-capable free models (gpt-oss and
+// llama-3.3-70b natively support function calling); combined with provider.require_parameters
+// below, OpenRouter only routes to a model that actually supports the tools we send, and skips any
+// that don't. `:free` membership churns; if these go stale, callModel surfaces the error to the
+// user instead of going silently empty. NB free-tier limits are ACCOUNT-WIDE: 20 req/min, and
+// 50 req/DAY unless the account has ever purchased >= $10 of credits (permanent -> 1000/day).
 const MODEL_POOL = [
-  "meta-llama/llama-3.3-70b-instruct:free",
   "openai/gpt-oss-120b:free",
-  "google/gemma-4-31b-it:free",
+  "meta-llama/llama-3.3-70b-instruct:free",
+  "openai/gpt-oss-20b:free",
 ];
 
 const SYSTEM_PROMPT =
-  "You are the DigiThings documentation assistant. Answer ONLY from the provided " +
-  "DigiVault context about the open-core agentic stack (DigiGraph, DigiQuant, " +
-  "DigiSearch, DigiChat, DigiKey, DigiSmith, DigiVault, DigiClaw, DigiBase, DigiLLM, " +
-  "DigiFetch, DigiDev, DigiLink, DigiStore, Olympus). Be concise and technical. If the " +
-  "context doesn't cover the question, say so plainly. Never invent features, ports, or APIs.";
+  "You are digichat, the documentation assistant for the digithings open-core agentic stack. " +
+  "You have ONE tool, search_digivault, which queries the digivault — the only source of truth " +
+  "about digithings. For ANY question about digithings, its modules, architecture, ports, APIs, " +
+  "or how it is built or run, you MUST call search_digivault first and answer ONLY from what it " +
+  "returns. If the tool returns nothing relevant, say you don't have that in the docs — never " +
+  "invent features, ports, or APIs. For greetings or small talk unrelated to digithings, reply " +
+  "normally without the tool. Be concise and technical. Always write digithings module names in " +
+  "lowercase (digithings, digigraph, digichat, …); Olympus, Atlas, and Hermes keep their " +
+  "capitalization.";
+
+// The one tool the model is given. Its description is the model's cue for WHEN to reach for the
+// vault vs. answer casual chat directly.
+const TOOLS = [
+  {
+    type: "function" as const,
+    function: {
+      name: "search_digivault",
+      description:
+        "Search the digithings architecture knowledge base (the digivault docs) for facts about " +
+        "the open-core stack: the modules (digigraph, digiquant, digisearch, digichat, digikey, " +
+        "digismith, digivault, digiclaw, digibase) and roadmap ones (digistore, digilink), their " +
+        "ports, APIs, how they connect, and how the system is built and run. Call this whenever " +
+        "the user asks anything about digithings, its modules, architecture, or how it works. Do " +
+        "NOT call it for greetings or small talk unrelated to digithings.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "What to look up in the digivault docs (a focused natural-language query).",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+];
+
+// Shown (as the answer body) when a model call succeeds at the HTTP level but yields no usable
+// content — almost always the free pool being rate-limited / out of daily quota.
+const NO_CONTENT_NOTE =
+  "⚠ the model pool returned no content — the free models may be rate-limited or out of daily " +
+  "quota. Please retry in a moment.";
 
 function jsonError(message: string, status = 400): Response {
   return new Response(JSON.stringify({ error: message }), {
@@ -86,6 +153,18 @@ function notConfigured(detail: string): Response {
   return new Response(JSON.stringify({ error: "chat not configured", detail }), {
     status: 503,
     headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+// The successful answer body: plain text the browser appends. Non-streamed — the full answer
+// arrives at once; the UI's "retrieving…" indicator covers the wait.
+function answerText(text: string): Response {
+  return new Response(text, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+    },
   });
 }
 
@@ -138,11 +217,9 @@ function sameSiteOK(request: Request): boolean {
   }
 }
 
-// Upstream fetch deadlines. Without these, a hung Supabase/OpenRouter call makes the Worker
-// wait until Cloudflare kills it with an opaque raw 502; with them, a slow/hung upstream
-// surfaces as our own clean JSON error instead. OpenRouter's free pool can be slow to start,
-// so its budget is generous — but the timer is cleared the instant the response resolves, so
-// a streaming body is never cut mid-stream.
+// Upstream fetch deadline. Without it, a hung Supabase/OpenRouter call makes the Worker wait
+// until Cloudflare kills it with an opaque raw 502; with it, a slow/hung upstream surfaces as our
+// own clean JSON error instead.
 const VAULT_TIMEOUT_MS = 10_000;
 const OPENROUTER_TIMEOUT_MS = 30_000;
 
@@ -152,11 +229,11 @@ async function fetchWithTimeout(url: string, init: RequestInit, ms: number): Pro
   try {
     return await fetch(url, { ...init, signal: controller.signal });
   } finally {
-    clearTimeout(timer); // response resolved (or threw) — no late abort of an open stream
+    clearTimeout(timer);
   }
 }
 
-// ---- Retrieval: FTS over the Supabase-hosted vault via the RPC (anon, RLS read) ----
+// ---- The search_digivault tool: FTS over the Supabase-hosted vault via the RPC (anon, RLS read) ----
 async function searchVault(env: Env, query: string, k: number): Promise<VaultHit[]> {
   const base = (env.CORE_SUPABASE_URL ?? "").replace(/\/+$/, "");
   const key = env.CORE_SUPABASE_ANON_KEY ?? "";
@@ -192,9 +269,117 @@ function buildContext(hits: VaultHit[]): string {
     .join("\n\n---\n\n");
 }
 
-// onRequestPost — Pages Functions route handler for POST /api/chat. A top-level guard turns
-// ANY unhandled throw into our JSON 500 (readable in the browser Network tab) instead of an
-// opaque Cloudflare raw 502 — so the endpoint can never fail silently at the edge.
+// Execute a tool call by name and return a string the model reads back. Tool failures return a
+// readable string (never throw) so the model can tell the user gracefully and the loop continues.
+async function runTool(env: Env, name: string, rawArgs: string): Promise<string> {
+  if (name !== "search_digivault") return `Unknown tool: ${name}`;
+  let query = "";
+  try {
+    const parsed = JSON.parse(rawArgs || "{}") as { query?: unknown };
+    if (typeof parsed.query === "string") query = parsed.query.trim();
+  } catch {
+    // malformed arguments — fall through to the empty-query message
+  }
+  if (!query) return "No search query was provided.";
+  try {
+    const hits = await searchVault(env, query, TOP_K);
+    if (!hits.length) return "No matching documentation was found in the digivault for that query.";
+    return buildContext(hits);
+  } catch (e) {
+    console.error("digivault tool failed:", (e as Error).message);
+    return "The digivault is temporarily unavailable — tell the user to try again shortly.";
+  }
+}
+
+// One non-streamed OpenRouter call with the free-model pool + the search_digivault tool. Throws on
+// transport/HTTP failure so the caller can return a proper error status.
+async function callModel(env: Env, messages: ConvoMessage[]): Promise<ChatCompletionResponse> {
+  const resp = await fetchWithTimeout(
+    "https://openrouter.ai/api/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+        "content-type": "application/json",
+        "HTTP-Referer": "https://digithings.ai",
+        "X-Title": "digithings docs assistant",
+      },
+      body: JSON.stringify({
+        models: MODEL_POOL,
+        messages,
+        tools: TOOLS,
+        tool_choice: "auto",
+        // Only route to a model that actually supports the tools we send; skip any that would
+        // silently ignore them. The pairing of this with `tools` is what makes a flaky/non-tool
+        // free model get bypassed instead of returning a toolless (hallucinated) answer.
+        provider: { require_parameters: true },
+        temperature: 0.2,
+        max_tokens: 800,
+      }),
+    },
+    OPENROUTER_TIMEOUT_MS,
+  );
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    throw new Error(`openrouter ${resp.status}: ${detail.slice(0, 300)}`);
+  }
+  return (await resp.json()) as ChatCompletionResponse;
+}
+
+export type LoopResult = { kind: "answer"; text: string } | { kind: "error"; message: string };
+
+// The agentic loop, dependency-injected so it can be unit-tested without a network or a key:
+// callModelFn returns a completion; runToolFn executes a tool by (name, args). The injection is
+// the seam — feeding scripted completions exercises every branch (tool-call→answer, casual,
+// error, empty, max-rounds) offline. Drives model⇄tool round trips until the model answers with
+// no tool call,
+// bounded by maxRounds. Hard upstream failures -> {error} (caller returns a real HTTP error);
+// soft "no content" -> {answer} carrying a readable ⚠ note (surfaced, never a silent blank).
+export async function runAgenticLoop(
+  convo: ConvoMessage[],
+  callModelFn: (messages: ConvoMessage[]) => Promise<ChatCompletionResponse>,
+  runToolFn: (name: string, args: string) => Promise<string>,
+  maxRounds: number = MAX_TOOL_ROUNDS,
+): Promise<LoopResult> {
+  const messages = [...convo];
+  for (let round = 0; round < maxRounds; round++) {
+    let data: ChatCompletionResponse;
+    try {
+      data = await callModelFn(messages);
+    } catch (e) {
+      console.error("model call failed:", (e as Error).message);
+      return { kind: "error", message: "the model pool is temporarily unavailable — please retry" };
+    }
+    if (data.error) {
+      console.error("openrouter error frame:", JSON.stringify(data.error).slice(0, 300));
+      return { kind: "error", message: `upstream: ${data.error.message ?? "model unavailable"}` };
+    }
+    const msg = data.choices?.[0]?.message;
+    if (!msg) return { kind: "answer", text: NO_CONTENT_NOTE };
+
+    const toolCalls = msg.tool_calls ?? [];
+    if (toolCalls.length > 0) {
+      // Record the assistant's tool-call turn. content "" (not null) — some providers reject null.
+      messages.push({ role: "assistant", content: msg.content ?? "", tool_calls: toolCalls });
+      for (const tc of toolCalls) {
+        const out = await runToolFn(tc.function?.name ?? "", tc.function?.arguments ?? "");
+        messages.push({ role: "tool", tool_call_id: tc.id, content: out });
+      }
+      continue; // let the model read the results and answer (or call again)
+    }
+
+    const text = (msg.content ?? "").trim();
+    return { kind: "answer", text: text || NO_CONTENT_NOTE };
+  }
+  return {
+    kind: "answer",
+    text: "⚠ I couldn't finish that within a few steps — please rephrase or try again.",
+  };
+}
+
+// onRequestPost — Pages Functions route handler for POST /api/chat. A top-level guard turns ANY
+// unhandled throw into our JSON 500 (readable in the browser Network tab) instead of an opaque
+// Cloudflare raw 502 — so the endpoint can never fail silently at the edge.
 export async function onRequestPost(ctx: EventContext): Promise<Response> {
   try {
     return await handleChat(ctx);
@@ -212,14 +397,16 @@ async function handleChat(ctx: EventContext): Promise<Response> {
     return notConfigured("OPENROUTER_API_KEY is not set on this deployment.");
   }
   if (!env.CORE_SUPABASE_URL || !env.CORE_SUPABASE_ANON_KEY) {
-    return notConfigured("CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY are not set — the vault is unreachable.");
+    return notConfigured(
+      "CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY are not set — the vault is unreachable.",
+    );
   }
 
   // 1b. Same-site guard — reject cross-site / scripted callers before any work.
   if (!sameSiteOK(request)) return jsonError("forbidden: cross-site requests are not allowed", 403);
 
-  // 2. Rate limit by client IP — best-effort bot deterrence (see rateLimit); never
-  // hard-fails the endpoint, since the chat runs on free models with no cost to ration.
+  // 2. Rate limit by client IP — best-effort bot deterrence (see rateLimit); never hard-fails the
+  // endpoint, since the chat runs on free models with no cost to ration.
   const ip = request.headers.get("cf-connecting-ip") ?? "anon";
   if (!(await rateLimit(env, ip))) return jsonError("rate limit exceeded — slow down a moment", 429);
 
@@ -230,124 +417,25 @@ async function handleChat(ctx: EventContext): Promise<Response> {
   } catch {
     return jsonError("invalid JSON body");
   }
-  const messages = Array.isArray(body.messages) ? body.messages : [];
-  if (messages.length === 0) return jsonError("messages required");
+  const inbound = Array.isArray(body.messages) ? body.messages : [];
+  if (inbound.length === 0) return jsonError("messages required");
 
-  const clean: ChatMessage[] = messages
+  const clean = inbound
     .filter(
       (m) => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string",
     )
     .slice(-MAX_TURNS)
     .map((m) => ({ role: m.role, content: m.content.slice(0, MAX_MSG_CHARS) }));
-  const lastUser = [...clean].reverse().find((m) => m.role === "user");
-  if (!lastUser) return jsonError("a user message is required");
+  if (!clean.some((m) => m.role === "user")) return jsonError("a user message is required");
 
-  // 4. Retrieve from the vault (the only knowledge source).
-  let context = "";
-  try {
-    context = buildContext(await searchVault(env, lastUser.content, TOP_K));
-  } catch (e) {
-    console.error("vault search failed:", (e as Error).message);
-    return jsonError("vault temporarily unavailable", 502);
-  }
+  // 4. Run the agentic loop: the model chats and calls search_digivault when it needs facts.
+  const convo: ConvoMessage[] = [{ role: "system", content: SYSTEM_PROMPT }, ...clean];
+  const result = await runAgenticLoop(
+    convo,
+    (messages) => callModel(env, messages),
+    (name, args) => runTool(env, name, args),
+  );
 
-  // 5. Compose upstream messages.
-  const upstream: ChatMessage[] = [
-    { role: "system", content: SYSTEM_PROMPT },
-    {
-      role: "system",
-      content:
-        "DigiVault context (answer ONLY from this; cite nothing outside it):\n\n" +
-        (context || "(no relevant documentation found for this question)"),
-    },
-    ...clean,
-  ];
-
-  // 6. Call OpenRouter with the free-model pool + streaming.
-  let orResp: Response;
-  try {
-    orResp = await fetchWithTimeout(
-      "https://openrouter.ai/api/v1/chat/completions",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
-          "content-type": "application/json",
-          "HTTP-Referer": "https://digithings.ai",
-          "X-Title": "DigiThings Docs Assistant",
-        },
-        body: JSON.stringify({
-          models: MODEL_POOL,
-          messages: upstream,
-          stream: true,
-          temperature: 0.2,
-          max_tokens: 700,
-        }),
-      },
-      OPENROUTER_TIMEOUT_MS,
-    );
-  } catch (e) {
-    console.error("openrouter request failed:", (e as Error).message);
-    return jsonError("upstream temporarily unavailable", 502);
-  }
-  if (!orResp.ok || !orResp.body) {
-    const detail = await orResp.text().catch(() => "");
-    console.error("openrouter pool error", orResp.status, detail.slice(0, 300));
-    return jsonError("model pool error", 502);
-  }
-
-  // 7. Transform OpenRouter SSE → plain-text token stream the browser appends.
-  const reader = orResp.body.getReader();
-  const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
-  let buf = "";
-  const stream = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        controller.close();
-        return;
-      }
-      buf += decoder.decode(value, { stream: true });
-      const lines = buf.split("\n");
-      buf = lines.pop() ?? ""; // keep the trailing partial line
-      for (const line of lines) {
-        const t = line.trim();
-        if (!t.startsWith("data:")) continue;
-        const payload = t.slice(5).trim();
-        if (payload === "[DONE]") {
-          controller.close();
-          return;
-        }
-        try {
-          const json = JSON.parse(payload);
-          const delta: string | undefined = json?.choices?.[0]?.delta?.content;
-          if (delta) {
-            controller.enqueue(encoder.encode(delta));
-          } else if (json?.error) {
-            // OpenRouter can return HTTP 200 with an error INSIDE the SSE stream (e.g. all free
-            // models unavailable / rate-limited). Surface it instead of going silently empty, so
-            // the failure is visible to the user and self-diagnosing rather than a blank reply.
-            const msg =
-              typeof json.error?.message === "string" ? json.error.message : "model unavailable";
-            console.error("openrouter sse error:", JSON.stringify(json.error).slice(0, 300));
-            controller.enqueue(encoder.encode(`⚠ upstream: ${msg}`));
-          }
-        } catch {
-          // ignore non-JSON keepalive / ": OPENROUTER PROCESSING" comment frames
-        }
-      }
-    },
-    cancel() {
-      reader.cancel().catch(() => {});
-    },
-  });
-
-  return new Response(stream, {
-    headers: {
-      "content-type": "text/plain; charset=utf-8",
-      "cache-control": "no-store",
-      "x-content-type-options": "nosniff",
-    },
-  });
+  if (result.kind === "error") return jsonError(result.message, 502);
+  return answerText(result.text);
 }

--- a/scripts/ci_paths.yaml
+++ b/scripts/ci_paths.yaml
@@ -1,60 +1,61 @@
 # Single source of truth for CI path filters (dorny/paths-filter in ci.yml).
 # Regenerate embedded block: python3 scripts/generate_ci_path_filters.py
-# Drift check: python3 scripts/generate_ci_path_filters.py --check
+# Drift check (enforced in CI by the ruff-and-scripts job):
+#   python3 scripts/generate_ci_path_filters.py --check
 
 digibase:
   - digibase/**
   - tests/db/**
-  - .github/workflows/digibase-test.yml
+  - .github/workflows/test-digibase.yml
 
 digikey:
   - digikey/**
   - tests/dk/**
-  - .github/workflows/digikey-test.yml
+  - .github/workflows/test-digikey.yml
 
 digismith:
   - digismith/**
   - tests/dsm/**
-  - .github/workflows/digismith-test.yml
+  - .github/workflows/test-digismith.yml
 
 digivault:
   - digivault/**
   - tests/dv/**
-  - .github/workflows/digivault-test.yml
+  - .github/workflows/test-digivault.yml
 
 digiclaw:
   - digiclaw/**
   - tests/dc/**
-  - .github/workflows/digiclaw-test.yml
+  - .github/workflows/test-digiclaw.yml
 
 digiquant:
   - digiquant/**
   - tests/dq/**
-  - .github/workflows/digiquant-test.yml
+  - .github/workflows/test-digiquant.yml
 
 digisearch:
   - digisearch/**
   - tests/ds/**
-  - .github/workflows/digisearch-test.yml
+  - .github/workflows/test-digisearch.yml
 
 digigraph:
   - digigraph/**
   - tests/dg/**
-  - .github/workflows/digigraph-test.yml
+  - .github/workflows/test-digigraph.yml
 
 digichat:
   - frontend/digichat/**
   - frontend/design/**
   - package.json
   - package-lock.json
-  - .github/workflows/digichat-test.yml
+  - .github/workflows/test-digichat.yml
 
 olympus:
   - frontend/olympus/**
   - frontend/design/**
   - package.json
   - package-lock.json
-  - .github/workflows/olympus-test.yml
+  - .github/workflows/test-olympus.yml
 
 web:
   - frontend/digithings-web/**
@@ -79,19 +80,19 @@ score:
   - tests/**
   - agents.yml
   - agents/**
-  - .github/workflows/score-pr.yml
+  - .github/workflows/test-score.yml
 
 e2e_contract:
   - tests/test_e2e.py
   - tests/test_e2e_contract.py
   - docker-compose.yml
   - digikey/**
-  - .github/workflows/e2e.yml
+  - .github/workflows/test-e2e.yml
 
 nautilus_smoke:
   - digiquant/**
   - tests/dq/test_nautilus_runner.py
-  - .github/workflows/nautilus-smoke.yml
+  - .github/workflows/test-nautilus.yml
 
 atlas_graph:
   - digiquant/src/digiquant/olympus/atlas/**
@@ -99,9 +100,11 @@ atlas_graph:
   - digiquant/supabase/**
   - tests/dq/atlas/**
   - digiquant/src/digiquant/olympus/hermes/**
+  - digiquant/src/digiquant/olympus/learning/**
   - tests/dq/hermes/**
-  - .github/workflows/atlas-graph-ci.yml
-  - .github/workflows/atlas-*.yml
+  - tests/dq/learning/**
+  - .github/workflows/test-atlas-graph.yml
+  - .github/workflows/pipeline-olympus.yml
 
 ruff_and_scripts:
   - digibase/**
@@ -127,4 +130,4 @@ compose:
 pip_audit:
   - "**/pyproject.toml"
   - pip-audit-ignore.txt
-  - .github/workflows/pip-audit.yml
+  - .github/workflows/security-pip-audit.yml


### PR DESCRIPTION
Promotes #1154 to production (the only delta on `develop` since the last promotion).

## What ships
Rebuilds `/api/chat` as an **agentic, free-model tool-caller** with one tool (`search_digivault` over the Supabase-hosted vault). The model chats normally and calls the tool when it needs stack facts. Going **non-streamed** structurally removes the raw-502 / empty-reply bug class — every upstream call is awaited under the top-level try/catch, so the endpoint returns proper HTTP codes and can never emit an opaque Cloudflare 502.

Fixes #1136.

## Triggered on merge to main
- Cloudflare Pages rebuilds **digithings.ai** with the new chat Function.

## Verified on #1154
- `web/lint`, `bash scripts/build-digithings.sh`, CodeQL (js-ts), `score` (10/10/10/10), gitleaks, linkage — all green.
- `runAgenticLoop` unit-harness: 9/9 branches pass.

## Post-deploy acceptance test
POST a stack question to `/api/chat`; expect a grounded answer (or a readable warning if the free pool is momentarily rate-limited) — never a raw 502. Agentic + free-tier is less deterministic than forced retrieval; tuning levers are the system prompt and the model pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
