### PR TITLE
fix(olympus): master-digest context diet + dashboard run-health RLS

### DIFF
--- a/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
@@ -352,9 +352,7 @@ def _carry_prior_digest_or_raise(
     state: AtlasResearchState, document_key: str, exc: Exception
 ) -> dict[str, Any]:
     """Fail-soft degrade: carry a valid prior digest instead of aborting Atlas."""
-    prior = _DigestPriorLoader(state, document_key).load(
-        ("digest", document_key), state.run_date
-    )
+    prior = _DigestPriorLoader(state, document_key).load(("digest", document_key), state.run_date)
     if prior is not None and _prior_is_valid_digest(prior):
         logger.warning(
             "master-digest failed (%s: %s); carrying prior digest from %s",

--- a/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
+++ b/digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py
@@ -21,7 +21,11 @@ from digiquant.olympus.atlas.phases._node_factory import (
 )
 from digiquant.olympus.atlas.segments import SegmentReport
 from digiquant.olympus.atlas.skills import load_skill, load_skill_edit
-from digiquant.olympus.atlas.state import AtlasResearchState, refresh_scope_forces_full
+from digiquant.olympus.atlas.state import (
+    AtlasResearchState,
+    PhaseError,
+    refresh_scope_forces_full,
+)
 from digiquant.olympus.edit_mode import DocumentPatch, MergeError, merge_document_patch
 from digiquant.olympus.edit_mode.models import TriageSignal
 from digiquant.olympus.edit_mode.prior import PriorPublished
@@ -226,6 +230,84 @@ class _DigestPriorLoader:
         )
 
 
+# Master-digest receives every fresh segment body on baseline runs — without
+# compression the prompt can exceed the 64k context window of the reasoning-tier
+# model (Jun-2026 incident: 68k–77k tokens → BadRequestError, Atlas crash, no
+# Hermes book, dashboard stale for 3 days).
+_DIGEST_TEXT_MAX = 400
+_DIGEST_FINDING_SUMMARY_MAX = 200
+_DIGEST_MAX_FINDINGS = 8
+_DIGEST_MAX_SOURCES = 10
+
+
+def _truncate_str(value: str, max_len: int) -> str:
+    if len(value) <= max_len:
+        return value
+    return value[:max_len] + "..."
+
+
+def _slim_segment_body(body: dict[str, Any]) -> dict[str, Any]:
+    """Compress one segment body for master-digest synthesis inputs.
+
+    Keeps the fields Phase 7 actually synthesizes from (stance, headline,
+    findings, sources) and drops/truncates verbose prose so a baseline Sunday
+    run with every segment fresh stays inside the model context window.
+    """
+    out: dict[str, Any] = {}
+    for key in ("segment", "date", "bias", "headline", "data_quality", "regime_label"):
+        if key in body:
+            out[key] = body[key]
+
+    findings = body.get("material_findings")
+    if isinstance(findings, list):
+        out["material_findings"] = [
+            {
+                "label": item.get("label", ""),
+                "summary": _truncate_str(
+                    str(item.get("summary", "")),
+                    _DIGEST_FINDING_SUMMARY_MAX,
+                ),
+                "source_ids": item.get("source_ids", [])[:3]
+                if isinstance(item.get("source_ids"), list)
+                else [],
+            }
+            for item in findings[:_DIGEST_MAX_FINDINGS]
+            if isinstance(item, dict)
+        ]
+
+    sources = body.get("sources")
+    if isinstance(sources, list):
+        out["sources"] = [
+            {k: src[k] for k in ("id", "title", "url") if k in src}
+            for src in sources[:_DIGEST_MAX_SOURCES]
+            if isinstance(src, dict)
+        ]
+
+    notes = body.get("notes")
+    if isinstance(notes, str) and notes:
+        out["notes"] = _truncate_str(notes, _DIGEST_TEXT_MAX)
+
+    for key, val in body.items():
+        if key in out or key in ("material_findings", "sources", "notes"):
+            continue
+        if isinstance(val, str) and val:
+            out[key] = _truncate_str(val, _DIGEST_TEXT_MAX)
+        elif isinstance(val, (int, float, bool)) or val is None:
+            out[key] = val
+
+    return out
+
+
+def _digest_shared_context(state: AtlasResearchState) -> dict[str, Any]:
+    """Shared context for master-digest — slim by design.
+
+    Phase inputs already carry the upstream segment bodies; the full
+    ``data_layer`` ETF/macro dump and the multi-snapshot history are redundant
+    here and were the main driver of the Jun-2026 context-overflow failures.
+    """
+    return _shared_context(state, data_layer_scope="none", slim_snapshots=True)
+
+
 def _digest_phase_inputs(state: AtlasResearchState) -> dict[str, Any]:
     phase_inputs: dict[str, Any] = {
         "segment": "master-digest",
@@ -266,6 +348,34 @@ def _prior_is_valid_digest(prior: PriorPublished) -> bool:
     return True
 
 
+def _carry_prior_digest_or_raise(
+    state: AtlasResearchState, document_key: str, exc: Exception
+) -> dict[str, Any]:
+    """Fail-soft degrade: carry a valid prior digest instead of aborting Atlas."""
+    prior = _DigestPriorLoader(state, document_key).load(
+        ("digest", document_key), state.run_date
+    )
+    if prior is not None and _prior_is_valid_digest(prior):
+        logger.warning(
+            "master-digest failed (%s: %s); carrying prior digest from %s",
+            type(exc).__name__,
+            exc,
+            prior.date.isoformat(),
+        )
+        return {
+            "phase7_digest": _carry_prior_digest(state, prior),
+            "errors": [
+                PhaseError(
+                    phase="phase7_synthesis",
+                    node="master-digest",
+                    message=f"{type(exc).__name__}: {exc}"[:500],
+                    retryable=True,
+                )
+            ],
+        }
+    raise exc
+
+
 def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
     document_key = _digest_document_key(state)
     mode = resolve_edit_mode(
@@ -276,6 +386,7 @@ def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
         force_full_rewrite=refresh_scope_forces_full(state.refresh_scope, artifact="digest"),
     )
     phase_inputs = _digest_phase_inputs(state)
+    shared = _digest_shared_context(state)
 
     if mode == "skip":
         prior = _DigestPriorLoader(state, document_key).load(
@@ -295,13 +406,16 @@ def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
                 prior=prior,
                 triage_reason="digest_edit",
             )
-            patch = run_research_agent(
-                skill_text=skill_text,
-                phase_inputs=edit_inputs,
-                shared_context=_shared_context(state),
-                output_model=DocumentPatch,
-                phase_slug="master-digest",
-            )
+            try:
+                patch = run_research_agent(
+                    skill_text=skill_text,
+                    phase_inputs=edit_inputs,
+                    shared_context=shared,
+                    output_model=DocumentPatch,
+                    phase_slug="master-digest",
+                )
+            except Exception as exc:  # noqa: BLE001 — observable degrade, not a swallow
+                return _carry_prior_digest_or_raise(state, document_key, exc)
             if not isinstance(patch, DocumentPatch):
                 msg = f"digest edit expected DocumentPatch, got {type(patch).__name__}"
                 raise TypeError(msg)
@@ -320,13 +434,16 @@ def _synthesis_node(state: AtlasResearchState) -> dict[str, Any]:
                     }
 
     skill_text = load_skill("digest")
-    result = run_research_agent(
-        skill_text=skill_text,
-        phase_inputs=phase_inputs,
-        shared_context=_shared_context(state),
-        output_model=DigestSnapshot,
-        phase_slug="master-digest",
-    )
+    try:
+        result = run_research_agent(
+            skill_text=skill_text,
+            phase_inputs=phase_inputs,
+            shared_context=shared,
+            output_model=DigestSnapshot,
+            phase_slug="master-digest",
+        )
+    except Exception as exc:  # noqa: BLE001 — observable degrade, not a swallow
+        return _carry_prior_digest_or_raise(state, document_key, exc)
     return {"phase7_digest": _finalize_digest(state, result.model_dump(mode="json"))}
 
 
@@ -340,7 +457,7 @@ def _regime_label_from_phase3(state: AtlasResearchState) -> str:
 def _body(slot: Any) -> dict[str, Any]:
     if slot is None or slot.payload.source != "today":
         return {}
-    return dict(slot.payload.body)
+    return _slim_segment_body(dict(slot.payload.body))
 
 
 def _bodies(bag: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -351,9 +468,15 @@ def _bodies(bag: dict[str, Any]) -> dict[str, dict[str, Any]]:
     unchanged baseline material, violating the research-only / delta boundary
     (ADR-0015). Carried provenance is still surfaced via ``segment_freshness``,
     which is derived from full state — not from this digest-input map.
+
+    Bodies are slimmed before serialization so baseline runs with every segment
+    fresh stay inside the reasoning-tier model context window.
     """
     return {
-        slug: slot.payload.model_dump(mode="json")
+        slug: {
+            **{k: v for k, v in slot.payload.model_dump(mode="json").items() if k != "body"},
+            "body": _slim_segment_body(slot.payload.body),
+        }
         for slug, slot in bag.items()
         if slot.payload.source == "today"
     }
@@ -373,4 +496,5 @@ __all__ = [
     "SegmentFreshness",
     "build_phase7",
     "_enforce_research_only_boundary",
+    "_slim_segment_body",
 ]

--- a/frontend/olympus/components/system/how-it-works.tsx
+++ b/frontend/olympus/components/system/how-it-works.tsx
@@ -11,7 +11,7 @@ const PERSISTS: { what: string; where: string; note: string }[] = [
   { what: 'Daily digest', where: 'documents + daily_snapshots', note: 'The read — headline, regime bias, digest markdown' },
   { what: 'Analyst & deliberation notes', where: 'documents', note: 'Per-ticker analyst verdicts and PM⇄analyst debates' },
   { what: 'Portfolio decisions', where: 'positions + decision_log', note: 'The booked book and each signed call with its thesis' },
-  { what: 'Run diagnostics', where: 'atlas_run_diagnostics', note: 'Cost, tokens, grounding, per-phase outcomes (this page)' },
+  { what: 'Run diagnostics', where: 'atlas_run_health', note: 'Run status, segment counts, timing (public view; cost/tokens operator-only)' },
 ];
 
 export function HowItWorks() {

--- a/frontend/olympus/lib/observability-queries.ts
+++ b/frontend/olympus/lib/observability-queries.ts
@@ -2,13 +2,15 @@
  * Observability dashboard data access (Pillar 3D).
  *
  * Reads the decision track record (`decision_log`) the Decision Scorecard needs, plus
- * — via `fetchAtlasRunDiagnostics` — the run economics the System surface reads directly
- * from `atlas_run_diagnostics`. Kept separate from `getFullDashboardData` so the main
- * Morning Read bundle stays lean; these fire only when their consumer mounts.
+ * — via `fetchAtlasRunDiagnostics` — run health from the anon-readable
+ * `atlas_run_health` view (migration 041). Kept separate from `getFullDashboardData`
+ * so the main Morning Read bundle stays lean; these fire only when their consumer mounts.
  *
  * Attribution and per-position risk now live on Performance/Holdings (which read their own
- * sources), and System reads run telemetry straight from `atlas_run_diagnostics` — so the
- * stripping `atlas_run_health` view is no longer read here.
+ * sources). System reads run telemetry from `atlas_run_health` — the curated projection
+ * that bypasses the base-table RLS on `atlas_run_diagnostics` (migration 033). Spend
+ * telemetry (cost, tokens, error_summary, breakdown) is intentionally excluded from the
+ * view; economics tiles render "—" on the public anon-key dashboard.
  *
  * Every query is FAIL-SOFT: a missing/forbidden source (e.g. an empty book) resolves to an
  * empty result rather than throwing, so consumers render a clean empty state instead of an
@@ -16,7 +18,7 @@
  */
 
 import { supabase, isSupabaseConfigured } from './supabase';
-import type { TableRow } from './database.types';
+import type { TableRow, ViewRow } from './database.types';
 import type { AtlasRunDiagnostics } from './types';
 import { computeEffectivePortfolioRiskMetrics } from './portfolio-risk-metrics';
 import { backtestDecisions, type DecisionInput } from './decision-track-record';
@@ -78,25 +80,16 @@ export async function fetchObservabilityData(): Promise<ObservabilityData> {
 
 const RUN_DIAGNOSTICS_LIMIT = 30;
 
-/** Lift cached_tokens out of the breakdown jsonb (top-level or by_kind.chat). */
-function cachedTokensOf(breakdown: unknown): number | null {
-  if (!breakdown || typeof breakdown !== 'object') return null;
-  const b = breakdown as Record<string, unknown>;
-  if (typeof b.cached_tokens === 'number') return b.cached_tokens;
-  const byKind = b.by_kind as Record<string, unknown> | undefined;
-  const chat = byKind?.chat as Record<string, unknown> | undefined;
-  return typeof chat?.cached_tokens === 'number' ? chat.cached_tokens : null;
-}
-
 /**
- * Read run economics directly from `atlas_run_diagnostics` (D3) — cost, tokens,
- * cache-hit, grounding, per-phase breakdown — bypassing the stripping
- * `atlas_run_health` view. Fail-soft: empty array on missing source / RLS deny.
+ * Read run health from the anon-readable `atlas_run_health` view (migration 041).
+ * Cost/tokens/grounding fields are null on the public dashboard — the view
+ * deliberately omits operator-internal spend telemetry. Fail-soft: empty array
+ * on missing source / RLS deny.
  */
 export async function fetchAtlasRunDiagnostics(): Promise<AtlasRunDiagnostics[]> {
-  const res = await safeSelect<TableRow<'atlas_run_diagnostics'>>('atlas_run_diagnostics', (sb) =>
+  const res = await safeSelect<ViewRow<'atlas_run_health'>>('atlas_run_health', (sb) =>
     sb
-      .from('atlas_run_diagnostics')
+      .from('atlas_run_health')
       .select('*')
       .order('created_at', { ascending: false })
       .limit(RUN_DIAGNOSTICS_LIMIT)
@@ -110,21 +103,21 @@ export async function fetchAtlasRunDiagnostics(): Promise<AtlasRunDiagnostics[]>
     started_at: r.started_at,
     finished_at: r.finished_at,
     duration_s: r.duration_s,
-    llm_calls: r.llm_calls,
-    prompt_tokens: r.prompt_tokens,
-    completion_tokens: r.completion_tokens,
-    total_tokens: r.total_tokens,
-    cached_tokens: cachedTokensOf(r.breakdown),
-    search_calls: r.search_calls,
-    grounding_ok: r.grounding_ok,
-    grounding_failed: r.grounding_failed,
-    est_cost_usd: r.est_cost_usd,
+    llm_calls: null,
+    prompt_tokens: null,
+    completion_tokens: null,
+    total_tokens: null,
+    cached_tokens: null,
+    search_calls: null,
+    grounding_ok: null,
+    grounding_failed: null,
+    est_cost_usd: null,
     segments_total: r.segments_total,
     segments_ok: r.segments_ok,
     segments_carried: r.segments_carried,
     segments_failed: r.segments_failed,
-    error_summary: r.error_summary,
-    breakdown: (r.breakdown ?? null) as Record<string, unknown> | null,
+    error_summary: null,
+    breakdown: null,
     created_at: r.created_at,
   }));
 }

--- a/frontend/olympus/lib/types.ts
+++ b/frontend/olympus/lib/types.ts
@@ -203,9 +203,9 @@ export interface ServerPortfolioMetrics {
 }
 
 /**
- * A single Atlas run's economics + health, read directly from
- * `atlas_run_diagnostics` (NOT the stripping `atlas_run_health` view) per D3.
- * `cached_tokens` is lifted out of the `breakdown` jsonb for convenience.
+ * A single Atlas run's health + optional economics. The public dashboard reads
+ * from the anon-safe `atlas_run_health` view (status, segment counts, timing);
+ * spend telemetry fields are null unless a BFF with service-role access is wired.
  */
 export interface AtlasRunDiagnostics {
   run_id: string;

--- a/tests/dq/atlas/test_phase67.py
+++ b/tests/dq/atlas/test_phase67.py
@@ -19,6 +19,7 @@ from digiquant.olympus.atlas.phases.phase7_synthesis import (
     DigestSnapshot,
     _bodies,
     _enforce_research_only_boundary,
+    _slim_segment_body,
     build_phase7,
 )
 from digiquant.olympus.hermes.models.analyst import AnalystPayload
@@ -378,6 +379,36 @@ class TestPhase7ResearchOnlyBoundary:
 def _carried_slot(slug: str, baseline: date = date(2026, 4, 19)) -> SegmentSlot:
     """A carry-forward slot (source='carried') as produced on a delta run."""
     return SegmentSlot(payload=Carried(baseline_date=baseline, reason="below_triage_threshold"))
+
+
+@pytest.mark.unit
+class TestSlimSegmentBodyForDigest:
+    def test_truncates_verbose_fields(self) -> None:
+        long_text = "x" * 500
+        body = {
+            "segment": "macro",
+            "bias": "bullish",
+            "headline": "Rates easing",
+            "notes": long_text,
+            "macro_summary": long_text,
+            "material_findings": [
+                {"label": "Fed", "summary": long_text, "source_ids": ["s1", "s2", "s3", "s4"]},
+                {"label": "CPI", "summary": "stable"},
+            ],
+            "sources": [
+                {"id": f"s{i}", "title": f"Source {i}", "url": f"https://x/{i}"} for i in range(20)
+            ],
+            "nested_blob": {"should": "drop"},
+        }
+        slim = _slim_segment_body(body)
+        assert slim["notes"].endswith("...")
+        assert len(slim["notes"]) <= 403
+        assert slim["macro_summary"].endswith("...")
+        assert len(slim["material_findings"]) == 2
+        assert len(slim["material_findings"][0]["summary"]) <= 203
+        assert slim["material_findings"][0]["source_ids"] == ["s1", "s2", "s3"]
+        assert len(slim["sources"]) == 10
+        assert "nested_blob" not in slim
 
 
 @pytest.mark.unit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated the Jun 27–29 Olympus pipeline failures and the stale dashboard.

**Root cause (pipeline):** All three daily runs failed at the `master-digest` phase with OpenRouter `BadRequestError` — input prompts exceeded the 64k context window (68k–77k tokens). Atlas crashed, Hermes was skipped (`atlas_research_produced` false), and no new `daily_snapshots` / `positions` / `nav_history` rows were written. Last successful run: **2026-06-26**.

**Root cause (dashboard):** The System page queried `atlas_run_diagnostics` directly, but migration 033 revoked anon SELECT on that table. Even when diagnostics rows *were* written (the chain always writes them in `finally`), the public dashboard saw "No runs recorded yet."

## Changes

### Pipeline (`phase7_synthesis.py`)
- **Slim segment bodies** before Phase 7 synthesis inputs (truncate verbose text, cap findings/sources)
- **Slim shared context** for master-digest (`data_layer_scope=none`, `slim_snapshots=True`) — segment bodies are already in `phase_inputs`
- **Fail-soft** on LLM errors: carry prior digest + record `PhaseError` instead of aborting the entire Atlas graph

### Dashboard (`observability-queries.ts`)
- Read run health from the anon-safe `atlas_run_health` view (migration 041)
- Cost/token/grounding tiles render `—` on the public dashboard (spend telemetry is operator-internal per migration 033)

## Verification
- `pytest tests/dq/atlas/test_phase67.py::TestSlimSegmentBodyForDigest -m unit` — pass
- `ruff check digiquant/src/digiquant/olympus/atlas/phases/phase7_synthesis.py` — pass

## Follow-up
- After merge, trigger a manual `pipeline-olympus.yml` workflow_dispatch to backfill Jun 29
- Confirm migration 041 (`atlas_run_health` view) is applied on prod Supabase if System page still empty

Fixes #976
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14a6-d00a-703c-9c8d-a425895f714a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14a6-d00a-703c-9c8d-a425895f714a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

