### PR TITLE
feat(digithings-web): BYOK keys, model picker, quota nudge

### DIFF
--- a/frontend/digiquant-web/app/_nav.tsx
+++ b/frontend/digiquant-web/app/_nav.tsx
@@ -8,6 +8,8 @@
  */
 import { type NavLink } from "@digithings/web";
 
+export const DQ_CONTACT_EMAIL = "contact@digiquant.io";
+
 // Transparent QR marks (no opaque tile): dark modules for light theme, light
 // modules for dark theme. CSS shows the one matching [data-theme]. (Two <img>s
 // rather than a CSS mask — mask-image proved unreliable here.)

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -1,5 +1,5 @@
 import { Footer, Reveal } from "@digithings/web";
-import { DQ_FOOTER, DQ_FOOTER_META } from "./_nav";
+import { DQ_CONTACT_EMAIL, DQ_FOOTER, DQ_FOOTER_META } from "./_nav";
 import { DqNav } from "@/components/landing/DqNav";
 import { HeroMesh } from "@/components/landing/HeroMesh";
 import { PipelineScene } from "@/components/landing/PipelineScene";
@@ -98,7 +98,7 @@ export default function Home() {
                   <li>Priority fixes + roadmap input</li>
                   <li>Optional on-prem deployment</li>
                 </ul>
-                <a className="btn btn-primary" href="mailto:hello@digithings.ai">
+                <a className="btn btn-primary" href={`mailto:${DQ_CONTACT_EMAIL}`}>
                   Get in touch <span aria-hidden="true">→</span>
                 </a>
               </Reveal>

--- a/frontend/digiquant-web/app/pricing/page.tsx
+++ b/frontend/digiquant-web/app/pricing/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Footer, Reveal } from "@digithings/web";
-import { DQ_FOOTER, DQ_FOOTER_META } from "../_nav";
+import { DQ_CONTACT_EMAIL, DQ_FOOTER, DQ_FOOTER_META } from "../_nav";
 import { DqNav } from "@/components/landing/DqNav";
 import { AmbientMesh } from "@/components/landing/AmbientMesh";
 
@@ -80,7 +80,7 @@ export default function PricingPage() {
                     <li key={f}>{f}</li>
                   ))}
                 </ul>
-                <a className="btn btn-primary" href="mailto:hello@digithings.ai?subject=Managed%20Olympus">
+                <a className="btn btn-primary" href={`mailto:${DQ_CONTACT_EMAIL}?subject=Managed%20Olympus`}>
                   Get in touch <span aria-hidden="true">→</span>
                 </a>
               </Reveal>
@@ -89,7 +89,7 @@ export default function PricingPage() {
             <Reveal>
               <p className="dq-built" style={{ textAlign: "center", marginTop: "2.4rem" }}>
                 Not sure which fits? Start self-managed — it&rsquo;s the full product — and{" "}
-                <a href="mailto:hello@digithings.ai?subject=Managed%20Olympus">get in touch</a> if you
+                <a href={`mailto:${DQ_CONTACT_EMAIL}?subject=Managed%20Olympus`}>get in touch</a> if you
                 later want it managed.
               </p>
             </Reveal>

--- a/frontend/digiquant/index.html
+++ b/frontend/digiquant/index.html
@@ -132,7 +132,7 @@
                     <h3>Managed Atlas</h3>
                     <p class="price">contact</p>
                     <ul><li>Managed Atlas runner with SLA</li><li>Custom strategy onboarding</li><li>Priority fixes + roadmap input</li><li>Optional on-prem deployment</li></ul>
-                    <a class="btn btn-primary" href="mailto:hello@digithings.ai">Get in touch <span aria-hidden="true">→</span></a>
+                    <a class="btn btn-primary" href="mailto:contact@digiquant.io">Get in touch <span aria-hidden="true">→</span></a>
                 </article>
             </div>
         </div>

--- a/frontend/digithings-web/app/_nav.tsx
+++ b/frontend/digithings-web/app/_nav.tsx
@@ -7,6 +7,8 @@
  */
 import { type NavLink } from "@digithings/web";
 
+export const DT_CONTACT_EMAIL = "digithings.ai@proton.me";
+
 // Transparent, theme-inverted QR mark: near-black modules in light mode,
 // white modules in dark mode (no tile/background). CSS shows the one matching
 // [data-theme]; two <img>s avoid the Lightning-CSS mask-image drop.
@@ -33,12 +35,14 @@ export const DT_NAV: NavLink[] = [
 export const DT_NAV_PRIMARY: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
   { label: "Docs", href: "/docs" },
+  { label: "Contact", href: "/#contact" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
 ];
 
 export const DT_FOOTER: NavLink[] = [
   { label: "Architecture", href: "/#architecture" },
   { label: "Docs", href: "/docs" },
+  { label: "Contact", href: "/#contact" },
   { label: "digichat", href: "/chat" },
   { label: "digiquant.io", href: "https://digiquant.io", external: true },
   { label: "GitHub", href: "https://github.com/digithings-ai", external: true },

--- a/frontend/digithings-web/app/_nav.tsx
+++ b/frontend/digithings-web/app/_nav.tsx
@@ -7,7 +7,7 @@
  */
 import { type NavLink } from "@digithings/web";
 
-export const DT_CONTACT_EMAIL = "digithings.ai@proton.me";
+export const DT_CONTACT_EMAIL = "contact@digithings.ai";
 
 // Transparent, theme-inverted QR mark: near-black modules in light mode,
 // white modules in dark mode (no tile/background). CSS shows the one matching

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -239,6 +239,9 @@ html { scroll-behavior: smooth; }
 .dc-bar.is-collapsed { max-height: 0; padding: 0; opacity: 0; }
 .dc-bar-meta { color: var(--ink-mute); }
 .dc-bar-model { margin-left: auto; font-size: 0.72rem; color: var(--ink-soft); }
+.dc-bar-key { font: inherit; font-size: 0.72rem; color: var(--ink-mute); background: transparent; border: 1px solid var(--hair); border-radius: 999px; padding: 0.1rem 0.45rem; cursor: pointer; margin-left: auto; transition: color 0.18s var(--ease), border-color 0.18s var(--ease); }
+.dc-bar-key:hover { color: var(--ink-soft); border-color: color-mix(in srgb, var(--ink) 25%, var(--hair)); }
+.dc-bar-model { margin-left: 0.5rem; }
 .dc-bar-toggle { align-self: flex-start; margin: 0 0 0.2rem; font: inherit; font-size: 0.7rem; color: var(--ink-mute); background: transparent; border: 0; cursor: pointer; padding: 0.1rem 0; letter-spacing: 0.04em; }
 .dc-bar-toggle:hover { color: var(--ink-soft); }
 @media (prefers-reduced-motion: reduce) { .dc-bar { transition: none; } }
@@ -315,6 +318,37 @@ html { scroll-behavior: smooth; }
 .dc-act-reasoning { margin: 0.15rem 0 0; }
 .dc-act-reasoning summary { cursor: pointer; color: var(--ink-mute); font-weight: 500; }
 .dc-act-reasoning pre { margin: 0.35rem 0 0; max-height: 10rem; overflow: auto; white-space: pre-wrap; color: var(--ink-mute); font-size: 0.9em; }
+
+/* BYOK settings + quota nudge */
+.dc-inline-link { font: inherit; font-size: inherit; color: var(--accent); background: none; border: 0; padding: 0; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+.dc-inline-link:hover { color: var(--ink); }
+.dc-intro-byok { display: inline; margin: 0; color: var(--ink-mute); }
+.dc-quota-banner { margin: 0.2rem 0 0 1.6rem; padding: 0.45rem 0.65rem; border: 1px solid color-mix(in srgb, #e5484d 35%, var(--hair)); border-radius: 8px; background: color-mix(in srgb, #e5484d 8%, transparent); font-size: 0.74rem; color: var(--ink-soft); }
+.dc-quota-banner p { margin: 0; }
+.dc-settings-backdrop { position: fixed; inset: 0; z-index: 80; background: color-mix(in srgb, var(--bg) 35%, transparent); backdrop-filter: blur(4px); display: flex; justify-content: flex-end; }
+.dc-settings-panel { width: min(22rem, 92vw); height: 100%; overflow-y: auto; padding: 1rem 1rem 1.25rem; background: var(--surface); border-left: 1px solid var(--hair); box-shadow: -8px 0 24px color-mix(in srgb, var(--ink) 8%, transparent); font-family: var(--font-mono); font-size: 0.78rem; }
+.dc-settings-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.75rem; }
+.dc-settings-title { margin: 0; font-size: 0.9rem; font-weight: 600; color: var(--ink); }
+.dc-settings-close { font: inherit; font-size: 1.2rem; line-height: 1; color: var(--ink-mute); background: transparent; border: 0; cursor: pointer; padding: 0.1rem 0.35rem; }
+.dc-settings-close:hover { color: var(--ink); }
+.dc-settings-note { margin: 0 0 1rem; padding: 0.5rem 0.6rem; border: 1px solid var(--hair); border-radius: 8px; background: color-mix(in srgb, var(--ink) 4%, transparent); color: var(--ink-mute); line-height: 1.45; font-size: 0.72rem; }
+.dc-settings-field { margin-bottom: 0.85rem; }
+.dc-settings-label { display: block; margin-bottom: 0.35rem; font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-mute); }
+.dc-settings-providers { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.dc-settings-provider { font: inherit; font-size: 0.72rem; color: var(--ink-soft); background: transparent; border: 1px solid var(--hair); border-radius: 6px; padding: 0.2rem 0.45rem; cursor: pointer; }
+.dc-settings-provider.is-active { color: var(--ink); border-color: color-mix(in srgb, var(--ink) 30%, var(--hair)); background: color-mix(in srgb, var(--ink) 6%, transparent); }
+.dc-settings-keyrow { display: flex; gap: 0.35rem; align-items: center; }
+.dc-settings-input, .dc-settings-select { flex: 1; font: inherit; font-size: 0.76rem; color: var(--ink); background: color-mix(in srgb, var(--ink) 4%, transparent); border: 1px solid var(--hair); border-radius: 6px; padding: 0.35rem 0.5rem; width: 100%; }
+.dc-settings-input:focus, .dc-settings-select:focus { outline: 1px solid color-mix(in srgb, var(--ink) 25%, transparent); outline-offset: 1px; }
+.dc-settings-ghost, .dc-settings-primary { font: inherit; font-size: 0.72rem; border-radius: 6px; padding: 0.28rem 0.55rem; cursor: pointer; border: 1px solid var(--hair); }
+.dc-settings-ghost { color: var(--ink-soft); background: transparent; }
+.dc-settings-ghost:hover:not(:disabled) { color: var(--ink); }
+.dc-settings-ghost:disabled { opacity: 0.45; cursor: default; }
+.dc-settings-primary { color: var(--on-accent); background: var(--accent); border-color: var(--accent); }
+.dc-settings-primary:hover { opacity: 0.92; }
+.dc-settings-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+.dc-settings-error { margin: 0.35rem 0 0; font-size: 0.72rem; color: color-mix(in srgb, #e5484d 80%, var(--ink)); }
+.dc-settings-test-ok { margin: 0.35rem 0 0; font-size: 0.72rem; color: color-mix(in srgb, #30a46c 75%, var(--ink)); }
 
 /* ---- /docs API reference (DocsLayout.tsx) — sidebar + per-module doc pages +
    copy-as-Markdown, generated from the shared module data. Terminal-consistent. */

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -109,6 +109,29 @@
 /* anchor-scroll to the architecture section clears the fixed nav + animates */
 html { scroll-behavior: smooth; }
 #architecture { scroll-margin-top: calc(var(--dq-nav-h) + 1.5rem); }
+#contact { scroll-margin-top: calc(var(--dq-nav-h) + 1.5rem); }
+
+/* closing contact CTA */
+.dqcta { text-align: center; }
+.dqcta .dq-sub { margin-inline: auto; }
+.dqcta-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 2rem;
+}
+.dt-contact-email {
+  margin-top: 1.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  color: var(--ink-mute);
+}
+.dt-contact-email a {
+  color: var(--accent);
+  text-underline-offset: 2px;
+}
+.dt-contact-email a:hover { color: var(--ink); }
 @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
 
 /* push subpage content (no full-bleed hero) clear of the fixed nav; relative so

--- a/frontend/digithings-web/app/page.tsx
+++ b/frontend/digithings-web/app/page.tsx
@@ -1,5 +1,5 @@
 import { Footer, Reveal } from "@digithings/web";
-import { DT_FOOTER, DT_FOOTER_META } from "./_nav";
+import { DT_CONTACT_EMAIL, DT_FOOTER, DT_FOOTER_META } from "./_nav";
 import { DigiNav } from "@/components/landing/DigiNav";
 import { HeroMesh } from "@/components/landing/HeroMesh";
 import { ModuleManifest } from "@/components/landing/ModuleManifest";
@@ -58,6 +58,34 @@ export default function Home() {
               <Reveal className="principle"><span className="principle-num">04</span><h3>Backend-swappable</h3><p>Swap vector DB or storage backend without touching business code.</p></Reveal>
             </div>
           </div>
+        </section>
+
+        <section className="section dqcta" id="contact">
+          <Reveal className="wrap">
+            <div className="dq-eyebrow">Contact</div>
+            <h2 className="dq-title">Questions, enterprise, or partnership.</h2>
+            <p className="dq-sub">
+              The stack is open core — reach out for managed deployments, on-prem setups, or
+              anything else about the platform.
+            </p>
+            <div className="dqcta-actions">
+              <a
+                className="btn btn-primary"
+                href={`mailto:${DT_CONTACT_EMAIL}?subject=DigiThings%20inquiry`}
+              >
+                Email us <span aria-hidden="true">→</span>
+              </a>
+              <a
+                className="btn btn-ghost"
+                href={`mailto:${DT_CONTACT_EMAIL}?subject=DigiThings%20enterprise`}
+              >
+                Enterprise
+              </a>
+            </div>
+            <p className="dt-contact-email">
+              <a href={`mailto:${DT_CONTACT_EMAIL}`}>{DT_CONTACT_EMAIL}</a>
+            </p>
+          </Reveal>
         </section>
       </main>
 

--- a/frontend/digithings-web/components/DigiChatSession.tsx
+++ b/frontend/digithings-web/components/DigiChatSession.tsx
@@ -6,10 +6,14 @@ import { MiniMarkdown } from "@/lib/miniMarkdown";
 import { CopyButton } from "@/lib/CopyButton";
 import { DigiChatWordmark } from "@/components/DigiChatMark";
 import { ChatActivities } from "@/components/ChatActivities";
+import { ProviderSettings } from "@/components/ProviderSettings";
+import { providerSummary, useProviderSettings } from "@/lib/providerSettings";
 
 const INTRO = `digichat — the assistant for the digithings stack.
 
-Ask about the architecture: how the modules fit together, how it's built, how it runs. I search digivault (the docs) before answering, so I cite real docs rather than guess. Running on OpenRouter's free model pool — no key needed.
+Ask about the architecture: how the modules fit together, how it's built, how it runs. I search digivault (the docs) before answering, so I cite real docs rather than guess.
+
+Free tier uses OpenRouter's model pool — no key needed. Or bring your own key (OpenRouter, OpenAI, Anthropic, Gemini) for any model.
 
 Try asking for a diagram of a pipeline.`;
 
@@ -21,12 +25,20 @@ const SUGGESTIONS = [
 ];
 
 export function DigiChatSession() {
-  const { messages, busy, error, send, stop, seed } = useStackChat();
+  const provider = useProviderSettings();
+  const { messages, busy, error, quotaPrompt, send, stop, seed, clearQuotaPrompt } =
+    useStackChat([], provider);
   const [input, setInput] = useState("");
   const [intro, setIntro] = useState("");
   const [barOpen, setBarOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const threadRef = useRef<HTMLDivElement>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
+
+  const openSettings = () => {
+    clearQuotaPrompt();
+    setSettingsOpen(true);
+  };
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
@@ -56,7 +68,7 @@ export function DigiChatSession() {
   useEffect(() => {
     const el = threadRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages, busy, intro]);
+  }, [messages, busy, intro, quotaPrompt]);
 
   function submit(question: string) {
     const q = question.trim();
@@ -74,6 +86,7 @@ export function DigiChatSession() {
   }
 
   const introDone = intro.length >= INTRO.length;
+  const modelLabel = providerSummary(provider);
 
   return (
     <section className="dc-session" aria-label="digichat">
@@ -87,7 +100,10 @@ export function DigiChatSession() {
       </button>
       <div className={`dc-bar${barOpen ? "" : " is-collapsed"}`} aria-hidden={!barOpen}>
         <span className="dc-bar-meta">vault-grounded · agentic · streams live</span>
-        <span className="dc-bar-model">model: free pool</span>
+        <button type="button" className="dc-bar-key" onClick={openSettings}>
+          {provider.isSet ? "key ✓" : "bring your own key"}
+        </button>
+        <span className="dc-bar-model">model: {modelLabel}</span>
       </div>
 
       <div className="dc-thread" ref={threadRef} aria-live="polite" aria-atomic="false">
@@ -98,6 +114,15 @@ export function DigiChatSession() {
           <div className="dc-body dc-intro-body">
             {intro}
             {!introDone && <span className="dt-cur" />}
+            {introDone && !provider.isSet ? (
+              <p className="dc-intro-byok">
+                {" "}
+                <button type="button" className="dc-inline-link" onClick={openSettings}>
+                  Bring your own API key
+                </button>{" "}
+                to use any provider.
+              </p>
+            ) : null}
           </div>
         </div>
 
@@ -145,9 +170,28 @@ export function DigiChatSession() {
           );
         })}
 
+        {quotaPrompt && !provider.isSet ? (
+          <div className="dc-quota-banner" role="status">
+            <p>
+              Free tier quota may be exhausted.{" "}
+              <button type="button" className="dc-inline-link" onClick={openSettings}>
+                Continue with your own key
+              </button>
+            </p>
+          </div>
+        ) : null}
+
         {error && (
           <p className="dtc-error" role="alert">
             {error}
+            {!provider.isSet ? (
+              <>
+                {" "}
+                <button type="button" className="dc-inline-link" onClick={openSettings}>
+                  Add your API key
+                </button>
+              </>
+            ) : null}
           </p>
         )}
       </div>
@@ -189,6 +233,17 @@ export function DigiChatSession() {
           </button>
         )}
       </form>
+
+      <ProviderSettings
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        apiKey={provider.apiKey}
+        provider={provider.provider}
+        model={provider.model}
+        isSet={provider.isSet}
+        onSave={provider.save}
+        onClear={provider.clear}
+      />
     </section>
   );
 }

--- a/frontend/digithings-web/components/ProviderSettings.tsx
+++ b/frontend/digithings-web/components/ProviderSettings.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  PROVIDER_LABELS,
+  PROVIDER_MODELS,
+  type ProviderId,
+  validateProviderKey,
+} from "@/lib/providerSettings";
+
+type TestResult = { ok: boolean; model?: string; error?: string } | null;
+
+export function ProviderSettings({
+  open,
+  onClose,
+  apiKey: storedKey,
+  provider: storedProvider,
+  model: storedModel,
+  isSet,
+  onSave,
+  onClear,
+}: {
+  open: boolean;
+  onClose: () => void;
+  apiKey: string;
+  provider: ProviderId;
+  model: string;
+  isSet: boolean;
+  onSave: (key: string, provider: ProviderId, model: string) => void;
+  onClear: () => void;
+}) {
+  const [inputKey, setInputKey] = useState(storedKey);
+  const [inputProvider, setInputProvider] = useState<ProviderId>(storedProvider);
+  const [inputModel, setInputModel] = useState(storedModel);
+  const [showKey, setShowKey] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<TestResult>(null);
+  const [testing, setTesting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setInputKey(storedKey);
+    setInputProvider(storedProvider);
+    setInputModel(storedModel);
+    setValidationError(null);
+    setTestResult(null);
+    setShowKey(false);
+  }, [open, storedKey, storedProvider, storedModel]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const handleProviderChange = useCallback((p: ProviderId) => {
+    setInputProvider(p);
+    setInputModel(PROVIDER_MODELS[p][0]?.id ?? "");
+    setTestResult(null);
+    if (inputKey) setValidationError(validateProviderKey(inputKey, p));
+    else setValidationError(null);
+  }, [inputKey]);
+
+  const handleTest = useCallback(async () => {
+    const err = validateProviderKey(inputKey, inputProvider);
+    if (err) {
+      setValidationError(err);
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const resp = await fetch("/api/byok/test", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-BYOK-Key": inputKey,
+          "X-BYOK-Provider": inputProvider,
+        },
+        body: JSON.stringify({}),
+      });
+      setTestResult((await resp.json()) as TestResult);
+    } catch {
+      setTestResult({ ok: false, error: "Network error — could not reach server." });
+    } finally {
+      setTesting(false);
+    }
+  }, [inputKey, inputProvider]);
+
+  const handleSave = useCallback(() => {
+    const err = validateProviderKey(inputKey, inputProvider);
+    if (err) {
+      setValidationError(err);
+      return;
+    }
+    onSave(inputKey, inputProvider, inputModel);
+    onClose();
+  }, [inputKey, inputProvider, inputModel, onSave, onClose]);
+
+  const handleClear = useCallback(() => {
+    onClear();
+    onClose();
+  }, [onClear, onClose]);
+
+  if (!open) return null;
+
+  const providers = Object.keys(PROVIDER_MODELS) as ProviderId[];
+
+  return (
+    <div className="dc-settings-backdrop" role="presentation" onClick={onClose}>
+      <aside
+        className="dc-settings-panel"
+        role="dialog"
+        aria-labelledby="dc-settings-title"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="dc-settings-head">
+          <h2 id="dc-settings-title" className="dc-settings-title">
+            Bring your own key
+          </h2>
+          <button type="button" className="dc-settings-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        <p className="dc-settings-note">
+          Your key stays in this browser only. It is sent per request to route your chat — never
+          stored on our servers.
+        </p>
+
+        <div className="dc-settings-field">
+          <span className="dc-settings-label">Provider</span>
+          <div className="dc-settings-providers">
+            {providers.map((p) => (
+              <button
+                key={p}
+                type="button"
+                className={`dc-settings-provider${inputProvider === p ? " is-active" : ""}`}
+                onClick={() => handleProviderChange(p)}
+              >
+                {PROVIDER_LABELS[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="dc-settings-field">
+          <label className="dc-settings-label" htmlFor="dc-byok-key">
+            API key
+          </label>
+          <div className="dc-settings-keyrow">
+            <input
+              id="dc-byok-key"
+              className="dc-settings-input"
+              type={showKey ? "text" : "password"}
+              value={inputKey}
+              onChange={(e) => {
+                setInputKey(e.target.value);
+                setValidationError(null);
+                setTestResult(null);
+              }}
+              onBlur={() => {
+                if (inputKey) setValidationError(validateProviderKey(inputKey, inputProvider));
+              }}
+              placeholder={
+                inputProvider === "openrouter"
+                  ? "sk-or-v1-…"
+                  : inputProvider === "anthropic"
+                    ? "sk-ant-…"
+                    : inputProvider === "gemini"
+                      ? "AI…"
+                      : "sk-…"
+              }
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              className="dc-settings-ghost"
+              onClick={() => setShowKey((v) => !v)}
+              aria-label={showKey ? "Hide key" : "Show key"}
+            >
+              {showKey ? "hide" : "show"}
+            </button>
+          </div>
+          {validationError ? (
+            <p className="dc-settings-error" role="alert">
+              {validationError}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="dc-settings-field">
+          <label className="dc-settings-label" htmlFor="dc-byok-model">
+            Model
+          </label>
+          <select
+            id="dc-byok-model"
+            className="dc-settings-select"
+            value={inputModel}
+            onChange={(e) => setInputModel(e.target.value)}
+          >
+            {PROVIDER_MODELS[inputProvider].map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {testResult ? (
+          <p
+            className={testResult.ok ? "dc-settings-test-ok" : "dc-settings-error"}
+            role="status"
+          >
+            {testResult.ok
+              ? `Key verified${testResult.model ? ` · ${testResult.model}` : ""}.`
+              : testResult.error}
+          </p>
+        ) : null}
+
+        <div className="dc-settings-actions">
+          <button
+            type="button"
+            className="dc-settings-ghost"
+            onClick={() => void handleTest()}
+            disabled={testing || !inputKey.trim()}
+          >
+            {testing ? "testing…" : "test key"}
+          </button>
+          <button type="button" className="dc-settings-primary" onClick={handleSave}>
+            {isSet ? "update" : "save"}
+          </button>
+          {isSet ? (
+            <button type="button" className="dc-settings-ghost" onClick={handleClear}>
+              use free pool
+            </button>
+          ) : null}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/digithings-web/components/ProviderSettings.tsx
+++ b/frontend/digithings-web/components/ProviderSettings.tsx
@@ -10,24 +10,22 @@ import {
 
 type TestResult = { ok: boolean; model?: string; error?: string } | null;
 
-export function ProviderSettings({
-  open,
-  onClose,
-  apiKey: storedKey,
-  provider: storedProvider,
-  model: storedModel,
+function ProviderSettingsForm({
+  storedKey,
+  storedProvider,
+  storedModel,
   isSet,
   onSave,
   onClear,
+  onClose,
 }: {
-  open: boolean;
-  onClose: () => void;
-  apiKey: string;
-  provider: ProviderId;
-  model: string;
+  storedKey: string;
+  storedProvider: ProviderId;
+  storedModel: string;
   isSet: boolean;
   onSave: (key: string, provider: ProviderId, model: string) => void;
   onClear: () => void;
+  onClose: () => void;
 }) {
   const [inputKey, setInputKey] = useState(storedKey);
   const [inputProvider, setInputProvider] = useState<ProviderId>(storedProvider);
@@ -37,32 +35,16 @@ export function ProviderSettings({
   const [testResult, setTestResult] = useState<TestResult>(null);
   const [testing, setTesting] = useState(false);
 
-  useEffect(() => {
-    if (!open) return;
-    setInputKey(storedKey);
-    setInputProvider(storedProvider);
-    setInputModel(storedModel);
-    setValidationError(null);
-    setTestResult(null);
-    setShowKey(false);
-  }, [open, storedKey, storedProvider, storedModel]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  const handleProviderChange = useCallback((p: ProviderId) => {
-    setInputProvider(p);
-    setInputModel(PROVIDER_MODELS[p][0]?.id ?? "");
-    setTestResult(null);
-    if (inputKey) setValidationError(validateProviderKey(inputKey, p));
-    else setValidationError(null);
-  }, [inputKey]);
+  const handleProviderChange = useCallback(
+    (p: ProviderId) => {
+      setInputProvider(p);
+      setInputModel(PROVIDER_MODELS[p][0]?.id ?? "");
+      setTestResult(null);
+      if (inputKey) setValidationError(validateProviderKey(inputKey, p));
+      else setValidationError(null);
+    },
+    [inputKey],
+  );
 
   const handleTest = useCallback(async () => {
     const err = validateProviderKey(inputKey, inputProvider);
@@ -105,9 +87,159 @@ export function ProviderSettings({
     onClose();
   }, [onClear, onClose]);
 
+  const providers = Object.keys(PROVIDER_MODELS) as ProviderId[];
+
+  return (
+    <>
+      <p className="dc-settings-note">
+        Your key stays in this browser only. It is sent per request to route your chat — never
+        stored on our servers.
+      </p>
+
+      <div className="dc-settings-field">
+        <span className="dc-settings-label">Provider</span>
+        <div className="dc-settings-providers">
+          {providers.map((p) => (
+            <button
+              key={p}
+              type="button"
+              className={`dc-settings-provider${inputProvider === p ? " is-active" : ""}`}
+              onClick={() => handleProviderChange(p)}
+            >
+              {PROVIDER_LABELS[p]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="dc-settings-field">
+        <label className="dc-settings-label" htmlFor="dc-byok-key">
+          API key
+        </label>
+        <div className="dc-settings-keyrow">
+          <input
+            id="dc-byok-key"
+            className="dc-settings-input"
+            type={showKey ? "text" : "password"}
+            value={inputKey}
+            onChange={(e) => {
+              setInputKey(e.target.value);
+              setValidationError(null);
+              setTestResult(null);
+            }}
+            onBlur={() => {
+              if (inputKey) setValidationError(validateProviderKey(inputKey, inputProvider));
+            }}
+            placeholder={
+              inputProvider === "openrouter"
+                ? "sk-or-v1-…"
+                : inputProvider === "anthropic"
+                  ? "sk-ant-…"
+                  : inputProvider === "gemini"
+                    ? "AI…"
+                    : "sk-…"
+            }
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            className="dc-settings-ghost"
+            onClick={() => setShowKey((v) => !v)}
+            aria-label={showKey ? "Hide key" : "Show key"}
+          >
+            {showKey ? "hide" : "show"}
+          </button>
+        </div>
+        {validationError ? (
+          <p className="dc-settings-error" role="alert">
+            {validationError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="dc-settings-field">
+        <label className="dc-settings-label" htmlFor="dc-byok-model">
+          Model
+        </label>
+        <select
+          id="dc-byok-model"
+          className="dc-settings-select"
+          value={inputModel}
+          onChange={(e) => setInputModel(e.target.value)}
+        >
+          {PROVIDER_MODELS[inputProvider].map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {testResult ? (
+        <p
+          className={testResult.ok ? "dc-settings-test-ok" : "dc-settings-error"}
+          role="status"
+        >
+          {testResult.ok
+            ? `Key verified${testResult.model ? ` · ${testResult.model}` : ""}.`
+            : testResult.error}
+        </p>
+      ) : null}
+
+      <div className="dc-settings-actions">
+        <button
+          type="button"
+          className="dc-settings-ghost"
+          onClick={() => void handleTest()}
+          disabled={testing || !inputKey.trim()}
+        >
+          {testing ? "testing…" : "test key"}
+        </button>
+        <button type="button" className="dc-settings-primary" onClick={handleSave}>
+          {isSet ? "update" : "save"}
+        </button>
+        {isSet ? (
+          <button type="button" className="dc-settings-ghost" onClick={handleClear}>
+            use free pool
+          </button>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+export function ProviderSettings({
+  open,
+  onClose,
+  apiKey: storedKey,
+  provider: storedProvider,
+  model: storedModel,
+  isSet,
+  onSave,
+  onClear,
+}: {
+  open: boolean;
+  onClose: () => void;
+  apiKey: string;
+  provider: ProviderId;
+  model: string;
+  isSet: boolean;
+  onSave: (key: string, provider: ProviderId, model: string) => void;
+  onClear: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
   if (!open) return null;
 
-  const providers = Object.keys(PROVIDER_MODELS) as ProviderId[];
+  const formKey = `${storedKey}:${storedProvider}:${storedModel}`;
 
   return (
     <div className="dc-settings-backdrop" role="presentation" onClick={onClose}>
@@ -127,120 +259,16 @@ export function ProviderSettings({
           </button>
         </header>
 
-        <p className="dc-settings-note">
-          Your key stays in this browser only. It is sent per request to route your chat — never
-          stored on our servers.
-        </p>
-
-        <div className="dc-settings-field">
-          <span className="dc-settings-label">Provider</span>
-          <div className="dc-settings-providers">
-            {providers.map((p) => (
-              <button
-                key={p}
-                type="button"
-                className={`dc-settings-provider${inputProvider === p ? " is-active" : ""}`}
-                onClick={() => handleProviderChange(p)}
-              >
-                {PROVIDER_LABELS[p]}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="dc-settings-field">
-          <label className="dc-settings-label" htmlFor="dc-byok-key">
-            API key
-          </label>
-          <div className="dc-settings-keyrow">
-            <input
-              id="dc-byok-key"
-              className="dc-settings-input"
-              type={showKey ? "text" : "password"}
-              value={inputKey}
-              onChange={(e) => {
-                setInputKey(e.target.value);
-                setValidationError(null);
-                setTestResult(null);
-              }}
-              onBlur={() => {
-                if (inputKey) setValidationError(validateProviderKey(inputKey, inputProvider));
-              }}
-              placeholder={
-                inputProvider === "openrouter"
-                  ? "sk-or-v1-…"
-                  : inputProvider === "anthropic"
-                    ? "sk-ant-…"
-                    : inputProvider === "gemini"
-                      ? "AI…"
-                      : "sk-…"
-              }
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <button
-              type="button"
-              className="dc-settings-ghost"
-              onClick={() => setShowKey((v) => !v)}
-              aria-label={showKey ? "Hide key" : "Show key"}
-            >
-              {showKey ? "hide" : "show"}
-            </button>
-          </div>
-          {validationError ? (
-            <p className="dc-settings-error" role="alert">
-              {validationError}
-            </p>
-          ) : null}
-        </div>
-
-        <div className="dc-settings-field">
-          <label className="dc-settings-label" htmlFor="dc-byok-model">
-            Model
-          </label>
-          <select
-            id="dc-byok-model"
-            className="dc-settings-select"
-            value={inputModel}
-            onChange={(e) => setInputModel(e.target.value)}
-          >
-            {PROVIDER_MODELS[inputProvider].map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {testResult ? (
-          <p
-            className={testResult.ok ? "dc-settings-test-ok" : "dc-settings-error"}
-            role="status"
-          >
-            {testResult.ok
-              ? `Key verified${testResult.model ? ` · ${testResult.model}` : ""}.`
-              : testResult.error}
-          </p>
-        ) : null}
-
-        <div className="dc-settings-actions">
-          <button
-            type="button"
-            className="dc-settings-ghost"
-            onClick={() => void handleTest()}
-            disabled={testing || !inputKey.trim()}
-          >
-            {testing ? "testing…" : "test key"}
-          </button>
-          <button type="button" className="dc-settings-primary" onClick={handleSave}>
-            {isSet ? "update" : "save"}
-          </button>
-          {isSet ? (
-            <button type="button" className="dc-settings-ghost" onClick={handleClear}>
-              use free pool
-            </button>
-          ) : null}
-        </div>
+        <ProviderSettingsForm
+          key={formKey}
+          storedKey={storedKey}
+          storedProvider={storedProvider}
+          storedModel={storedModel}
+          isSet={isSet}
+          onSave={onSave}
+          onClear={onClear}
+          onClose={onClose}
+        />
       </aside>
     </div>
   );

--- a/frontend/digithings-web/functions/api/byok/test.ts
+++ b/frontend/digithings-web/functions/api/byok/test.ts
@@ -1,0 +1,150 @@
+// Cloudflare Pages Function — POST /api/byok/test
+// Validates a BYOK key against the selected provider (no persistence).
+
+type ProviderId = "openrouter" | "openai" | "anthropic" | "gemini";
+
+interface EventContext {
+  request: Request;
+}
+
+type TestResult = { ok: boolean; model?: string; error?: string };
+
+const TIMEOUT_MS = 10_000;
+
+function jsonResponse(body: TestResult, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function validateKey(key: string, provider: ProviderId): string | null {
+  if (!key) return "API key is required.";
+  switch (provider) {
+    case "openrouter":
+      if (!key.startsWith("sk-or-")) return "OpenRouter keys start with sk-or-.";
+      break;
+    case "openai":
+      if (!key.startsWith("sk-")) return "OpenAI keys start with sk-.";
+      break;
+    case "anthropic":
+      if (!key.startsWith("sk-ant-")) return "Anthropic keys start with sk-ant-.";
+      break;
+    case "gemini":
+      if (!key.startsWith("AI")) return "Gemini keys start with AI.";
+      break;
+  }
+  return null;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function abortMessage(e: unknown): string {
+  if (e instanceof Error) {
+    return e.name === "AbortError" ? `Request timed out after ${TIMEOUT_MS / 1000} s.` : e.message;
+  }
+  return "Unknown error";
+}
+
+async function testOpenRouter(key: string): Promise<TestResult> {
+  const resp = await fetchWithTimeout("https://openrouter.ai/api/v1/models", {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!resp.ok) {
+    const body = (await resp.json().catch(() => ({}))) as { error?: { message?: string } };
+    return { ok: false, error: body.error?.message ?? `OpenRouter returned HTTP ${resp.status}` };
+  }
+  return { ok: true, model: "openai/gpt-4o-mini" };
+}
+
+async function testOpenAI(key: string): Promise<TestResult> {
+  const resp = await fetchWithTimeout("https://api.openai.com/v1/models", {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!resp.ok) {
+    const body = (await resp.json().catch(() => ({}))) as { error?: { message?: string } };
+    return { ok: false, error: body.error?.message ?? `OpenAI returned HTTP ${resp.status}` };
+  }
+  const data = (await resp.json()) as { data?: { id: string }[] };
+  return { ok: true, model: data.data?.[0]?.id ?? "gpt-4o-mini" };
+}
+
+async function testAnthropic(key: string): Promise<TestResult> {
+  const resp = await fetchWithTimeout("https://api.anthropic.com/v1/models", {
+    headers: { "x-api-key": key, "anthropic-version": "2023-06-01" },
+  });
+  if (!resp.ok) {
+    const body = (await resp.json().catch(() => ({}))) as { error?: { message?: string } };
+    return { ok: false, error: body.error?.message ?? `Anthropic returned HTTP ${resp.status}` };
+  }
+  const data = (await resp.json()) as { data?: { id: string }[] };
+  return { ok: true, model: data.data?.[0]?.id ?? "claude-3-5-haiku-20241022" };
+}
+
+async function testGemini(key: string): Promise<TestResult> {
+  const resp = await fetchWithTimeout(
+    `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
+  );
+  if (!resp.ok) {
+    const body = (await resp.json().catch(() => ({}))) as { error?: { message?: string } };
+    return { ok: false, error: body.error?.message ?? `Gemini returned HTTP ${resp.status}` };
+  }
+  return { ok: true, model: "gemini-2.5-flash" };
+}
+
+function sameSiteOK(request: Request): boolean {
+  const reqHost = new URL(request.url).hostname;
+  if (reqHost === "localhost" || reqHost === "127.0.0.1") return true;
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  try {
+    return new URL(origin).hostname === reqHost;
+  } catch {
+    return false;
+  }
+}
+
+export async function onRequestPost(ctx: EventContext): Promise<Response> {
+  if (!sameSiteOK(ctx.request)) {
+    return jsonResponse({ ok: false, error: "Cross-site requests are not allowed." }, 403);
+  }
+
+  const key = ctx.request.headers.get("x-byok-key")?.trim() ?? "";
+  const raw = ctx.request.headers.get("x-byok-provider")?.trim() ?? "openrouter";
+  const provider: ProviderId =
+    raw === "openai" || raw === "anthropic" || raw === "gemini" || raw === "openrouter"
+      ? raw
+      : "openrouter";
+
+  const validation = validateKey(key, provider);
+  if (validation) return jsonResponse({ ok: false, error: validation }, 400);
+
+  try {
+    let result: TestResult;
+    switch (provider) {
+      case "openrouter":
+        result = await testOpenRouter(key);
+        break;
+      case "openai":
+        result = await testOpenAI(key);
+        break;
+      case "anthropic":
+        result = await testAnthropic(key);
+        break;
+      case "gemini":
+        result = await testGemini(key);
+        break;
+    }
+    return jsonResponse(result, result.ok ? 200 : 400);
+  } catch (e) {
+    return jsonResponse({ ok: false, error: abortMessage(e) }, 500);
+  }
+}

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -146,6 +146,10 @@ const NO_CONTENT_NOTE =
   "⚠ the model pool returned no content — the free models may be rate-limited or out of daily " +
   "quota. Please retry in a moment.";
 
+const EMPTY_ANSWER_NOTE =
+  "⚠ the model thought about your question but didn't finish an answer — it may have failed to " +
+  "call digivault. Retry, or add your own API key in settings for more reliable tool use.";
+
 const QUOTA_MESSAGE =
   "The free model pool is out of quota. Add your own API key to keep chatting.";
 
@@ -405,7 +409,7 @@ function openAiHeaders(route: OpenAiCompatRoute): Record<string, string> {
 function openAiBody(
   route: OpenAiCompatRoute,
   messages: ConvoMessage[],
-  opts: { stream: boolean; tools?: boolean },
+  opts: { stream: boolean; tools?: boolean; forceTool?: string },
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {
     messages,
@@ -421,7 +425,9 @@ function openAiBody(
   }
   if (opts.tools) {
     body.tools = TOOLS;
-    body.tool_choice = "auto";
+    body.tool_choice = opts.forceTool
+      ? { type: "function", function: { name: opts.forceTool } }
+      : "auto";
   }
   return body;
 }
@@ -438,13 +444,16 @@ class UpstreamError extends Error {
 async function callOpenAiCompat(
   route: OpenAiCompatRoute,
   messages: ConvoMessage[],
+  forceTool?: string,
 ): Promise<ChatCompletionResponse> {
   const resp = await fetchWithTimeout(
     route.url,
     {
       method: "POST",
       headers: openAiHeaders(route),
-      body: JSON.stringify(openAiBody(route, messages, { stream: false, tools: true })),
+      body: JSON.stringify(
+        openAiBody(route, messages, { stream: false, tools: true, forceTool }),
+      ),
     },
     LLM_TIMEOUT_MS,
   );
@@ -488,13 +497,16 @@ async function streamOpenAiCompat(
   route: OpenAiCompatRoute,
   messages: ConvoMessage[],
   emit: (ev: ChatStreamEvent) => void,
+  withTools: boolean,
 ): Promise<string> {
   const resp = await fetchWithTimeout(
     route.url,
     {
       method: "POST",
       headers: openAiHeaders(route),
-      body: JSON.stringify(openAiBody(route, messages, { stream: true })),
+      body: JSON.stringify(
+        openAiBody(route, messages, { stream: true, tools: withTools }),
+      ),
     },
     LLM_TIMEOUT_MS,
   );
@@ -711,14 +723,19 @@ async function streamAnthropic(
   return content.trim();
 }
 
+function hasVaultResults(messages: ConvoMessage[]): boolean {
+  return messages.some((m) => m.role === "tool");
+}
+
 async function callModel(
   route: LlmRoute,
   messages: ConvoMessage[],
+  forceTool?: string,
 ): Promise<{ content: string; tool_calls: ToolCall[] }> {
   if (route.kind === "anthropic") {
     return callAnthropic(route, messages);
   }
-  const data = await callOpenAiCompat(route, messages);
+  const data = await callOpenAiCompat(route, messages, forceTool);
   if (data.error) {
     throw new UpstreamError(data.error.message ?? "model unavailable", route.isFreePool);
   }
@@ -734,10 +751,11 @@ async function streamFinalAnswer(
   messages: ConvoMessage[],
   emit: (ev: ChatStreamEvent) => void,
 ): Promise<string> {
+  const withTools = !hasVaultResults(messages);
   if (route.kind === "anthropic") {
     return streamAnthropic(route, messages, emit);
   }
-  return streamOpenAiCompat(route, messages, emit);
+  return streamOpenAiCompat(route, messages, emit, withTools);
 }
 
 function emitQuotaIfFree(route: LlmRoute, emit: (ev: ChatStreamEvent) => void): void {
@@ -796,6 +814,44 @@ async function runAgenticLoopStream(
       continue;
     }
 
+    // Free models often emit reasoning but skip structured tool_calls on the first pass.
+    if (!hasVaultResults(messages) && !(msg.content ?? "").trim() && round === 0) {
+      emit({ type: "status", message: "Requesting digivault search…" });
+      try {
+        const retry = await callModel(route, messages, "search_digivault");
+        if (retry.tool_calls.length > 0) {
+          messages.push({
+            role: "assistant",
+            content: retry.content ?? "",
+            tool_calls: retry.tool_calls,
+          });
+          for (const tc of retry.tool_calls) {
+            const name = tc.function?.name ?? "search_digivault";
+            const rawArgs = tc.function?.arguments ?? "";
+            const query = parseToolQuery(rawArgs) || "(unspecified)";
+            emit({ type: "tool_call", name, query });
+            emit({ type: "status", message: "Searching digivault…" });
+            const result = await runVaultTool(env, name, rawArgs);
+            emit({
+              type: "tool_result",
+              name,
+              query: result.query || query,
+              hits: result.hits.map((h) => ({ title: h.title, path: h.vault_path })),
+              count: result.hits.length,
+            });
+            messages.push({ role: "tool", tool_call_id: tc.id, content: result.text });
+          }
+          continue;
+        }
+        if ((retry.content ?? "").trim()) {
+          emit({ type: "content", delta: retry.content.trim() });
+          return;
+        }
+      } catch (e) {
+        console.error("forced tool retry failed:", (e as Error).message);
+      }
+    }
+
     emit({ type: "status", message: "Writing answer…" });
     const prefilled = (msg.content ?? "").trim();
     if (prefilled) {
@@ -803,11 +859,20 @@ async function runAgenticLoopStream(
       return;
     }
 
+    let sawReasoning = false;
+    const emitWithReasoning = (ev: ChatStreamEvent) => {
+      if (ev.type === "reasoning") sawReasoning = true;
+      emit(ev);
+    };
+
     try {
-      const streamed = await streamFinalAnswer(route, messages, emit);
+      const streamed = await streamFinalAnswer(route, messages, emitWithReasoning);
       if (!streamed) {
-        emitQuotaIfFree(route, emit);
-        emit({ type: "content", delta: NO_CONTENT_NOTE });
+        emit({
+          type: "content",
+          delta: sawReasoning ? EMPTY_ANSWER_NOTE : NO_CONTENT_NOTE,
+        });
+        if (!sawReasoning) emitQuotaIfFree(route, emit);
       }
     } catch (e) {
       const err = e as UpstreamError;

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -99,16 +99,31 @@ const DEFAULT_BYOK_MODEL: Record<ProviderId, string> = {
   gemini: "gemini-2.5-flash",
 };
 
-const SYSTEM_PROMPT =
-  "You are digichat, the documentation assistant for the digithings open-core agentic stack. " +
-  "You have ONE tool, search_digivault, which queries the digivault — the only source of truth " +
-  "about digithings. For ANY question about digithings, its modules, architecture, ports, APIs, " +
-  "or how it is built or run, you MUST call search_digivault first and answer ONLY from what it " +
-  "returns. If the tool returns nothing relevant, say you don't have that in the docs — never " +
-  "invent features, ports, or APIs. For greetings or small talk unrelated to digithings, reply " +
-  "normally without the tool. Be concise and technical. Always write digithings module names in " +
-  "lowercase (digithings, digigraph, digichat, …); Olympus, Atlas, and Hermes keep their " +
-  "capitalization.";
+const SYSTEM_PROMPT = [
+  "You are digichat, the documentation assistant for the digithings open-core agentic stack.",
+  "",
+  "You have ONE tool: search_digivault. It queries the digivault — the only source of truth about digithings.",
+  "",
+  "Every turn you MUST follow exactly ONE of these two paths:",
+  "",
+  "PATH A — Direct answer (no tool):",
+  "For greetings, small talk, or questions clearly unrelated to digithings architecture/docs.",
+  "Reply directly with helpful content. Do NOT call search_digivault.",
+  "",
+  "PATH B — Tool call, then answer from results:",
+  "For ANY question about digithings, its modules, architecture, ports, APIs, build/run, or how the system works:",
+  "1. In the same turn, MUST emit a structured search_digivault tool_call with a focused query.",
+  "2. After tool results return, answer ONLY from those results (summarize/cite). Never invent features, ports, or APIs.",
+  "3. If the tool returns nothing relevant, say you don't have that in the docs.",
+  "",
+  "FORBIDDEN (broken third path):",
+  "- Reasoning about needing to search without emitting a structured search_digivault tool_call.",
+  "- Returning empty content or reasoning-only output with no user-visible answer.",
+  "- Answering digithings questions from memory instead of calling the tool first.",
+  "",
+  "Be concise and technical. Write digithings module names in lowercase (digithings, digigraph, digichat, …);",
+  "keep Olympus, Atlas, and Hermes capitalized.",
+].join("\n");
 
 const TOOLS = [
   {
@@ -116,12 +131,12 @@ const TOOLS = [
     function: {
       name: "search_digivault",
       description:
-        "Search the digithings architecture knowledge base (the digivault docs) for facts about " +
-        "the open-core stack: the modules (digigraph, digiquant, digisearch, digichat, digikey, " +
-        "digismith, digivault, digiclaw, digibase) and roadmap ones (digistore, digilink), their " +
-        "ports, APIs, how they connect, and how the system is built and run. Call this whenever " +
-        "the user asks anything about digithings, its modules, architecture, or how it works. Do " +
-        "NOT call it for greetings or small talk unrelated to digithings.",
+        "PATH B tool — search the digithings architecture knowledge base (digivault) for facts about " +
+        "the open-core stack: modules (digigraph, digiquant, digisearch, digichat, digikey, " +
+        "digismith, digivault, digiclaw, digibase) and roadmap ones (digistore, digilink), ports, " +
+        "APIs, connections, build/run. REQUIRED for any digithings-related question: emit this " +
+        "structured tool_call in the same turn (do not only reason about searching). Do NOT use " +
+        "for PATH A (greetings or small talk unrelated to digithings).",
       parameters: {
         type: "object",
         properties: {

--- a/frontend/digithings-web/functions/api/chat.ts
+++ b/frontend/digithings-web/functions/api/chat.ts
@@ -33,13 +33,15 @@ interface ChatCompletionResponse {
   choices?: Array<{
     message?: { role?: string; content?: string | null; tool_calls?: ToolCall[] };
   }>;
-  error?: { message?: string };
+  error?: { message?: string; code?: number };
 }
 interface VaultHit {
   vault_path: string;
   title: string;
   body_markdown: string;
 }
+
+type ProviderId = "openrouter" | "openai" | "anthropic" | "gemini";
 
 type ChatStreamEvent =
   | { type: "status"; message: string }
@@ -54,7 +56,26 @@ type ChatStreamEvent =
   | { type: "reasoning"; delta: string }
   | { type: "content"; delta: string }
   | { type: "error"; message: string }
+  | { type: "quota_exhausted"; message: string }
   | { type: "done" };
+
+type OpenAiCompatRoute = {
+  kind: "openai_compat";
+  url: string;
+  apiKey: string;
+  model?: string;
+  models?: string[];
+  isFreePool: boolean;
+  extraHeaders?: Record<string, string>;
+};
+
+type AnthropicRoute = {
+  kind: "anthropic";
+  apiKey: string;
+  model: string;
+};
+
+type LlmRoute = OpenAiCompatRoute | AnthropicRoute;
 
 const MAX_TURNS = 12;
 const MAX_MSG_CHARS = 2000;
@@ -70,6 +91,13 @@ const MODEL_POOL = [
   "meta-llama/llama-3.3-70b-instruct:free",
   "openai/gpt-oss-20b:free",
 ];
+
+const DEFAULT_BYOK_MODEL: Record<ProviderId, string> = {
+  openrouter: "openai/gpt-4o-mini",
+  openai: "gpt-4o-mini",
+  anthropic: "claude-3-5-haiku-20241022",
+  gemini: "gemini-2.5-flash",
+};
 
 const SYSTEM_PROMPT =
   "You are digichat, the documentation assistant for the digithings open-core agentic stack. " +
@@ -108,9 +136,18 @@ const TOOLS = [
   },
 ];
 
+const ANTHROPIC_TOOL = {
+  name: "search_digivault",
+  description: TOOLS[0].function.description,
+  input_schema: TOOLS[0].function.parameters,
+};
+
 const NO_CONTENT_NOTE =
   "⚠ the model pool returned no content — the free models may be rate-limited or out of daily " +
   "quota. Please retry in a moment.";
+
+const QUOTA_MESSAGE =
+  "The free model pool is out of quota. Add your own API key to keep chatting.";
 
 function jsonError(message: string, status = 400): Response {
   return new Response(JSON.stringify({ error: message }), {
@@ -124,6 +161,111 @@ function notConfigured(detail: string): Response {
     status: 503,
     headers: { "content-type": "application/json; charset=utf-8" },
   });
+}
+
+function validateByokKey(key: string, provider: ProviderId): string | null {
+  if (!key) return "API key is required.";
+  switch (provider) {
+    case "openrouter":
+      if (!key.startsWith("sk-or-")) return "OpenRouter keys start with sk-or-.";
+      break;
+    case "openai":
+      if (!key.startsWith("sk-")) return "OpenAI keys start with sk-.";
+      break;
+    case "anthropic":
+      if (!key.startsWith("sk-ant-")) return "Anthropic keys start with sk-ant-.";
+      break;
+    case "gemini":
+      if (!key.startsWith("AI")) return "Gemini keys start with AI.";
+      break;
+  }
+  return null;
+}
+
+function resolveRoute(request: Request, env: Env, bodyModel?: string): LlmRoute | Response {
+  const byokKey = request.headers.get("x-byok-key")?.trim() ?? "";
+  const rawProvider = request.headers.get("x-byok-provider")?.trim() ?? "openrouter";
+  const provider: ProviderId =
+    rawProvider === "openai" ||
+    rawProvider === "anthropic" ||
+    rawProvider === "gemini" ||
+    rawProvider === "openrouter"
+      ? rawProvider
+      : "openrouter";
+  const model =
+    bodyModel?.trim() ||
+    request.headers.get("x-byok-model")?.trim() ||
+    DEFAULT_BYOK_MODEL[provider];
+
+  if (byokKey) {
+    const err = validateByokKey(byokKey, provider);
+    if (err) return jsonError(err, 400);
+
+    if (provider === "anthropic") {
+      return { kind: "anthropic", apiKey: byokKey, model };
+    }
+    if (provider === "openai") {
+      return {
+        kind: "openai_compat",
+        url: "https://api.openai.com/v1/chat/completions",
+        apiKey: byokKey,
+        model,
+        isFreePool: false,
+      };
+    }
+    if (provider === "gemini") {
+      return {
+        kind: "openai_compat",
+        url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        apiKey: byokKey,
+        model,
+        isFreePool: false,
+      };
+    }
+    return {
+      kind: "openai_compat",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      apiKey: byokKey,
+      model,
+      isFreePool: false,
+      extraHeaders: {
+        "HTTP-Referer": "https://digithings.ai",
+        "X-Title": "digithings docs assistant",
+      },
+    };
+  }
+
+  if (!env.OPENROUTER_API_KEY) {
+    return notConfigured(
+      "OPENROUTER_API_KEY is not set — add your own key in chat settings to continue.",
+    );
+  }
+  return {
+    kind: "openai_compat",
+    url: "https://openrouter.ai/api/v1/chat/completions",
+    apiKey: env.OPENROUTER_API_KEY,
+    models: MODEL_POOL,
+    isFreePool: true,
+    extraHeaders: {
+      "HTTP-Referer": "https://digithings.ai",
+      "X-Title": "digithings docs assistant",
+    },
+  };
+}
+
+function isQuotaStatus(status: number): boolean {
+  return status === 402 || status === 429;
+}
+
+function parseUpstreamQuota(detail: string): boolean {
+  const lower = detail.toLowerCase();
+  return (
+    lower.includes("quota") ||
+    lower.includes("rate limit") ||
+    lower.includes("rate_limit") ||
+    lower.includes("insufficient") ||
+    lower.includes("credits")
+  );
 }
 
 const memHits = new Map<string, { count: number; reset: number }>();
@@ -163,7 +305,7 @@ function sameSiteOK(request: Request): boolean {
 }
 
 const VAULT_TIMEOUT_MS = 10_000;
-const OPENROUTER_TIMEOUT_MS = 45_000;
+const LLM_TIMEOUT_MS = 45_000;
 
 async function fetchWithTimeout(url: string, init: RequestInit, ms: number): Promise<Response> {
   const controller = new AbortController();
@@ -252,37 +394,64 @@ async function runVaultTool(
   }
 }
 
-function openRouterHeaders(apiKey: string): Record<string, string> {
+function openAiHeaders(route: OpenAiCompatRoute): Record<string, string> {
   return {
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${route.apiKey}`,
     "content-type": "application/json",
-    "HTTP-Referer": "https://digithings.ai",
-    "X-Title": "digithings docs assistant",
+    ...route.extraHeaders,
   };
 }
 
-async function callModel(env: Env, messages: ConvoMessage[]): Promise<ChatCompletionResponse> {
+function openAiBody(
+  route: OpenAiCompatRoute,
+  messages: ConvoMessage[],
+  opts: { stream: boolean; tools?: boolean },
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    messages,
+    temperature: 0.2,
+    max_tokens: 800,
+    stream: opts.stream,
+  };
+  if (route.models?.length) {
+    body.models = route.models;
+    if (opts.tools) body.provider = { require_parameters: true };
+  } else if (route.model) {
+    body.model = route.model;
+  }
+  if (opts.tools) {
+    body.tools = TOOLS;
+    body.tool_choice = "auto";
+  }
+  return body;
+}
+
+class UpstreamError extends Error {
+  constructor(
+    message: string,
+    readonly quota = false,
+  ) {
+    super(message);
+  }
+}
+
+async function callOpenAiCompat(
+  route: OpenAiCompatRoute,
+  messages: ConvoMessage[],
+): Promise<ChatCompletionResponse> {
   const resp = await fetchWithTimeout(
-    "https://openrouter.ai/api/v1/chat/completions",
+    route.url,
     {
       method: "POST",
-      headers: openRouterHeaders(env.OPENROUTER_API_KEY ?? ""),
-      body: JSON.stringify({
-        models: MODEL_POOL,
-        messages,
-        tools: TOOLS,
-        tool_choice: "auto",
-        provider: { require_parameters: true },
-        temperature: 0.2,
-        max_tokens: 800,
-        stream: false,
-      }),
+      headers: openAiHeaders(route),
+      body: JSON.stringify(openAiBody(route, messages, { stream: false, tools: true })),
     },
-    OPENROUTER_TIMEOUT_MS,
+    LLM_TIMEOUT_MS,
   );
   if (!resp.ok) {
     const detail = await resp.text().catch(() => "");
-    throw new Error(`openrouter ${resp.status}: ${detail.slice(0, 300)}`);
+    const quota = route.isFreePool && (isQuotaStatus(resp.status) || parseUpstreamQuota(detail));
+    throw new UpstreamError(`upstream ${resp.status}: ${detail.slice(0, 300)}`, quota);
   }
   return (await resp.json()) as ChatCompletionResponse;
 }
@@ -315,35 +484,30 @@ async function* iterateOpenAiSse(
   }
 }
 
-async function streamFinalAnswer(
-  env: Env,
+async function streamOpenAiCompat(
+  route: OpenAiCompatRoute,
   messages: ConvoMessage[],
   emit: (ev: ChatStreamEvent) => void,
 ): Promise<string> {
   const resp = await fetchWithTimeout(
-    "https://openrouter.ai/api/v1/chat/completions",
+    route.url,
     {
       method: "POST",
-      headers: openRouterHeaders(env.OPENROUTER_API_KEY ?? ""),
-      body: JSON.stringify({
-        models: MODEL_POOL,
-        messages,
-        temperature: 0.2,
-        max_tokens: 800,
-        stream: true,
-      }),
+      headers: openAiHeaders(route),
+      body: JSON.stringify(openAiBody(route, messages, { stream: true })),
     },
-    OPENROUTER_TIMEOUT_MS,
+    LLM_TIMEOUT_MS,
   );
   if (!resp.ok || !resp.body) {
     const detail = await resp.text().catch(() => "");
-    throw new Error(`openrouter stream ${resp.status}: ${detail.slice(0, 300)}`);
+    const quota = route.isFreePool && (isQuotaStatus(resp.status) || parseUpstreamQuota(detail));
+    throw new UpstreamError(`upstream stream ${resp.status}: ${detail.slice(0, 300)}`, quota);
   }
 
   let content = "";
   for await (const json of iterateOpenAiSse(resp.body)) {
     const err = json.error as { message?: string } | undefined;
-    if (err?.message) throw new Error(err.message);
+    if (err?.message) throw new UpstreamError(err.message, route.isFreePool);
     const delta = (json.choices as Array<{ delta?: Record<string, unknown> }> | undefined)?.[0]
       ?.delta;
     if (!delta) continue;
@@ -360,9 +524,232 @@ async function streamFinalAnswer(
   return content.trim();
 }
 
+type AnthropicBlock =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "tool_result"; tool_use_id: string; content: string };
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicBlock[];
+}
+
+function toAnthropicMessages(convo: ConvoMessage[]): {
+  system: string;
+  messages: AnthropicMessage[];
+} {
+  const systemParts: string[] = [];
+  const messages: AnthropicMessage[] = [];
+
+  for (const m of convo) {
+    if (m.role === "system") {
+      systemParts.push(m.content);
+      continue;
+    }
+    if (m.role === "user") {
+      messages.push({ role: "user", content: m.content });
+      continue;
+    }
+    if (m.role === "assistant") {
+      if (m.tool_calls?.length) {
+        const blocks: AnthropicBlock[] = [];
+        if (m.content) blocks.push({ type: "text", text: m.content });
+        for (const tc of m.tool_calls) {
+          let input: Record<string, unknown> = {};
+          try {
+            input = JSON.parse(tc.function.arguments || "{}") as Record<string, unknown>;
+          } catch {
+            /* keep empty */
+          }
+          blocks.push({
+            type: "tool_use",
+            id: tc.id,
+            name: tc.function.name,
+            input,
+          });
+        }
+        messages.push({ role: "assistant", content: blocks });
+      } else {
+        messages.push({ role: "assistant", content: m.content });
+      }
+      continue;
+    }
+    if (m.role === "tool" && m.tool_call_id) {
+      messages.push({
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: m.tool_call_id, content: m.content }],
+      });
+    }
+  }
+  return { system: systemParts.join("\n\n"), messages };
+}
+
+interface AnthropicResponse {
+  content?: AnthropicBlock[];
+  stop_reason?: string;
+  error?: { message?: string };
+}
+
+function anthropicToAssistant(msg: AnthropicResponse): {
+  content: string;
+  tool_calls: ToolCall[];
+} {
+  const tool_calls: ToolCall[] = [];
+  let content = "";
+  for (const block of msg.content ?? []) {
+    if (block.type === "text") content += block.text;
+    if (block.type === "tool_use") {
+      tool_calls.push({
+        id: block.id,
+        type: "function",
+        function: {
+          name: block.name,
+          arguments: JSON.stringify(block.input ?? {}),
+        },
+      });
+    }
+  }
+  return { content, tool_calls };
+}
+
+async function callAnthropic(route: AnthropicRoute, convo: ConvoMessage[]): Promise<{
+  content: string;
+  tool_calls: ToolCall[];
+}> {
+  const { system, messages } = toAnthropicMessages(convo);
+  const resp = await fetchWithTimeout(
+    "https://api.anthropic.com/v1/messages",
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": route.apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: route.model,
+        max_tokens: 800,
+        system,
+        messages,
+        tools: [ANTHROPIC_TOOL],
+        temperature: 0.2,
+      }),
+    },
+    LLM_TIMEOUT_MS,
+  );
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "");
+    throw new UpstreamError(`anthropic ${resp.status}: ${detail.slice(0, 300)}`);
+  }
+  const data = (await resp.json()) as AnthropicResponse;
+  if (data.error?.message) throw new UpstreamError(data.error.message);
+  return anthropicToAssistant(data);
+}
+
+async function streamAnthropic(
+  route: AnthropicRoute,
+  convo: ConvoMessage[],
+  emit: (ev: ChatStreamEvent) => void,
+): Promise<string> {
+  const { system, messages } = toAnthropicMessages(convo);
+  const resp = await fetchWithTimeout(
+    "https://api.anthropic.com/v1/messages",
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": route.apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: route.model,
+        max_tokens: 800,
+        system,
+        messages,
+        temperature: 0.2,
+        stream: true,
+      }),
+    },
+    LLM_TIMEOUT_MS,
+  );
+  if (!resp.ok || !resp.body) {
+    const detail = await resp.text().catch(() => "");
+    throw new UpstreamError(`anthropic stream ${resp.status}: ${detail.slice(0, 300)}`);
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let content = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line.startsWith("data: ")) continue;
+      try {
+        const json = JSON.parse(line.slice(6)) as {
+          type?: string;
+          delta?: { type?: string; text?: string };
+        };
+        if (json.type === "content_block_delta" && json.delta?.type === "text_delta") {
+          const piece = json.delta.text ?? "";
+          if (piece) {
+            content += piece;
+            emit({ type: "content", delta: piece });
+          }
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  return content.trim();
+}
+
+async function callModel(
+  route: LlmRoute,
+  messages: ConvoMessage[],
+): Promise<{ content: string; tool_calls: ToolCall[] }> {
+  if (route.kind === "anthropic") {
+    return callAnthropic(route, messages);
+  }
+  const data = await callOpenAiCompat(route, messages);
+  if (data.error) {
+    throw new UpstreamError(data.error.message ?? "model unavailable", route.isFreePool);
+  }
+  const msg = data.choices?.[0]?.message;
+  return {
+    content: msg?.content ?? "",
+    tool_calls: msg?.tool_calls ?? [],
+  };
+}
+
+async function streamFinalAnswer(
+  route: LlmRoute,
+  messages: ConvoMessage[],
+  emit: (ev: ChatStreamEvent) => void,
+): Promise<string> {
+  if (route.kind === "anthropic") {
+    return streamAnthropic(route, messages, emit);
+  }
+  return streamOpenAiCompat(route, messages, emit);
+}
+
+function emitQuotaIfFree(route: LlmRoute, emit: (ev: ChatStreamEvent) => void): void {
+  if (route.kind === "openai_compat" && route.isFreePool) {
+    emit({ type: "quota_exhausted", message: QUOTA_MESSAGE });
+  }
+}
+
 async function runAgenticLoopStream(
   convo: ConvoMessage[],
   env: Env,
+  route: LlmRoute,
   emit: (ev: ChatStreamEvent) => void,
 ): Promise<void> {
   const messages = [...convo];
@@ -372,22 +759,18 @@ async function runAgenticLoopStream(
       message: round === 0 ? "Thinking…" : "Reviewing digivault results…",
     });
 
-    let data: ChatCompletionResponse;
+    let msg: { content: string; tool_calls: ToolCall[] };
     try {
-      data = await callModel(env, messages);
+      msg = await callModel(route, messages);
     } catch (e) {
-      console.error("model call failed:", (e as Error).message);
-      emit({ type: "error", message: "the model pool is temporarily unavailable — please retry" });
-      return;
-    }
-    if (data.error) {
-      emit({ type: "error", message: `upstream: ${data.error.message ?? "model unavailable"}` });
-      return;
-    }
-
-    const msg = data.choices?.[0]?.message;
-    if (!msg) {
-      emit({ type: "content", delta: NO_CONTENT_NOTE });
+      const err = e as UpstreamError;
+      console.error("model call failed:", err.message);
+      if (err.quota) {
+        emitQuotaIfFree(route, emit);
+        emit({ type: "content", delta: NO_CONTENT_NOTE });
+        return;
+      }
+      emit({ type: "error", message: "the model is temporarily unavailable — please retry" });
       return;
     }
 
@@ -420,8 +803,21 @@ async function runAgenticLoopStream(
       return;
     }
 
-    const streamed = await streamFinalAnswer(env, messages, emit);
-    if (!streamed) emit({ type: "content", delta: NO_CONTENT_NOTE });
+    try {
+      const streamed = await streamFinalAnswer(route, messages, emit);
+      if (!streamed) {
+        emitQuotaIfFree(route, emit);
+        emit({ type: "content", delta: NO_CONTENT_NOTE });
+      }
+    } catch (e) {
+      const err = e as UpstreamError;
+      if (err.quota) {
+        emitQuotaIfFree(route, emit);
+        emit({ type: "content", delta: NO_CONTENT_NOTE });
+        return;
+      }
+      emit({ type: "error", message: "the model is temporarily unavailable — please retry" });
+    }
     return;
   }
 
@@ -470,9 +866,6 @@ export async function onRequestPost(ctx: EventContext): Promise<Response> {
 async function handleChat(ctx: EventContext): Promise<Response> {
   const { request, env } = ctx;
 
-  if (!env.OPENROUTER_API_KEY) {
-    return notConfigured("OPENROUTER_API_KEY is not set on this deployment.");
-  }
   if (!env.CORE_SUPABASE_URL || !env.CORE_SUPABASE_ANON_KEY) {
     return notConfigured(
       "CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY are not set — the vault is unreachable.",
@@ -484,12 +877,16 @@ async function handleChat(ctx: EventContext): Promise<Response> {
   const ip = request.headers.get("cf-connecting-ip") ?? "anon";
   if (!(await rateLimit(env, ip))) return jsonError("rate limit exceeded — slow down a moment", 429);
 
-  let body: { messages?: ChatMessage[] };
+  let body: { messages?: ChatMessage[]; model?: string };
   try {
-    body = (await request.json()) as { messages?: ChatMessage[] };
+    body = (await request.json()) as { messages?: ChatMessage[]; model?: string };
   } catch {
     return jsonError("invalid JSON body");
   }
+
+  const route = resolveRoute(request, env, body.model);
+  if (route instanceof Response) return route;
+
   const inbound = Array.isArray(body.messages) ? body.messages : [];
   if (inbound.length === 0) return jsonError("messages required");
 
@@ -502,5 +899,5 @@ async function handleChat(ctx: EventContext): Promise<Response> {
   if (!clean.some((m) => m.role === "user")) return jsonError("a user message is required");
 
   const convo: ConvoMessage[] = [{ role: "system", content: SYSTEM_PROMPT }, ...clean];
-  return ndjsonResponse((emit) => runAgenticLoopStream(convo, env, emit));
+  return ndjsonResponse((emit) => runAgenticLoopStream(convo, env, route, emit));
 }

--- a/frontend/digithings-web/lib/chatStream.ts
+++ b/frontend/digithings-web/lib/chatStream.ts
@@ -27,6 +27,7 @@ export type ChatStreamEvent =
   | { type: "reasoning"; delta: string }
   | { type: "content"; delta: string }
   | { type: "error"; message: string }
+  | { type: "quota_exhausted"; message: string }
   | { type: "done" };
 
 export const CHAT_STREAM_MIME = "application/x-ndjson";

--- a/frontend/digithings-web/lib/providerSettings.ts
+++ b/frontend/digithings-web/lib/providerSettings.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export type ProviderId = "openrouter" | "openai" | "anthropic" | "gemini";
+
+export type ProviderModel = { id: string; label: string };
+
+export const PROVIDER_MODELS: Record<ProviderId, ProviderModel[]> = {
+  openrouter: [
+    { id: "openai/gpt-4o-mini", label: "GPT-4o mini" },
+    { id: "anthropic/claude-sonnet-4", label: "Claude Sonnet 4" },
+    { id: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+    { id: "meta-llama/llama-3.3-70b-instruct", label: "Llama 3.3 70B" },
+    { id: "deepseek/deepseek-chat-v3", label: "DeepSeek V3" },
+  ],
+  openai: [
+    { id: "gpt-4o-mini", label: "GPT-4o mini" },
+    { id: "gpt-4o", label: "GPT-4o" },
+    { id: "gpt-4.1-mini", label: "GPT-4.1 mini" },
+  ],
+  anthropic: [
+    { id: "claude-sonnet-4-20250514", label: "Claude Sonnet 4" },
+    { id: "claude-3-5-haiku-20241022", label: "Claude 3.5 Haiku" },
+  ],
+  gemini: [
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+    { id: "gemini-2.0-flash", label: "Gemini 2.0 Flash" },
+  ],
+};
+
+export const PROVIDER_LABELS: Record<ProviderId, string> = {
+  openrouter: "OpenRouter",
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  gemini: "Gemini",
+};
+
+const STORAGE_KEY = "digichat:api_key";
+const STORAGE_PROVIDER = "digichat:provider";
+const STORAGE_MODEL = "digichat:model";
+
+export type ProviderSettings = {
+  apiKey: string;
+  provider: ProviderId;
+  model: string;
+  isSet: boolean;
+};
+
+function defaultModel(provider: ProviderId): string {
+  return PROVIDER_MODELS[provider][0]?.id ?? "";
+}
+
+function readFromStorage(): ProviderSettings {
+  try {
+    const apiKey = localStorage.getItem(STORAGE_KEY) ?? "";
+    const rawProvider = localStorage.getItem(STORAGE_PROVIDER);
+    const provider: ProviderId =
+      rawProvider === "openai" ||
+      rawProvider === "anthropic" ||
+      rawProvider === "gemini" ||
+      rawProvider === "openrouter"
+        ? rawProvider
+        : "openrouter";
+    const storedModel = localStorage.getItem(STORAGE_MODEL) ?? "";
+    const model =
+      storedModel && PROVIDER_MODELS[provider].some((m) => m.id === storedModel)
+        ? storedModel
+        : defaultModel(provider);
+    return { apiKey, provider, model, isSet: apiKey.length > 0 };
+  } catch {
+    return { apiKey: "", provider: "openrouter", model: defaultModel("openrouter"), isSet: false };
+  }
+}
+
+export function validateProviderKey(key: string, provider: ProviderId): string | null {
+  const trimmed = key.trim();
+  if (!trimmed) return "API key is required.";
+  switch (provider) {
+    case "openrouter":
+      if (!trimmed.startsWith("sk-or-")) return "OpenRouter keys start with sk-or-.";
+      break;
+    case "openai":
+      if (!trimmed.startsWith("sk-")) return "OpenAI keys start with sk-.";
+      break;
+    case "anthropic":
+      if (!trimmed.startsWith("sk-ant-")) return "Anthropic keys start with sk-ant-.";
+      break;
+    case "gemini":
+      if (!trimmed.startsWith("AI")) return "Gemini keys start with AI.";
+      break;
+  }
+  return null;
+}
+
+export function useProviderSettings() {
+  const [state, setState] = useState<ProviderSettings>(readFromStorage);
+
+  const save = useCallback((apiKey: string, provider: ProviderId, model: string) => {
+    const trimmed = apiKey.trim();
+    const resolvedModel =
+      model && PROVIDER_MODELS[provider].some((m) => m.id === model)
+        ? model
+        : defaultModel(provider);
+    try {
+      if (trimmed) {
+        localStorage.setItem(STORAGE_KEY, trimmed);
+        localStorage.setItem(STORAGE_PROVIDER, provider);
+        localStorage.setItem(STORAGE_MODEL, resolvedModel);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+        localStorage.removeItem(STORAGE_PROVIDER);
+        localStorage.removeItem(STORAGE_MODEL);
+      }
+    } catch {
+      /* private mode */
+    }
+    setState({
+      apiKey: trimmed,
+      provider,
+      model: resolvedModel,
+      isSet: trimmed.length > 0,
+    });
+  }, []);
+
+  const clear = useCallback(() => save("", "openrouter", defaultModel("openrouter")), [save]);
+
+  return { ...state, save, clear };
+}
+
+export function providerSummary(settings: ProviderSettings): string {
+  if (!settings.isSet) return "free pool";
+  const label = PROVIDER_LABELS[settings.provider];
+  const model =
+    PROVIDER_MODELS[settings.provider].find((m) => m.id === settings.model)?.label ??
+    settings.model;
+  return `${label} · ${model}`;
+}

--- a/frontend/digithings-web/lib/useStackChat.ts
+++ b/frontend/digithings-web/lib/useStackChat.ts
@@ -5,6 +5,7 @@ import {
   type ChatActivity,
   type ChatStreamEvent,
 } from "@/lib/chatStream";
+import type { ProviderSettings as ProviderConfig } from "@/lib/providerSettings";
 
 export interface ChatMessage {
   role: "user" | "assistant";
@@ -16,24 +17,31 @@ export interface UseStackChat {
   messages: ChatMessage[];
   busy: boolean;
   error: string | null;
+  quotaPrompt: boolean;
   send: (question: string) => Promise<void>;
   stop: () => void;
   reset: () => void;
   seed: (messages: ChatMessage[]) => void;
+  clearQuotaPrompt: () => void;
 }
 
 function foldEvent(
   activities: ChatActivity[],
   content: string,
   ev: ChatStreamEvent,
-): { activities: ChatActivity[]; content: string } {
+): { activities: ChatActivity[]; content: string; quotaPrompt: boolean } {
   switch (ev.type) {
     case "status":
-      return { activities: [...activities, { kind: "status", message: ev.message }], content };
+      return {
+        activities: [...activities, { kind: "status", message: ev.message }],
+        content,
+        quotaPrompt: false,
+      };
     case "tool_call":
       return {
         activities: [...activities, { kind: "tool_call", name: ev.name, query: ev.query }],
         content,
+        quotaPrompt: false,
       };
     case "tool_result":
       return {
@@ -48,6 +56,7 @@ function foldEvent(
           },
         ],
         content,
+        quotaPrompt: false,
       };
     case "reasoning": {
       const last = activities.at(-1);
@@ -58,23 +67,36 @@ function foldEvent(
             { kind: "reasoning", text: last.text + ev.delta },
           ],
           content,
+          quotaPrompt: false,
         };
       }
-      return { activities: [...activities, { kind: "reasoning", text: ev.delta }], content };
+      return {
+        activities: [...activities, { kind: "reasoning", text: ev.delta }],
+        content,
+        quotaPrompt: false,
+      };
     }
     case "content":
-      return { activities, content: content + ev.delta };
+      return { activities, content: content + ev.delta, quotaPrompt: false };
+    case "quota_exhausted":
+      return { activities, content, quotaPrompt: true };
     default:
-      return { activities, content };
+      return { activities, content, quotaPrompt: false };
   }
 }
 
-export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
+export function useStackChat(
+  initial: ChatMessage[] = [],
+  provider?: ProviderConfig,
+): UseStackChat {
   const [messages, setMessages] = useState<ChatMessage[]>(initial);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [quotaPrompt, setQuotaPrompt] = useState(false);
   const messagesRef = useRef<ChatMessage[]>(initial);
   const abortRef = useRef<AbortController | null>(null);
+  const providerRef = useRef(provider);
+  providerRef.current = provider;
 
   const apply = useCallback((next: ChatMessage[]) => {
     messagesRef.current = next;
@@ -88,6 +110,7 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
       const q = question.trim();
       if (!q || abortRef.current) return;
       setError(null);
+      setQuotaPrompt(false);
 
       const base: ChatMessage[] = [...messagesRef.current, { role: "user", content: q }];
       apply([...base, { role: "assistant", content: "" }]);
@@ -97,6 +120,7 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
       abortRef.current = controller;
       let activities: ChatActivity[] = [];
       let content = "";
+      let sawQuota = false;
 
       const flush = () => {
         apply([
@@ -109,11 +133,24 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
         ]);
       };
 
+      const cfg = providerRef.current;
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        accept: CHAT_STREAM_MIME,
+      };
+      const body: { messages: ChatMessage[]; model?: string } = { messages: base };
+      if (cfg?.isSet) {
+        headers["X-BYOK-Key"] = cfg.apiKey;
+        headers["X-BYOK-Provider"] = cfg.provider;
+        headers["X-BYOK-Model"] = cfg.model;
+        body.model = cfg.model;
+      }
+
       try {
         const res = await fetch("/api/chat", {
           method: "POST",
-          headers: { "content-type": "application/json", accept: CHAT_STREAM_MIME },
-          body: JSON.stringify({ messages: base }),
+          headers,
+          body: JSON.stringify(body),
           signal: controller.signal,
         });
 
@@ -123,7 +160,7 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
           try {
             const data = (await res.json()) as { error?: string };
             if (data.error === "chat not configured") {
-              msg = "chat not configured on this deployment";
+              msg = "chat not configured — add your own API key in settings";
             } else if (data.error) {
               msg = String(data.error);
             }
@@ -132,6 +169,7 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
           }
           apply(base);
           setError(msg);
+          if (!cfg?.isSet) setQuotaPrompt(true);
           return;
         }
 
@@ -161,14 +199,20 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
               return;
             }
             if (ev.type === "done") break;
-            ({ activities, content } = foldEvent(activities, content, ev));
+            const folded = foldEvent(activities, content, ev);
+            activities = folded.activities;
+            content = folded.content;
+            if (folded.quotaPrompt) sawQuota = true;
             flush();
           }
         }
 
+        if (sawQuota) setQuotaPrompt(true);
+
         if (!content.trim()) {
           apply(base);
           setError("no answer returned — try rephrasing");
+          if (!cfg?.isSet) setQuotaPrompt(true);
         }
       } catch (e) {
         if ((e as Error).name === "AbortError") return;
@@ -193,16 +237,20 @@ export function useStackChat(initial: ChatMessage[] = []): UseStackChat {
     abortRef.current = null;
     apply([]);
     setError(null);
+    setQuotaPrompt(false);
     setBusy(false);
   }, [apply]);
 
   const seed = useCallback(
     (next: ChatMessage[]) => {
       setError(null);
+      setQuotaPrompt(false);
       apply(next);
     },
     [apply],
   );
 
-  return { messages, busy, error, send, stop, reset, seed };
+  const clearQuotaPrompt = useCallback(() => setQuotaPrompt(false), []);
+
+  return { messages, busy, error, quotaPrompt, send, stop, reset, seed, clearQuotaPrompt };
 }


### PR DESCRIPTION
## Summary
- Settings slide-over: OpenRouter, OpenAI, Anthropic, or Gemini key + model picker (browser-only storage)
- `/api/chat` routes per provider; BYOK keys sent via `X-BYOK-*` headers, never persisted server-side
- `/api/byok/test` validates keys against each provider
- Quota exhaustion on the free pool shows an inline nudge + links to open settings

## Test plan
- [x] `npm run build` in `frontend/digithings-web`
- [x] `bash scripts/build-digithings.sh`
- [ ] Save OpenRouter key → model label updates in bar
- [ ] Free pool exhausted → "Continue with your own key" banner appears
- [ ] Test key button returns ok/error per provider

Fixes #1172

Made with [Cursor](https://cursor.com)