### PR TITLE
chore(release): promote develop to main (API docs + emblems + DigiVault sync)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,13 @@ openapi-digigraph:
 	@mkdir -p docs/openapi
 	@python -c 'import json; from digigraph.server import app; open("docs/openapi/digigraph.json","w").write(json.dumps(app.openapi(), indent=2))'
 
+# Regenerate the DigiVault API-reference notes (docs/vision/api/) from the authored
+# /docs content (frontend/digithings-web/lib/apiDocs.ts + sharedDocs.ts). Commit the
+# output; the architecture-vault sync upserts it to Supabase on push to main.
+.PHONY: gen-api-vault
+gen-api-vault:
+	node_modules/.bin/tsx scripts/gen-api-vault.ts
+
 # ── Agent development kit ──────────────────────────────────────────────────────
 
 # Generate platform adapter files (.github/copilot-instructions.md, .cursor/rules/digithings.mdc) from agents.yml

--- a/docs/vision/.digivault.yml
+++ b/docs/vision/.digivault.yml
@@ -25,4 +25,6 @@ allowed_tags:
   - storage
   - knowledge-vault
   - dashboard
+  - api
+  - guide
 allow_orphans: false

--- a/docs/vision/api/digibase-api.md
+++ b/docs/vision/api/digibase-api.md
@@ -1,0 +1,54 @@
+---
+title: "digibase — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digibase
+---
+# digibase — API reference
+
+> The shared Python library every service builds on — and nothing more.
+
+**Role:** Shared HTTP + audit library · **Tier:** support
+
+## Overview
+Not a service but a deliberately minimal library: auth middleware, error handlers, request-ID logging, and a Prometheus metrics endpoint.
+
+Imported by every other module so they all behave consistently, with optional OpenTelemetry setup.
+
+## Authentication
+Shared Python library imported by every service — not a network surface.
+
+
+## Run locally
+```bash
+# installed as a dependency of each service; no standalone run
+```
+
+## Configuration
+- `DIGI_ENV` (default `dev`): Environment label for metrics.
+- `DIGI_CORS_ORIGINS`: Global CORS allowlist (comma-separated).
+- `DIGI_PII_PATTERNS`: Extra regex patterns for PII redaction.
+
+## Public interface
+- `from digibase.errors import register_fastapi_error_handlers` — Standard error envelope: {error:{code,message,request_id,service}}.
+- `from digibase.http import outbound_service_headers` — Builds X-Request-ID + Authorization headers for service-to-service calls.
+- `from digibase.http import install_request_id_middleware` — Reads/generates X-Request-ID, stores on request.state, echoes on the response.
+- `from digibase.audit import redact_mapping` — Redacts password/api_key/token/secret keys from a payload before logging.
+- `from digibase.metrics import install_metrics` — Mounts Prometheus /metrics with http_requests_total / _duration / _in_flight.
+- `from digibase.otel import setup_otel_fastapi` — Optional OTel wiring; no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set.
+
+## Stack
+Pydantic, FastAPI, Prometheus, OpenTelemetry
+
+## Related
+digismith, digisearch
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digibase]].

--- a/docs/vision/api/digichat-api.md
+++ b/docs/vision/api/digichat-api.md
@@ -1,0 +1,87 @@
+---
+title: "digichat — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digichat
+---
+# digichat — API reference
+
+> Talk to your stack with your keys, your models, your audit log.
+
+**Role:** Chat surface · Next.js BFF · BYOK · **Tier:** core
+
+## Overview
+A Next.js and React BFF streaming digigraph through the Vercel AI SDK, your key forwarded per request — never stored, never logged.
+
+NextAuth handles identity; Postgres and Drizzle persist sessions for humans and agents alike.
+
+## Authentication
+The deployed digithings.ai chat is an agentic Cloudflare Pages Function (no login) that grounds answers in the digivault docs. The full Docker BFF additionally authenticates users via NextAuth and exchanges a BFF session for a digikey JWT to call DigiGraph.
+
+
+## Run locally
+```bash
+docker compose --profile digichat up -d
+```
+
+```bash
+make digichat-dev   # Next.js dev server with hot reload
+```
+
+## Configuration
+- `OPENROUTER_API_KEY` — required: LLM calls via OpenRouter free models.
+- `CORE_SUPABASE_URL` — required: Vault Supabase project URL (RLS read).
+- `CORE_SUPABASE_ANON_KEY` — required: Anon key for RLS-gated vault reads.
+- `AUTH_SECRET`: NextAuth secret (Docker BFF): openssl rand -base64 32.
+- `DIGIKEY_BFF_TOKEN`: Bearer for grant_type=bff_session (Docker BFF).
+
+## Endpoints
+
+Base URL: `$DIGICHAT_URL` (the service URL from docker-compose.yml).
+
+### GET /api/health
+Liveness probe.
+
+auth: none
+
+Response example:
+```json
+{ "ok": true }
+```
+
+### POST /api/chat
+Agentic chat grounded in digivault (single tool: search_digivault).
+
+auth: none (public, rate-limited)
+
+Request:
+- `messages` ({role,content}[]) — required: Conversation so far.
+- `model` (string): OpenRouter free model id.
+
+Response example:
+```json
+{ "content": "…grounded answer…", "tool_calls": [] }
+```
+
+```bash
+curl -X POST $DIGICHAT_URL/api/chat \
+  -H "content-type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What does digigraph do?"}]}'
+```
+
+## Stack
+Next.js, React, Vercel AI SDK, NextAuth, Postgres, Drizzle
+
+## Related
+digigraph, digikey, digisearch
+
+## Links
+- [Open digichat](https://digithings.ai/chat)
+- [Source](https://github.com/digithings-ai)
+
+See also [[digichat]].

--- a/docs/vision/api/digiclaw-api.md
+++ b/docs/vision/api/digiclaw-api.md
@@ -1,0 +1,57 @@
+---
+title: "digiclaw — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digiclaw
+---
+# digiclaw — API reference
+
+> The always-on agent runtime — heartbeats, scheduling, immutable audit.
+
+**Role:** Always-on runtime · heartbeat · audit · **Tier:** support
+
+## Overview
+A heartbeat service that keeps agents running: Atlas runner scheduling and drift detection, calling digigraph over HTTP on an interval.
+
+Every action lands in an immutable audit log, and it runs no LLM of its own.
+
+## Authentication
+CLI-only — no HTTP service. A heartbeat runner pings service health and appends an immutable audit log.
+
+
+## Run locally
+```bash
+python -m digiclaw            # one cycle
+docker compose --profile heartbeat up -d heartbeat
+```
+
+## Configuration
+- `DIGIGRAPH_URL`: DigiGraph base URL for health checks.
+- `DIGIQUANT_URL`: DigiQuant base URL for health + drift checks.
+- `DIGICLAW_DIGIKEY_API_KEY`: Key (digiquant:backtest+optimize) for auth-gated drift checks.
+- `AUDIT_LOG_PATH` (default `digiquant/results/audit/events.jsonl`): Append-only JSONL audit destination.
+- `REOPTIMIZE_STRATEGY` (default `mean_reversion_tech`): Strategy id for the drift check.
+
+## Public interface
+- `python -m digiclaw` — Run one heartbeat cycle: health-check services, run an auth-gated drift check, and (on drift) trigger re-optimization.
+- `audit_log(event_type, agent_id, payload)` — Append one redacted JSON line to the audit log.
+
+## Notes
+- Audit event types: heartbeat, reoptimize_triggered, reoptimize_completed, reoptimize_failed, drift_check_skipped.
+- Keys matching password / api_key / token / secret are redacted before write.
+
+## Stack
+HTTPx, digibase
+
+## Related
+digiquant, digismith
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digiclaw]].

--- a/docs/vision/api/digigraph-api.md
+++ b/docs/vision/api/digigraph-api.md
@@ -1,0 +1,187 @@
+---
+title: "digigraph — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digigraph
+---
+# digigraph — API reference
+
+> One supervisor decides which specialist runs. Every time.
+
+**Role:** Orchestration · LangGraph supervisor · **Tier:** core
+
+## Overview
+A LangGraph supervisor inspects each request and routes it to the right sub-graph — quant, retrieval, or chat — through a declarative tool registry.
+
+Speaks the OpenAI API so existing clients work unchanged; LiteLLM handles routing, caching, and checkpointed state across hops.
+
+## Authentication
+Endpoints accept a digikey-issued RS256 JWT in `Authorization: Bearer`. When no JWKS is configured the service runs in passthrough mode (dev/test only). `/healthz` and `/v1/status` are auth-exempt.
+
+- `digigraph:workflow` — POST /workflow + debug routes (default fallback)
+- `digigraph:chat` — /v1/chat/completions, /v1/models, /v1/model-info
+- `digigraph:mcp` — /threads/*, /files/* (when enabled)
+
+## Run locally
+```bash
+docker compose up -d digigraph
+```
+
+```bash
+uvicorn digigraph.server:app
+```
+
+MCP: `FastMCP streamable-http (workflow, chat, thread_state, list_orchestrator_tools)`
+
+## Configuration
+- `DIGIQUANT_URL`: DigiQuant base URL (defaults to the compose service URL).
+- `DIGISEARCH_URL`: DigiSearch base URL; empty disables retrieval.
+- `DIGIKEY_JWKS_URL`: JWT public-key (JWKS) endpoint.
+- `OPENAI_API_BASE`: LiteLLM proxy base URL.
+- `DIGI_LLM_MODE` (default `test`): Model tier: test / medium / best.
+- `DIGI_CHECKPOINTER` (default `memory`): LangGraph state backend: memory / sqlite / postgres / none.
+- `DIGI_ENABLE_THREAD_API` (default `0`): Gate /threads/* and /files/*.
+- `DIGI_ENABLE_DEBUG_ENDPOINTS` (default `0`): Gate /test_llm and /v1/debug/*.
+
+## Endpoints
+
+Base URL: `$DIGIGRAPH_URL` (the service URL from docker-compose.yml).
+
+### GET /healthz
+Liveness probe. Auth-exempt; always 200.
+
+auth: none
+
+Response example:
+```json
+{ "ok": true }
+```
+
+```bash
+curl $DIGIGRAPH_URL/healthz
+```
+
+### GET /v1/status
+Public, secret-free project status.
+
+auth: none · rate: 30/min/IP
+
+Response example:
+```json
+{
+  "service": "digigraph",
+  "project_name": "demo",
+  "agents_enabled": true,
+  "llm_mode": "test",
+  "mcp_enabled": true,
+  "workflow_profile": "default"
+}
+```
+
+```bash
+curl $DIGIGRAPH_URL/v1/status
+```
+
+### POST /workflow
+Run the full research + backtest graph (DigiClaw custom skill).
+
+auth: digigraph:workflow (optional) · rate: 10/min/IP
+
+Request:
+- `prompt` (string) — required: The user request to route through the supervisor.
+- `session_id` (string): Conversation/session correlation id.
+- `allowed_tools` (string[]): Tool allowlist override for this run.
+- `digi_bearer` (string): JWT forwarded downstream to DigiSearch/DigiQuant.
+
+Response:
+- `success` (boolean): Whether the workflow completed.
+- `message` (string): Human-readable summary or full RAG answer.
+- `backtest_result` (object | null): DigiQuant BacktestResult, if a backtest ran.
+- `rag_sources` (object[] | null): Aggregated DigiSearch citations.
+
+```bash
+curl -X POST $DIGIGRAPH_URL/workflow \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"prompt": "Backtest a momentum strategy on AAPL"}'
+```
+
+```python
+import os, httpx
+
+r = httpx.post(
+    f"{os.environ['DIGIGRAPH_URL']}/workflow",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"prompt": "Backtest a momentum strategy on AAPL"},
+    timeout=120,
+)
+print(r.json()["message"])
+```
+
+```typescript
+const r = await fetch(`${process.env.DIGIGRAPH_URL}/workflow`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.DIGI_JWT}`,
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({ prompt: "Backtest a momentum strategy on AAPL" }),
+});
+const { message } = await r.json();
+```
+
+### POST /v1/chat/completions
+OpenAI-compatible chat. Set stream:true for SSE (events: tool_call, content, done).
+
+auth: digigraph:chat (optional) · rate: 10/min/IP
+
+Request:
+- `model` (string): Model id; default "sitaas-rag".
+- `messages` ({role,content}[]) — required: Chat messages.
+- `stream` (boolean): Stream tokens as SSE.
+
+```bash
+curl -X POST $DIGIGRAPH_URL/v1/chat/completions \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"model":"sitaas-rag","messages":[{"role":"user","content":"hi"}]}'
+```
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url=os.environ["DIGIGRAPH_URL"] + "/v1", api_key=os.environ["DIGI_JWT"])
+resp = client.chat.completions.create(
+    model="sitaas-rag",
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+### GET /v1/models
+OpenAI-style model list.
+
+auth: digigraph:chat (optional) · rate: 30/min/IP
+
+```bash
+curl $DIGIGRAPH_URL/v1/models -H "Authorization: Bearer $JWT"
+```
+
+## MCP tools
+- `workflow(prompt, thread_id?)` — Run the full research + backtest graph; returns a JSON WorkflowResult.
+- `chat(message, thread_id?, model?)` — Single-turn chat via /v1/chat/completions.
+- `thread_state(thread_id)` — Return the LangGraph checkpoint state for a thread.
+- `list_orchestrator_tools()` — List registered orchestrator tool names.
+- `list_orchestrator_tools_detailed()` — Tool manifest: name, tags, dynamic_schema flag.
+
+## Stack
+LangGraph, FastAPI, LiteLLM, Pydantic, Polars, OpenAI SDK
+
+## Related
+digiquant, digisearch, digichat
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digigraph]].

--- a/docs/vision/api/digikey-api.md
+++ b/docs/vision/api/digikey-api.md
@@ -1,0 +1,129 @@
+---
+title: "digikey — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digikey
+---
+# digikey — API reference
+
+> Identity, JWTs, and scoped keys — one issuer for humans and machines.
+
+**Role:** Auth · RS256 JWTs · scoped API keys · **Tier:** support
+
+## Overview
+RS256-signed JWTs with a published JWKS, organization and project membership, and row-level scopes baked into the token.
+
+SQLAlchemy over Postgres stores keys, bcrypt hashes them, and an optional Redis blocklist handles revocation.
+
+## Authentication
+digikey is the issuer. Admin routes require the `DIGIKEY_ADMIN_TOKEN` bearer; token exchange takes a raw API key or a BFF-session grant. JWKS and /healthz are public.
+
+- `digigraph:workflow / :chat / :mcp` — DigiGraph routes
+- `digiquant:backtest / :optimize` — DigiQuant routes
+- `digisearch:query / :ingest` — DigiSearch routes
+- `*` — Wildcard (all scopes) — dev_global keys only
+
+## Run locally
+```bash
+docker compose up -d digikey
+```
+
+```bash
+uvicorn digikey.server:app
+```
+
+## Configuration
+- `DIGIKEY_DATABASE_URL` — required: SQLite or Postgres URL for key storage.
+- `DIGIKEY_PRIVATE_KEY_PEM`: RSA 2048 PEM for RS256 signing (prod).
+- `DIGIKEY_ADMIN_TOKEN` — required: Bearer for POST /v1/admin/keys.
+- `DIGIKEY_BFF_TOKEN`: Bearer for grant_type=bff_session (DigiChat).
+- `DIGIKEY_JWT_TTL_SEC` (default `900`): Access-token lifetime.
+- `DIGIKEY_BLOCKLIST_REDIS_URL`: Redis for JWT revocation (prod).
+
+## Endpoints
+
+Base URL: `$DIGIKEY_URL` (the service URL from docker-compose.yml).
+
+### GET /.well-known/jwks.json
+RSA public key set for verifying issued JWTs.
+
+auth: none
+
+```bash
+curl $DIGIKEY_URL/.well-known/jwks.json
+```
+
+### POST /v1/admin/keys
+Create an API key. The raw key is returned ONCE.
+
+auth: admin token · rate: 10/min/IP
+
+Request:
+- `tenant_slug` (string) — required: Tenant identifier.
+- `label` (string): Human-readable key name.
+- `scopes` (string[]): Granted scopes.
+
+Response example:
+```json
+{ "key_prefix": "dgk_live_…", "api_key": "dgk_live_…(once)", "id": "<uuid>" }
+```
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/admin/keys \
+  -H "Authorization: Bearer $DIGIKEY_ADMIN_TOKEN" -H "content-type: application/json" \
+  -d '{"tenant_slug":"acme","scopes":["digiquant:backtest"]}'
+```
+
+### POST /v1/oauth/token
+Exchange an API key (or BFF session) for a short-lived RS256 JWT.
+
+auth: none (key in body) · rate: 10/min/IP
+
+Request:
+- `grant_type` (string) — required: "api_key" | "bff_session".
+- `api_key` (string): Raw dgk_live_ key (api_key grant).
+- `requested_scopes` (string[]): Downscope to a subset of granted scopes.
+
+Response example:
+```json
+{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }
+```
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/oauth/token \
+  -H "content-type: application/json" \
+  -d '{"grant_type":"api_key","api_key":"'"$DIGI_API_KEY"'"}'
+```
+
+```python
+tok = httpx.post(
+    f"{os.environ['DIGIKEY_URL']}/v1/oauth/token",
+    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},
+).json()["access_token"]
+```
+
+### POST /v1/admin/keys/{key_id}/revoke
+Revoke a key and blocklist its live JWTs (when Redis is configured).
+
+auth: admin token · rate: 10/min/IP
+
+Response example:
+```json
+{ "revoked": true, "jtis_invalidated": 3 }
+```
+
+## Stack
+PyJWT, cryptography, bcrypt, SQLAlchemy, Postgres, Redis
+
+## Related
+digichat, digigraph, digismith
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digikey]].

--- a/docs/vision/api/digilink-api.md
+++ b/docs/vision/api/digilink-api.md
@@ -1,0 +1,40 @@
+---
+title: "digilink — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - roadmap
+relevance:
+  - digilink
+---
+# digilink — API reference
+
+> A protocol bridge so non-native transports speak MCP.
+
+**Role:** MCP protocol bridge · roadmap · **Tier:** roadmap
+
+## Overview
+Roadmap: a translation layer registering adapters that turn REST, gRPC, or bespoke transports into MCP tools.
+
+Today MCP is built into individual modules; this keeps the stack open instead of locked to one protocol.
+
+## Authentication
+Roadmap. Today MCP is built into individual modules (e.g. digisearch-mcp).
+
+
+## Notes
+- Planned: a protocol bridge registering adapters that turn REST, gRPC, or bespoke transports into MCP tools.
+- Planned surface: digilink.register_adapter("rest", …) to expose a non-native transport as MCP.
+
+## Stack
+MCP, HTTPx
+
+## Related
+digigraph, digiquant
+
+## Links
+- [Roadmap](https://github.com/digithings-ai)
+
+See also [[digilink]].

--- a/docs/vision/api/digiquant-api.md
+++ b/docs/vision/api/digiquant-api.md
@@ -1,0 +1,147 @@
+---
+title: "digiquant — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digiquant
+---
+# digiquant — API reference
+
+> Strategy research that ends in an order, not a markdown file.
+
+**Role:** Quant engine · NautilusTrader · **Tier:** core
+
+## Overview
+Atlas runs scheduled research, Hermes turns it into signals, Kairos executes on a NautilusTrader core, with Optuna driving optimization.
+
+Every step writes an immutable audit trail; live trading stays loopback-only until a human flips the gate.
+
+## Authentication
+Backtest/optimize/pipeline routes accept a digikey JWT (optional in passthrough mode). Async jobs stream progress over SSE.
+
+- `digiquant:backtest` — /run_backtest, /backtest/*, /v1/jobs/*, /v1/orchestrator_tools
+- `digiquant:optimize` — /run_optimize, /run_pipeline, /v1/workflow
+
+## Run locally
+```bash
+docker compose up -d digiquant
+```
+
+```bash
+uvicorn digiquant.server:app
+```
+
+## Configuration
+- `DIGIQUANT_DATA_DIR` (default `/app/data`): Directory of OHLCV CSVs for backtests.
+- `DIGIKEY_JWKS_URL`: JWT public-key (JWKS) endpoint.
+- `DIGIQUANT_ALLOW_EXPORT` (default `1`): Enable export of strategy configs.
+
+## Endpoints
+
+Base URL: `$DIGIQUANT_URL` (the service URL from docker-compose.yml).
+
+### GET /strategies
+List registered NautilusTrader strategies.
+
+auth: none · rate: 30/min/IP
+
+Response example:
+```json
+[{ "name": "mean_reversion_tech", "aliases": [], "description": "...", "default_params": {} }]
+```
+
+```bash
+curl $DIGIQUANT_URL/strategies
+```
+
+### POST /run_backtest
+Synchronous backtest. Returns a BacktestResult.
+
+auth: digiquant:backtest (optional) · rate: 10/min/IP
+
+Request:
+- `strategy_name` (string) — required: Registered strategy id.
+- `symbols` (string[]) — required: Instruments to test.
+- `data_dir` (string): Directory of {symbol}.csv OHLCV files.
+- `strategy_params` (object): Strategy parameter overrides.
+- `full_tearsheet` (boolean): Include extended charts (default true).
+
+Response:
+- `run_id` (string): Unique run identifier.
+- `total_pnl` (number): Total P&L.
+- `sharpe_ratio` (number | null): Sharpe ratio.
+- `num_trades` (integer): Number of trades executed.
+- `status` (string): "completed" | "failed".
+
+```bash
+curl -X POST $DIGIQUANT_URL/run_backtest \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"strategy_name":"mean_reversion_tech","symbols":["AAPL"]}'
+```
+
+```python
+r = httpx.post(
+    f"{os.environ['DIGIQUANT_URL']}/run_backtest",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"strategy_name": "mean_reversion_tech", "symbols": ["AAPL"]},
+    timeout=300,
+)
+print(r.json()["sharpe_ratio"])
+```
+
+### POST /backtest/start
+Submit an async backtest job; returns {job_id}. Poll progress over SSE.
+
+auth: none · rate: 10/min/IP
+
+Response example:
+```json
+{ "job_id": "..." }
+```
+
+### GET /backtest/{job_id}/progress
+SSE stream of backtest progress events (JSON frames).
+
+auth: none
+
+```bash
+curl -N $DIGIQUANT_URL/backtest/$JOB_ID/progress
+```
+
+### POST /run_optimize
+Parameter optimization (grid / bayesian / random). Returns best params.
+
+auth: digiquant:optimize (optional) · rate: 10/min/IP
+
+Request:
+- `strategy_name` (string) — required: Registered strategy id.
+- `symbols` (string[]) — required: Instruments.
+- `method` (string): "grid" | "bayesian" | "random" (default grid).
+- `n_trials` (integer): Trial budget (default 50).
+- `objective` (string): "sharpe" | "return" | "pnl".
+
+Response:
+- `best_params` (object): Best parameter set found.
+- `best_sharpe` (number | null): Objective value at best params.
+- `num_evaluations` (integer): Trials evaluated.
+
+### POST /run_pipeline
+Full pipeline: backtest → optimize → export.
+
+auth: digiquant:optimize (optional) · rate: 10/min/IP
+
+## Stack
+NautilusTrader, Optuna, LangGraph, Polars, yfinance, Supabase
+
+## Related
+digigraph, digistore, digilink
+
+## Links
+- [digiquant.io](https://digiquant.io)
+- [Source](https://github.com/digithings-ai)
+
+See also [[digiquant]].

--- a/docs/vision/api/digisearch-api.md
+++ b/docs/vision/api/digisearch-api.md
@@ -1,0 +1,118 @@
+---
+title: "digisearch — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - core
+relevance:
+  - digisearch
+---
+# digisearch — API reference
+
+> Production RAG without a stack rewrite when you switch vector DB.
+
+**Role:** Vector retrieval · multi-backend · **Tier:** core
+
+## Overview
+One client over Chroma or Azure AI Search, with backend-neutral entities so you swap engines without touching business code.
+
+Dense, sparse, and hybrid retrieval are first-class; BeautifulSoup and pdfplumber handle ingest, Polars throughout.
+
+## Authentication
+All query/ingest routes require a digikey JWT carrying the matching scope.
+
+- `digisearch:query` — /query, /v1/research_turn, orchestrator routes, /indexes/*
+- `digisearch:ingest` — /ingest
+
+## Run locally
+```bash
+docker compose up -d digisearch
+```
+
+```bash
+uvicorn digisearch.server:app
+```
+
+MCP: `digisearch mcp   (FastMCP streamable-http: digisearch_query, digisearch_research_turn)`
+
+## Configuration
+- `CHROMA_PATH`: Persistent Chroma directory (activates the Chroma backend).
+- `AZURE_SEARCH_ENDPOINT`: Azure AI Search endpoint (alternative backend).
+- `AZURE_SEARCH_API_KEY`: Azure AI Search key.
+- `OPENAI_API_KEY`: Embeddings provider key.
+- `DIGIKEY_JWKS_URL` — required: JWT public-key endpoint.
+
+## Endpoints
+
+Base URL: `$DIGISEARCH_URL` (the service URL from docker-compose.yml).
+
+### POST /query
+Hybrid / keyword / vector search over an index.
+
+auth: digisearch:query · rate: 10/min/IP
+
+Request:
+- `text` (string) — required: Query text.
+- `index_name` (string): Target index (default "default").
+- `top_k` (integer): Results to return, 1–100 (default 10).
+- `mode` (string): "keyword" | "vector" | "hybrid" (default hybrid).
+- `filters` ({field,op,value}[]): Structured metadata filters.
+
+Response:
+- `results` (object[]): Normalized hits (chunk_id, doc_id, score, content, metadata).
+- `total` (integer): Total matches.
+- `backend` (string): "chroma" | "azure_ai_search" | "stub".
+
+```bash
+curl -X POST $DIGISEARCH_URL/query \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"text":"momentum factor","index_name":"default","top_k":5}'
+```
+
+```python
+r = httpx.post(
+    f"{os.environ['DIGISEARCH_URL']}/query",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"text": "momentum factor", "top_k": 5},
+)
+for hit in r.json()["results"]:
+    print(hit["score"], hit["content"][:80])
+```
+
+### POST /ingest
+Ingest a document (parse → chunk → embed → index).
+
+auth: digisearch:ingest · rate: 30/min/IP
+
+Request:
+- `source` (string) — required: Server-side path to the document.
+- `index_name` (string): Target index.
+- `doc_type` (string): pdf | html | docx | markdown | csv | plaintext.
+- `metadata` (object): Evidence metadata (tier, venue, tags, …).
+
+Response example:
+```json
+{ "doc_id": "...", "chunks_created": 12, "index_name": "default", "status": "ok" }
+```
+
+### POST /v1/research_turn
+Composite research turn (plan → retrieve → aggregate) with citations.
+
+auth: digisearch:query · rate: 10/min/IP · requires the digisearch[agent] extra
+
+## MCP tools
+- `digisearch_query` — Search documents; returns formatted hits with score + preview.
+- `digisearch_research_turn` — Composite research turn with citations (needs digisearch[agent]).
+
+## Stack
+Chroma, OpenAI, BeautifulSoup, pdfplumber, LangGraph, FastAPI
+
+## Related
+digigraph, digistore, digibase
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digisearch]].

--- a/docs/vision/api/digismith-api.md
+++ b/docs/vision/api/digismith-api.md
@@ -1,0 +1,87 @@
+---
+title: "digismith — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - support
+relevance:
+  - digismith
+---
+# digismith — API reference
+
+> Correlation IDs across every span; PII redacted before logs hit disk.
+
+**Role:** Observability · spans · PII redaction · **Tier:** support
+
+## Overview
+Structured logging, Prometheus metrics, and OpenTelemetry spans thread through every request so a multi-hop run is traceable end to end.
+
+PII is redacted before anything is written, with optional LangSmith trace export.
+
+## Authentication
+Status and metrics are public diagnostics. Tracing is a library wrapper, not an HTTP surface.
+
+
+## Run locally
+```bash
+docker compose up -d digismith
+```
+
+```bash
+uvicorn digismith.server:app
+```
+
+## Configuration
+- `LANGSMITH_API_KEY`: Enable LangSmith trace export; absent = no-op.
+- `LANGSMITH_ENDPOINT` (default `https://api.smith.langchain.com`): LangSmith API base (host shown in /v1/status).
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: Enable OTel HTTP export when set.
+
+## Endpoints
+
+Base URL: `$DIGISMITH_URL` (the service URL from docker-compose.yml).
+
+### GET /v1/status
+Tracing configuration diagnostic (operator-facing; secret-free).
+
+auth: none
+
+Response example:
+```json
+{
+  "version": "0.1.0",
+  "tracing_configured": true,
+  "langsmith_sdk_installed": true,
+  "langsmith_host": "api.smith.langchain.com",
+  "request_id": "..."
+}
+```
+
+```bash
+curl $DIGISMITH_URL/v1/status
+```
+
+### GET /metrics
+Prometheus metrics (text/plain 0.0.4).
+
+auth: none
+
+## Public interface
+- `from digismith.trace import traceable` — @traceable("name") wraps a function with langsmith.traceable when LANGSMITH_API_KEY is set; otherwise a no-op. PII is redacted from span inputs/outputs.
+- `from digismith.config import tracing_enabled` — Returns True when tracing is configured (key set + SDK importable).
+
+## Notes
+- Span attributes SHOULD include workflow_id, request_id, session_id, job_id.
+- Spans MUST NOT include raw prompts/completions, secrets, or full document bodies.
+
+## Stack
+LangSmith, OpenTelemetry, Prometheus, FastAPI
+
+## Related
+digigraph, digiclaw, digibase
+
+## Links
+- [Source](https://github.com/digithings-ai)
+
+See also [[digismith]].

--- a/docs/vision/api/digistore-api.md
+++ b/docs/vision/api/digistore-api.md
@@ -1,0 +1,40 @@
+---
+title: "digistore — API reference"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - roadmap
+relevance:
+  - digistore
+---
+# digistore — API reference
+
+> One storage API over S3, MinIO, Postgres, or SQLite.
+
+**Role:** Storage abstraction · roadmap · **Tier:** roadmap
+
+## Overview
+Roadmap: a storage abstraction so business code never binds to a backend, today a session-scoped dataset manager living inside digigraph.
+
+Run SQLite on a laptop, then swap to S3 and Postgres in production without rewriting.
+
+## Authentication
+Roadmap. Today a session-scoped dataset manager lives inside digigraph; the standalone storage service is planned.
+
+
+## Notes
+- Planned: one storage API over S3, MinIO, Postgres, or SQLite so business code never binds to a backend.
+- Planned surface: DigiStore.configure(backend=…) + get/put/list over a backend-neutral interface.
+
+## Stack
+Postgres, SQLite, S3, MinIO
+
+## Related
+digiquant, digisearch
+
+## Links
+- [Roadmap](https://github.com/digithings-ai)
+
+See also [[digistore]].

--- a/docs/vision/api/guide-authentication.md
+++ b/docs/vision/api/guide-authentication.md
@@ -1,0 +1,68 @@
+---
+title: "Authentication — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Authentication
+
+> Issue and use digikey JWTs across the stack — mint a key, exchange for a token, call a service.
+
+digikey is the single issuer of RS256 JWTs. Services verify tokens against digikey's JWKS and enforce per-route scopes. The flow: mint an API key (admin), exchange it for a short-lived JWT, then call services with `Authorization: Bearer <jwt>`.
+
+### 1 · Mint an API key (admin)
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/admin/keys \
+  -H "Authorization: Bearer $DIGIKEY_ADMIN_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"tenant_slug":"acme","scopes":["digiquant:backtest","digigraph:workflow"]}'
+# → { "api_key": "dgk_live_… (shown once)", "key_prefix": "dgk_live_…", "id": "<uuid>" }
+```
+
+### 2 · Exchange for a JWT
+
+```bash
+curl -X POST $DIGIKEY_URL/v1/oauth/token \
+  -H "content-type: application/json" \
+  -d '{"grant_type":"api_key","api_key":"'"$DIGI_API_KEY"'"}'
+# → { "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }
+```
+
+```python
+import os, httpx
+
+tok = httpx.post(
+    f"{os.environ['DIGIKEY_URL']}/v1/oauth/token",
+    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},
+).json()["access_token"]
+```
+
+```typescript
+const r = await fetch(`${process.env.DIGIKEY_URL}/v1/oauth/token`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ grant_type: "api_key", api_key: process.env.DIGI_API_KEY }),
+});
+const { access_token } = await r.json();
+```
+
+### 3 · Call a service
+
+```bash
+curl -X POST $DIGIGRAPH_URL/workflow \
+  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \
+  -d '{"prompt":"Backtest a momentum strategy on AAPL"}'
+```
+
+### Scopes
+
+- `digigraph:workflow`, `digigraph:chat`, `digigraph:mcp`
+- `digiquant:backtest`, `digiquant:optimize`
+- `digisearch:query`, `digisearch:ingest`
+- JWTs are short-lived (default 900s); revoke a key via `POST /v1/admin/keys/{id}/revoke`.
+
+See also [[digikey]].

--- a/docs/vision/api/guide-conventions.md
+++ b/docs/vision/api/guide-conventions.md
@@ -1,0 +1,45 @@
+---
+title: "Conventions — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Conventions
+
+> Shared HTTP conventions across services — liveness, error envelope, correlation IDs, rate limits, CORS.
+
+### Liveness vs status
+
+`GET /healthz` is the auth-exempt liveness probe — always `{"ok": true}`, for load balancers. `GET /v1/status` (DigiGraph, DigiSmith) is a richer operator diagnostic; never use it for health checks.
+
+### Error envelope
+
+Every service returns the same error shape:
+
+```json
+{
+  "error": {
+    "code": "http_401",
+    "message": "Bearer token required",
+    "request_id": "req-…",
+    "service": "digigraph"
+  }
+}
+```
+
+- `http_401` — missing/invalid token · `http_403` / `insufficient_scope` — scope denied.
+- `validation_error` — request body failed validation.
+- `rate_limited` — HTTP 429, with a `Retry-After` header.
+
+### Correlation
+
+Send `X-Request-ID` to correlate a call across services; it is generated if absent and echoed on the response and in the audit log.
+
+### Rate limits & CORS
+
+Mutating routes are rate-limited per IP (typically 10/min, 429 + `Retry-After` on breach). CORS uses an explicit allowlist (`DIGI_CORS_ORIGINS`) — no wildcard — with credentials enabled for session cookies.
+
+See also [[digibase]].

--- a/docs/vision/api/guide-getting-started.md
+++ b/docs/vision/api/guide-getting-started.md
@@ -1,0 +1,46 @@
+---
+title: "Getting started — guide"
+type: reference
+status: generated
+created: 2026-06-29
+tags:
+  - api
+  - guide
+---
+# Getting started
+
+> Run the digithings stack locally — prerequisites, compose, environment, and make targets.
+
+digithings is an open-core agentic stack — orchestration, quant research, retrieval, and chat behind one supervisor. Self-hosted, BYOK, audit-on by default.
+
+### Prerequisites
+
+- Docker (with Compose)
+- Python ≥ 3.12 (for running services outside Docker)
+- Node.js LTS (for the frontends)
+
+### Run the whole stack
+
+```bash
+git clone https://github.com/digithings-ai/digithings && cd digithings
+cp .env.example .env   # add your keys
+docker compose up -d
+```
+
+Each backend service exposes a liveness probe at `GET /healthz`. The service URLs and ports are defined in `docker-compose.yml`; reference them through env vars (`$DIGIGRAPH_URL`, `$DIGIKEY_URL`, …) rather than hardcoding an address.
+
+### Essential environment
+
+- `OPENROUTER_API_KEY` / `OPENAI_API_KEY` — LLM access via the LiteLLM proxy.
+- `DIGIKEY_ADMIN_TOKEN` — required to mint API keys (see Authentication).
+- `DIGIKEY_PRIVATE_KEY_PEM` — stable RS256 signing key for production.
+- See `.env.example` for the full, annotated list.
+
+### Useful make targets
+
+- `make up` / `make down` — start / stop the core stack.
+- `make up-digichat` — start the chat BFF + its Postgres.
+- `make stack-local` — run the Python services without Docker.
+- `make test-unit` — unit tests (no stack required).
+
+See also [[digigraph]].

--- a/frontend/digithings-web/app/_nav.tsx
+++ b/frontend/digithings-web/app/_nav.tsx
@@ -20,6 +20,7 @@ export const Brand = () => (
 
 export const DT_NAV: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
+  { label: "Docs", href: "/docs" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },
   { label: "Ask digichat", href: "/chat", cta: true },
@@ -31,11 +32,13 @@ export const DT_NAV: NavLink[] = [
  *  omitted here to avoid rendering it twice. */
 export const DT_NAV_PRIMARY: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
+  { label: "Docs", href: "/docs" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
 ];
 
 export const DT_FOOTER: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
+  { label: "Docs", href: "/docs" },
   { label: "digichat", href: "/chat" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },

--- a/frontend/digithings-web/app/docs/page.tsx
+++ b/frontend/digithings-web/app/docs/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { Footer } from "@digithings/web";
+import { DT_FOOTER, DT_FOOTER_META } from "../_nav";
+import { DigiNav } from "@/components/landing/DigiNav";
+import { DocsLayout } from "@/components/docs/DocsLayout";
+
+export const metadata: Metadata = {
+  title: "docs — the digithings API reference",
+  description:
+    "API reference for the digithings stack: per-module usage, local deploy, and endpoints. " +
+    "Copy any page as Markdown for AI agents. Self-hosted, open core.",
+};
+
+// /docs — full API reference with a tier-grouped sidebar, a doc page per module,
+// and copy-as-Markdown. Generated from the shared module data so it never drifts.
+// Server component; statically exported like the rest of the site.
+export default function DocsPage() {
+  return (
+    <>
+      <DigiNav />
+      <main className="docs-main dq-subpage">
+        <DocsLayout />
+      </main>
+      <Footer links={DT_FOOTER} meta={DT_FOOTER_META} />
+    </>
+  );
+}

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -288,3 +288,111 @@ html { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) {
   .dtc-chip { transition: none; }
 }
+
+/* ---- /docs API reference (DocsLayout.tsx) — sidebar + per-module doc pages +
+   copy-as-Markdown, generated from the shared module data. Terminal-consistent. */
+.docs-main { padding-bottom: clamp(2rem, 5vw, 4rem); }
+.docs-shell { display: grid; grid-template-columns: 1fr; gap: clamp(1.4rem, 3vw, 2.4rem); max-width: 1040px; margin: 0 auto; padding: 0 clamp(1rem, 4vw, 2rem); }
+.docs-side { display: none; }
+.docs-side nav { display: flex; flex-direction: column; gap: 0.1rem; }
+.docs-side a { font-family: var(--font-mono); font-size: 0.82rem; color: var(--ink-soft); text-decoration: none; padding: 0.28rem 0.6rem; border-radius: 7px; border-left: 2px solid transparent; transition: color 0.16s var(--ease), background 0.16s var(--ease); }
+.docs-side a:hover { color: var(--ink); background: var(--accent-weak); }
+.docs-side a.is-active { color: var(--ink); border-left-color: var(--accent); background: var(--accent-weak); }
+.docs-side a .dt-d { color: inherit; }
+.docs-side a .dt-s { color: var(--accent); }
+.docs-side-group { display: flex; flex-direction: column; gap: 0.1rem; margin-top: 0.8rem; }
+.docs-side-label { font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-mute); padding: 0 0.6rem; margin-bottom: 0.2rem; }
+.docs-content { min-width: 0; display: flex; flex-direction: column; gap: clamp(1.6rem, 3.5vw, 2.6rem); }
+.docs-hero { scroll-margin-top: calc(var(--dq-nav-h, 62px) + 1rem); }
+.docs-hero h1 { font-family: var(--serif); font-weight: 400; font-size: clamp(1.9rem, 4vw, 2.7rem); letter-spacing: -0.02em; margin: 0.5rem 0 0.7rem; color: var(--ink); }
+.docs-hero p { color: var(--ink-soft); max-width: 60ch; line-height: 1.6; margin: 0; }
+.docs-hero-actions { margin-top: 1rem; }
+.docs-copy { font: inherit; font-family: var(--font-mono); font-size: 0.76rem; color: var(--ink-soft); background: transparent; border: 1px solid var(--hair); border-radius: 7px; cursor: pointer; padding: 0.3rem 0.65rem; transition: background 0.18s var(--ease), color 0.18s var(--ease); }
+.docs-copy:hover { background: var(--accent-weak); color: var(--ink); }
+
+.doc-block { margin: 0; }
+.doc-block h3 { margin: 0 0 0.5rem; font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-mute); font-weight: 500; }
+.doc-meta-line { margin: 0.5rem 0 0; font-size: 0.8rem; color: var(--ink-mute); }
+.doc-intro { background: color-mix(in srgb, var(--surface) 70%, transparent); border: 1px solid var(--hair); border-radius: 14px; padding: clamp(1rem, 2.4vw, 1.4rem); }
+.doc-code { position: relative; margin: 0.5rem 0 0; }
+.doc-code pre { margin: 0; background: color-mix(in srgb, var(--ink) 6%, transparent); border: 1px solid var(--hair); border-radius: 9px; padding: 0.7rem 0.8rem; overflow-x: auto; }
+.doc-code code { font-family: var(--font-mono); font-size: 0.8rem; color: var(--ink); white-space: pre; }
+.doc-code .dc-code-copy { position: absolute; top: 0.4rem; right: 0.4rem; }
+.doc-code:hover .dc-code-copy, .doc-code .dc-code-copy:focus-visible { opacity: 1; }
+
+.doc-index { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.doc-index a { font-family: var(--font-mono); font-size: 0.78rem; color: var(--ink-soft); border: 1px solid var(--hair); border-radius: 999px; padding: 0.2rem 0.6rem; text-decoration: none; transition: border-color 0.18s var(--ease), color 0.18s var(--ease); }
+.doc-index a:hover { border-color: var(--hair-2); color: var(--ink); }
+.doc-index .dt-d { color: var(--ink); }
+.doc-index .dt-s { color: var(--accent); }
+
+.doc-mod { scroll-margin-top: calc(var(--dq-nav-h, 62px) + 1rem); border-top: 1px solid var(--hair); padding-top: clamp(1.2rem, 3vw, 1.8rem); display: flex; flex-direction: column; gap: 0.7rem; }
+.doc-mod-head { display: flex; align-items: center; gap: 0.7rem; }
+.doc-mod-title { display: flex; flex-direction: column; gap: 0.1rem; margin-right: auto; }
+.doc-mod-title h2 { margin: 0; font-family: var(--font-mono); font-size: 1.05rem; font-weight: 500; letter-spacing: -0.01em; }
+.doc-mod-title .dt-d { color: var(--ink); }
+.doc-mod-title .dt-s { color: var(--accent); }
+.doc-mod-role { font-size: 0.78rem; color: var(--ink-mute); }
+.doc-badge { font-family: var(--font-mono); font-size: 0.72rem; color: var(--ink-soft); border: 1px solid var(--hair); border-radius: 7px; padding: 0.15rem 0.45rem; white-space: nowrap; }
+.doc-badge.is-road { color: var(--ink-mute); }
+.doc-tagline { margin: 0; color: var(--ink); font-size: 0.96rem; line-height: 1.5; }
+.doc-summary { margin: 0; color: var(--ink-soft); font-size: 0.88rem; line-height: 1.65; }
+
+.doc-api { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.doc-api li { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+.doc-api-label { font-size: 0.82rem; color: var(--ink-soft); min-width: 8.5rem; }
+.doc-links { display: flex; flex-wrap: wrap; gap: 1rem; margin-top: 0.2rem; }
+.doc-links a { font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent); text-decoration: none; text-underline-offset: 2px; }
+.doc-links a:hover { text-decoration: underline; }
+.doc-links a .dt-d { color: var(--ink); }
+.doc-links a .dt-s { color: var(--accent); }
+
+/* Desktop: reveal the sticky sidebar beside the content. */
+@media (min-width: 860px) {
+  .docs-shell { grid-template-columns: 200px minmax(0, 1fr); align-items: start; gap: clamp(2rem, 4vw, 3rem); }
+  .docs-side { display: block; position: sticky; top: calc(var(--dq-nav-h, 62px) + 1.2rem); max-height: calc(100vh - var(--dq-nav-h, 62px) - 2rem); overflow-y: auto; scrollbar-width: thin; }
+}
+
+/* ---- shared guides ---- */
+.doc-guide { scroll-margin-top: calc(var(--dq-nav-h, 62px) + 1rem); border-top: 1px solid var(--hair); padding-top: clamp(1.2rem, 3vw, 1.8rem); display: flex; flex-direction: column; gap: 0.6rem; }
+.doc-guide-title { margin: 0; font-family: var(--serif); font-weight: 400; font-size: clamp(1.4rem, 2.6vw, 1.9rem); letter-spacing: -0.01em; color: var(--ink); }
+.doc-guide-h { margin: 0.6rem 0 0; font-family: var(--font-mono); font-size: 0.74rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-mute); font-weight: 500; }
+.doc-guide-list { margin: 0.2rem 0 0; padding-left: 1.1rem; display: flex; flex-direction: column; gap: 0.35rem; color: var(--ink-soft); font-size: 0.9rem; line-height: 1.6; }
+
+/* ---- run + endpoints ---- */
+.doc-run-line { display: flex; flex-direction: column; gap: 0.25rem; margin-top: 0.5rem; }
+.doc-run-label { font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); }
+.doc-endpoints { display: flex; flex-direction: column; gap: 1rem; }
+.doc-endpoint { border: 1px solid var(--hair); border-radius: 12px; padding: clamp(0.8rem, 2vw, 1.1rem); display: flex; flex-direction: column; gap: 0.55rem; background: color-mix(in srgb, var(--surface) 55%, transparent); }
+.doc-ep-head { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.doc-method { font-family: var(--font-mono); font-size: 0.7rem; font-weight: 600; letter-spacing: 0.04em; padding: 0.15rem 0.45rem; border-radius: 6px; color: var(--on-accent); background: var(--ink-mute); }
+.doc-method.get { background: #3b82a6; }
+.doc-method.post { background: #3f9e74; }
+.doc-method.put { background: #b5832a; }
+.doc-method.delete { background: #c9533b; }
+.doc-ep-path { font-family: var(--font-mono); font-size: 0.92rem; color: var(--ink); word-break: break-all; }
+.doc-ep-badges { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.doc-ep-badges .doc-badge { font-size: 0.68rem; }
+
+/* ---- field + scope + env tables ---- */
+.doc-fieldset { display: flex; flex-direction: column; gap: 0.3rem; }
+.doc-fieldset-h { font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-mute); }
+.doc-fields { width: 100%; border-collapse: collapse; font-size: 0.84rem; }
+.doc-fields td { padding: 0.3rem 0.6rem 0.3rem 0; vertical-align: top; border-bottom: 1px solid color-mix(in srgb, var(--hair) 60%, transparent); }
+.doc-fields tr:last-child td { border-bottom: 0; }
+.doc-f-name { white-space: nowrap; }
+.doc-f-type { color: var(--ink-mute); font-family: var(--font-mono); font-size: 0.78rem; white-space: nowrap; }
+.doc-f-desc { color: var(--ink-soft); line-height: 1.5; width: 100%; }
+.doc-req { color: var(--down, #c9533b); margin-left: 0.15rem; }
+
+/* ---- public interface / mcp lists ---- */
+.doc-iface { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.doc-iface li { display: flex; flex-direction: column; gap: 0.2rem; }
+.doc-iface-desc { color: var(--ink-soft); font-size: 0.86rem; line-height: 1.55; }
+
+/* ---- code language tabs ---- */
+.doc-tabs { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.3rem; }
+.doc-tabbar { display: flex; gap: 0.2rem; }
+.doc-tab { font-family: var(--font-mono); font-size: 0.72rem; color: var(--ink-mute); background: transparent; border: 1px solid transparent; border-radius: 7px 7px 0 0; cursor: pointer; padding: 0.2rem 0.6rem; transition: color 0.15s var(--ease), background 0.15s var(--ease); }
+.doc-tab:hover { color: var(--ink-soft); }
+.doc-tab.is-active { color: var(--ink); background: var(--accent-weak); }

--- a/frontend/digithings-web/components/docs/CodeTabs.tsx
+++ b/frontend/digithings-web/components/docs/CodeTabs.tsx
@@ -1,0 +1,39 @@
+"use client";
+import { useState } from "react";
+import { CopyButton } from "@/lib/CopyButton";
+import type { CodeExample } from "@/lib/apiDocs";
+
+const LABEL: Record<string, string> = { bash: "curl", python: "Python", typescript: "TypeScript" };
+
+/** Language-tabbed code block (curl / Python / TypeScript) with a copy button. */
+export function CodeTabs({ examples }: { examples: CodeExample[] }) {
+  const [sel, setSel] = useState(0);
+  if (!examples.length) return null;
+  const cur = examples[Math.min(sel, examples.length - 1)];
+  return (
+    <div className="doc-tabs">
+      {examples.length > 1 && (
+        <div className="doc-tabbar" role="tablist">
+          {examples.map((e, i) => (
+            <button
+              key={e.lang}
+              type="button"
+              role="tab"
+              aria-selected={i === sel}
+              className={`doc-tab${i === sel ? " is-active" : ""}`}
+              onClick={() => setSel(i)}
+            >
+              {LABEL[e.lang] ?? e.lang}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="doc-code">
+        <CopyButton text={cur.code} className="dc-code-copy" ariaLabel={`Copy ${LABEL[cur.lang] ?? cur.lang} example`} />
+        <pre>
+          <code>{cur.code}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/digithings-web/components/docs/DocsLayout.tsx
+++ b/frontend/digithings-web/components/docs/DocsLayout.tsx
@@ -1,0 +1,458 @@
+"use client";
+import { Fragment, useEffect, useState, type ReactNode } from "react";
+import { modules, type ModuleNode, StackRow, Emblem } from "@digithings/web";
+import { CopyButton } from "@/lib/CopyButton";
+import { apiDocs, type ModuleApiDoc, type Endpoint } from "@/lib/apiDocs";
+import { guides, type Guide, type Block } from "@/lib/sharedDocs";
+import { EndpointDoc } from "./Endpoint";
+
+/**
+ * Full docs experience: shared guides (Getting started / Authentication /
+ * Conventions) + a complete per-module API reference, a sticky tier-grouped
+ * sidebar with scroll-spy, and "copy as Markdown" for AI agents. Content is the
+ * shared module data (@digithings/web) merged with the authored apiDocs/guides —
+ * all static, so the site exports cleanly.
+ */
+const ordered = [...modules].sort((a, b) => a.graphOrder - b.graphOrder);
+const TIERS: { key: ModuleNode["tier"]; label: string }[] = [
+  { key: "core", label: "Core" },
+  { key: "support", label: "Support" },
+  { key: "roadmap", label: "Roadmap" },
+];
+
+// ── inline backtick → <code> for guide text ──────────────────────────────────
+function Inline({ text }: { text: string }): ReactNode {
+  const parts = text.split(/(`[^`]+`)/g);
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.startsWith("`") && p.endsWith("`") ? (
+          <code key={i} className="dc-code-inline">
+            {p.slice(1, -1)}
+          </code>
+        ) : (
+          <Fragment key={i}>{p}</Fragment>
+        ),
+      )}
+    </>
+  );
+}
+
+function Blocks({ blocks }: { blocks: Block[] }) {
+  return (
+    <>
+      {blocks.map((b, i) => {
+        if (b.kind === "h") return <h3 key={i} className="doc-guide-h">{b.text}</h3>;
+        if (b.kind === "code")
+          return (
+            <div key={i} className="doc-code">
+              <CopyButton text={b.code} className="dc-code-copy" ariaLabel="Copy code" />
+              <pre>
+                <code>{b.code}</code>
+              </pre>
+            </div>
+          );
+        if (b.kind === "list")
+          return (
+            <ul key={i} className="doc-guide-list">
+              {b.items.map((it, j) => (
+                <li key={j}>
+                  <Inline text={it} />
+                </li>
+              ))}
+            </ul>
+          );
+        return (
+          <p key={i} className="doc-summary">
+            <Inline text={b.text} />
+          </p>
+        );
+      })}
+    </>
+  );
+}
+
+// ── markdown serializers (for "copy as Markdown") ─────────────────────────────
+function guideToMarkdown(g: Guide): string {
+  const L: string[] = [`## ${g.title}`, ""];
+  for (const b of g.blocks) {
+    if (b.kind === "h") L.push(`### ${b.text}`, "");
+    else if (b.kind === "p") L.push(b.text, "");
+    else if (b.kind === "list") {
+      b.items.forEach((it) => L.push(`- ${it}`));
+      L.push("");
+    } else if (b.kind === "code") L.push("```" + b.lang, b.code, "```", "");
+  }
+  return L.join("\n").trim();
+}
+
+function endpointToMarkdown(ep: Endpoint, L: string[]): void {
+  L.push(`### ${ep.method} ${ep.path}`, ep.summary, "");
+  const meta = [ep.auth && `auth: ${ep.auth}`, ep.rateLimit && `rate: ${ep.rateLimit}`, ep.flag]
+    .filter(Boolean)
+    .join(" · ");
+  if (meta) L.push(meta, "");
+  if (ep.request?.length) {
+    L.push("Request:");
+    ep.request.forEach((f) => L.push(`- \`${f.name}\` (${f.type})${f.required ? " — required" : ""}: ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseFields?.length) {
+    L.push("Response:");
+    ep.responseFields.forEach((f) => L.push(`- \`${f.name}\` (${f.type}): ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseExample) L.push("Response example:", "```json", ep.responseExample, "```", "");
+  ep.examples?.forEach((ex) => L.push("```" + ex.lang, ex.code, "```", ""));
+}
+
+function moduleToMarkdown(m: ModuleNode): string {
+  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
+  const L: string[] = [`# ${m.id}`, "", `> ${m.tagline}`, ""];
+  L.push(`**Role:** ${m.role} · **Tier:** ${m.tier}`, "");
+  L.push("## Overview");
+  m.summary.forEach((s) => L.push(s, ""));
+  if (d.authNote || d.scopes?.length) {
+    L.push("## Authentication");
+    if (d.authNote) L.push(d.authNote, "");
+    d.scopes?.forEach((s) => L.push(`- \`${s.scope}\` — ${s.grants}`));
+    L.push("");
+  }
+  if (d.run) {
+    L.push("## Run locally");
+    if (d.run.compose) L.push("```bash", d.run.compose, "```", "");
+    if (d.run.standalone) L.push("```bash", d.run.standalone, "```", "");
+    if (d.run.cli) L.push("```bash", d.run.cli, "```", "");
+    if (d.run.mcp) L.push(`MCP: \`${d.run.mcp}\``, "");
+  }
+  if (d.env?.length) {
+    L.push("## Configuration");
+    d.env.forEach((e) => L.push(`- \`${e.name}\`${e.def ? ` (default \`${e.def}\`)` : ""}${e.required ? " — required" : ""}: ${e.description}`));
+    L.push("");
+  }
+  if (d.endpoints?.length) {
+    L.push("## Endpoints", "");
+    if (d.baseUrlVar) L.push(`Base URL: \`$${d.baseUrlVar}\` (the service URL from docker-compose.yml).`, "");
+    d.endpoints.forEach((ep) => endpointToMarkdown(ep, L));
+  }
+  if (d.publicInterface?.length) {
+    L.push("## Public interface");
+    d.publicInterface.forEach((it) => L.push(`- \`${it.signature}\` — ${it.description}`));
+    L.push("");
+  }
+  if (d.mcp?.length) {
+    L.push("## MCP tools");
+    d.mcp.forEach((t) => L.push(`- \`${t.name}\` — ${t.description}`));
+    L.push("");
+  }
+  if (d.notes?.length) {
+    L.push("## Notes");
+    d.notes.forEach((n) => L.push(`- ${n}`));
+    L.push("");
+  }
+  L.push("## Stack", m.stack.map((s) => s.name).join(", "), "");
+  if (m.related.length) L.push("## Related", m.related.join(", "), "");
+  if (m.links.length) {
+    L.push("## Links");
+    m.links.forEach((l) => L.push(`- [${l.label}](${l.href})`));
+    L.push("");
+  }
+  return L.join("\n").trim() + "\n";
+}
+
+const PAGE_MD = [
+  "# digithings API reference",
+  "",
+  ...guides.map(guideToMarkdown),
+  ...ordered.map(moduleToMarkdown),
+].join("\n\n---\n\n");
+
+/** Labeled "copy as Markdown" button with a confirmation flip. */
+function CopyMd({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="docs-copy"
+      aria-label={label}
+      onClick={() =>
+        navigator.clipboard?.writeText(text).then(
+          () => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1400);
+          },
+          () => {},
+        )
+      }
+    >
+      <span aria-hidden="true">{copied ? "✓ " : "⌘ "}</span>
+      {copied ? "copied" : label}
+    </button>
+  );
+}
+
+function RunBlock({ label, code }: { label: string; code: string }) {
+  return (
+    <div className="doc-run-line">
+      <span className="doc-run-label">{label}</span>
+      <div className="doc-code">
+        <CopyButton text={code} className="dc-code-copy" ariaLabel={`Copy ${label}`} />
+        <pre>
+          <code>{code}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function ModuleDoc({ m }: { m: ModuleNode }) {
+  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
+  const suffix = m.id.replace(/^digi/, "");
+  const isRoad = m.tier === "roadmap";
+  return (
+    <article className="doc-mod" id={m.id}>
+      <header className="doc-mod-head">
+        <Emblem id={m.emblem} size={32} />
+        <div className="doc-mod-title">
+          <h2>
+            <span className="dt-d">digi</span>
+            <span className="dt-s">{suffix}</span>
+          </h2>
+          <span className="doc-mod-role">{m.role}</span>
+        </div>
+        <span className={`doc-badge${isRoad ? " is-road" : ""}`}>{m.tier}</span>
+        <CopyMd text={moduleToMarkdown(m)} label="Markdown" />
+      </header>
+
+      <p className="doc-tagline">{m.tagline}</p>
+
+      <section className="doc-block">
+        <h3>Overview</h3>
+        {m.summary.map((s, i) => (
+          <p className="doc-summary" key={i}>
+            {s}
+          </p>
+        ))}
+      </section>
+
+      {(d.authNote || d.scopes?.length) && (
+        <section className="doc-block">
+          <h3>Authentication</h3>
+          {d.authNote && <p className="doc-summary">{d.authNote}</p>}
+          {d.scopes && d.scopes.length > 0 && (
+            <table className="doc-fields">
+              <tbody>
+                {d.scopes.map((s) => (
+                  <tr key={s.scope}>
+                    <td className="doc-f-name">
+                      <code className="dc-code-inline">{s.scope}</code>
+                    </td>
+                    <td className="doc-f-desc">{s.grants}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      )}
+
+      {d.run && (
+        <section className="doc-block">
+          <h3>Run locally</h3>
+          {d.run.compose && <RunBlock label="compose" code={d.run.compose} />}
+          {d.run.standalone && <RunBlock label="standalone" code={d.run.standalone} />}
+          {d.run.cli && <RunBlock label="cli" code={d.run.cli} />}
+          {d.run.mcp && <RunBlock label="mcp" code={d.run.mcp} />}
+        </section>
+      )}
+
+      {d.env && d.env.length > 0 && (
+        <section className="doc-block">
+          <h3>Configuration</h3>
+          <table className="doc-fields">
+            <tbody>
+              {d.env.map((e) => (
+                <tr key={e.name}>
+                  <td className="doc-f-name">
+                    <code className="dc-code-inline">{e.name}</code>
+                    {e.required && <span className="doc-req" title="required">*</span>}
+                  </td>
+                  <td className="doc-f-type">{e.def ? e.def : "—"}</td>
+                  <td className="doc-f-desc">{e.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {d.endpoints && d.endpoints.length > 0 && (
+        <section className="doc-block">
+          <h3>Endpoints</h3>
+          {d.baseUrlVar && (
+            <p className="doc-meta-line">
+              Base URL <code className="dc-code-inline">${d.baseUrlVar}</code> — the service URL from{" "}
+              <code className="dc-code-inline">docker-compose.yml</code>.
+            </p>
+          )}
+          <div className="doc-endpoints">
+            {d.endpoints.map((ep) => (
+              <EndpointDoc key={`${ep.method} ${ep.path}`} ep={ep} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {d.publicInterface && d.publicInterface.length > 0 && (
+        <section className="doc-block">
+          <h3>Public interface</h3>
+          <ul className="doc-iface">
+            {d.publicInterface.map((it, i) => (
+              <li key={i}>
+                <code className="dc-code-inline">{it.signature}</code>
+                <span className="doc-iface-desc">{it.description}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {d.mcp && d.mcp.length > 0 && (
+        <section className="doc-block">
+          <h3>MCP tools</h3>
+          <ul className="doc-iface">
+            {d.mcp.map((t) => (
+              <li key={t.name}>
+                <code className="dc-code-inline">{t.name}</code>
+                <span className="doc-iface-desc">{t.description}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {d.notes && d.notes.length > 0 && (
+        <section className="doc-block">
+          <h3>Notes</h3>
+          <ul className="doc-guide-list">
+            {d.notes.map((n, i) => (
+              <li key={i}>
+                <Inline text={n} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="doc-block">
+        <h3>Stack</h3>
+        <StackRow items={m.stack} />
+      </section>
+
+      {m.related.length > 0 && (
+        <section className="doc-block">
+          <h3>Related</h3>
+          <nav className="doc-links">
+            {m.related.map((r) => (
+              <a key={r} href={`#${r}`}>
+                <span className="dt-d">digi</span>
+                <span className="dt-s">{r.replace(/^digi/, "")}</span>
+              </a>
+            ))}
+          </nav>
+        </section>
+      )}
+
+      {m.links.length > 0 && (
+        <section className="doc-block">
+          <h3>Links</h3>
+          <nav className="doc-links">
+            {m.links.map((l, i) => (
+              <a key={i} href={l.href} {...(l.href.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}>
+                {l.label} <span aria-hidden="true">→</span>
+              </a>
+            ))}
+          </nav>
+        </section>
+      )}
+    </article>
+  );
+}
+
+export function DocsLayout() {
+  const [active, setActive] = useState(guides[0]?.id ?? "");
+
+  useEffect(() => {
+    const ids = [...guides.map((g) => g.id), ...ordered.map((m) => m.id)];
+    const els = ids.map((id) => document.getElementById(id)).filter((e): e is HTMLElement => !!e);
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      { rootMargin: "-20% 0px -70% 0px", threshold: 0 },
+    );
+    els.forEach((el) => obs.observe(el));
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div className="docs-shell">
+      <aside className="docs-side">
+        <nav aria-label="docs">
+          <div className="docs-side-group">
+            <span className="docs-side-label">Guides</span>
+            {guides.map((g) => (
+              <a key={g.id} href={`#${g.id}`} className={active === g.id ? "is-active" : ""}>
+                {g.title}
+              </a>
+            ))}
+          </div>
+          {TIERS.map((t) => {
+            const rows = ordered.filter((m) => m.tier === t.key);
+            if (!rows.length) return null;
+            return (
+              <div className="docs-side-group" key={t.key}>
+                <span className="docs-side-label">{t.label}</span>
+                {rows.map((m) => (
+                  <a key={m.id} href={`#${m.id}`} className={active === m.id ? "is-active" : ""}>
+                    <span className="dt-d">digi</span>
+                    <span className="dt-s">{m.id.replace(/^digi/, "")}</span>
+                  </a>
+                ))}
+              </div>
+            );
+          })}
+        </nav>
+      </aside>
+
+      <div className="docs-content">
+        <header className="docs-hero">
+          <span className="kicker">{"// api docs"}</span>
+          <h1>digithings API reference.</h1>
+          <p>
+            Complete, end-to-end reference for the stack — setup, authentication, and every module&apos;s
+            endpoints with request/response schemas and runnable examples. Copy any page (or the whole
+            reference) as Markdown to drop into an AI agent.
+          </p>
+          <div className="docs-hero-actions">
+            <CopyMd text={PAGE_MD} label="Copy all as Markdown" />
+          </div>
+        </header>
+
+        {guides.map((g) => (
+          <section className="doc-guide" id={g.id} key={g.id}>
+            <h2 className="doc-guide-title">{g.title}</h2>
+            <Blocks blocks={g.blocks} />
+          </section>
+        ))}
+
+        {ordered.map((m) => (
+          <ModuleDoc key={m.id} m={m} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/digithings-web/components/docs/DocsLayout.tsx
+++ b/frontend/digithings-web/components/docs/DocsLayout.tsx
@@ -2,8 +2,9 @@
 import { Fragment, useEffect, useState, type ReactNode } from "react";
 import { modules, type ModuleNode, StackRow, Emblem } from "@digithings/web";
 import { CopyButton } from "@/lib/CopyButton";
-import { apiDocs, type ModuleApiDoc, type Endpoint } from "@/lib/apiDocs";
-import { guides, type Guide, type Block } from "@/lib/sharedDocs";
+import { apiDocs, type ModuleApiDoc } from "@/lib/apiDocs";
+import { guides, type Block } from "@/lib/sharedDocs";
+import { guideToMarkdown, moduleToMarkdown } from "@/lib/docsSerializers";
 import { EndpointDoc } from "./Endpoint";
 
 /**
@@ -70,94 +71,6 @@ function Blocks({ blocks }: { blocks: Block[] }) {
       })}
     </>
   );
-}
-
-// ── markdown serializers (for "copy as Markdown") ─────────────────────────────
-function guideToMarkdown(g: Guide): string {
-  const L: string[] = [`## ${g.title}`, ""];
-  for (const b of g.blocks) {
-    if (b.kind === "h") L.push(`### ${b.text}`, "");
-    else if (b.kind === "p") L.push(b.text, "");
-    else if (b.kind === "list") {
-      b.items.forEach((it) => L.push(`- ${it}`));
-      L.push("");
-    } else if (b.kind === "code") L.push("```" + b.lang, b.code, "```", "");
-  }
-  return L.join("\n").trim();
-}
-
-function endpointToMarkdown(ep: Endpoint, L: string[]): void {
-  L.push(`### ${ep.method} ${ep.path}`, ep.summary, "");
-  const meta = [ep.auth && `auth: ${ep.auth}`, ep.rateLimit && `rate: ${ep.rateLimit}`, ep.flag]
-    .filter(Boolean)
-    .join(" · ");
-  if (meta) L.push(meta, "");
-  if (ep.request?.length) {
-    L.push("Request:");
-    ep.request.forEach((f) => L.push(`- \`${f.name}\` (${f.type})${f.required ? " — required" : ""}: ${f.description}`));
-    L.push("");
-  }
-  if (ep.responseFields?.length) {
-    L.push("Response:");
-    ep.responseFields.forEach((f) => L.push(`- \`${f.name}\` (${f.type}): ${f.description}`));
-    L.push("");
-  }
-  if (ep.responseExample) L.push("Response example:", "```json", ep.responseExample, "```", "");
-  ep.examples?.forEach((ex) => L.push("```" + ex.lang, ex.code, "```", ""));
-}
-
-function moduleToMarkdown(m: ModuleNode): string {
-  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
-  const L: string[] = [`# ${m.id}`, "", `> ${m.tagline}`, ""];
-  L.push(`**Role:** ${m.role} · **Tier:** ${m.tier}`, "");
-  L.push("## Overview");
-  m.summary.forEach((s) => L.push(s, ""));
-  if (d.authNote || d.scopes?.length) {
-    L.push("## Authentication");
-    if (d.authNote) L.push(d.authNote, "");
-    d.scopes?.forEach((s) => L.push(`- \`${s.scope}\` — ${s.grants}`));
-    L.push("");
-  }
-  if (d.run) {
-    L.push("## Run locally");
-    if (d.run.compose) L.push("```bash", d.run.compose, "```", "");
-    if (d.run.standalone) L.push("```bash", d.run.standalone, "```", "");
-    if (d.run.cli) L.push("```bash", d.run.cli, "```", "");
-    if (d.run.mcp) L.push(`MCP: \`${d.run.mcp}\``, "");
-  }
-  if (d.env?.length) {
-    L.push("## Configuration");
-    d.env.forEach((e) => L.push(`- \`${e.name}\`${e.def ? ` (default \`${e.def}\`)` : ""}${e.required ? " — required" : ""}: ${e.description}`));
-    L.push("");
-  }
-  if (d.endpoints?.length) {
-    L.push("## Endpoints", "");
-    if (d.baseUrlVar) L.push(`Base URL: \`$${d.baseUrlVar}\` (the service URL from docker-compose.yml).`, "");
-    d.endpoints.forEach((ep) => endpointToMarkdown(ep, L));
-  }
-  if (d.publicInterface?.length) {
-    L.push("## Public interface");
-    d.publicInterface.forEach((it) => L.push(`- \`${it.signature}\` — ${it.description}`));
-    L.push("");
-  }
-  if (d.mcp?.length) {
-    L.push("## MCP tools");
-    d.mcp.forEach((t) => L.push(`- \`${t.name}\` — ${t.description}`));
-    L.push("");
-  }
-  if (d.notes?.length) {
-    L.push("## Notes");
-    d.notes.forEach((n) => L.push(`- ${n}`));
-    L.push("");
-  }
-  L.push("## Stack", m.stack.map((s) => s.name).join(", "), "");
-  if (m.related.length) L.push("## Related", m.related.join(", "), "");
-  if (m.links.length) {
-    L.push("## Links");
-    m.links.forEach((l) => L.push(`- [${l.label}](${l.href})`));
-    L.push("");
-  }
-  return L.join("\n").trim() + "\n";
 }
 
 const PAGE_MD = [

--- a/frontend/digithings-web/components/docs/Endpoint.tsx
+++ b/frontend/digithings-web/components/docs/Endpoint.tsx
@@ -1,0 +1,55 @@
+import type { Endpoint, Field } from "@/lib/apiDocs";
+import { CodeTabs } from "./CodeTabs";
+
+function FieldTable({ title, fields }: { title: string; fields: Field[] }) {
+  return (
+    <div className="doc-fieldset">
+      <span className="doc-fieldset-h">{title}</span>
+      <table className="doc-fields">
+        <tbody>
+          {fields.map((f) => (
+            <tr key={f.name}>
+              <td className="doc-f-name">
+                <code className="dc-code-inline">{f.name}</code>
+                {f.required && <span className="doc-req" title="required">*</span>}
+              </td>
+              <td className="doc-f-type">{f.type}</td>
+              <td className="doc-f-desc">{f.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** One HTTP endpoint: method pill + path, summary, badges, request/response, examples. */
+export function EndpointDoc({ ep }: { ep: Endpoint }) {
+  return (
+    <div className="doc-endpoint">
+      <div className="doc-ep-head">
+        <span className={`doc-method ${ep.method.toLowerCase()}`}>{ep.method}</span>
+        <code className="doc-ep-path">{ep.path}</code>
+      </div>
+      <p className="doc-summary">{ep.summary}</p>
+      <div className="doc-ep-badges">
+        {ep.auth && <span className="doc-badge">auth · {ep.auth}</span>}
+        {ep.rateLimit && <span className="doc-badge">{ep.rateLimit}</span>}
+        {ep.flag && <span className="doc-badge is-road">{ep.flag}</span>}
+      </div>
+      {ep.request && ep.request.length > 0 && <FieldTable title="Request" fields={ep.request} />}
+      {ep.responseFields && ep.responseFields.length > 0 && <FieldTable title="Response" fields={ep.responseFields} />}
+      {ep.responseExample && (
+        <div className="doc-fieldset">
+          <span className="doc-fieldset-h">Response</span>
+          <div className="doc-code">
+            <pre>
+              <code>{ep.responseExample}</code>
+            </pre>
+          </div>
+        </div>
+      )}
+      {ep.examples && ep.examples.length > 0 && <CodeTabs examples={ep.examples} />}
+    </div>
+  );
+}

--- a/frontend/digithings-web/lib/apiDocs.ts
+++ b/frontend/digithings-web/lib/apiDocs.ts
@@ -1,0 +1,663 @@
+/**
+ * Full API reference content for the digithings stack, keyed by module id and
+ * merged with the base `ModuleNode` (tagline/summary/stack/links) at render time.
+ *
+ * Authored from the codebase (each `{component}/ARCHITECTURE.md` + server.py) and
+ * kept honest by the OpenAPI contract tests (`tests/contracts/test_openapi_contract.py`).
+ * It is static — no runtime fetch — so the site exports cleanly to Cloudflare.
+ *
+ * Examples use base-URL variables ($DIGIGRAPH_URL, $DIGIKEY_URL, …) rather than a
+ * hardcoded host:port — the canonical ports live only in docker-compose.yml.
+ */
+
+export type Method = "GET" | "POST" | "PUT" | "DELETE";
+
+export interface Field {
+  name: string;
+  type: string;
+  required?: boolean;
+  description: string;
+}
+
+export interface CodeExample {
+  lang: "bash" | "python" | "typescript";
+  code: string;
+}
+
+export interface Endpoint {
+  method: Method;
+  path: string;
+  summary: string;
+  auth?: string; // e.g. "digisearch:query", "none", "admin token"
+  rateLimit?: string; // e.g. "10/min/IP"
+  flag?: string; // env flag that gates the route
+  request?: Field[];
+  responseFields?: Field[];
+  responseExample?: string; // JSON string, when a shape is clearer than a table
+  examples?: CodeExample[];
+}
+
+export interface EnvVar {
+  name: string;
+  def?: string;
+  required?: boolean;
+  description: string;
+}
+
+export interface McpTool {
+  name: string;
+  description: string;
+}
+
+export interface InterfaceItem {
+  signature: string;
+  description: string;
+}
+
+export interface ModuleApiDoc {
+  /** Base URL variable used in examples, e.g. "$DIGIGRAPH_URL". */
+  baseUrlVar?: string;
+  authNote?: string;
+  scopes?: { scope: string; grants: string }[];
+  run?: { compose?: string; standalone?: string; mcp?: string; cli?: string };
+  env?: EnvVar[];
+  endpoints?: Endpoint[];
+  /** For library / CLI modules instead of HTTP endpoints. */
+  publicInterface?: InterfaceItem[];
+  mcp?: McpTool[];
+  notes?: string[];
+}
+
+const BEARER = (v: string) => `-H "Authorization: Bearer $${v}"`;
+
+export const apiDocs: Record<string, ModuleApiDoc> = {
+  // ─────────────────────────────────────────────────────────────────────────
+  digigraph: {
+    baseUrlVar: "DIGIGRAPH_URL",
+    authNote:
+      "Endpoints accept a digikey-issued RS256 JWT in `Authorization: Bearer`. " +
+      "When no JWKS is configured the service runs in passthrough mode (dev/test only). " +
+      "`/healthz` and `/v1/status` are auth-exempt.",
+    scopes: [
+      { scope: "digigraph:workflow", grants: "POST /workflow + debug routes (default fallback)" },
+      { scope: "digigraph:chat", grants: "/v1/chat/completions, /v1/models, /v1/model-info" },
+      { scope: "digigraph:mcp", grants: "/threads/*, /files/* (when enabled)" },
+    ],
+    run: {
+      compose: "docker compose up -d digigraph",
+      standalone: "uvicorn digigraph.server:app",
+      mcp: "FastMCP streamable-http (workflow, chat, thread_state, list_orchestrator_tools)",
+    },
+    env: [
+      { name: "DIGIQUANT_URL", description: "DigiQuant base URL (defaults to the compose service URL)." },
+      { name: "DIGISEARCH_URL", description: "DigiSearch base URL; empty disables retrieval." },
+      { name: "DIGIKEY_JWKS_URL", description: "JWT public-key (JWKS) endpoint." },
+      { name: "OPENAI_API_BASE", description: "LiteLLM proxy base URL." },
+      { name: "DIGI_LLM_MODE", def: "test", description: "Model tier: test / medium / best." },
+      { name: "DIGI_CHECKPOINTER", def: "memory", description: "LangGraph state backend: memory / sqlite / postgres / none." },
+      { name: "DIGI_ENABLE_THREAD_API", def: "0", description: "Gate /threads/* and /files/*." },
+      { name: "DIGI_ENABLE_DEBUG_ENDPOINTS", def: "0", description: "Gate /test_llm and /v1/debug/*." },
+    ],
+    endpoints: [
+      {
+        method: "GET",
+        path: "/healthz",
+        summary: "Liveness probe. Auth-exempt; always 200.",
+        auth: "none",
+        responseExample: `{ "ok": true }`,
+        examples: [{ lang: "bash", code: `curl $DIGIGRAPH_URL/healthz` }],
+      },
+      {
+        method: "GET",
+        path: "/v1/status",
+        summary: "Public, secret-free project status.",
+        auth: "none",
+        rateLimit: "30/min/IP",
+        responseExample: `{
+  "service": "digigraph",
+  "project_name": "demo",
+  "agents_enabled": true,
+  "llm_mode": "test",
+  "mcp_enabled": true,
+  "workflow_profile": "default"
+}`,
+        examples: [{ lang: "bash", code: `curl $DIGIGRAPH_URL/v1/status` }],
+      },
+      {
+        method: "POST",
+        path: "/workflow",
+        summary: "Run the full research + backtest graph (DigiClaw custom skill).",
+        auth: "digigraph:workflow (optional)",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "prompt", type: "string", required: true, description: "The user request to route through the supervisor." },
+          { name: "session_id", type: "string", description: "Conversation/session correlation id." },
+          { name: "allowed_tools", type: "string[]", description: "Tool allowlist override for this run." },
+          { name: "digi_bearer", type: "string", description: "JWT forwarded downstream to DigiSearch/DigiQuant." },
+        ],
+        responseFields: [
+          { name: "success", type: "boolean", description: "Whether the workflow completed." },
+          { name: "message", type: "string", description: "Human-readable summary or full RAG answer." },
+          { name: "backtest_result", type: "object | null", description: "DigiQuant BacktestResult, if a backtest ran." },
+          { name: "rag_sources", type: "object[] | null", description: "Aggregated DigiSearch citations." },
+        ],
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGIGRAPH_URL/workflow \\
+  ${BEARER("JWT")} -H "content-type: application/json" \\
+  -d '{"prompt": "Backtest a momentum strategy on AAPL"}'`,
+          },
+          {
+            lang: "python",
+            code: `import os, httpx
+
+r = httpx.post(
+    f"{os.environ['DIGIGRAPH_URL']}/workflow",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"prompt": "Backtest a momentum strategy on AAPL"},
+    timeout=120,
+)
+print(r.json()["message"])`,
+          },
+          {
+            lang: "typescript",
+            code: `const r = await fetch(\`\${process.env.DIGIGRAPH_URL}/workflow\`, {
+  method: "POST",
+  headers: {
+    Authorization: \`Bearer \${process.env.DIGI_JWT}\`,
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({ prompt: "Backtest a momentum strategy on AAPL" }),
+});
+const { message } = await r.json();`,
+          },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/v1/chat/completions",
+        summary: "OpenAI-compatible chat. Set stream:true for SSE (events: tool_call, content, done).",
+        auth: "digigraph:chat (optional)",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "model", type: "string", description: 'Model id; default "sitaas-rag".' },
+          { name: "messages", type: "{role,content}[]", required: true, description: "Chat messages." },
+          { name: "stream", type: "boolean", description: "Stream tokens as SSE." },
+        ],
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGIGRAPH_URL/v1/chat/completions \\
+  ${BEARER("JWT")} -H "content-type: application/json" \\
+  -d '{"model":"sitaas-rag","messages":[{"role":"user","content":"hi"}]}'`,
+          },
+          {
+            lang: "python",
+            code: `from openai import OpenAI
+client = OpenAI(base_url=os.environ["DIGIGRAPH_URL"] + "/v1", api_key=os.environ["DIGI_JWT"])
+resp = client.chat.completions.create(
+    model="sitaas-rag",
+    messages=[{"role": "user", "content": "hi"}],
+)`,
+          },
+        ],
+      },
+      {
+        method: "GET",
+        path: "/v1/models",
+        summary: "OpenAI-style model list.",
+        auth: "digigraph:chat (optional)",
+        rateLimit: "30/min/IP",
+        examples: [{ lang: "bash", code: `curl $DIGIGRAPH_URL/v1/models ${BEARER("JWT")}` }],
+      },
+    ],
+    mcp: [
+      { name: "workflow(prompt, thread_id?)", description: "Run the full research + backtest graph; returns a JSON WorkflowResult." },
+      { name: "chat(message, thread_id?, model?)", description: "Single-turn chat via /v1/chat/completions." },
+      { name: "thread_state(thread_id)", description: "Return the LangGraph checkpoint state for a thread." },
+      { name: "list_orchestrator_tools()", description: "List registered orchestrator tool names." },
+      { name: "list_orchestrator_tools_detailed()", description: "Tool manifest: name, tags, dynamic_schema flag." },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digiquant: {
+    baseUrlVar: "DIGIQUANT_URL",
+    authNote:
+      "Backtest/optimize/pipeline routes accept a digikey JWT (optional in passthrough mode). " +
+      "Async jobs stream progress over SSE.",
+    scopes: [
+      { scope: "digiquant:backtest", grants: "/run_backtest, /backtest/*, /v1/jobs/*, /v1/orchestrator_tools" },
+      { scope: "digiquant:optimize", grants: "/run_optimize, /run_pipeline, /v1/workflow" },
+    ],
+    run: {
+      compose: "docker compose up -d digiquant",
+      standalone: "uvicorn digiquant.server:app",
+    },
+    env: [
+      { name: "DIGIQUANT_DATA_DIR", def: "/app/data", description: "Directory of OHLCV CSVs for backtests." },
+      { name: "DIGIKEY_JWKS_URL", description: "JWT public-key (JWKS) endpoint." },
+      { name: "DIGIQUANT_ALLOW_EXPORT", def: "1", description: "Enable export of strategy configs." },
+    ],
+    endpoints: [
+      {
+        method: "GET",
+        path: "/strategies",
+        summary: "List registered NautilusTrader strategies.",
+        auth: "none",
+        rateLimit: "30/min/IP",
+        responseExample: `[{ "name": "mean_reversion_tech", "aliases": [], "description": "...", "default_params": {} }]`,
+        examples: [{ lang: "bash", code: `curl $DIGIQUANT_URL/strategies` }],
+      },
+      {
+        method: "POST",
+        path: "/run_backtest",
+        summary: "Synchronous backtest. Returns a BacktestResult.",
+        auth: "digiquant:backtest (optional)",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "strategy_name", type: "string", required: true, description: "Registered strategy id." },
+          { name: "symbols", type: "string[]", required: true, description: "Instruments to test." },
+          { name: "data_dir", type: "string", description: "Directory of {symbol}.csv OHLCV files." },
+          { name: "strategy_params", type: "object", description: "Strategy parameter overrides." },
+          { name: "full_tearsheet", type: "boolean", description: "Include extended charts (default true)." },
+        ],
+        responseFields: [
+          { name: "run_id", type: "string", description: "Unique run identifier." },
+          { name: "total_pnl", type: "number", description: "Total P&L." },
+          { name: "sharpe_ratio", type: "number | null", description: "Sharpe ratio." },
+          { name: "num_trades", type: "integer", description: "Number of trades executed." },
+          { name: "status", type: "string", description: '"completed" | "failed".' },
+        ],
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGIQUANT_URL/run_backtest \\
+  ${BEARER("JWT")} -H "content-type: application/json" \\
+  -d '{"strategy_name":"mean_reversion_tech","symbols":["AAPL"]}'`,
+          },
+          {
+            lang: "python",
+            code: `r = httpx.post(
+    f"{os.environ['DIGIQUANT_URL']}/run_backtest",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"strategy_name": "mean_reversion_tech", "symbols": ["AAPL"]},
+    timeout=300,
+)
+print(r.json()["sharpe_ratio"])`,
+          },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/backtest/start",
+        summary: "Submit an async backtest job; returns {job_id}. Poll progress over SSE.",
+        auth: "none",
+        rateLimit: "10/min/IP",
+        responseExample: `{ "job_id": "..." }`,
+      },
+      {
+        method: "GET",
+        path: "/backtest/{job_id}/progress",
+        summary: "SSE stream of backtest progress events (JSON frames).",
+        auth: "none",
+        examples: [{ lang: "bash", code: `curl -N $DIGIQUANT_URL/backtest/$JOB_ID/progress` }],
+      },
+      {
+        method: "POST",
+        path: "/run_optimize",
+        summary: "Parameter optimization (grid / bayesian / random). Returns best params.",
+        auth: "digiquant:optimize (optional)",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "strategy_name", type: "string", required: true, description: "Registered strategy id." },
+          { name: "symbols", type: "string[]", required: true, description: "Instruments." },
+          { name: "method", type: "string", description: '"grid" | "bayesian" | "random" (default grid).' },
+          { name: "n_trials", type: "integer", description: "Trial budget (default 50)." },
+          { name: "objective", type: "string", description: '"sharpe" | "return" | "pnl".' },
+        ],
+        responseFields: [
+          { name: "best_params", type: "object", description: "Best parameter set found." },
+          { name: "best_sharpe", type: "number | null", description: "Objective value at best params." },
+          { name: "num_evaluations", type: "integer", description: "Trials evaluated." },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/run_pipeline",
+        summary: "Full pipeline: backtest → optimize → export.",
+        auth: "digiquant:optimize (optional)",
+        rateLimit: "10/min/IP",
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digisearch: {
+    baseUrlVar: "DIGISEARCH_URL",
+    authNote: "All query/ingest routes require a digikey JWT carrying the matching scope.",
+    scopes: [
+      { scope: "digisearch:query", grants: "/query, /v1/research_turn, orchestrator routes, /indexes/*" },
+      { scope: "digisearch:ingest", grants: "/ingest" },
+    ],
+    run: {
+      compose: "docker compose up -d digisearch",
+      standalone: "uvicorn digisearch.server:app",
+      mcp: "digisearch mcp   (FastMCP streamable-http: digisearch_query, digisearch_research_turn)",
+    },
+    env: [
+      { name: "CHROMA_PATH", description: "Persistent Chroma directory (activates the Chroma backend)." },
+      { name: "AZURE_SEARCH_ENDPOINT", description: "Azure AI Search endpoint (alternative backend)." },
+      { name: "AZURE_SEARCH_API_KEY", description: "Azure AI Search key." },
+      { name: "OPENAI_API_KEY", description: "Embeddings provider key." },
+      { name: "DIGIKEY_JWKS_URL", required: true, description: "JWT public-key endpoint." },
+    ],
+    endpoints: [
+      {
+        method: "POST",
+        path: "/query",
+        summary: "Hybrid / keyword / vector search over an index.",
+        auth: "digisearch:query",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "text", type: "string", required: true, description: "Query text." },
+          { name: "index_name", type: "string", description: 'Target index (default "default").' },
+          { name: "top_k", type: "integer", description: "Results to return, 1–100 (default 10)." },
+          { name: "mode", type: "string", description: '"keyword" | "vector" | "hybrid" (default hybrid).' },
+          { name: "filters", type: "{field,op,value}[]", description: "Structured metadata filters." },
+        ],
+        responseFields: [
+          { name: "results", type: "object[]", description: "Normalized hits (chunk_id, doc_id, score, content, metadata)." },
+          { name: "total", type: "integer", description: "Total matches." },
+          { name: "backend", type: "string", description: '"chroma" | "azure_ai_search" | "stub".' },
+        ],
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGISEARCH_URL/query \\
+  ${BEARER("JWT")} -H "content-type: application/json" \\
+  -d '{"text":"momentum factor","index_name":"default","top_k":5}'`,
+          },
+          {
+            lang: "python",
+            code: `r = httpx.post(
+    f"{os.environ['DIGISEARCH_URL']}/query",
+    headers={"Authorization": f"Bearer {os.environ['DIGI_JWT']}"},
+    json={"text": "momentum factor", "top_k": 5},
+)
+for hit in r.json()["results"]:
+    print(hit["score"], hit["content"][:80])`,
+          },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/ingest",
+        summary: "Ingest a document (parse → chunk → embed → index).",
+        auth: "digisearch:ingest",
+        rateLimit: "30/min/IP",
+        request: [
+          { name: "source", type: "string", required: true, description: "Server-side path to the document." },
+          { name: "index_name", type: "string", description: "Target index." },
+          { name: "doc_type", type: "string", description: "pdf | html | docx | markdown | csv | plaintext." },
+          { name: "metadata", type: "object", description: "Evidence metadata (tier, venue, tags, …)." },
+        ],
+        responseExample: `{ "doc_id": "...", "chunks_created": 12, "index_name": "default", "status": "ok" }`,
+      },
+      {
+        method: "POST",
+        path: "/v1/research_turn",
+        summary: "Composite research turn (plan → retrieve → aggregate) with citations.",
+        auth: "digisearch:query",
+        rateLimit: "10/min/IP",
+        flag: "requires the digisearch[agent] extra",
+      },
+    ],
+    mcp: [
+      { name: "digisearch_query", description: "Search documents; returns formatted hits with score + preview." },
+      { name: "digisearch_research_turn", description: "Composite research turn with citations (needs digisearch[agent])." },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digikey: {
+    baseUrlVar: "DIGIKEY_URL",
+    authNote:
+      "digikey is the issuer. Admin routes require the `DIGIKEY_ADMIN_TOKEN` bearer; " +
+      "token exchange takes a raw API key or a BFF-session grant. JWKS and /healthz are public.",
+    scopes: [
+      { scope: "digigraph:workflow / :chat / :mcp", grants: "DigiGraph routes" },
+      { scope: "digiquant:backtest / :optimize", grants: "DigiQuant routes" },
+      { scope: "digisearch:query / :ingest", grants: "DigiSearch routes" },
+      { scope: "*", grants: "Wildcard (all scopes) — dev_global keys only" },
+    ],
+    run: {
+      compose: "docker compose up -d digikey",
+      standalone: "uvicorn digikey.server:app",
+    },
+    env: [
+      { name: "DIGIKEY_DATABASE_URL", required: true, description: "SQLite or Postgres URL for key storage." },
+      { name: "DIGIKEY_PRIVATE_KEY_PEM", description: "RSA 2048 PEM for RS256 signing (prod)." },
+      { name: "DIGIKEY_ADMIN_TOKEN", required: true, description: "Bearer for POST /v1/admin/keys." },
+      { name: "DIGIKEY_BFF_TOKEN", description: "Bearer for grant_type=bff_session (DigiChat)." },
+      { name: "DIGIKEY_JWT_TTL_SEC", def: "900", description: "Access-token lifetime." },
+      { name: "DIGIKEY_BLOCKLIST_REDIS_URL", description: "Redis for JWT revocation (prod)." },
+    ],
+    endpoints: [
+      {
+        method: "GET",
+        path: "/.well-known/jwks.json",
+        summary: "RSA public key set for verifying issued JWTs.",
+        auth: "none",
+        examples: [{ lang: "bash", code: `curl $DIGIKEY_URL/.well-known/jwks.json` }],
+      },
+      {
+        method: "POST",
+        path: "/v1/admin/keys",
+        summary: "Create an API key. The raw key is returned ONCE.",
+        auth: "admin token",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "tenant_slug", type: "string", required: true, description: "Tenant identifier." },
+          { name: "label", type: "string", description: "Human-readable key name." },
+          { name: "scopes", type: "string[]", description: "Granted scopes." },
+        ],
+        responseExample: `{ "key_prefix": "dgk_live_…", "api_key": "dgk_live_…(once)", "id": "<uuid>" }`,
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGIKEY_URL/v1/admin/keys \\
+  ${BEARER("DIGIKEY_ADMIN_TOKEN")} -H "content-type: application/json" \\
+  -d '{"tenant_slug":"acme","scopes":["digiquant:backtest"]}'`,
+          },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/v1/oauth/token",
+        summary: "Exchange an API key (or BFF session) for a short-lived RS256 JWT.",
+        auth: "none (key in body)",
+        rateLimit: "10/min/IP",
+        request: [
+          { name: "grant_type", type: "string", required: true, description: '"api_key" | "bff_session".' },
+          { name: "api_key", type: "string", description: "Raw dgk_live_ key (api_key grant)." },
+          { name: "requested_scopes", type: "string[]", description: "Downscope to a subset of granted scopes." },
+        ],
+        responseExample: `{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }`,
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGIKEY_URL/v1/oauth/token \\
+  -H "content-type: application/json" \\
+  -d '{"grant_type":"api_key","api_key":"'"$DIGI_API_KEY"'"}'`,
+          },
+          {
+            lang: "python",
+            code: `tok = httpx.post(
+    f"{os.environ['DIGIKEY_URL']}/v1/oauth/token",
+    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},
+).json()["access_token"]`,
+          },
+        ],
+      },
+      {
+        method: "POST",
+        path: "/v1/admin/keys/{key_id}/revoke",
+        summary: "Revoke a key and blocklist its live JWTs (when Redis is configured).",
+        auth: "admin token",
+        rateLimit: "10/min/IP",
+        responseExample: `{ "revoked": true, "jtis_invalidated": 3 }`,
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digismith: {
+    baseUrlVar: "DIGISMITH_URL",
+    authNote: "Status and metrics are public diagnostics. Tracing is a library wrapper, not an HTTP surface.",
+    run: {
+      compose: "docker compose up -d digismith",
+      standalone: "uvicorn digismith.server:app",
+    },
+    env: [
+      { name: "LANGSMITH_API_KEY", description: "Enable LangSmith trace export; absent = no-op." },
+      { name: "LANGSMITH_ENDPOINT", def: "https://api.smith.langchain.com", description: "LangSmith API base (host shown in /v1/status)." },
+      { name: "OTEL_EXPORTER_OTLP_ENDPOINT", description: "Enable OTel HTTP export when set." },
+    ],
+    endpoints: [
+      {
+        method: "GET",
+        path: "/v1/status",
+        summary: "Tracing configuration diagnostic (operator-facing; secret-free).",
+        auth: "none",
+        responseExample: `{
+  "version": "0.1.0",
+  "tracing_configured": true,
+  "langsmith_sdk_installed": true,
+  "langsmith_host": "api.smith.langchain.com",
+  "request_id": "..."
+}`,
+        examples: [{ lang: "bash", code: `curl $DIGISMITH_URL/v1/status` }],
+      },
+      { method: "GET", path: "/metrics", summary: "Prometheus metrics (text/plain 0.0.4).", auth: "none" },
+    ],
+    publicInterface: [
+      {
+        signature: "from digismith.trace import traceable",
+        description:
+          "@traceable(\"name\") wraps a function with langsmith.traceable when LANGSMITH_API_KEY is set; otherwise a no-op. PII is redacted from span inputs/outputs.",
+      },
+      {
+        signature: "from digismith.config import tracing_enabled",
+        description: "Returns True when tracing is configured (key set + SDK importable).",
+      },
+    ],
+    notes: [
+      "Span attributes SHOULD include workflow_id, request_id, session_id, job_id.",
+      "Spans MUST NOT include raw prompts/completions, secrets, or full document bodies.",
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digichat: {
+    baseUrlVar: "DIGICHAT_URL",
+    authNote:
+      "The deployed digithings.ai chat is an agentic Cloudflare Pages Function (no login) that " +
+      "grounds answers in the digivault docs. The full Docker BFF additionally authenticates users " +
+      "via NextAuth and exchanges a BFF session for a digikey JWT to call DigiGraph.",
+    run: {
+      compose: "docker compose --profile digichat up -d",
+      cli: "make digichat-dev   # Next.js dev server with hot reload",
+    },
+    env: [
+      { name: "OPENROUTER_API_KEY", required: true, description: "LLM calls via OpenRouter free models." },
+      { name: "CORE_SUPABASE_URL", required: true, description: "Vault Supabase project URL (RLS read)." },
+      { name: "CORE_SUPABASE_ANON_KEY", required: true, description: "Anon key for RLS-gated vault reads." },
+      { name: "AUTH_SECRET", description: "NextAuth secret (Docker BFF): openssl rand -base64 32." },
+      { name: "DIGIKEY_BFF_TOKEN", description: "Bearer for grant_type=bff_session (Docker BFF)." },
+    ],
+    endpoints: [
+      { method: "GET", path: "/api/health", summary: "Liveness probe.", auth: "none", responseExample: `{ "ok": true }` },
+      {
+        method: "POST",
+        path: "/api/chat",
+        summary: "Agentic chat grounded in digivault (single tool: search_digivault).",
+        auth: "none (public, rate-limited)",
+        request: [
+          { name: "messages", type: "{role,content}[]", required: true, description: "Conversation so far." },
+          { name: "model", type: "string", description: "OpenRouter free model id." },
+        ],
+        responseExample: `{ "content": "…grounded answer…", "tool_calls": [] }`,
+        examples: [
+          {
+            lang: "bash",
+            code: `curl -X POST $DIGICHAT_URL/api/chat \\
+  -H "content-type: application/json" \\
+  -d '{"messages":[{"role":"user","content":"What does digigraph do?"}]}'`,
+          },
+        ],
+      },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digiclaw: {
+    authNote: "CLI-only — no HTTP service. A heartbeat runner pings service health and appends an immutable audit log.",
+    run: {
+      cli: "python -m digiclaw            # one cycle\ndocker compose --profile heartbeat up -d heartbeat",
+    },
+    env: [
+      { name: "DIGIGRAPH_URL", description: "DigiGraph base URL for health checks." },
+      { name: "DIGIQUANT_URL", description: "DigiQuant base URL for health + drift checks." },
+      { name: "DIGICLAW_DIGIKEY_API_KEY", description: "Key (digiquant:backtest+optimize) for auth-gated drift checks." },
+      { name: "AUDIT_LOG_PATH", def: "digiquant/results/audit/events.jsonl", description: "Append-only JSONL audit destination." },
+      { name: "REOPTIMIZE_STRATEGY", def: "mean_reversion_tech", description: "Strategy id for the drift check." },
+    ],
+    publicInterface: [
+      { signature: "python -m digiclaw", description: "Run one heartbeat cycle: health-check services, run an auth-gated drift check, and (on drift) trigger re-optimization." },
+      { signature: "audit_log(event_type, agent_id, payload)", description: "Append one redacted JSON line to the audit log." },
+    ],
+    notes: [
+      "Audit event types: heartbeat, reoptimize_triggered, reoptimize_completed, reoptimize_failed, drift_check_skipped.",
+      "Keys matching password / api_key / token / secret are redacted before write.",
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digibase: {
+    authNote: "Shared Python library imported by every service — not a network surface.",
+    run: { cli: "# installed as a dependency of each service; no standalone run" },
+    publicInterface: [
+      { signature: "from digibase.errors import register_fastapi_error_handlers", description: 'Standard error envelope: {error:{code,message,request_id,service}}.' },
+      { signature: "from digibase.http import outbound_service_headers", description: "Builds X-Request-ID + Authorization headers for service-to-service calls." },
+      { signature: "from digibase.http import install_request_id_middleware", description: "Reads/generates X-Request-ID, stores on request.state, echoes on the response." },
+      { signature: "from digibase.audit import redact_mapping", description: "Redacts password/api_key/token/secret keys from a payload before logging." },
+      { signature: "from digibase.metrics import install_metrics", description: "Mounts Prometheus /metrics with http_requests_total / _duration / _in_flight." },
+      { signature: "from digibase.otel import setup_otel_fastapi", description: "Optional OTel wiring; no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set." },
+    ],
+    env: [
+      { name: "DIGI_ENV", def: "dev", description: "Environment label for metrics." },
+      { name: "DIGI_CORS_ORIGINS", description: "Global CORS allowlist (comma-separated)." },
+      { name: "DIGI_PII_PATTERNS", description: "Extra regex patterns for PII redaction." },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digistore: {
+    authNote: "Roadmap. Today a session-scoped dataset manager lives inside digigraph; the standalone storage service is planned.",
+    notes: [
+      "Planned: one storage API over S3, MinIO, Postgres, or SQLite so business code never binds to a backend.",
+      "Planned surface: DigiStore.configure(backend=…) + get/put/list over a backend-neutral interface.",
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  digilink: {
+    authNote: "Roadmap. Today MCP is built into individual modules (e.g. digisearch-mcp).",
+    notes: [
+      "Planned: a protocol bridge registering adapters that turn REST, gRPC, or bespoke transports into MCP tools.",
+      "Planned surface: digilink.register_adapter(\"rest\", …) to expose a non-native transport as MCP.",
+    ],
+  },
+};

--- a/frontend/digithings-web/lib/docsSerializers.ts
+++ b/frontend/digithings-web/lib/docsSerializers.ts
@@ -1,0 +1,99 @@
+/**
+ * Markdown serializers for the API docs — shared by the /docs page (the
+ * "copy as Markdown" buttons in DocsLayout) and the DigiVault sync generator
+ * (scripts/gen-api-vault.ts), so the two never drift.
+ *
+ * Pure functions, no React or client-only deps; `ModuleNode` is imported as a
+ * type only, so this module runs under plain Node (type-stripping) as well as
+ * inside the Next.js bundle.
+ */
+import type { ModuleNode } from "@digithings/web";
+import { apiDocs, type ModuleApiDoc, type Endpoint } from "./apiDocs";
+import { type Guide } from "./sharedDocs";
+
+export function guideToMarkdown(g: Guide): string {
+  const L: string[] = [`## ${g.title}`, ""];
+  for (const b of g.blocks) {
+    if (b.kind === "h") L.push(`### ${b.text}`, "");
+    else if (b.kind === "p") L.push(b.text, "");
+    else if (b.kind === "list") {
+      b.items.forEach((it) => L.push(`- ${it}`));
+      L.push("");
+    } else if (b.kind === "code") L.push("```" + b.lang, b.code, "```", "");
+  }
+  return L.join("\n").trim();
+}
+
+function endpointToMarkdown(ep: Endpoint, L: string[]): void {
+  L.push(`### ${ep.method} ${ep.path}`, ep.summary, "");
+  const meta = [ep.auth && `auth: ${ep.auth}`, ep.rateLimit && `rate: ${ep.rateLimit}`, ep.flag]
+    .filter(Boolean)
+    .join(" · ");
+  if (meta) L.push(meta, "");
+  if (ep.request?.length) {
+    L.push("Request:");
+    ep.request.forEach((f) => L.push(`- \`${f.name}\` (${f.type})${f.required ? " — required" : ""}: ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseFields?.length) {
+    L.push("Response:");
+    ep.responseFields.forEach((f) => L.push(`- \`${f.name}\` (${f.type}): ${f.description}`));
+    L.push("");
+  }
+  if (ep.responseExample) L.push("Response example:", "```json", ep.responseExample, "```", "");
+  ep.examples?.forEach((ex) => L.push("```" + ex.lang, ex.code, "```", ""));
+}
+
+export function moduleToMarkdown(m: ModuleNode): string {
+  const d: ModuleApiDoc = apiDocs[m.id] ?? {};
+  const L: string[] = [`# ${m.id}`, "", `> ${m.tagline}`, ""];
+  L.push(`**Role:** ${m.role} · **Tier:** ${m.tier}`, "");
+  L.push("## Overview");
+  m.summary.forEach((s) => L.push(s, ""));
+  if (d.authNote || d.scopes?.length) {
+    L.push("## Authentication");
+    if (d.authNote) L.push(d.authNote, "");
+    d.scopes?.forEach((s) => L.push(`- \`${s.scope}\` — ${s.grants}`));
+    L.push("");
+  }
+  if (d.run) {
+    L.push("## Run locally");
+    if (d.run.compose) L.push("```bash", d.run.compose, "```", "");
+    if (d.run.standalone) L.push("```bash", d.run.standalone, "```", "");
+    if (d.run.cli) L.push("```bash", d.run.cli, "```", "");
+    if (d.run.mcp) L.push(`MCP: \`${d.run.mcp}\``, "");
+  }
+  if (d.env?.length) {
+    L.push("## Configuration");
+    d.env.forEach((e) => L.push(`- \`${e.name}\`${e.def ? ` (default \`${e.def}\`)` : ""}${e.required ? " — required" : ""}: ${e.description}`));
+    L.push("");
+  }
+  if (d.endpoints?.length) {
+    L.push("## Endpoints", "");
+    if (d.baseUrlVar) L.push(`Base URL: \`$${d.baseUrlVar}\` (the service URL from docker-compose.yml).`, "");
+    d.endpoints.forEach((ep) => endpointToMarkdown(ep, L));
+  }
+  if (d.publicInterface?.length) {
+    L.push("## Public interface");
+    d.publicInterface.forEach((it) => L.push(`- \`${it.signature}\` — ${it.description}`));
+    L.push("");
+  }
+  if (d.mcp?.length) {
+    L.push("## MCP tools");
+    d.mcp.forEach((t) => L.push(`- \`${t.name}\` — ${t.description}`));
+    L.push("");
+  }
+  if (d.notes?.length) {
+    L.push("## Notes");
+    d.notes.forEach((n) => L.push(`- ${n}`));
+    L.push("");
+  }
+  L.push("## Stack", m.stack.map((s) => s.name).join(", "), "");
+  if (m.related.length) L.push("## Related", m.related.join(", "), "");
+  if (m.links.length) {
+    L.push("## Links");
+    m.links.forEach((l) => L.push(`- [${l.label}](${l.href})`));
+    L.push("");
+  }
+  return L.join("\n").trim() + "\n";
+}

--- a/frontend/digithings-web/lib/sharedDocs.ts
+++ b/frontend/digithings-web/lib/sharedDocs.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared guide sections for the docs (rendered above the per-module reference and
+ * included in the "Copy all as Markdown" export). Structured as simple blocks so a
+ * single renderer + markdown serializer covers them. Codebase-accurate; examples
+ * use base-URL variables rather than hardcoded host:port.
+ */
+
+export type Block =
+  | { kind: "p"; text: string }
+  | { kind: "h"; text: string }
+  | { kind: "code"; lang: string; code: string }
+  | { kind: "list"; items: string[] };
+
+export interface Guide {
+  id: string;
+  title: string;
+  blocks: Block[];
+}
+
+export const guides: Guide[] = [
+  {
+    id: "getting-started",
+    title: "Getting started",
+    blocks: [
+      { kind: "p", text: "digithings is an open-core agentic stack — orchestration, quant research, retrieval, and chat behind one supervisor. Self-hosted, BYOK, audit-on by default." },
+      { kind: "h", text: "Prerequisites" },
+      { kind: "list", items: ["Docker (with Compose)", "Python ≥ 3.12 (for running services outside Docker)", "Node.js LTS (for the frontends)"] },
+      { kind: "h", text: "Run the whole stack" },
+      { kind: "code", lang: "bash", code: "git clone https://github.com/digithings-ai/digithings && cd digithings\ncp .env.example .env   # add your keys\ndocker compose up -d" },
+      { kind: "p", text: "Each backend service exposes a liveness probe at `GET /healthz`. The service URLs and ports are defined in `docker-compose.yml`; reference them through env vars (`$DIGIGRAPH_URL`, `$DIGIKEY_URL`, …) rather than hardcoding an address." },
+      { kind: "h", text: "Essential environment" },
+      { kind: "list", items: [
+        "`OPENROUTER_API_KEY` / `OPENAI_API_KEY` — LLM access via the LiteLLM proxy.",
+        "`DIGIKEY_ADMIN_TOKEN` — required to mint API keys (see Authentication).",
+        "`DIGIKEY_PRIVATE_KEY_PEM` — stable RS256 signing key for production.",
+        "See `.env.example` for the full, annotated list.",
+      ] },
+      { kind: "h", text: "Useful make targets" },
+      { kind: "list", items: [
+        "`make up` / `make down` — start / stop the core stack.",
+        "`make up-digichat` — start the chat BFF + its Postgres.",
+        "`make stack-local` — run the Python services without Docker.",
+        "`make test-unit` — unit tests (no stack required).",
+      ] },
+    ],
+  },
+  {
+    id: "authentication",
+    title: "Authentication",
+    blocks: [
+      { kind: "p", text: "digikey is the single issuer of RS256 JWTs. Services verify tokens against digikey's JWKS and enforce per-route scopes. The flow: mint an API key (admin), exchange it for a short-lived JWT, then call services with `Authorization: Bearer <jwt>`." },
+      { kind: "h", text: "1 · Mint an API key (admin)" },
+      { kind: "code", lang: "bash", code: 'curl -X POST $DIGIKEY_URL/v1/admin/keys \\\n  -H "Authorization: Bearer $DIGIKEY_ADMIN_TOKEN" \\\n  -H "content-type: application/json" \\\n  -d \'{"tenant_slug":"acme","scopes":["digiquant:backtest","digigraph:workflow"]}\'\n# → { "api_key": "dgk_live_… (shown once)", "key_prefix": "dgk_live_…", "id": "<uuid>" }' },
+      { kind: "h", text: "2 · Exchange for a JWT" },
+      { kind: "code", lang: "bash", code: 'curl -X POST $DIGIKEY_URL/v1/oauth/token \\\n  -H "content-type: application/json" \\\n  -d \'{"grant_type":"api_key","api_key":"\'"$DIGI_API_KEY"\'"}\'\n# → { "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 900 }' },
+      { kind: "code", lang: "python", code: 'import os, httpx\n\ntok = httpx.post(\n    f"{os.environ[\'DIGIKEY_URL\']}/v1/oauth/token",\n    json={"grant_type": "api_key", "api_key": os.environ["DIGI_API_KEY"]},\n).json()["access_token"]' },
+      { kind: "code", lang: "typescript", code: 'const r = await fetch(`${process.env.DIGIKEY_URL}/v1/oauth/token`, {\n  method: "POST",\n  headers: { "content-type": "application/json" },\n  body: JSON.stringify({ grant_type: "api_key", api_key: process.env.DIGI_API_KEY }),\n});\nconst { access_token } = await r.json();' },
+      { kind: "h", text: "3 · Call a service" },
+      { kind: "code", lang: "bash", code: 'curl -X POST $DIGIGRAPH_URL/workflow \\\n  -H "Authorization: Bearer $JWT" -H "content-type: application/json" \\\n  -d \'{"prompt":"Backtest a momentum strategy on AAPL"}\'' },
+      { kind: "h", text: "Scopes" },
+      { kind: "list", items: [
+        "`digigraph:workflow`, `digigraph:chat`, `digigraph:mcp`",
+        "`digiquant:backtest`, `digiquant:optimize`",
+        "`digisearch:query`, `digisearch:ingest`",
+        "JWTs are short-lived (default 900s); revoke a key via `POST /v1/admin/keys/{id}/revoke`.",
+      ] },
+    ],
+  },
+  {
+    id: "conventions",
+    title: "Conventions",
+    blocks: [
+      { kind: "h", text: "Liveness vs status" },
+      { kind: "p", text: "`GET /healthz` is the auth-exempt liveness probe — always `{\"ok\": true}`, for load balancers. `GET /v1/status` (DigiGraph, DigiSmith) is a richer operator diagnostic; never use it for health checks." },
+      { kind: "h", text: "Error envelope" },
+      { kind: "p", text: "Every service returns the same error shape:" },
+      { kind: "code", lang: "json", code: '{\n  "error": {\n    "code": "http_401",\n    "message": "Bearer token required",\n    "request_id": "req-…",\n    "service": "digigraph"\n  }\n}' },
+      { kind: "list", items: [
+        "`http_401` — missing/invalid token · `http_403` / `insufficient_scope` — scope denied.",
+        "`validation_error` — request body failed validation.",
+        "`rate_limited` — HTTP 429, with a `Retry-After` header.",
+      ] },
+      { kind: "h", text: "Correlation" },
+      { kind: "p", text: "Send `X-Request-ID` to correlate a call across services; it is generated if absent and echoed on the response and in the audit log." },
+      { kind: "h", text: "Rate limits & CORS" },
+      { kind: "p", text: "Mutating routes are rate-limited per IP (typically 10/min, 429 + `Retry-After` on breach). CORS uses an explicit allowlist (`DIGI_CORS_ORIGINS`) — no wildcard — with credentials enabled for session cookies." },
+    ],
+  },
+];

--- a/frontend/digithings/chat.html
+++ b/frontend/digithings/chat.html
@@ -101,8 +101,8 @@
             <div class="section-head"><span class="kicker">// run it yourself</span><h2>Three commands.</h2></div>
             <pre class="codeblock">git clone https://github.com/digithings-ai/digithings
 cd digithings
-make up-digichat      <span class="c"># starts DigiGraph + DigiChat on port 3005</span>
-<span class="c"># visit http://localhost:3005</span></pre>
+make up-digichat      <span class="c"># start the chat stack</span>
+<span class="c"># then open the local URL it prints</span></pre>
             <p style="color:var(--ink-soft);font-size:.92rem;margin-top:1rem">Requires Docker and an <code class="snippet" style="display:inline">OPENAI_API_KEY</code> or LiteLLM-compatible key in your environment. No account needed.</p>
         </div>
     </section>

--- a/frontend/digithings/modules.html
+++ b/frontend/digithings/modules.html
@@ -106,7 +106,7 @@
         const tier = el("span", "m-tier", m.tier === "core" ? "core vertical" : "support module");
         const title = el("h1", "m-title", m.name);
         const tag = el("p", "m-tag", m.tagline || "");
-        const role = el("p", "m-role", m.role + (m.port ? "  ·  :" + m.port : ""));
+        const role = el("p", "m-role", m.role);
 
         const summary = el("div", "m-summary");
         (m.summary || []).forEach((para) => summary.append(el("p", null, para)));

--- a/frontend/digithings/modules.json
+++ b/frontend/digithings/modules.json
@@ -4,7 +4,6 @@
       "id": "digigraph",
       "name": "DigiGraph",
       "tier": "core",
-      "port": "8000",
       "role": "Orchestration · LangGraph supervisor",
       "tagline": "One supervisor decides which specialist runs. Every time.",
       "summary": [
@@ -22,7 +21,6 @@
       "id": "digiquant",
       "name": "DigiQuant",
       "tier": "core",
-      "port": "8001",
       "role": "Quant engine · NautilusTrader",
       "tagline": "Strategy research that ends in an order, not a markdown file.",
       "summary": [
@@ -40,7 +38,6 @@
       "id": "digisearch",
       "name": "DigiSearch",
       "tier": "core",
-      "port": "8002",
       "role": "Vector retrieval · multi-backend",
       "tagline": "Production RAG without a stack rewrite when you switch vector DB.",
       "summary": [
@@ -55,7 +52,6 @@
       "id": "digichat",
       "name": "DigiChat",
       "tier": "core",
-      "port": "3005",
       "role": "Chat surface · Next.js BFF · BYOK",
       "tagline": "Talk to your stack with your keys, your models, your audit log.",
       "summary": [
@@ -73,7 +69,6 @@
       "id": "digikey",
       "name": "DigiKey",
       "tier": "support",
-      "port": "8005",
       "role": "Auth · RS256 JWTs · scoped API keys",
       "tagline": "Identity, JWTs, and scoped keys — one issuer for humans and machines.",
       "summary": [
@@ -88,7 +83,6 @@
       "id": "digismith",
       "name": "DigiSmith",
       "tier": "support",
-      "port": "8003",
       "role": "Observability · spans · PII redaction",
       "tagline": "Correlation IDs across every span; PII redacted before logs hit disk.",
       "summary": [

--- a/frontend/web/src/components/emblems.tsx
+++ b/frontend/web/src/components/emblems.tsx
@@ -1,7 +1,10 @@
 /**
- * Bespoke monoline emblem family — one visual grammar across modules.
- * viewBox 0 0 32 32, stroke=currentColor (= --accent), no fill, round caps.
- * Size via the `size` prop; color via container `color`/`currentColor`.
+ * Module emblem family — one minimal, modern visual grammar across modules.
+ * Each mark is a single geometric idea representing what the module does, drawn
+ * on a 0 0 32 32 grid (centered at 16,16), monoline with round caps and exactly
+ * one filled accent element for hierarchy. Stroke + fill use `currentColor`; the
+ * `Emblem` wrapper sets that to the module's own accent token, so each renders in
+ * its own colour while staying a single, cohesive set.
  */
 import { type SVGProps } from "react";
 
@@ -13,99 +16,112 @@ const Svg = ({ size = 32, children, ...rest }: P & { children: React.ReactNode }
     viewBox="0 0 32 32"
     fill="none"
     stroke="currentColor"
-    strokeWidth={1.75}
+    strokeWidth={2.2}
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden="true"
     {...rest}
   >
-    {children}
+    <g transform="translate(16 16)">{children}</g>
   </svg>
 );
 
-// orchestration — central hub branching to satellites
+// orchestration — a supervisor hub branching to specialist nodes
 const DigiGraph = (p: P) => (
   <Svg {...p}>
-    <circle cx="16" cy="16" r="3.2" />
-    <circle cx="6" cy="7" r="2" /><circle cx="26" cy="8" r="2" /><circle cx="25" cy="25" r="2" />
-    <path d="M13.4 14.2 7.6 8.6M18.7 14.4 24.2 9.4M18.2 18.1 23.4 23.3" />
+    <circle cx="0" cy="-4" r="4.3" fill="currentColor" stroke="none" />
+    <circle cx="-10" cy="10" r="3" />
+    <circle cx="10" cy="10" r="3" />
+    <path d="M-3 -1 -8 6M3 -1 8 6" />
   </Svg>
 );
-// quant — candles + rising curve
+// quant — ascending candles, the leader filled (research that ends in an order)
 const DigiQuant = (p: P) => (
   <Svg {...p}>
-    <path d="M5 20l6-4 5 3 6-7 5 3" />
-    <path d="M9 24v-3M9 16v-2M20 22v-3M20 13v-2" />
-    <rect x="7" y="14" width="4" height="7" rx="1" /><rect x="18" y="11" width="4" height="6" rx="1" />
+    <rect x="-13" y="2" width="6" height="11" rx="2" />
+    <rect x="-3" y="-5" width="6" height="18" rx="2" />
+    <rect x="7" y="-12" width="6" height="25" rx="2" fill="currentColor" stroke="none" />
   </Svg>
 );
-// retrieval — lens + vector points
+// retrieval — a lens over a focal point (vector search)
 const DigiSearch = (p: P) => (
   <Svg {...p}>
-    <circle cx="13" cy="13" r="7" /><path d="M18.5 18.5 26 26" />
-    <circle cx="10.5" cy="13" r="0.6" fill="currentColor" /><circle cx="13" cy="11" r="0.6" fill="currentColor" /><circle cx="15.5" cy="14" r="0.6" fill="currentColor" />
+    <circle cx="-3" cy="-3" r="10" />
+    <path d="M5 5 13 13" />
+    <circle cx="-3" cy="-3" r="2.4" fill="currentColor" stroke="none" />
   </Svg>
 );
-// chat — prompt chevron in a bubble
+// chat — a terminal prompt (`>_`)
 const DigiChat = (p: P) => (
   <Svg {...p}>
-    <path d="M6 8h20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H14l-6 5v-5H6a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2z" />
-    <path d="M11 12l3 2.5-3 2.5M17 17h4" />
+    <path d="M-10 -8 -1 0 -10 8" />
+    <path d="M3 8 13 8" />
   </Svg>
 );
-// auth — key
+// auth — a key with cut bits
 const DigiKey = (p: P) => (
   <Svg {...p}>
-    <circle cx="11" cy="12" r="5" /><path d="M14.5 15.5 25 26M21 22l3-3M24 25l3-3" />
+    <circle cx="-7" cy="-7" r="5.5" />
+    <path d="M-3 -3 11 11M7 7 11 3M9 9 13 5" />
   </Svg>
 );
-// observability — waveform crossed by span ticks
+// observability — offset trace spans, the lead span filled
 const DigiSmith = (p: P) => (
   <Svg {...p}>
-    <path d="M4 18l4-6 4 9 4-13 4 10 4-5 4 5" />
-    <path d="M8 24v3M16 24v3M24 24v3" opacity="0.7" />
+    <rect x="-13" y="-11" width="16" height="5.5" rx="2.75" fill="currentColor" stroke="none" />
+    <rect x="-5" y="-2" width="18" height="5.5" rx="2.75" />
+    <rect x="-10" y="7" width="13" height="5.5" rx="2.75" />
   </Svg>
 );
-// runtime — heartbeat in a ring
+// runtime — a heartbeat closed in a ring (always-on, on an interval)
 const DigiClaw = (p: P) => (
   <Svg {...p}>
-    <circle cx="16" cy="16" r="12" />
-    <path d="M7 16h4l2-4 3 8 2-4h7" />
+    <circle cx="0" cy="0" r="12" />
+    <path d="M-8 0 -3 0 -1 -6 2 6 4 0 8 0" />
   </Svg>
 );
-// library — stacked bars
+// library — stacked layers on a filled base (the foundation everything builds on)
 const DigiBase = (p: P) => (
   <Svg {...p}>
-    <path d="M10 8h12M7 16h18M5 24h22" />
+    <rect x="-14" y="-11" width="28" height="5.5" rx="2" />
+    <rect x="-14" y="-3" width="28" height="5.5" rx="2" />
+    <rect x="-14" y="5" width="28" height="5.5" rx="2" fill="currentColor" stroke="none" />
   </Svg>
 );
-// storage (roadmap) — DB cylinder + swap arrow
+// storage (roadmap) — a database cylinder
 const DigiStore = (p: P) => (
   <Svg {...p}>
-    <ellipse cx="16" cy="9" rx="9" ry="3.2" /><path d="M7 9v14c0 1.8 4 3.2 9 3.2s9-1.4 9-3.2V9" />
-    <path d="M12 16h8M18 13l3 3-3 3" opacity="0.8" />
+    <ellipse cx="0" cy="-9" rx="12" ry="3.5" />
+    <path d="M-12 -9 -12 9c0 2 5.4 3.5 12 3.5s12 -1.5 12 -3.5V-9" />
   </Svg>
 );
-// link (roadmap) — interlocking links bridging a gap
+// link (roadmap) — two interlocking rings, one tinted (protocol bridge)
 const DigiLink = (p: P) => (
   <Svg {...p}>
-    <path d="M13 10a5 5 0 0 0 0 12h2M19 10h2a5 5 0 0 1 0 12" /><path d="M12 16h8" />
+    <circle cx="-5" cy="0" r="7.5" />
+    <circle cx="5" cy="0" r="7.5" fill="currentColor" fillOpacity="0.16" />
   </Svg>
 );
-// subsystems
+// subsystems — research scheduler (globe), signal messenger (send), execution timing (clock)
 const Atlas = (p: P) => (
   <Svg {...p}>
-    <circle cx="16" cy="16" r="11" /><path d="M16 5c4 3 4 19 0 22M16 5c-4 3-4 19 0 22M5.5 13h21M5.5 19h21" opacity="0.85" />
+    <circle cx="0" cy="0" r="12" />
+    <path d="M0 -12a5 12 0 0 0 0 24a5 12 0 0 0 0 -24" />
+    <path d="M-12 0 12 0" />
   </Svg>
 );
 const Hermes = (p: P) => (
   <Svg {...p}>
-    <path d="M6 22l14-12M20 10h-6M20 10v6" /><path d="M6 14l5-4M9 26l4-4" opacity="0.7" />
+    <path d="M-11 11 11 -11" />
+    <path d="M11 -11 3 -11M11 -11 11 -3" />
+    <circle cx="-11" cy="11" r="1.6" fill="currentColor" stroke="none" />
   </Svg>
 );
 const Kairos = (p: P) => (
   <Svg {...p}>
-    <path d="M8 6v20M24 6v20" /><path d="M8 11h16M8 16h16M8 21h16" opacity="0.85" />
+    <circle cx="0" cy="0" r="12" />
+    <path d="M0 0 0 -7M0 0 5 3" />
+    <circle cx="0" cy="0" r="1.6" fill="currentColor" stroke="none" />
   </Svg>
 );
 
@@ -118,5 +134,12 @@ export const emblems: Record<string, (p: P) => React.ReactNode> = {
 export function Emblem({ id, size = 32, className }: { id: string; size?: number; className?: string }) {
   const E = emblems[id];
   if (!E) return null;
-  return <span className={className} style={{ display: "inline-flex", color: "var(--accent)" }}>{E({ size })}</span>;
+  // Per-module accent (--accent-<id>, defined at :root in tokens.css), falling back
+  // to the page accent. The platform accent is neutralized on digithings.ai, but the
+  // per-module tokens keep their colour, so emblems carry the module's own hue.
+  return (
+    <span className={className} style={{ display: "inline-flex", color: `var(--accent-${id}, var(--accent))` }}>
+      {E({ size })}
+    </span>
+  );
 }

--- a/frontend/web/src/data/modules.ts
+++ b/frontend/web/src/data/modules.ts
@@ -1,7 +1,7 @@
 /**
  * Single source of truth for DigiThings modules — drives the landing cards,
  * the architecture/scrollytelling graph, the per-module detail pages, and the
- * stack rows. Content is codebase-accurate (real packages, ports, docker
+ * stack rows. Content is codebase-accurate (real packages, docker
  * commands, init snippets). DigiStore/DigiLink are tier "roadmap".
  */
 
@@ -19,7 +19,6 @@ export interface ModuleNode {
   id: string;
   name: string;
   tier: Tier;
-  port: string | null;
   graphOrder: number;
   graph: { x: number; y: number; r: number; hub?: boolean };
   emblem: string;
@@ -56,7 +55,6 @@ export const modules: ModuleNode[] = [
     id: "digigraph",
     name: "digigraph",
     tier: "core",
-    port: "8000",
     graphOrder: 0,
     graph: { x: 460, y: 280, r: 34, hub: true },
     emblem: "digigraph",
@@ -77,11 +75,11 @@ export const modules: ModuleNode[] = [
     dockerCmd: "docker compose up -d digigraph",
     initSnippet: {
       lang: "python",
-      code: "from digigraph.server import app\n# uvicorn digigraph.server:app --port 8000",
+      code: "from digigraph.server import app\n# uvicorn digigraph.server:app",
     },
     api: [
-      { label: "Run a workflow", code: "POST /v1/workflow" },
-      { label: "Register a tool", code: "POST /v1/orchestrator_tools" },
+      { label: "Run a workflow", code: "POST /workflow" },
+      { label: "Chat completions", code: "POST /v1/chat/completions" },
     ],
     links: [{ label: "Source", href: "https://github.com/digithings-ai" }],
     related: ["digiquant", "digisearch", "digichat"],
@@ -90,7 +88,6 @@ export const modules: ModuleNode[] = [
     id: "digiquant",
     name: "digiquant",
     tier: "core",
-    port: "8001",
     graphOrder: 1,
     graph: { x: 300, y: 175, r: 26 },
     emblem: "digiquant",
@@ -124,7 +121,6 @@ export const modules: ModuleNode[] = [
     id: "digisearch",
     name: "digisearch",
     tier: "core",
-    port: "8002",
     graphOrder: 2,
     graph: { x: 620, y: 175, r: 26 },
     emblem: "digisearch",
@@ -155,7 +151,6 @@ export const modules: ModuleNode[] = [
     id: "digichat",
     name: "digichat",
     tier: "core",
-    port: "3005",
     graphOrder: 3,
     graph: { x: 460, y: 440, r: 26 },
     emblem: "digichat",
@@ -176,7 +171,7 @@ export const modules: ModuleNode[] = [
     dockerCmd: "docker compose --profile digichat up -d",
     initSnippet: {
       lang: "bash",
-      code: "make up-digichat   # DigiGraph + DigiChat on :3005\n# visit http://localhost:3005",
+      code: "make up-digichat   # start the chat stack\n# then open the local URL it prints",
     },
     api: [{ label: "Stream a turn", code: "streamText({ model, messages })" }],
     links: [
@@ -189,7 +184,6 @@ export const modules: ModuleNode[] = [
     id: "digikey",
     name: "digikey",
     tier: "support",
-    port: "8005",
     graphOrder: 4,
     graph: { x: 150, y: 120, r: 20 },
     emblem: "digikey",
@@ -220,7 +214,6 @@ export const modules: ModuleNode[] = [
     id: "digismith",
     name: "digismith",
     tier: "support",
-    port: "8003",
     graphOrder: 5,
     graph: { x: 95, y: 300, r: 20 },
     emblem: "digismith",
@@ -249,7 +242,6 @@ export const modules: ModuleNode[] = [
     id: "digiclaw",
     name: "digiclaw",
     tier: "support",
-    port: null,
     graphOrder: 6,
     graph: { x: 250, y: 475, r: 20 },
     emblem: "digiclaw",
@@ -273,7 +265,6 @@ export const modules: ModuleNode[] = [
     id: "digibase",
     name: "digibase",
     tier: "support",
-    port: null,
     graphOrder: 7,
     graph: { x: 670, y: 475, r: 20 },
     emblem: "digibase",
@@ -302,7 +293,6 @@ export const modules: ModuleNode[] = [
     id: "digistore",
     name: "digistore",
     tier: "roadmap",
-    port: null,
     graphOrder: 8,
     graph: { x: 770, y: 120, r: 20 },
     emblem: "digistore",
@@ -328,7 +318,6 @@ export const modules: ModuleNode[] = [
     id: "digilink",
     name: "digilink",
     tier: "roadmap",
-    port: null,
     graphOrder: 9,
     graph: { x: 825, y: 300, r: 20 },
     emblem: "digilink",

--- a/scripts/gen-api-vault.ts
+++ b/scripts/gen-api-vault.ts
@@ -1,0 +1,91 @@
+/**
+ * Generate DigiVault notes for the API reference.
+ *
+ * Reads the same authored content + serializers that drive the /docs page
+ * (single source of truth) and writes one Obsidian-style markdown note per
+ * module and per guide into `docs/vision/api/`. The existing production sync
+ * (`scripts/sync_architecture_vault.py`, triggered on push to main when
+ * `docs/vision/**` changes) then upserts them into Supabase `architecture_notes`,
+ * so the digithings.ai chat can search and cite the API docs.
+ *
+ * Run from the repo root:  node_modules/.bin/tsx scripts/gen-api-vault.ts
+ * (Re-run whenever apiDocs.ts / sharedDocs.ts change; commit the output.)
+ */
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { modules } from "../frontend/web/src/data/modules";
+import { guides } from "../frontend/digithings-web/lib/sharedDocs";
+import { guideToMarkdown, moduleToMarkdown } from "../frontend/digithings-web/lib/docsSerializers";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const OUT_DIR = `${ROOT}docs/vision/api`;
+const CREATED = new Date().toISOString().slice(0, 10);
+
+/** One-line summaries for the guide notes (the curated tagline becomes FTS weight B). */
+const GUIDE_SUMMARY: Record<string, string> = {
+  "getting-started": "Run the digithings stack locally — prerequisites, compose, environment, and make targets.",
+  authentication: "Issue and use digikey JWTs across the stack — mint a key, exchange for a token, call a service.",
+  conventions: "Shared HTTP conventions across services — liveness, error envelope, correlation IDs, rate limits, CORS.",
+};
+
+/** A related module per guide, so the note isn't an orphan (allow_orphans: false). */
+const GUIDE_LINK: Record<string, string> = {
+  "getting-started": "digigraph",
+  authentication: "digikey",
+  conventions: "digibase",
+};
+
+function frontmatter(fields: { title: string; tags: string[]; relevance?: string[] }): string {
+  const lines = [
+    "---",
+    `title: "${fields.title}"`,
+    "type: reference",
+    "status: generated",
+    `created: ${CREATED}`,
+    "tags:",
+    ...fields.tags.map((t) => `  - ${t}`),
+  ];
+  if (fields.relevance?.length) {
+    lines.push("relevance:", ...fields.relevance.map((r) => `  - ${r}`));
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/** Site-relative links (e.g. [Open digichat](/chat)) are app routes, not vault
+ * paths — absolutize them so they resolve and the doc-link checker skips them. */
+function absolutizeLinks(md: string): string {
+  return md.replace(/\]\(\/(?!\/)/g, "](https://digithings.ai/");
+}
+
+function write(stem: string, body: string): string {
+  const path = `${OUT_DIR}/${stem}.md`;
+  writeFileSync(path, body.endsWith("\n") ? body : body + "\n", "utf8");
+  return `docs/vision/api/${stem}.md`;
+}
+
+// Fresh directory each run so deletions/renames don't leave orphans behind.
+if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+const written: string[] = [];
+
+// Guide notes
+for (const g of guides) {
+  const summary = GUIDE_SUMMARY[g.id] ?? g.title;
+  const md = absolutizeLinks(guideToMarkdown(g).replace(/^## .*\n+/, "")); // drop the leading "## Title"
+  const link = GUIDE_LINK[g.id];
+  const seeAlso = link ? `\n\nSee also [[${link}]].` : "";
+  const body = `${frontmatter({ title: `${g.title} — guide`, tags: ["api", "guide"] })}# ${g.title}\n\n> ${summary}\n\n${md}${seeAlso}\n`;
+  written.push(write(`guide-${g.id}`, body));
+}
+
+// Module notes — reuse moduleToMarkdown; retitle the H1 as an API-reference note.
+for (const m of modules) {
+  const md = absolutizeLinks(moduleToMarkdown(m).replace(`# ${m.id}\n`, `# ${m.id} — API reference\n`));
+  const body = `${frontmatter({ title: `${m.id} — API reference`, tags: ["api", m.tier], relevance: [m.id] })}${md}\nSee also [[${m.id}]].\n`;
+  written.push(write(`${m.id}-api`, body));
+}
+
+console.log(`Wrote ${written.length} API notes to docs/vision/api/:`);
+written.forEach((p) => console.log(`  ${p}`));


### PR DESCRIPTION
## Promote develop → main

Brings the two new content changes on `develop` up to `main`:

- **#1166** — full `/docs` API reference (shared guides + per-module endpoints with curl/Python/TypeScript examples), redesigned module emblems, neutral platform palette, zero hardcoded ports.
- **#1168** — sync the API reference into DigiVault (`docs/vision/api/` notes → `architecture_notes` via the production vault sync), so the chat can cite the docs.

All checks were green on both PRs into develop. Promoting publishes the static sites (Cloudflare Pages) and, via the `sync-architecture-vault` workflow that runs on push to main, upserts the new API notes into Supabase.

Closes #1167
