### PR TITLE
chore(docs): refresh agent backlog snapshot

### DIFF
--- a/docs/agent-backlog/generated-snapshot.md
+++ b/docs/agent-backlog/generated-snapshot.md
@@ -1,5 +1,5 @@
 # Agent backlog snapshot
 
-**Generated:** 2026-06-22 12:09 UTC · **repo:** `digithings-ai/digithings` · **label:** `agent-task`
+**Generated:** 2026-06-29 11:04 UTC · **repo:** `digithings-ai/digithings` · **label:** `agent-task`
 
 *No open issues with label `agent-task`.*


### PR DESCRIPTION
Auto-generated weekly refresh of `docs/agent-backlog/generated-snapshot.md`.

Triggered by the [Agent backlog snapshot](../actions/workflows/agent-backlog-snapshot.yml) scheduled workflow.