### PR TITLE
feat(docs): sync API reference into DigiVault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,13 @@ openapi-digigraph:
 	@mkdir -p docs/openapi
 	@python -c 'import json; from digigraph.server import app; open("docs/openapi/digigraph.json","w").write(json.dumps(app.openapi(), indent=2))'
 
+# Regenerate the DigiVault API-reference notes (docs/vision/api/) from the authored
+# /docs content (frontend/digithings-web/lib/apiDocs.ts + sharedDocs.ts). Commit the
+# output; the architecture-vault sync upserts it to Supabase on push to main.
+.PHONY: gen-api-vault
+gen-api-vault:
+	node_modules/.bin/tsx scripts/gen-api-vault.ts
+
 # ── Agent development kit ──────────────────────────────────────────────────────
 
 # Generate platform adapter files (.github/copilot-instructions.md, .cursor/rules/digithings.mdc) from agents.yml

--- a/docs/vision/.digivault.yml
+++ b/docs/vision/.digivault.yml
@@ -25,4 +25,6 @@ allowed_tags:
   - storage
   - knowledge-vault
   - dashboard
+  - api
+  - guide
 allow_orphans: false

--- a/docs/vision/api/digibase-api.md
+++ b/docs/vision/api/digibase-api.md
@@ -1,0 +1,54 @@
+---
+title: "digibase — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digibase
+---
+# digibase — API reference
+
+> The shared Python library every service builds on — and nothing more.
+
+**Role:** Shared HTTP + audit library · **Tier:** support
+
+## Overview
+Not a service but a deliberately minimal library: auth middleware, error handlers, request-ID logging, and a Prometheus metrics endpoint.
+
+Imported by every other module so they all behave consistently, with optional OpenTelemetry setup.
+
+## Authentication
+Shared Python library imported by every service — not a network surface.
+
+
+## Run locally
+```bash
+# installed as a dependency of each service; no standalone run
+```
+
+## Configuration
+- `DIGI_ENV` (default `dev`): Environment label for metrics.
+- `DIGI_CORS_ORIGINS`: Global CORS allowlist (comma-separated).
+- `DIGI_PII_PATTERNS`: Extra regex patterns for PII redaction.
+
+## Public interface
+- `from digibase.errors import register_fastapi_error_handlers` — Standard error envelope: {error:{code,message,request_id,service}}.
+- `from digibase.http import outbound_service_headers` — Builds X-Request-ID + Authorization headers for service-to-service calls.
+- `from digibase.http import install_request_id_middleware` — Reads/generates X-Request-ID, stores on request.state, echoes on the response.
+- `from digibase.audit import redact_mapping` — Redacts password/api_key/token/secret keys from a payload before logging.
+- `from digibase.metrics import install_metrics` — Mounts Prometheus /metrics with http_requests_total / _duration / _in_flight.
+- `from digibase.otel import setup_otel_fastapi` — Optional OTel wiring; no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set.
+
+## Stack
+Pydantic, FastAPI, Prometheus, OpenTelemetry
+
+## Related
+digismith, digisearch
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digibase]].

--- a/docs/vision/api/digichat-api.md
+++ b/docs/vision/api/digichat-api.md
@@ -81,7 +81,7 @@ Next.js, React, Vercel AI SDK, NextAuth, Postgres, Drizzle
 digigraph, digikey, digisearch
 
 ## Links
-- [Open digichat](/chat)
+- [Open digichat](https://digithings.ai/chat)
 - [Source](https://github.com/digithings-ai)
 
 See also [[digichat]].

--- a/docs/vision/api/digichat-api.md
+++ b/docs/vision/api/digichat-api.md
@@ -1,0 +1,87 @@
+---
+title: "digichat — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digichat
+---
+# digichat — API reference
+
+> Talk to your stack with your keys, your models, your audit log.
+
+**Role:** Chat surface · Next.js BFF · BYOK · **Tier:** core
+
+## Overview
+A Next.js and React BFF streaming digigraph through the Vercel AI SDK, your key forwarded per request — never stored, never logged.
+
+NextAuth handles identity; Postgres and Drizzle persist sessions for humans and agents alike.
+
+## Authentication
+The deployed digithings.ai chat is an agentic Cloudflare Pages Function (no login) that grounds answers in the digivault docs. The full Docker BFF additionally authenticates users via NextAuth and exchanges a BFF session for a digikey JWT to call DigiGraph.
+
+
+## Run locally
+```bash
+docker compose --profile digichat up -d
+```
+
+```bash
+make digichat-dev   # Next.js dev server with hot reload
+```
+
+## Configuration
+- `OPENROUTER_API_KEY` — required: LLM calls via OpenRouter free models.
+- `CORE_SUPABASE_URL` — required: Vault Supabase project URL (RLS read).
+- `CORE_SUPABASE_ANON_KEY` — required: Anon key for RLS-gated vault reads.
+- `AUTH_SECRET`: NextAuth secret (Docker BFF): openssl rand -base64 32.
+- `DIGIKEY_BFF_TOKEN`: Bearer for grant_type=bff_session (Docker BFF).
+
+## Endpoints
+
+Base URL: `$DIGICHAT_URL` (the service URL from docker-compose.yml).
+
+### GET /api/health
+Liveness probe.
+
+auth: none
+
+Response example:
+```json
+{ "ok": true }
+```
+
+### POST /api/chat
+Agentic chat grounded in digivault (single tool: search_digivault).
+
+auth: none (public, rate-limited)
+
+Request:
+- `messages` ({role,content}[]) — required: Conversation so far.
+- `model` (string): OpenRouter free model id.
+
+Response example:
+```json
+{ "content": "…grounded answer…", "tool_calls": [] }
+```
+
+```bash
+curl -X POST $DIGICHAT_URL/api/chat \
+  -H "content-type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What does digigraph do?"}]}'
+```
+
+## Stack
+Next.js, React, Vercel AI SDK, NextAuth, Postgres, Drizzle
+
+## Related
+digigraph, digikey, digisearch
+
+## Links
+- [Open digichat](/chat)
+- [Source](https://github.com/digithings-ai)
+
+See also [[digichat]].

--- a/docs/vision/api/digiclaw-api.md
+++ b/docs/vision/api/digiclaw-api.md
@@ -1,0 +1,57 @@
+---
+title: "digiclaw — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digiclaw
+---
+# digiclaw — API reference
+
+> The always-on agent runtime — heartbeats, scheduling, immutable audit.
+
+**Role:** Always-on runtime · heartbeat · audit · **Tier:** support
+
+## Overview
+A heartbeat service that keeps agents running: Atlas runner scheduling and drift detection, calling digigraph over HTTP on an interval.
+
+Every action lands in an immutable audit log, and it runs no LLM of its own.
+
+## Authentication
+CLI-only — no HTTP service. A heartbeat runner pings service health and appends an immutable audit log.
+
+
+## Run locally
+```bash
+python -m digiclaw            # one cycle
+docker compose --profile heartbeat up -d heartbeat
+```
+
+## Configuration
+- `DIGIGRAPH_URL`: DigiGraph base URL for health checks.
+- `DIGIQUANT_URL`: DigiQuant base URL for health + drift checks.
+- `DIGICLAW_DIGIKEY_API_KEY`: Key (digiquant:backtest+optimize) for auth-gated drift checks.
+- `AUDIT_LOG_PATH` (default `digiquant/results/audit/events.jsonl`): Append-only JSONL audit destination.
+- `REOPTIMIZE_STRATEGY` (default `mean_reversion_tech`): Strategy id for the drift check.
+
+## Public interface
+- `python -m digiclaw` — Run one heartbeat cycle: health-check services, run an auth-gated drift check, and (on drift) trigger re-optimization.
+- `audit_log(event_type, agent_id, payload)` — Append one redacted JSON line to the audit log.
+
+## Notes
+- Audit event types: heartbeat, reoptimize_triggered, reoptimize_completed, reoptimize_failed, drift_check_skipped.
+- Keys matching password / api_key / token / secret are redacted before write.
+
+## Stack
+HTTPx, digibase
+
+## Related
+digiquant, digismith
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digiclaw]].

--- a/docs/vision/api/digigraph-api.md
+++ b/docs/vision/api/digigraph-api.md
@@ -1,0 +1,187 @@
+---
+title: "digigraph — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digigraph
+---
+# digigraph — API reference
+
+> One supervisor decides which specialist runs. Every time.
+
+**Role:** Orchestration · LangGraph supervisor · **Tier:** core
+
+## Overview
+A LangGraph supervisor inspects each request and routes it to the right sub-graph — quant, retrieval, or chat — through a declarative tool registry.
+
+Speaks the OpenAI API so existing clients work unchanged; LiteLLM handles routing, caching, and checkpointed state across hops.
+
+## Authentication
+Endpoints accept a digikey-issued RS256 JWT in `Authorization: Bearer`. When no JWKS is configured the service runs in passthrough mode (dev/test only). `/healthz` and `/v1/status` are auth-exempt.
+
+- `digigraph:workflow` — POST /workflow + debug routes (default fallback)
+- `digigraph:chat` — /v1/chat/completions, /v1/models, /v1/model-info
+- `digigraph:mcp` — /threads/*, /files/* (when enabled)
+
+## Run locally
+```bash
+docker compose up -d digigraph
+```
+
+```bash
+uvicorn digigraph.server:app
+```
+
+MCP: `FastMCP streamable-http (workflow, chat, thread_state, list_orchestrator_tools)`
+
+## Configuration
+- `DIGIQUANT_URL`: DigiQuant base URL (defaults to the compose service URL).
+- `DIGISEARCH_URL`: DigiSearch base URL; empty disables retrieval.
+- `DIGIKEY_JWKS_URL`: JWT public-key (JWKS) endpoint.
+- `OPENAI_API_BASE`: LiteLLM proxy base URL.
+- `DIGI_LLM_MODE` (default `test`): Model tier: test / medium / best.
+- `DIGI_CHECKPOINTER` (default `memory`): LangGraph state backend: memory / sqlite / postgres / none.
+- `DIGI_ENABLE_THREAD_API` (default `0`): Gate /threads/* and /files/*.
+- `DIGI_ENABLE_DEBUG_ENDPOINTS` (default `0`): Gate /test_llm and /v1/debug/*.
+
+## Endpoints
+
+Base URL: `$DIGIGRAPH_URL` (the service URL from docker-compose.yml).
+
+### GET /healthz
+Liveness probe. Auth-exempt; always 200.
+
+auth: none
+
+Response example:
+```json
+{ "ok": true }
+```
+
+```bash
+curl $DIGIGRAPH_URL/healthz
+```
+
+### GET /v1/status
+Public, secret-free project status.
+
+auth: none · rate: 30/min/IP
+
+Response example:
+```json
+{
+  "service": "digigraph",
+  "project_name": "demo",
+  "agents_enabled": true,
+  "llm_mode": "test",
+  "mcp_enabled": true,
+  "workflow_profile": "default"
+}
+```
+
+```bash
+curl $DIGIGRAPH_URL/v1/status
+```
+
+### POST /workflow
+Run the full research + backtest graph (DigiClaw custom skill).
+
+auth: digigraph:workflow (optional) · rate: 10/min/IP
+
+Request:
+- `prompt` (string) — required: The user request to route through the supervisor.
+- `session_id` (string): Conversation/session correlation id.
+- `allowed_tools` (string[]): Tool allowlist override for this run.
+- `digi_bearer` (string): JWT forwarded downstream to DigiSearch/DigiQuant.
+
+Response:
+- `success` (boolean): Whether the workflow completed.
+- `message` (string): Human-readable summary or full RAG answer.
+- `backtest_result` (object | null): DigiQuant BacktestResult, if a backtest ran.
+- `rag_sources` (object[] | null): Aggregated DigiSearch citations.
+
+```bash
+curl -X POST $DIGIGRAPH_URL/workflow \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"prompt": "Backtest a momentum strategy on AAPL"}'
+```
+
+```python
+import os, httpx
+
+r = httpx.post(
+    f"{os.environ['DIGIGRAPH_URL']}/workflow",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"prompt": "Backtest a momentum strategy on AAPL"},
+    timeout=120,
+)
+print(r.json()["message"])
+```
+
+```typescript
+const r = await fetch(`${process.env.DIGIGRAPH_URL}/workflow`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.DIGI_JWT}`,
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({ prompt: "Backtest a momentum strategy on AAPL" }),
+});
+const { message } = await r.json();
+```
+
+### POST /v1/chat/completions
+OpenAI-compatible chat. Set stream:true for SSE (events: tool_call, content, done).
+
+auth: digigraph:chat (optional) · rate: 10/min/IP
+
+Request:
+- `model` (string): Model id; default "sitaas-rag".
+- `messages` ({role,content}[]) — required: Chat messages.
+- `stream` (boolean): Stream tokens as SSE.
+
+```bash
+curl -X POST $DIGIGRAPH_URL/v1/chat/completions \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"model":"sitaas-rag","messages":[{"role":"user","content":"hi"}]}'
+```
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url=os.environ["DIGIGRAPH_URL"] + "/v1", api_key=os.environ["DIGI_JWT"])
+resp = client.chat.completions.create(
+    model="sitaas-rag",
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+### GET /v1/models
+OpenAI-style model list.
+
+auth: digigraph:chat (optional) · rate: 30/min/IP
+
+```bash
+curl $DIGIGRAPH_URL/v1/models -H "Authorization: Bearer $JWT"
+```
+
+## MCP tools
+- `workflow(prompt, thread_id?)` — Run the full research + backtest graph; returns a JSON WorkflowResult.
+- `chat(message, thread_id?, model?)` — Single-turn chat via /v1/chat/completions.
+- `thread_state(thread_id)` — Return the LangGraph checkpoint state for a thread.
+- `list_orchestrator_tools()` — List registered orchestrator tool names.
+- `list_orchestrator_tools_detailed()` — Tool manifest: name, tags, dynamic_schema flag.
+
+## Stack
+LangGraph, FastAPI, LiteLLM, Pydantic, Polars, OpenAI SDK
+
+## Related
+digiquant, digisearch, digichat
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digigraph]].

--- a/docs/vision/api/digikey-api.md
+++ b/docs/vision/api/digikey-api.md
@@ -1,0 +1,129 @@
+---
+title: "digikey — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digikey
+---
+# digikey — API reference
+
+> Identity, JWTs, and scoped keys — one issuer for humans and machines.
+
+**Role:** Auth · RS256 JWTs · scoped API keys · **Tier:** support
+
+## Overview
+RS256-signed JWTs with a published JWKS, organization and project membership, and row-level scopes baked into the token.
+
+SQLAlchemy over Postgres stores keys, bcrypt hashes them, and an optional Redis blocklist handles revocation.
+
+## Authentication
+digikey is the issuer. Admin routes require the `DIGIKEY_ADMIN_TOKEN` bearer; token exchange takes a raw API key or a BFF-session grant. JWKS and /healthz are public.
+
+- `digigraph:workflow / :chat / :mcp` — DigiGraph routes
+- `digiquant:backtest / :optimize` — DigiQuant routes
+- `digisearch:query / :ingest` — DigiSearch routes
+- `*` — Wildcard (all scopes) — dev_global keys only
+
+## Run locally
+```bash
+docker compose up -d digikey
+```
+
+```bash
+uvicorn digikey.server:app
+```
+
+## Configuration
+- `DIGIKEY_DATABASE_URL` — required: SQLite or Postgres URL for key storage.
+- `DIGIKEY_PRIVATE_KEY_PEM`: RSA 2048 PEM for RS256 signing (prod).
+- `DIGIKEY_ADMIN_TOKEN` — required: Bearer for POST /v1/admin/keys.
+- `DIGIKEY_BFF_TOKEN`: Bearer for grant_type=bff_session (DigiChat).
+- `DIGIKEY_JWT_TTL_SEC` (default `900`): Access-token lifetime.
+- `DIGIKEY_BLOCKLIST_REDIS_URL`: Redis for JWT revocation (prod).
+
+## Endpoints
+
+Base URL: `$DIGIKEY_URL` (the service URL from docker-compose.yml).
+
+### GET /.well-known/jwks.json
+RSA public key set for verifying issued JWTs.
+
+auth: none
+
+```bash
+curl $DIGIKEY_URL/.well-known/jwks.json
+```
+
+### POST /v1/admin/keys
+Create an API key. The raw key is returned ONCE.
+
+auth: admin token · rate: 10/min/IP
+
+Request:
+- `tenant_slug` (string) — required: Tenant identifier.
+- `label` (string): Human-readable key name.
+- `scopes` (string[]): Granted scopes.
+
+Response example:
+```json
+{ "key_prefix": "dgk_live_…", "api_key": "dgk_live_…(once)", "id": "<uuid>" }
+```
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/admin/keys \
+  -H "Authorization: Bearer $DIGIKEY_ADMIN_TOKEN" -H "content-type: application/json" \
+  -d '{"tenant_slug":"acme","scopes":["digiquant:backtest"]}'
+```
+
+### POST /v1/oauth/token
+Exchange an API key (or BFF session) for a short-lived RS256 JWT.
+
+auth: none (key in body) · rate: 10/min/IP
+
+Request:
+- `grant_type` (string) — required: "api_key" | "bff_session".
+- `api_key` (string): Raw dgk_live_ key (api_key grant).
+- `requested_scopes` (string[]): Downscope to a subset of granted scopes.
+
+Response example:
+```json
+{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }
+```
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/oauth/token \
+  -H "content-type: application/json" \
+  -d '{"grant_type":"api_key","api_key":"'"$DIGI_API_KEY"'"}'
+```
+
+```python
+tok = httpx.post(
+    f"{os.environ['DIGIKEY_URL']}/v1/oauth/token",
+    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},
+).json()["access_token"]
+```
+
+### POST /v1/admin/keys/{key_id}/revoke
+Revoke a key and blocklist its live JWTs (when Redis is configured).
+
+auth: admin token · rate: 10/min/IP
+
+Response example:
+```json
+{ "revoked": true, "jtis_invalidated": 3 }
+```
+
+## Stack
+PyJWT, cryptography, bcrypt, SQLAlchemy, Postgres, Redis
+
+## Related
+digichat, digigraph, digismith
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digikey]].

--- a/docs/vision/api/digilink-api.md
+++ b/docs/vision/api/digilink-api.md
@@ -1,0 +1,40 @@
+---
+title: "digilink — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - roadmap
+relevance:
+  - digilink
+---
+# digilink — API reference
+
+> A protocol bridge so non-native transports speak MCP.
+
+**Role:** MCP protocol bridge · roadmap · **Tier:** roadmap
+
+## Overview
+Roadmap: a translation layer registering adapters that turn REST, gRPC, or bespoke transports into MCP tools.
+
+Today MCP is built into individual modules; this keeps the stack open instead of locked to one protocol.
+
+## Authentication
+Roadmap. Today MCP is built into individual modules (e.g. digisearch-mcp).
+
+
+## Notes
+- Planned: a protocol bridge registering adapters that turn REST, gRPC, or bespoke transports into MCP tools.
+- Planned surface: digilink.register_adapter("rest", …) to expose a non-native transport as MCP.
+
+## Stack
+MCP, HTTPx
+
+## Related
+digigraph, digiquant
+
+## Links
+- [Roadmap](https://github.com/digithings-ai)
+
+See also [[digilink]].

--- a/docs/vision/api/digiquant-api.md
+++ b/docs/vision/api/digiquant-api.md
@@ -1,0 +1,147 @@
+---
+title: "digiquant — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digiquant
+---
+# digiquant — API reference
+
+> Strategy research that ends in an order, not a markdown file.
+
+**Role:** Quant engine · NautilusTrader · **Tier:** core
+
+## Overview
+Atlas runs scheduled research, Hermes turns it into signals, Kairos executes on a NautilusTrader core, with Optuna driving optimization.
+
+Every step writes an immutable audit trail; live trading stays loopback-only until a human flips the gate.
+
+## Authentication
+Backtest/optimize/pipeline routes accept a digikey JWT (optional in passthrough mode). Async jobs stream progress over SSE.
+
+- `digiquant:backtest` — /run_backtest, /backtest/*, /v1/jobs/*, /v1/orchestrator_tools
+- `digiquant:optimize` — /run_optimize, /run_pipeline, /v1/workflow
+
+## Run locally
+```bash
+docker compose up -d digiquant
+```
+
+```bash
+uvicorn digiquant.server:app
+```
+
+## Configuration
+- `DIGIQUANT_DATA_DIR` (default `/app/data`): Directory of OHLCV CSVs for backtests.
+- `DIGIKEY_JWKS_URL`: JWT public-key (JWKS) endpoint.
+- `DIGIQUANT_ALLOW_EXPORT` (default `1`): Enable export of strategy configs.
+
+## Endpoints
+
+Base URL: `$DIGIQUANT_URL` (the service URL from docker-compose.yml).
+
+### GET /strategies
+List registered NautilusTrader strategies.
+
+auth: none · rate: 30/min/IP
+
+Response example:
+```json
+[{ "name": "mean_reversion_tech", "aliases": [], "description": "...", "default_params": {} }]
+```
+
+```bash
+curl $DIGIQUANT_URL/strategies
+```
+
+### POST /run_backtest
+Synchronous backtest. Returns a BacktestResult.
+
+auth: digiquant:backtest (optional) · rate: 10/min/IP
+
+Request:
+- `strategy_name` (string) — required: Registered strategy id.
+- `symbols` (string[]) — required: Instruments to test.
+- `data_dir` (string): Directory of {symbol}.csv OHLCV files.
+- `strategy_params` (object): Strategy parameter overrides.
+- `full_tearsheet` (boolean): Include extended charts (default true).
+
+Response:
+- `run_id` (string): Unique run identifier.
+- `total_pnl` (number): Total P&L.
+- `sharpe_ratio` (number | null): Sharpe ratio.
+- `num_trades` (integer): Number of trades executed.
+- `status` (string): "completed" | "failed".
+
+```bash
+curl -X POST $DIGIQUANT_URL/run_backtest \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"strategy_name":"mean_reversion_tech","symbols":["AAPL"]}'
+```
+
+```python
+r = httpx.post(
+    f"{os.environ['DIGIQUANT_URL']}/run_backtest",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"strategy_name": "mean_reversion_tech", "symbols": ["AAPL"]},
+    timeout=300,
+)
+print(r.json()["sharpe_ratio"])
+```
+
+### POST /backtest/start
+Submit an async backtest job; returns {job_id}. Poll progress over SSE.
+
+auth: none · rate: 10/min/IP
+
+Response example:
+```json
+{ "job_id": "..." }
+```
+
+### GET /backtest/{job_id}/progress
+SSE stream of backtest progress events (JSON frames).
+
+auth: none
+
+```bash
+curl -N $DIGIQUANT_URL/backtest/$JOB_ID/progress
+```
+
+### POST /run_optimize
+Parameter optimization (grid / bayesian / random). Returns best params.
+
+auth: digiquant:optimize (optional) · rate: 10/min/IP
+
+Request:
+- `strategy_name` (string) — required: Registered strategy id.
+- `symbols` (string[]) — required: Instruments.
+- `method` (string): "grid" | "bayesian" | "random" (default grid).
+- `n_trials` (integer): Trial budget (default 50).
+- `objective` (string): "sharpe" | "return" | "pnl".
+
+Response:
+- `best_params` (object): Best parameter set found.
+- `best_sharpe` (number | null): Objective value at best params.
+- `num_evaluations` (integer): Trials evaluated.
+
+### POST /run_pipeline
+Full pipeline: backtest → optimize → export.
+
+auth: digiquant:optimize (optional) · rate: 10/min/IP
+
+## Stack
+NautilusTrader, Optuna, LangGraph, Polars, yfinance, Supabase
+
+## Related
+digigraph, digistore, digilink
+
+## Links
+- [digiquant.io](https://digiquant.io)
+- [Source](https://github.com/digithings-ai)
+
+See also [[digiquant]].

--- a/docs/vision/api/digisearch-api.md
+++ b/docs/vision/api/digisearch-api.md
@@ -1,0 +1,118 @@
+---
+title: "digisearch — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digisearch
+---
+# digisearch — API reference
+
+> Production RAG without a stack rewrite when you switch vector DB.
+
+**Role:** Vector retrieval · multi-backend · **Tier:** core
+
+## Overview
+One client over Chroma or Azure AI Search, with backend-neutral entities so you swap engines without touching business code.
+
+Dense, sparse, and hybrid retrieval are first-class; BeautifulSoup and pdfplumber handle ingest, Polars throughout.
+
+## Authentication
+All query/ingest routes require a digikey JWT carrying the matching scope.
+
+- `digisearch:query` — /query, /v1/research_turn, orchestrator routes, /indexes/*
+- `digisearch:ingest` — /ingest
+
+## Run locally
+```bash
+docker compose up -d digisearch
+```
+
+```bash
+uvicorn digisearch.server:app
+```
+
+MCP: `digisearch mcp   (FastMCP streamable-http: digisearch_query, digisearch_research_turn)`
+
+## Configuration
+- `CHROMA_PATH`: Persistent Chroma directory (activates the Chroma backend).
+- `AZURE_SEARCH_ENDPOINT`: Azure AI Search endpoint (alternative backend).
+- `AZURE_SEARCH_API_KEY`: Azure AI Search key.
+- `OPENAI_API_KEY`: Embeddings provider key.
+- `DIGIKEY_JWKS_URL` — required: JWT public-key endpoint.
+
+## Endpoints
+
+Base URL: `$DIGISEARCH_URL` (the service URL from docker-compose.yml).
+
+### POST /query
+Hybrid / keyword / vector search over an index.
+
+auth: digisearch:query · rate: 10/min/IP
+
+Request:
+- `text` (string) — required: Query text.
+- `index_name` (string): Target index (default "default").
+- `top_k` (integer): Results to return, 1–100 (default 10).
+- `mode` (string): "keyword" | "vector" | "hybrid" (default hybrid).
+- `filters` ({field,op,value}[]): Structured metadata filters.
+
+Response:
+- `results` (object[]): Normalized hits (chunk_id, doc_id, score, content, metadata).
+- `total` (integer): Total matches.
+- `backend` (string): "chroma" | "azure_ai_search" | "stub".
+
+```bash
+curl -X POST $DIGISEARCH_URL/query \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"text":"momentum factor","index_name":"default","top_k":5}'
+```
+
+```python
+r = httpx.post(
+    f"{os.environ['DIGISEARCH_URL']}/query",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"text": "momentum factor", "top_k": 5},
+)
+for hit in r.json()["results"]:
+    print(hit["score"], hit["content"][:80])
+```
+
+### POST /ingest
+Ingest a document (parse → chunk → embed → index).
+
+auth: digisearch:ingest · rate: 30/min/IP
+
+Request:
+- `source` (string) — required: Server-side path to the document.
+- `index_name` (string): Target index.
+- `doc_type` (string): pdf | html | docx | markdown | csv | plaintext.
+- `metadata` (object): Evidence metadata (tier, venue, tags, …).
+
+Response example:
+```json
+{ "doc_id": "...", "chunks_created": 12, "index_name": "default", "status": "ok" }
+```
+
+### POST /v1/research_turn
+Composite research turn (plan → retrieve → aggregate) with citations.
+
+auth: digisearch:query · rate: 10/min/IP · requires the digisearch[agent] extra
+
+## MCP tools
+- `digisearch_query` — Search documents; returns formatted hits with score + preview.
+- `digisearch_research_turn` — Composite research turn with citations (needs digisearch[agent]).
+
+## Stack
+Chroma, OpenAI, BeautifulSoup, pdfplumber, LangGraph, FastAPI
+
+## Related
+digigraph, digistore, digibase
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digisearch]].

--- a/docs/vision/api/digismith-api.md
+++ b/docs/vision/api/digismith-api.md
@@ -1,0 +1,87 @@
+---
+title: "digismith — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digismith
+---
+# digismith — API reference
+
+> Correlation IDs across every span; PII redacted before logs hit disk.
+
+**Role:** Observability · spans · PII redaction · **Tier:** support
+
+## Overview
+Structured logging, Prometheus metrics, and OpenTelemetry spans thread through every request so a multi-hop run is traceable end to end.
+
+PII is redacted before anything is written, with optional LangSmith trace export.
+
+## Authentication
+Status and metrics are public diagnostics. Tracing is a library wrapper, not an HTTP surface.
+
+
+## Run locally
+```bash
+docker compose up -d digismith
+```
+
+```bash
+uvicorn digismith.server:app
+```
+
+## Configuration
+- `LANGSMITH_API_KEY`: Enable LangSmith trace export; absent = no-op.
+- `LANGSMITH_ENDPOINT` (default `https://api.smith.langchain.com`): LangSmith API base (host shown in /v1/status).
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Enable OTel HTTP export when set.
+
+## Endpoints
+
+Base URL: `$DIGISMITH_URL` (the service URL from docker-compose.yml).
+
+### GET /v1/status
+Tracing configuration diagnostic (operator-facing; secret-free).
+
+auth: none
+
+Response example:
+```json
+{
+  "version": "0.1.0",
+  "tracing_configured": true,
+  "langsmith_sdk_installed": true,
+  "langsmith_host": "api.smith.langchain.com",
+  "request_id": "..."
+}
+```
+
+```bash
+curl $DIGISMITH_URL/v1/status
+```
+
+### GET /metrics
+Prometheus metrics (text/plain 0.0.4).
+
+auth: none
+
+## Public interface
+- `from digismith.trace import traceable` — @traceable("name") wraps a function with langsmith.traceable when LANGSMITH_API_KEY is set; otherwise a no-op. PII is redacted from span inputs/outputs.
+- `from digismith.config import tracing_enabled` — Returns True when tracing is configured (key set + SDK importable).
+
+## Notes
+- Span attributes SHOULD include workflow_id, request_id, session_id, job_id.
+- Spans MUST NOT include raw prompts/completions, secrets, or full document bodies.
+
+## Stack
+LangSmith, OpenTelemetry, Prometheus, FastAPI
+
+## Related
+digigraph, digiclaw, digibase
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digismith]].

--- a/docs/vision/api/digistore-api.md
+++ b/docs/vision/api/digistore-api.md
@@ -1,0 +1,40 @@
+---
+title: "digistore — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - roadmap
+relevance:
+  - digistore
+---
+# digistore — API reference
+
+> One storage API over S3, MinIO, Postgres, or SQLite.
+
+**Role:** Storage abstraction · roadmap · **Tier:** roadmap
+
+## Overview
+Roadmap: a storage abstraction so business code never binds to a backend, today a session-scoped dataset manager living inside digigraph.
+
+Run SQLite on a laptop, then swap to S3 and Postgres in production without rewriting.
+
+## Authentication
+Roadmap. Today a session-scoped dataset manager lives inside digigraph; the standalone storage service is planned.
+
+
+## Notes
+- Planned: one storage API over S3, MinIO, Postgres, or SQLite so business code never binds to a backend.
+- Planned surface: DigiStore.configure(backend=…) + get/put/list over a backend-neutral interface.
+
+## Stack
+Postgres, SQLite, S3, MinIO
+
+## Related
+digiquant, digisearch
+
+## Links
+- [Roadmap](https://github.com/digithings-ai)
+
+See also [[digistore]].

--- a/docs/vision/api/guide-authentication.md
+++ b/docs/vision/api/guide-authentication.md
@@ -64,3 +64,5 @@ curl -X POST $DIGIGRAPH_URL/workflow \
 - `digiquant:backtest`, `digiquant:optimize`
 - `digisearch:query`, `digisearch:ingest`
 - JWTs are short-lived (default 900s); revoke a key via `POST /v1/admin/keys/{id}/revoke`.
+
+See also [[digikey]].

--- a/docs/vision/api/guide-authentication.md
+++ b/docs/vision/api/guide-authentication.md
@@ -1,0 +1,66 @@
+---
+title: "Authentication — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Authentication
+
+> Issue and use digikey JWTs across the stack — mint a key, exchange for a token, call a service.
+
+digikey is the single issuer of RS256 JWTs. Services verify tokens against digikey's JWKS and enforce per-route scopes. The flow: mint an API key (admin), exchange it for a short-lived JWT, then call services with `Authorization: Bearer <jwt>`.
+
+### 1 · Mint an API key (admin)
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/admin/keys \
+  -H "Authorization: Bearer $DIGIKEY_ADMIN_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"tenant_slug":"acme","scopes":["digiquant:backtest","digigraph:workflow"]}'
+# → { "api_key": "dgk_live_… (shown once)", "key_prefix": "dgk_live_…", "id": "<uuid>" }
+```
+
+### 2 · Exchange for a JWT
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/oauth/token \
+  -H "content-type: application/json" \
+  -d '{"grant_type":"api_key","api_key":"'"$DIGI_API_KEY"'"}'
+# → { "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }
+```
+
+```python
+import os, httpx
+
+tok = httpx.post(
+    f"{os.environ['DIGIKEY_URL']}/v1/oauth/token",
+    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},
+).json()["access_token"]
+```
+
+```typescript
+const r = await fetch(`${process.env.DIGIKEY_URL}/v1/oauth/token`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ grant_type: "api_key", api_key: process.env.DIGI_API_KEY }),
+});
+const { access_token } = await r.json();
+```
+
+### 3 · Call a service
+
+```bash
+curl -X POST $DIGIGRAPH_URL/workflow \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"prompt":"Backtest a momentum strategy on AAPL"}'
+```
+
+### Scopes
+
+- `digigraph:workflow`, `digigraph:chat`, `digigraph:mcp`
+- `digiquant:backtest`, `digiquant:optimize`
+- `digisearch:query`, `digisearch:ingest`
+- JWTs are short-lived (default 900s); revoke a key via `POST /v1/admin/keys/{id}/revoke`.

--- a/docs/vision/api/guide-conventions.md
+++ b/docs/vision/api/guide-conventions.md
@@ -1,0 +1,43 @@
+---
+title: "Conventions — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Conventions
+
+> Shared HTTP conventions across services — liveness, error envelope, correlation IDs, rate limits, CORS.
+
+### Liveness vs status
+
+`GET /healthz` is the auth-exempt liveness probe — always `{"ok": true}`, for load balancers. `GET /v1/status` (DigiGraph, DigiSmith) is a richer operator diagnostic; never use it for health checks.
+
+### Error envelope
+
+Every service returns the same error shape:
+
+```json
+{
+  "error": {
+    "code": "http_401",
+    "message": "Bearer token required",
+    "request_id": "req-…",
+    "service": "digigraph"
+  }
+}
+```
+
+- `http_401` — missing/invalid token · `http_403` / `insufficient_scope` — scope denied.
+- `validation_error` — request body failed validation.
+- `rate_limited` — HTTP 429, with a `Retry-After` header.
+
+### Correlation
+
+Send `X-Request-ID` to correlate a call across services; it is generated if absent and echoed on the response and in the audit log.
+
+### Rate limits & CORS
+
+Mutating routes are rate-limited per IP (typically 10/min, 429 + `Retry-After` on breach). CORS uses an explicit allowlist (`DIGI_CORS_ORIGINS`) — no wildcard — with credentials enabled for session cookies.

--- a/docs/vision/api/guide-conventions.md
+++ b/docs/vision/api/guide-conventions.md
@@ -41,3 +41,5 @@ Send `X-Request-ID` to correlate a call across services; it is generated if abse
 ### Rate limits & CORS
 
 Mutating routes are rate-limited per IP (typically 10/min, 429 + `Retry-After` on breach). CORS uses an explicit allowlist (`DIGI_CORS_ORIGINS`) — no wildcard — with credentials enabled for session cookies.
+
+See also [[digibase]].

--- a/docs/vision/api/guide-getting-started.md
+++ b/docs/vision/api/guide-getting-started.md
@@ -42,3 +42,5 @@ Each backend service exposes a liveness probe at `GET /healthz`. The service URL
 - `make up-digichat` — start the chat BFF + its Postgres.
 - `make stack-local` — run the Python services without Docker.
 - `make test-unit` — unit tests (no stack required).
+
+See also [[digigraph]].

--- a/docs/vision/api/guide-getting-started.md
+++ b/docs/vision/api/guide-getting-started.md
@@ -1,0 +1,44 @@
+---
+title: "Getting started — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Getting started
+
+> Run the digithings stack locally — prerequisites, compose, environment, and make targets.
+
+digithings is an open-core agentic stack — orchestration, quant research, retrieval, and chat behind one supervisor. Self-hosted, BYOK, audit-on by default.
+
+### Prerequisites
+
+- Docker (with Compose)
+- Python ≥ 3.12 (for running services outside Docker)
+- Node.js LTS (for the frontends)
+
+### Run the whole stack
+
+```bash
+git clone https://github.com/digithings-ai/digithings && cd digithings
+cp .env.example .env   # add your keys
+docker compose up -d
+```
+
+Each backend service exposes a liveness probe at `GET /healthz`. The service URLs and ports are defined in `docker-compose.yml`; reference them through env vars (`$DIGIGRAPH_URL`, `$DIGIKEY_URL`, …) rather than hardcoding an address.
+
+### Essential environment
+
+- `OPENROUTER_API_KEY` / `OPENAI_API_KEY` — LLM access via the LiteLLM proxy.
+- `DIGIKEY_ADMIN_TOKEN` — required to mint API keys (see Authentication).
+- `DIGIKEY_PRIVATE_KEY_PEM` — stable RS256 signing key for production.
+- See `.env.example` for the full, annotated list.
+
+### Useful make targets
+
+- `make up` / `make down` — start / stop the core stack.
+- `make up-digichat` — start the chat BFF + its Postgres.
+- `make stack-local` — run the Python services without Docker.
+- `make test-unit` — unit tests (no stack required).

--- a/frontend/digithings-web/components/docs/DocsLayout.tsx
+++ b/frontend/digithings-web/components/docs/DocsLayout.tsx
@@ -2,8 +2,9 @@
 import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { modules, type ModuleNode, StackRow, Emblem } from "@digithings/web";
 import { CopyButton } from "@/lib/CopyButton";
-import { apiDocs, type ModuleApiDoc, type Endpoint } from "@/lib/apiDocs";
-import { guides, type Guide, type Block } from "@/lib/sharedDocs";
+import { apiDocs, type ModuleApiDoc } from "@/lib/apiDocs";
+import { guides, type Block } from "@/lib/sharedDocs";
+import { guideToMarkdown, moduleToMarkdown } from "@/lib/docsSerializers";
 import { EndpointDoc } from "./Endpoint";
 
 /**
@@ -70,94 +71,6 @@ function Blocks({ blocks }: { blocks: Block[] }) {
       })}
     </>
   );
-}
-
-// ── markdown serializers (for "copy as Markdown") ─────────────────────────────
-function guideToMarkdown(g: Guide): string {
-  const L: string[] = [`## ${g.title}`, ""];
-  for (const b of g.blocks) {
-    if (b.kind === "h") L.push(`### ${b.text}`, "");
-    else if (b.kind === "p") L.push(b.text, "");
-    else if (b.kind === "list") {
-      b.items.forEach((it) => L.push(`- ${it}`));
-      L.push("");
-    } else if (b.kind === "code") L.push("```" + b.lang, b.code, "```", "");
-  }
-  return L.join("\n").trim();
-}
-
-function endpointToMarkdown(ep: Endpoint, L: string[]): void {
-  L.push(`### ${ep.method} ${ep.path}`, ep.summary, "");
-  const meta = [ep.auth && `auth: ${ep.auth}`, ep.rateLimit && `rate: ${ep.rateLimit}`, ep.flag]
-    .filter(Boolean)
-    .join(" · ");
-  if (meta) L.push(meta, "");
-  if (ep.request?.length) {
-    L.push("Request:");
-    ep.request.forEach((f) => L.push(`- \`${f.name}\` (${f.type})${f.required ? " — required" : ""}: ${f.description}`));
-    L.push("");
-  }
-  if (ep.responseFields?.length) {
-    L.push("Response:");
-    ep.responseFields.forEach((f) => L.push(`- \`${f.name}\` (${f.type}): ${f.description}`));
-    L.push("");
-  }
-  if (ep.responseExample) L.push("Response example:", "```json", ep.responseExample, "```", "");
-  ep.examples?.forEach((ex) => L.push("```" + ex.lang, ex.code, "```", ""));
-}
-
-function moduleToMarkdown(m: ModuleNode): string {
-  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
-  const L: string[] = [`# ${m.id}`, "", `> ${m.tagline}`, ""];
-  L.push(`**Role:** ${m.role} · **Tier:** ${m.tier}`, "");
-  L.push("## Overview");
-  m.summary.forEach((s) => L.push(s, ""));
-  if (d.authNote || d.scopes?.length) {
-    L.push("## Authentication");
-    if (d.authNote) L.push(d.authNote, "");
-    d.scopes?.forEach((s) => L.push(`- \`${s.scope}\` — ${s.grants}`));
-    L.push("");
-  }
-  if (d.run) {
-    L.push("## Run locally");
-    if (d.run.compose) L.push("```bash", d.run.compose, "```", "");
-    if (d.run.standalone) L.push("```bash", d.run.standalone, "```", "");
-    if (d.run.cli) L.push("```bash", d.run.cli, "```", "");
-    if (d.run.mcp) L.push(`MCP: \`${d.run.mcp}\``, "");
-  }
-  if (d.env?.length) {
-    L.push("## Configuration");
-    d.env.forEach((e) => L.push(`- \`${e.name}\`${e.def ? ` (default \`${e.def}\`)` : ""}${e.required ? " — required" : ""}: ${e.description}`));
-    L.push("");
-  }
-  if (d.endpoints?.length) {
-    L.push("## Endpoints", "");
-    if (d.baseUrlVar) L.push(`Base URL: \`$${d.baseUrlVar}\` (the service URL from docker-compose.yml).`, "");
-    d.endpoints.forEach((ep) => endpointToMarkdown(ep, L));
-  }
-  if (d.publicInterface?.length) {
-    L.push("## Public interface");
-    d.publicInterface.forEach((it) => L.push(`- \`${it.signature}\` — ${it.description}`));
-    L.push("");
-  }
-  if (d.mcp?.length) {
-    L.push("## MCP tools");
-    d.mcp.forEach((t) => L.push(`- \`${t.name}\` — ${t.description}`));
-    L.push("");
-  }
-  if (d.notes?.length) {
-    L.push("## Notes");
-    d.notes.forEach((n) => L.push(`- ${n}`));
-    L.push("");
-  }
-  L.push("## Stack", m.stack.map((s) => s.name).join(", "), "");
-  if (m.related.length) L.push("## Related", m.related.join(", "), "");
-  if (m.links.length) {
-    L.push("## Links");
-    m.links.forEach((l) => L.push(`- [${l.label}](${l.href})`));
-    L.push("");
-  }
-  return L.join("\n").trim() + "\n";
 }
 
 const PAGE_MD = [

--- a/frontend/digithings-web/lib/docsSerializers.ts
+++ b/frontend/digithings-web/lib/docsSerializers.ts
@@ -1,0 +1,99 @@
+/**
+ * Markdown serializers for the API docs — shared by the /docs page (the
+ * "copy as Markdown" buttons in DocsLayout) and the DigiVault sync generator
+ * (scripts/gen-api-vault.ts), so the two never drift.
+ *
+ * Pure functions, no React or client-only deps; `ModuleNode` is imported as a
+ * type only, so this module runs under plain Node (type-stripping) as well as
+ * inside the Next.js bundle.
+ */
+import type { ModuleNode } from "@digithings/web";
+import { apiDocs, type ModuleApiDoc, type Endpoint } from "./apiDocs";
+import { type Guide } from "./sharedDocs";
+
+export function guideToMarkdown(g: Guide): string {
+  const L: string[] = [`## ${g.title}`, ""];
+  for (const b of g.blocks) {
+    if (b.kind === "h") L.push(`### ${b.text}`, "");
+    else if (b.kind === "p") L.push(b.text, "");
+    else if (b.kind === "list") {
+      b.items.forEach((it) => L.push(`- ${it}`));
+      L.push("");
+    } else if (b.kind === "code") L.push("```" + b.lang, b.code, "```", "");
+  }
+  return L.join("\n").trim();
+}
+
+function endpointToMarkdown(ep: Endpoint, L: string[]): void {
+  L.push(`### ${ep.method} ${ep.path}`, ep.summary, "");
+  const meta = [ep.auth && `auth: ${ep.auth}`, ep.rateLimit && `rate: ${ep.rateLimit}`, ep.flag]
+    .filter(Boolean)
+    .join(" · ");
+  if (meta) L.push(meta, "");
+  if (ep.request?.length) {
+    L.push("Request:");
+    ep.request.forEach((f) => L.push(`- \`${f.name}\` (${f.type})${f.required ? " — required" : ""}: ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseFields?.length) {
+    L.push("Response:");
+    ep.responseFields.forEach((f) => L.push(`- \`${f.name}\` (${f.type}): ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseExample) L.push("Response example:", "```json", ep.responseExample, "```", "");
+  ep.examples?.forEach((ex) => L.push("```" + ex.lang, ex.code, "```", ""));
+}
+
+export function moduleToMarkdown(m: ModuleNode): string {
+  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
+  const L: string[] = [`# ${m.id}`, "", `> ${m.tagline}`, ""];
+  L.push(`**Role:** ${m.role} · **Tier:** ${m.tier}`, "");
+  L.push("## Overview");
+  m.summary.forEach((s) => L.push(s, ""));
+  if (d.authNote || d.scopes?.length) {
+    L.push("## Authentication");
+    if (d.authNote) L.push(d.authNote, "");
+    d.scopes?.forEach((s) => L.push(`- \`${s.scope}\` — ${s.grants}`));
+    L.push("");
+  }
+  if (d.run) {
+    L.push("## Run locally");
+    if (d.run.compose) L.push("```bash", d.run.compose, "```", "");
+    if (d.run.standalone) L.push("```bash", d.run.standalone, "```", "");
+    if (d.run.cli) L.push("```bash", d.run.cli, "```", "");
+    if (d.run.mcp) L.push(`MCP: \`${d.run.mcp}\``, "");
+  }
+  if (d.env?.length) {
+    L.push("## Configuration");
+    d.env.forEach((e) => L.push(`- \`${e.name}\`${e.def ? ` (default \`${e.def}\`)` : ""}${e.required ? " — required" : ""}: ${e.description}`));
+    L.push("");
+  }
+  if (d.endpoints?.length) {
+    L.push("## Endpoints", "");
+    if (d.baseUrlVar) L.push(`Base URL: \`$${d.baseUrlVar}\` (the service URL from docker-compose.yml).`, "");
+    d.endpoints.forEach((ep) => endpointToMarkdown(ep, L));
+  }
+  if (d.publicInterface?.length) {
+    L.push("## Public interface");
+    d.publicInterface.forEach((it) => L.push(`- \`${it.signature}\` — ${it.description}`));
+    L.push("");
+  }
+  if (d.mcp?.length) {
+    L.push("## MCP tools");
+    d.mcp.forEach((t) => L.push(`- \`${t.name}\` — ${t.description}`));
+    L.push("");
+  }
+  if (d.notes?.length) {
+    L.push("## Notes");
+    d.notes.forEach((n) => L.push(`- ${n}`));
+    L.push("");
+  }
+  L.push("## Stack", m.stack.map((s) => s.name).join(", "), "");
+  if (m.related.length) L.push("## Related", m.related.join(", "), "");
+  if (m.links.length) {
+    L.push("## Links");
+    m.links.forEach((l) => L.push(`- [${l.label}](${l.href})`));
+    L.push("");
+  }
+  return L.join("\n").trim() + "\n";
+}

--- a/scripts/gen-api-vault.ts
+++ b/scripts/gen-api-vault.ts
@@ -1,0 +1,76 @@
+/**
+ * Generate DigiVault notes for the API reference.
+ *
+ * Reads the same authored content + serializers that drive the /docs page
+ * (single source of truth) and writes one Obsidian-style markdown note per
+ * module and per guide into `docs/vision/api/`. The existing production sync
+ * (`scripts/sync_architecture_vault.py`, triggered on push to main when
+ * `docs/vision/**` changes) then upserts them into Supabase `architecture_notes`,
+ * so the digithings.ai chat can search and cite the API docs.
+ *
+ * Run from the repo root:  node_modules/.bin/tsx scripts/gen-api-vault.ts
+ * (Re-run whenever apiDocs.ts / sharedDocs.ts change; commit the output.)
+ */
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { modules } from "../frontend/web/src/data/modules";
+import { guides } from "../frontend/digithings-web/lib/sharedDocs";
+import { guideToMarkdown, moduleToMarkdown } from "../frontend/digithings-web/lib/docsSerializers";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const OUT_DIR = `${ROOT}docs/vision/api`;
+const CREATED = new Date().toISOString().slice(0, 10);
+
+/** One-line summaries for the guide notes (the curated tagline becomes FTS weight B). */
+const GUIDE_SUMMARY: Record<string, string> = {
+  "getting-started": "Run the digithings stack locally — prerequisites, compose, environment, and make targets.",
+  authentication: "Issue and use digikey JWTs across the stack — mint a key, exchange for a token, call a service.",
+  conventions: "Shared HTTP conventions across services — liveness, error envelope, correlation IDs, rate limits, CORS.",
+};
+
+function frontmatter(fields: { title: string; tags: string[]; relevance?: string[] }): string {
+  const lines = [
+    "---",
+    `title: "${fields.title}"`,
+    "type: reference",
+    "status: generated",
+    `created: ${CREATED}`,
+    "tags:",
+    ...fields.tags.map((t) => `  - ${t}`),
+  ];
+  if (fields.relevance?.length) {
+    lines.push("relevance:", ...fields.relevance.map((r) => `  - ${r}`));
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+function write(stem: string, body: string): string {
+  const path = `${OUT_DIR}/${stem}.md`;
+  writeFileSync(path, body.endsWith("\n") ? body : body + "\n", "utf8");
+  return `docs/vision/api/${stem}.md`;
+}
+
+// Fresh directory each run so deletions/renames don't leave orphans behind.
+if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+const written: string[] = [];
+
+// Guide notes
+for (const g of guides) {
+  const summary = GUIDE_SUMMARY[g.id] ?? g.title;
+  const md = guideToMarkdown(g).replace(/^## .*\n+/, ""); // drop the leading "## Title"
+  const body = `${frontmatter({ title: `${g.title} — guide`, tags: ["api", "guide"] })}# ${g.title}\n\n> ${summary}\n\n${md}\n`;
+  written.push(write(`guide-${g.id}`, body));
+}
+
+// Module notes — reuse moduleToMarkdown; retitle the H1 as an API-reference note.
+for (const m of modules) {
+  const md = moduleToMarkdown(m).replace(`# ${m.id}\n`, `# ${m.id} — API reference\n`);
+  const body = `${frontmatter({ title: `${m.id} — API reference`, tags: ["api", m.tier], relevance: [m.id] })}${md}\nSee also [[${m.id}]].\n`;
+  written.push(write(`${m.id}-api`, body));
+}
+
+console.log(`Wrote ${written.length} API notes to docs/vision/api/:`);
+written.forEach((p) => console.log(`  ${p}`));

--- a/scripts/gen-api-vault.ts
+++ b/scripts/gen-api-vault.ts
@@ -28,6 +28,13 @@ const GUIDE_SUMMARY: Record<string, string> = {
   conventions: "Shared HTTP conventions across services — liveness, error envelope, correlation IDs, rate limits, CORS.",
 };
 
+/** A related module per guide, so the note isn't an orphan (allow_orphans: false). */
+const GUIDE_LINK: Record<string, string> = {
+  "getting-started": "digigraph",
+  authentication: "digikey",
+  conventions: "digibase",
+};
+
 function frontmatter(fields: { title: string; tags: string[]; relevance?: string[] }): string {
   const lines = [
     "---",
@@ -67,7 +74,9 @@ const written: string[] = [];
 for (const g of guides) {
   const summary = GUIDE_SUMMARY[g.id] ?? g.title;
   const md = absolutizeLinks(guideToMarkdown(g).replace(/^## .*\n+/, "")); // drop the leading "## Title"
-  const body = `${frontmatter({ title: `${g.title} — guide`, tags: ["api", "guide"] })}# ${g.title}\n\n> ${summary}\n\n${md}\n`;
+  const link = GUIDE_LINK[g.id];
+  const seeAlso = link ? `\n\nSee also [[${link}]].` : "";
+  const body = `${frontmatter({ title: `${g.title} — guide`, tags: ["api", "guide"] })}# ${g.title}\n\n> ${summary}\n\n${md}${seeAlso}\n`;
   written.push(write(`guide-${g.id}`, body));
 }
 

--- a/scripts/gen-api-vault.ts
+++ b/scripts/gen-api-vault.ts
@@ -45,6 +45,12 @@ function frontmatter(fields: { title: string; tags: string[]; relevance?: string
   return lines.join("\n");
 }
 
+/** Site-relative links (e.g. [Open digichat](/chat)) are app routes, not vault
+ * paths — absolutize them so they resolve and the doc-link checker skips them. */
+function absolutizeLinks(md: string): string {
+  return md.replace(/\]\(\/(?!\/)/g, "](https://digithings.ai/");
+}
+
 function write(stem: string, body: string): string {
   const path = `${OUT_DIR}/${stem}.md`;
   writeFileSync(path, body.endsWith("\n") ? body : body + "\n", "utf8");
@@ -60,14 +66,14 @@ const written: string[] = [];
 // Guide notes
 for (const g of guides) {
   const summary = GUIDE_SUMMARY[g.id] ?? g.title;
-  const md = guideToMarkdown(g).replace(/^## .*\n+/, ""); // drop the leading "## Title"
+  const md = absolutizeLinks(guideToMarkdown(g).replace(/^## .*\n+/, "")); // drop the leading "## Title"
   const body = `${frontmatter({ title: `${g.title} — guide`, tags: ["api", "guide"] })}# ${g.title}\n\n> ${summary}\n\n${md}\n`;
   written.push(write(`guide-${g.id}`, body));
 }
 
 // Module notes — reuse moduleToMarkdown; retitle the H1 as an API-reference note.
 for (const m of modules) {
-  const md = moduleToMarkdown(m).replace(`# ${m.id}\n`, `# ${m.id} — API reference\n`);
+  const md = absolutizeLinks(moduleToMarkdown(m).replace(`# ${m.id}\n`, `# ${m.id} — API reference\n`));
   const body = `${frontmatter({ title: `${m.id} — API reference`, tags: ["api", m.tier], relevance: [m.id] })}${md}\nSee also [[${m.id}]].\n`;
   written.push(write(`${m.id}-api`, body));
 }


### PR DESCRIPTION
## What

Syncs the `/docs` API reference into DigiVault so the chat can cite it — completing the deferred sync portion of #1163.

The authored `/docs` content (`lib/apiDocs.ts` + `lib/sharedDocs.ts`) stays the **single source of truth**. A generator reuses the shared markdown serializers to emit one Obsidian-style note per module and per guide into `docs/vision/api/`; the existing production sync (`scripts/sync_architecture_vault.py`, triggered on push to `main` when `docs/vision/**` changes) upserts them into Supabase `architecture_notes`. **No new prod-write path, no direct DB writes.**

## Changes

- **New** `scripts/gen-api-vault.ts` — generator (run via `make gen-api-vault`); fresh-writes `docs/vision/api/` from `modules` + `apiDocs` + `guides`.
- **New** `frontend/digithings-web/lib/docsSerializers.ts` — the markdown serializers (`guideToMarkdown`, `moduleToMarkdown`) extracted from `DocsLayout.tsx` so the page and the generator share one implementation (no drift). Pure, Node-runnable (type-only `ModuleNode` import).
- **New** `docs/vision/api/*.md` (13) — per-module + per-guide notes with frontmatter (`type: reference`, `tags: [api, …]`, `relevance`, summary blockquote).
- `DocsLayout.tsx` now imports the serializers (behavior unchanged).
- `Makefile`: `make gen-api-vault`.

## How it reaches the chat

The chat queries `architecture_notes` via the `search_architecture_notes` FTS RPC (anon, read-only). The notes' title/summary/tags/body feed the weighted tsvector, so questions like "how do I authenticate?" or "what endpoints does digiquant expose?" will surface the new API notes. This takes effect once the change lands on `main` and the production-gated `sync-architecture-vault` workflow runs.

## Verification

- `node_modules/.bin/tsx scripts/gen-api-vault.ts` → 13 notes written.
- `scripts/sync_architecture_vault.py --dry-run` → parses all `api/` notes (exit 0), correct `vault_path`s (`api/digigraph-api`, …) and summaries.
- Confirmed no CHECK constraint on `architecture_notes.status` (so `status: generated` upserts fine).
- `npm run lint` (0 errors) / `npm run build` (static export OK) after the serializer extraction.
- `make score`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10.

Fixes #1167
