### PR TITLE
fix(frontend): lowercase all user-facing digi-module names

### DIFF
--- a/frontend/digiquant-web/app/_nav.tsx
+++ b/frontend/digiquant-web/app/_nav.tsx
@@ -32,7 +32,7 @@ export const DQ_FOOTER: NavLink[] = [
   { label: "Pipeline", href: "/pipeline" },
   { label: "Strategies", href: "/strategies" },
   { label: "Olympus", href: "/olympus/" },
-  { label: "Built on DigiThings", href: "https://digithings.ai", external: true },
+  { label: "Built on digithings", href: "https://digithings.ai", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },
 ];
 

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
               <p className="dq-built" style={{ textAlign: "center", marginTop: "2.2rem" }}>
                 digiquant is the quant module of{" "}
                 <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer">
-                  the DigiThings platform
+                  the digithings platform
                 </a>{" "}
                 — the same open-core, self-hosted, audit-on stack.
               </p>

--- a/frontend/digiquant-web/app/pipeline/page.tsx
+++ b/frontend/digiquant-web/app/pipeline/page.tsx
@@ -34,7 +34,7 @@ export default function PipelinePage() {
             <Reveal className="dq-sechead">
               <div className="dq-eyebrow">{"// the pipeline"}</div>
               <h2 className="dq-title">Research in, orders out — in a straight line.</h2>
-              <p className="dq-sub">digiquant is not a hub of services routing messages around; it&rsquo;s a linear research workflow. You start in a chat, and each stage hands its output to the next until a strategy is ready to run. Built on the open <a href="https://digiquant.io" style={{ color: "var(--accent)" }}>digiquant</a> stack — itself a module of <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)" }}>the DigiThings platform</a>.</p>
+              <p className="dq-sub">digiquant is not a hub of services routing messages around; it&rsquo;s a linear research workflow. You start in a chat, and each stage hands its output to the next until a strategy is ready to run. Built on the open <a href="https://digiquant.io" style={{ color: "var(--accent)" }}>digiquant</a> stack — itself a module of <a href="https://digithings.ai" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)" }}>the digithings platform</a>.</p>
             </Reveal>
 
             <Reveal>

--- a/frontend/digithings-web/app/_nav.tsx
+++ b/frontend/digithings-web/app/_nav.tsx
@@ -22,7 +22,7 @@ export const DT_NAV: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },
-  { label: "Ask DigiChat", href: "/chat", cta: true },
+  { label: "Ask digichat", href: "/chat", cta: true },
 ];
 
 /** v7 nav shape (used by <DigiNav />): wayfinding links on the left of the tail,
@@ -36,9 +36,9 @@ export const DT_NAV_PRIMARY: NavLink[] = [
 
 export const DT_FOOTER: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
-  { label: "DigiChat", href: "/chat" },
+  { label: "digichat", href: "/chat" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },
 ];
 
-export const DT_FOOTER_META = "© 2026 DigiThings · open core";
+export const DT_FOOTER_META = "© 2026 digithings · open core";

--- a/frontend/digithings-web/app/chat/page.tsx
+++ b/frontend/digithings-web/app/chat/page.tsx
@@ -3,9 +3,9 @@ import { DigiNav } from "@/components/landing/DigiNav";
 import { DigiChatSession } from "@/components/DigiChatSession";
 
 export const metadata: Metadata = {
-  title: "DigiChat — the DigiThings assistant",
+  title: "digichat — the digithings assistant",
   description:
-    "Ask DigiChat anything about the DigiThings architecture — grounded in the DigiVault docs, " +
+    "Ask digichat anything about the digithings architecture — grounded in the digivault docs, " +
     "running on a free model pool. No sign-up.",
 };
 

--- a/frontend/digithings-web/app/layout.tsx
+++ b/frontend/digithings-web/app/layout.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
     "An open-core agentic stack — research, retrieval, and chat behind one supervisor. Self-hosted, BYOK, audit-on by default. No vendor lock-in.",
   icons: { icon: "/favicon-qr.svg" },
   openGraph: {
-    title: "DigiThings — An open-core agentic stack",
+    title: "digithings — an open-core agentic stack",
     description: "Open-core agentic stack — research, retrieval, chat behind one supervisor. Self-hosted, BYOK, audit-on by default.",
     url: "https://digithings.ai",
     images: ["/design/assets/og.png"],

--- a/frontend/digithings-web/components/DigiChatSession.tsx
+++ b/frontend/digithings-web/components/DigiChatSession.tsx
@@ -19,19 +19,19 @@ import { DigiChatMark, DigiChatWordmark } from "@/components/DigiChatMark";
  * Theme-aware via the design tokens (not hardcoded dark), consistent with the
  * module manifest.
  */
-const INTRO = `Hi — I'm DigiChat, the assistant for the DigiThings stack.
+const INTRO = `Hi — I'm digichat, the assistant for the digithings stack.
 
-I answer questions about the architecture: how the modules fit together, how the system is built, and how it runs. Ask me anything — DigiGraph orchestration, DigiQuant backtests, auth in DigiKey, retrieval in DigiSearch — the lot.
+I answer questions about the architecture: how the modules fit together, how the system is built, and how it runs. Ask me anything — digigraph orchestration, digiquant backtests, auth in digikey, retrieval in digisearch — the lot.
 
-A bit about me: I'm grounded in DigiVault, a self-hosted, Obsidian-style vault in the cloud, and I search it before every answer, so I cite the real docs instead of guessing. I run on OpenRouter's free model pool — no sign-up, no key needed. For heavier use or stronger models, bring-your-own-key is coming soon.
+A bit about me: I'm grounded in digivault, a self-hosted, Obsidian-style vault in the cloud, and I search it before every answer, so I cite the real docs instead of guessing. I run on OpenRouter's free model pool — no sign-up, no key needed. For heavier use or stronger models, bring-your-own-key is coming soon.
 
 Where should we start?`;
 
 const SUGGESTIONS = [
-  "What does DigiGraph orchestrate?",
+  "What does digigraph orchestrate?",
   "How does auth work?",
   "How are you built?",
-  "What can I do with DigiQuant?",
+  "What can I do with digiquant?",
 ];
 
 export function DigiChatSession() {
@@ -92,7 +92,7 @@ export function DigiChatSession() {
   const introDone = intro.length >= INTRO.length;
 
   return (
-    <section className="dc-session" aria-label="DigiChat">
+    <section className="dc-session" aria-label="digichat">
       <div className="dc-bar">
         <DigiChatMark size={18} />
         <DigiChatWordmark />
@@ -180,7 +180,7 @@ export function DigiChatSession() {
           }}
           onKeyDown={onKeyDown}
           placeholder="ask digichat anything…   (enter to send · shift+enter for a new line)"
-          aria-label="Ask DigiChat"
+          aria-label="Ask digichat"
           rows={1}
           maxLength={2000}
         />

--- a/frontend/digithings-web/components/landing/DigiNav.tsx
+++ b/frontend/digithings-web/components/landing/DigiNav.tsx
@@ -79,9 +79,9 @@ export function DigiNav() {
           >
             <GitHubGlyph />
           </a>
-          <Link className="btn btn-primary btn-sm dt-askcta" href="/chat" aria-label="Ask DigiChat">
+          <Link className="btn btn-primary btn-sm dt-askcta" href="/chat" aria-label="Ask digichat">
             <DigiChatMark size={16} />
-            Ask DigiChat
+            Ask digichat
           </Link>
         </div>
       </div>

--- a/frontend/digithings-web/components/landing/ModuleManifest.tsx
+++ b/frontend/digithings-web/components/landing/ModuleManifest.tsx
@@ -58,7 +58,7 @@ export function ModuleManifest() {
   /* eslint-enable react-hooks/set-state-in-effect */
 
   return (
-    <div className="dt-manifest" aria-label="DigiThings module manifest">
+    <div className="dt-manifest" aria-label="digithings module manifest">
       <div className="dt-manifest-head">
         <span className="dt-mh-prompt">$</span> digithings ps
         <span className="dt-mh-meta"> · {online} online · {road} on the roadmap</span>

--- a/frontend/digithings-web/components/landing/StackChat.tsx
+++ b/frontend/digithings-web/components/landing/StackChat.tsx
@@ -15,7 +15,7 @@ import { writeHandoff } from "@/lib/chatHandoff";
  * Terminal aesthetic via the shared `.dt-*` / `.dtc-*` tokens; theme-aware and
  * keyboard accessible. Errors render as a friendly line, not a thrown thread.
  */
-const SUGGESTIONS = ["What is DigiQuant?", "How does auth work?", "What does Olympus do?"];
+const SUGGESTIONS = ["What is digiquant?", "How does auth work?", "What does Olympus do?"];
 
 export function StackChat() {
   const { messages, busy, error, send } = useStackChat();
@@ -67,7 +67,7 @@ export function StackChat() {
           <div className="dtc-empty">
             <p className="dt-out-dim">
               Ask one quick question about the stack — answers come only from the published
-              docs. Follow-ups open a full session in DigiChat.
+              docs. Follow-ups open a full session in digichat.
             </p>
             <div className="dtc-suggest">
               {SUGGESTIONS.map((s) => (
@@ -111,7 +111,7 @@ export function StackChat() {
 
       {escalateNext && (
         <p className="dtc-escalate dt-out-dim">
-          More questions? Your next one opens a full session in <strong>DigiChat</strong>.
+          More questions? Your next one opens a full session in <strong>digichat</strong>.
         </p>
       )}
 
@@ -125,7 +125,7 @@ export function StackChat() {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder={escalateNext ? "ask a follow-up in digichat…" : "ask one quick question…"}
-          aria-label="Ask one quick question about the DigiThings stack"
+          aria-label="Ask one quick question about the digithings stack"
           disabled={busy}
           autoComplete="off"
           maxLength={500}
@@ -134,7 +134,7 @@ export function StackChat() {
           className="dtc-send"
           type="submit"
           disabled={busy || !input.trim()}
-          aria-label={escalateNext ? "Open follow-up in DigiChat" : "Send question"}
+          aria-label={escalateNext ? "Open follow-up in digichat" : "Send question"}
         >
           {busy ? "…" : escalateNext ? "↗" : "↵"}
         </button>

--- a/frontend/olympus/app/layout.tsx
+++ b/frontend/olympus/app/layout.tsx
@@ -34,8 +34,8 @@ const instrumentSerif = Instrument_Serif({
 });
 
 export const metadata = {
-  title: 'Olympus — DigiQuant',
-  description: 'DigiQuant Olympus — AI-orchestrated investment intelligence (Atlas research + Hermes analysis & PM)',
+  title: 'Olympus — digiquant',
+  description: 'digiquant Olympus — AI-orchestrated investment intelligence (Atlas research + Hermes analysis & PM)',
   icons: {
     icon: '/olympus/favicon.svg',
     shortcut: '/olympus/favicon.svg',

--- a/frontend/web/src/components/graph.tsx
+++ b/frontend/web/src/components/graph.tsx
@@ -25,7 +25,7 @@ function neighboursOf(id: string): Set<string> {
 export function GraphSVG({ activeId, onPick }: { activeId: string | null; onPick: (id: string) => void }) {
   const near = activeId ? neighboursOf(activeId) : null;
   return (
-    <svg className="dg-graph" viewBox="0 0 920 560" role="img" aria-label="DigiThings module graph" preserveAspectRatio="xMidYMid meet">
+    <svg className="dg-graph" viewBox="0 0 920 560" role="img" aria-label="digithings module graph" preserveAspectRatio="xMidYMid meet">
       <g>
         {edges.map((e, i) => {
           const a = modules.find((m) => m.id === e.a)!.graph;

--- a/frontend/web/src/data/modules.ts
+++ b/frontend/web/src/data/modules.ts
@@ -54,7 +54,7 @@ export const edges: { a: string; b: string }[] = [
 export const modules: ModuleNode[] = [
   {
     id: "digigraph",
-    name: "DigiGraph",
+    name: "digigraph",
     tier: "core",
     port: "8000",
     graphOrder: 0,
@@ -88,7 +88,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digiquant",
-    name: "DigiQuant",
+    name: "digiquant",
     tier: "core",
     port: "8001",
     graphOrder: 1,
@@ -122,7 +122,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digisearch",
-    name: "DigiSearch",
+    name: "digisearch",
     tier: "core",
     port: "8002",
     graphOrder: 2,
@@ -153,7 +153,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digichat",
-    name: "DigiChat",
+    name: "digichat",
     tier: "core",
     port: "3005",
     graphOrder: 3,
@@ -162,7 +162,7 @@ export const modules: ModuleNode[] = [
     role: "Chat surface · Next.js BFF · BYOK",
     tagline: "Talk to your stack with your keys, your models, your audit log.",
     summary: [
-      "A Next.js + React BFF streaming DigiGraph via the Vercel AI SDK. BYOK every request — your key is forwarded per-request, never stored, never logged.",
+      "A Next.js + React BFF streaming digigraph via the Vercel AI SDK. BYOK every request — your key is forwarded per-request, never stored, never logged.",
       "NextAuth handles identity; Postgres + Drizzle persist sessions. The same deployment serves humans and agents.",
     ],
     stack: [
@@ -180,14 +180,14 @@ export const modules: ModuleNode[] = [
     },
     api: [{ label: "Stream a turn", code: "streamText({ model, messages })" }],
     links: [
-      { label: "Open DigiChat", href: "/chat" },
+      { label: "Open digichat", href: "/chat" },
       { label: "Source", href: "https://github.com/digithings-ai" },
     ],
     related: ["digigraph", "digikey", "digisearch"],
   },
   {
     id: "digikey",
-    name: "DigiKey",
+    name: "digikey",
     tier: "support",
     port: "8005",
     graphOrder: 4,
@@ -218,7 +218,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digismith",
-    name: "DigiSmith",
+    name: "digismith",
     tier: "support",
     port: "8003",
     graphOrder: 5,
@@ -247,7 +247,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digiclaw",
-    name: "DigiClaw",
+    name: "digiclaw",
     tier: "support",
     port: null,
     graphOrder: 6,
@@ -256,12 +256,12 @@ export const modules: ModuleNode[] = [
     role: "Always-on runtime · heartbeat · audit",
     tagline: "The always-on agent runtime — heartbeats, scheduling, immutable audit.",
     summary: [
-      "A heartbeat service that keeps agents running: Atlas runner scheduling and drift detection, calling DigiGraph over HTTP on an interval.",
+      "A heartbeat service that keeps agents running: Atlas runner scheduling and drift detection, calling digigraph over HTTP on an interval.",
       "Every action lands in an immutable audit log; no LLM of its own.",
     ],
     stack: [
       { name: "HTTPx", icon: null, mono: "hx" },
-      { name: "DigiBase", icon: null, mono: "DB" },
+      { name: "digibase", icon: null, mono: "DB" },
     ],
     dockerCmd: "docker compose --profile heartbeat up -d heartbeat",
     initSnippet: { lang: "bash", code: "python -m digiclaw   # runs on an interval" },
@@ -271,7 +271,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digibase",
-    name: "DigiBase",
+    name: "digibase",
     tier: "support",
     port: null,
     graphOrder: 7,
@@ -300,7 +300,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digistore",
-    name: "DigiStore",
+    name: "digistore",
     tier: "roadmap",
     port: null,
     graphOrder: 8,
@@ -309,7 +309,7 @@ export const modules: ModuleNode[] = [
     role: "Storage abstraction · roadmap",
     tagline: "One storage API over S3, MinIO, Postgres, or SQLite.",
     summary: [
-      "Roadmap: a storage abstraction so business code never binds to a backend. Today it exists as a session-scoped dataset manager inside DigiGraph; the standalone module is planned.",
+      "Roadmap: a storage abstraction so business code never binds to a backend. Today it exists as a session-scoped dataset manager inside digigraph; the standalone module is planned.",
       "Run SQLite on a laptop, swap to S3 + Postgres in production without rewriting.",
     ],
     stack: [
@@ -326,7 +326,7 @@ export const modules: ModuleNode[] = [
   },
   {
     id: "digilink",
-    name: "DigiLink",
+    name: "digilink",
     tier: "roadmap",
     port: null,
     graphOrder: 9,


### PR DESCRIPTION
## What

Lowercases every **user-facing** digi-prefixed module name across all four deployed frontends. Module names must always render lowercase in copy the user sees — tab titles, CTA buttons, nav/footer labels, aria-labels, intro text, suggestion chips, and the manifest/graph data.

Covers: `digichat`, `digithings`, `digigraph`, `digiquant`, `digisearch`, `digikey`, `digismith`, `digiclaw`, `digibase`, `digistore`, `digilink`.

## Why

Reported: the chat CTA button and the `/chat` tab title rendered "DigiChat" instead of "digichat". The fix is applied consistently to every module name wherever capitalization leaked into user-facing strings.

## Scope / non-goals

- **Preserved capitalization:** `Olympus`, `Atlas`, `Hermes` (not digi-modules) and `OpenRouter` (third-party).
- **Untouched:** real code symbols — `code:` API snippets and `id:` fields in `modules.ts`, class names, route paths.

## Files (13)

- `frontend/web/src/data/modules.ts` — single source of truth for the manifest + graph (`name:` fields, summary prose, one stack chip, one link label)
- `frontend/web/src/components/graph.tsx` — svg aria-label
- `frontend/digithings-web/` — `app/_nav.tsx`, `app/chat/page.tsx`, `app/layout.tsx`, `components/DigiChatSession.tsx`, `components/landing/{DigiNav,ModuleManifest,StackChat}.tsx`
- `frontend/digiquant-web/` — `app/_nav.tsx`, `app/page.tsx`, `app/pipeline/page.tsx`
- `frontend/olympus/app/layout.tsx`

Display-string-only changes; no logic, types, or routes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #1159
