### PR TITLE
fix(digiquant-web): strategy suite scroll fit, CTA placement, nav hydration

### DIFF
--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -865,6 +865,13 @@
    ========================================================================== */
 :root { --dq-nav-h: 62px; }
 
+/* Page chrome sits above the fixed grain/glow layers (site.css z-index: 0). */
+main,
+.footer {
+  position: relative;
+  z-index: 1;
+}
+
 html {
   scroll-behavior: auto;
   scroll-padding-top: var(--dq-nav-h);
@@ -874,6 +881,11 @@ html {
 #strategies,
 #contact {
   scroll-margin-top: var(--dq-nav-h);
+}
+#contact {
+  position: relative;
+  z-index: 3;
+  background: var(--bg);
 }
 
 /* editorial heading set (serif), shared by the suite intro + closing section */
@@ -1186,14 +1198,14 @@ html {
 .dqp-spacer { border: none; background: transparent; opacity: 0; padding: 0; pointer-events: none; }
 @media (max-width: 820px) { .dqp-step { width: 150px; } .dqp-heads { min-height: 180px; } .dqp-scrolly { height: 360vh; } .dqp-node { width: 90px; } }
 
-/* ---- STRATEGY SUITE: scroll-driven sticky card stack ---- */
-.dqss { position: relative; z-index: 2; border-top: 1px solid var(--hair); }
+/* ---- STRATEGY SUITE: scroll-pinned fitted peek stack ---- */
+.dqss { position: relative; z-index: 1; border-top: 1px solid var(--hair); }
 .dqss-intro {
   flex: 0 0 auto;
   max-width: 52ch;
   width: 100%;
-  margin-bottom: clamp(1rem, 2vw, 1.5rem);
-  padding-top: clamp(2rem, 4vw, 3.25rem);
+  margin-bottom: clamp(0.75rem, 1.5vw, 1.1rem);
+  padding-top: clamp(1.25rem, 3vw, 2rem);
   transition: opacity 0.35s ease, transform 0.35s ease;
 }
 .dqss-intro[data-phase="stack"] {
@@ -1207,13 +1219,15 @@ html {
   --dqss-intro-hold: 4svh;
   --dqss-enter-scroll: 88svh;
   --dqss-cta-scroll: 40svh;
-  /* Match JS cardEnterBudgetsPx: 0.82 + 1.12×(n−1) card budgets + pin viewport + tail. */
+  --dqss-card-h: 32rem;
+  --dqss-fit-scale: 1;
   --dqss-budget-sum: calc(0.82 + 1.12 * (var(--stack-count, var(--dqss-stack-count)) - 1));
-  height: calc(
+  --dqss-pin-h: calc(100svh - var(--dq-nav-h));
+  min-height: calc(
     var(--dqss-intro-hold) +
     var(--dqss-budget-sum) * var(--dqss-enter-scroll) +
     var(--dqss-cta-scroll) +
-    (100svh - var(--dq-nav-h)) +
+    var(--dqss-pin-h) +
     32svh
   );
   position: relative;
@@ -1221,34 +1235,38 @@ html {
 .dqss-stack-pin {
   position: sticky;
   top: var(--dq-nav-h);
-  height: calc(100svh - var(--dq-nav-h));
+  min-height: calc(100svh - var(--dq-nav-h));
+  height: auto;
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   justify-content: center;
-  align-items: stretch;
-  padding: 0 clamp(0.75rem, 2.5vw, 1.25rem);
+  align-items: center;
+  padding: clamp(0.5rem, 1.5vw, 1rem) clamp(0.75rem, 2.5vw, 1.25rem);
 }
 .dqss-pin-col {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   width: min(100%, 52rem);
-  height: 100%;
   min-height: 0;
+  height: auto;
+  transform: scale(var(--dqss-fit-scale, 1));
+  transform-origin: top center;
 }
 .dqss-stack-clip {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   position: relative;
   width: 100%;
-  min-height: 0;
   overflow: hidden;
 }
 .dqss-stack {
   --dqss-peek: 3.75rem;
   position: relative;
   width: min(100%, 52rem);
-  min-height: calc(32rem + var(--dqss-peek) * (var(--stack-count, var(--dqss-stack-count)) - 1));
+  min-height: calc(
+    var(--dqss-card-h, 32rem) + var(--dqss-peek) * (var(--stack-count, var(--dqss-stack-count)) - 1)
+  );
   overflow: visible;
 }
 .dqss-stack-card {
@@ -1264,13 +1282,13 @@ html {
   pointer-events: none;
 }
 .dqss-library-cta {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 60;
+  position: relative;
+  flex: 0 0 auto;
+  width: 100%;
+  z-index: 1;
   display: flex;
   justify-content: center;
+  margin-top: clamp(1rem, 2.2vw, 1.35rem);
   padding-bottom: clamp(0.35rem, 1.5vw, 0.65rem);
   will-change: transform;
   pointer-events: none;
@@ -1324,9 +1342,8 @@ html {
   container-name: dqss-card;
   display: flex;
   flex-direction: column;
-  --dqss-preview-pane-h: 220px;
-  --dqss-preview-block-h: var(--dqss-preview-pane-h);
-  min-height: 32rem;
+  height: auto;
+  min-height: 0;
   border: 1px solid var(--hair);
   border-radius: 16px;
   background: linear-gradient(180deg, var(--surface), var(--surface-2));
@@ -1387,14 +1404,15 @@ html {
 
 .dqss-card .ts-kpis-primary {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: stretch;
   margin-bottom: clamp(0.65rem, 1.5cqi, 0.9rem);
   gap: clamp(0.3rem, 0.8cqi, 0.5rem);
 }
 .dqss-card .ts-kpis-primary .ts-kpi {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 1 1 calc(33.333% - 0.35rem);
+  min-width: 4.25rem;
+  max-width: 100%;
   padding: clamp(0.38rem, 1cqi, 0.55rem) clamp(0.35rem, 0.9cqi, 0.5rem);
   gap: 0.12rem;
 }
@@ -1403,15 +1421,15 @@ html {
 
 .dqss-card .ts-mode-bar { margin-bottom: clamp(0.55rem, 1.2cqi, 0.75rem); }
 .dqss-card .dqss-preview-panel {
-  flex: 0 0 var(--dqss-preview-block-h);
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   margin-bottom: 0;
-  height: var(--dqss-preview-block-h);
-  min-height: var(--dqss-preview-block-h);
-  max-height: var(--dqss-preview-block-h);
+  height: auto;
+  min-height: 0;
+  max-height: none;
   padding: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 .dqss-card .ts-panel.dqss-preview-panel {
   box-shadow: none;
@@ -1422,27 +1440,29 @@ html {
 .dqss-card .ts-tab-content { min-height: 0; }
 .dqss-preview-pane {
   position: relative;
-  min-height: 0;
-  height: 100%;
-  max-height: 100%;
-  overflow: hidden;
+  width: 100%;
+  height: auto;
+  overflow: visible;
 }
-.dqss-preview-pane-layer {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  min-height: 0;
+.dqss-card .dqss-preview-pane-layer {
+  position: relative;
+  width: 100%;
+  overflow: visible;
 }
-.dqss-preview-pane-layer[hidden] { display: block; visibility: hidden; pointer-events: none; }
-.dqss-card .dqss-preview-table-pane { overflow: hidden; }
+.dqss-preview-chart {
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+}
 .dqss-card .dqss-preview-table-pane .ts-pivot-stats-compact {
-  height: 100%;
+  height: auto;
   min-height: 0;
 }
 .dqss-card .dqss-preview-table-pane .ts-pivot-wrap-compact {
-  max-height: 100%;
-  height: 100%;
-  overflow: hidden;
+  max-height: none;
+  height: auto;
+  overflow: visible;
 }
 .dqss-card .dqss-preview-table-pane .ts-pivot-table-compact {
   min-width: 0;
@@ -1468,33 +1488,38 @@ html {
 .dqss-card .dqss-preview-table-pane .ts-pivot-wrap { max-height: none; }
 .dqss-card .ts-pivot-table { min-width: max(100%, 380px); font-size: 0.78rem; }
 .dqss-card .ts-pivot-metric-col { font-size: 0.72rem; }
-.dqss-preview-chart {
-  width: 100%;
-  height: 100%;
-  min-height: 0;
-  max-height: 100%;
-  overflow: hidden;
-}
 .dqss-preview-chart .ts-chart-wrap {
   width: 100%;
-  height: 100%;
-  min-height: 0;
-  max-height: 100%;
+  height: auto;
   margin: 0;
 }
-.dqss-preview-chart .ts-chart { height: 100%; min-height: 0; max-height: 100%; margin: 0; }
+.dqss-preview-chart .ts-chart { height: auto; margin: 0; }
 .dqss-preview-chart svg {
   display: block;
   width: 100%;
-  height: 100%;
-  min-height: 0;
-  max-height: 100%;
+  height: auto;
 }
 .dqss-preview-chart .ts-axis { font-size: 10px; }
 .dqss-preview-footer { margin: clamp(0.55rem, 1.2cqi, 0.75rem) 0 0; }
-.dqss-chart-skeleton { width: 100%; height: 100%; border-radius: 8px; background: linear-gradient(90deg, color-mix(in srgb, var(--hair) 55%, transparent) 0%, color-mix(in srgb, var(--hair) 25%, transparent) 50%, color-mix(in srgb, var(--hair) 55%, transparent) 100%); background-size: 200% 100%; animation: dqss-skel 1.2s ease-in-out infinite; }
+.dqss-chart-skeleton {
+  width: 100%;
+  min-height: 13.75rem;
+  border-radius: 8px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--hair) 55%, transparent) 0%, color-mix(in srgb, var(--hair) 25%, transparent) 50%, color-mix(in srgb, var(--hair) 55%, transparent) 100%);
+  background-size: 200% 100%;
+  animation: dqss-skel 1.2s ease-in-out infinite;
+}
 @keyframes dqss-skel { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }
-.dqss-chart-empty { display: flex; align-items: center; justify-content: center; height: 100%; font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.04em; color: var(--ink-mute); }
+.dqss-chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 13.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+}
 .dqss-full { display: inline-block; margin-top: 0.15rem; font-family: var(--font-mono); font-size: 0.72rem; color: var(--ink-mute); opacity: 0.9; }
 .dqss-full:hover { color: var(--accent); text-decoration: underline; }
 
@@ -1513,7 +1538,6 @@ html {
   .dqss-stack {
     --dqss-peek: 3.25rem;
   }
-  .dqss-card { min-height: 30rem; }
 }
 
 /* ---- closing CTA ---- */
@@ -1525,19 +1549,9 @@ html {
   .dqhero-h1 .ln > span, .dqhero-lede, .dqhero-cta { opacity: 1 !important; transform: none !important; transition: none !important; }
   .dqhero-scroll::after { animation: none; opacity: 0.85; transform: translateY(30px); }
   .dqpipe-step { opacity: 1; transform: none; transition: none; }
-  .dqss-scrolly { height: auto; }
-  .dqss-stack-pin { position: relative; height: auto; }
-  .dqss-stack-card {
-    position: relative;
-    top: auto;
-    transform: none !important;
-    margin-bottom: 1.5rem;
-  }
-  .dqss-library-cta {
-    position: relative;
-    transform: none !important;
-    margin-top: 0.5rem;
-    padding-bottom: 0;
-  }
+  .dqss-scrolly { height: auto !important; }
+  .dqss-stack-pin { position: relative; top: auto; min-height: 0; }
+  .dqss-stack-card { transform: none !important; }
+  .dqss-library-cta { transform: none !important; visibility: visible; pointer-events: auto; }
   .dqss-chart-skeleton { animation: none; }
 }

--- a/frontend/digiquant-web/components/landing/DqNav.tsx
+++ b/frontend/digiquant-web/components/landing/DqNav.tsx
@@ -47,9 +47,15 @@ function NavLinks({
 export function DqNav() {
   const navRef = useRef<HTMLElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
-  const portalReady = typeof window !== "undefined";
+  // Portal only after hydration — first client render must match SSR (no portal nodes).
+  const [portalReady, setPortalReady] = useState(false);
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mount gate for createPortal
+    setPortalReady(true);
+  }, []);
 
   useEffect(() => {
     const nav = navRef.current;

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -1,8 +1,9 @@
 "use client";
 /**
- * Homepage strategy spotlight — scroll-pinned card stack (BTC / ETH / SOL).
+ * Homepage strategy spotlight — scroll-pinned peek stack (BTC / ETH / SOL).
  *
- * Scroll progress slides each tearsheet up over the previous one.
+ * Cards slide in from below as you scroll; the full stack + library CTA scale to
+ * fit the viewport when zoom or content height would otherwise clip.
  */
 import {
   useEffect,
@@ -34,18 +35,32 @@ const STRATEGIES = SLAPPER_ORDER.map(
 
 const PREVIEW_PANE_H = 220;
 const PREVIEW_LOOKBACK = "6m" as const;
+const MIN_FIT_SCALE = 0.68;
 
 type PreviewMode = "charts" | "tables";
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
-/** Smooth ease — slow start and end so cards glide in rather than snap. */
 function easeInOutCubic(t: number): number {
   const x = clamp(t, 0, 1);
   return x < 0.5 ? 4 * x * x * x : 1 - (-2 * x + 2) ** 3 / 2;
 }
 
-/** Scroll distance (px) allocated to each card's bottom-to-seat entrance. */
+function parseCssLengthPx(raw: string, viewportH: number): number {
+  const trimmed = raw.trim();
+  if (!trimmed) return 0;
+  const n = Number.parseFloat(trimmed);
+  if (!Number.isFinite(n)) return 0;
+  if (trimmed.endsWith("svh") || trimmed.endsWith("vh")) return (n / 100) * viewportH;
+  if (trimmed.endsWith("rem")) return n * 16;
+  return n;
+}
+
+function introHoldPx(scrolly: HTMLElement): number {
+  const raw = getComputedStyle(scrolly).getPropertyValue("--dqss-intro-hold").trim();
+  return parseCssLengthPx(raw, window.innerHeight);
+}
+
 function cardEnterBudgetsPx(scrolly: HTMLElement, count: number): number[] {
   const base = parseCssLengthPx(
     getComputedStyle(scrolly).getPropertyValue("--dqss-enter-scroll").trim() || "80svh",
@@ -53,7 +68,6 @@ function cardEnterBudgetsPx(scrolly: HTMLElement, count: number): number[] {
   );
   if (count <= 0) return [];
   if (count === 1) return [base];
-  // First card still leads, but every entrance gets a long scroll runway.
   return Array.from({ length: count }, (_, i) => (i === 0 ? base * 0.82 : base * 1.12));
 }
 
@@ -112,21 +126,6 @@ function libraryCtaOffsetY(
   return hideOffset * (1 - easeInOutCubic(t));
 }
 
-function parseCssLengthPx(raw: string, viewportH: number): number {
-  const trimmed = raw.trim();
-  if (!trimmed) return 0;
-  const n = Number.parseFloat(trimmed);
-  if (!Number.isFinite(n)) return 0;
-  if (trimmed.endsWith("svh") || trimmed.endsWith("vh")) return (n / 100) * viewportH;
-  if (trimmed.endsWith("rem")) return n * 16;
-  return n;
-}
-
-function introHoldPx(scrolly: HTMLElement): number {
-  const raw = getComputedStyle(scrolly).getPropertyValue("--dqss-intro-hold").trim();
-  return parseCssLengthPx(raw, window.innerHeight);
-}
-
 function useElementWidth(ref: RefObject<HTMLDivElement | null>): number {
   const [width, setWidth] = useState(640);
 
@@ -142,24 +141,6 @@ function useElementWidth(ref: RefObject<HTMLDivElement | null>): number {
   }, [ref]);
 
   return width;
-}
-
-function useElementHeight(ref: RefObject<HTMLElement | null>, fallback = PREVIEW_PANE_H): number {
-  const [height, setHeight] = useState(fallback);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-
-    const ro = new ResizeObserver(([entry]) => {
-      const next = Math.floor(entry.contentRect.height);
-      if (next > 0) setHeight(next);
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [ref]);
-
-  return height;
 }
 
 type LoadStatus = "idle" | "loading" | "loaded" | "error";
@@ -246,9 +227,7 @@ function Kpi({ label, value, className }: { label: string; value: ReactNode; cla
 
 function StrategyTearsheetCard({ entry }: { entry: StrategyIndexEntry }) {
   const cardRef = useRef<HTMLDivElement>(null);
-  const previewPaneRef = useRef<HTMLDivElement>(null);
   const cardWidth = useElementWidth(cardRef);
-  const chartPaneHeight = useElementHeight(previewPaneRef);
   const [mode, setMode] = useState<PreviewMode>("charts");
   const { data, status } = useTearsheetData(entry.strategy);
 
@@ -359,42 +338,37 @@ function StrategyTearsheetCard({ entry }: { entry: StrategyIndexEntry }) {
         className="ts-panel ts-tab-stack dqss-preview-panel"
         aria-label={mode === "charts" ? "Price chart" : "Statistics table"}
       >
-        <div className="dqss-preview-pane" ref={previewPaneRef}>
-          <div
-            className="dqss-preview-pane-layer dqss-preview-chart-pane"
-            hidden={mode !== "charts"}
-            aria-hidden={mode !== "charts"}
-          >
-            <div className="ts-chart dqss-preview-chart">
-              {chartLoading ? (
-                <div className="dqss-chart-skeleton" aria-hidden="true" />
-              ) : chartReady ? (
+        <div className="dqss-preview-pane">
+          {mode === "charts" ? (
+            <div className="dqss-preview-pane-layer dqss-preview-chart-pane">
+              <div className="ts-chart dqss-preview-chart">
+                {chartLoading ? (
+                  <div className="dqss-chart-skeleton" aria-hidden="true" />
+                ) : chartReady ? (
                   <CandlestickChart
                     bars={chartOhlc}
                     trades={previewTrades}
-                    height={chartPaneHeight}
+                    height={PREVIEW_PANE_H}
                     view={view6m}
                     fullSpan={fullSpan}
                     compact
                   />
+                ) : (
+                  <div className="dqss-chart-empty">
+                    {chartUnavailable ? "Chart unavailable" : "Could not load chart"}
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="dqss-preview-pane-layer dqss-preview-table-pane">
+              {data ? (
+                <PivotStatsTable data={data} pivot="direction" compact />
               ) : (
-                <div className="dqss-chart-empty">
-                  {chartUnavailable ? "Chart unavailable" : "Could not load chart"}
-                </div>
+                <p className="dqss-chart-empty">Loading statistics…</p>
               )}
             </div>
-          </div>
-          <div
-            className="dqss-preview-pane-layer dqss-preview-table-pane"
-            hidden={mode !== "tables"}
-            aria-hidden={mode !== "tables"}
-          >
-            {data ? (
-              <PivotStatsTable data={data} pivot="direction" compact />
-            ) : (
-              <p className="dqss-chart-empty">Loading statistics…</p>
-            )}
-          </div>
+          )}
         </div>
       </section>
 
@@ -413,28 +387,97 @@ function navHeightPx(): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function peekHeightPx(scrolly: HTMLElement): number {
-  const stack = scrolly.querySelector<HTMLElement>(".dqss-stack");
-  const raw = getComputedStyle(stack ?? document.documentElement).getPropertyValue("--dqss-peek").trim();
+function peekHeightPx(stack: HTMLElement | null): number {
+  const raw = getComputedStyle(stack ?? document.documentElement)
+    .getPropertyValue("--dqss-peek")
+    .trim();
   const parsed = Number.parseFloat(raw);
   if (!Number.isFinite(parsed)) return 60;
   return raw.endsWith("rem") ? parsed * 16 : parsed;
 }
 
-function measureStackMetrics(scrolly: HTMLElement) {
-  const navH = navHeightPx();
-  const pin = scrolly.querySelector<HTMLElement>(".dqss-stack-pin");
-  const card = scrolly.querySelector<HTMLElement>(".dqss-card");
+function tallestCardHeightPx(scrolly: HTMLElement): number {
+  let tallest = 0;
+  scrolly.querySelectorAll<HTMLElement>(".dqss-card").forEach((card) => {
+    tallest = Math.max(tallest, card.offsetHeight);
+  });
+  return tallest > 0 ? tallest : 620;
+}
+
+function libraryCtaHideOffsetPx(scrolly: HTMLElement): number {
+  const cta = scrolly.querySelector<HTMLElement>(".dqss-library-cta");
+  return (cta?.offsetHeight ?? 52) + 40;
+}
+
+function syncStackHeight(scrolly: HTMLElement, count: number): number {
+  const stack = scrolly.querySelector<HTMLElement>(".dqss-stack");
+  if (!stack) return 620;
+  const cardH = tallestCardHeightPx(scrolly);
+  const peek = peekHeightPx(stack);
+  const stackH = cardH + peek * Math.max(0, count - 1) + 16;
+  stack.style.setProperty("--dqss-card-h", `${cardH}px`);
+  stack.style.height = `${stackH}px`;
   const clip = scrolly.querySelector<HTMLElement>(".dqss-stack-clip");
-  const pinH = pin?.getBoundingClientRect().height ?? Math.max(320, window.innerHeight - navH);
-  const cardH = card?.offsetHeight ?? 620;
-  const clipH = clip?.clientHeight ?? Math.max(280, pinH * 0.55);
-  const peek = peekHeightPx(scrolly);
-  const scrollable = Math.max(1, scrolly.offsetHeight - pinH);
-  // Push cards fully below the clip so nothing peeks before its segment starts.
-  const hideOffset = clipH + peek + 24;
-  const slide = hideOffset;
-  return { pinH, scrollable, slide, hideOffset, cardH };
+  if (clip) clip.style.height = `${stackH}px`;
+  return stackH;
+}
+
+function applyViewportFit(scrolly: HTMLElement, count: number): void {
+  const col = scrolly.querySelector<HTMLElement>(".dqss-pin-col");
+  const stack = scrolly.querySelector<HTMLElement>(".dqss-stack");
+  if (!col) return;
+
+  col.style.setProperty("--dqss-fit-scale", "1");
+  if (stack) stack.style.removeProperty("--dqss-peek");
+
+  syncStackHeight(scrolly, count);
+
+  const available = window.innerHeight - navHeightPx() - 24;
+  let contentH = col.scrollHeight;
+  if (contentH <= available) return;
+
+  let scale = clamp(available / contentH, MIN_FIT_SCALE, 1);
+  if (stack && scale < 0.92) {
+    stack.style.setProperty("--dqss-peek", scale < 0.8 ? "2.35rem" : "2.75rem");
+    syncStackHeight(scrolly, count);
+    contentH = col.scrollHeight;
+    scale = clamp(available / contentH, MIN_FIT_SCALE, 1);
+  }
+  col.style.setProperty("--dqss-fit-scale", scale.toFixed(4));
+}
+
+function totalScrollyHeightPx(scrolly: HTMLElement, pinH: number, count: number): number {
+  const viewportMin = Math.max(320, window.innerHeight - navHeightPx());
+  const pinRunway = Math.max(pinH, viewportMin);
+  const style = getComputedStyle(scrolly);
+  const introHold = parseCssLengthPx(style.getPropertyValue("--dqss-intro-hold").trim(), window.innerHeight);
+  const ctaScroll = parseCssLengthPx(style.getPropertyValue("--dqss-cta-scroll").trim(), window.innerHeight);
+  const budgetSum = totalCardBudgetPx(cardEnterBudgetsPx(scrolly, count));
+  const tail = 0.32 * window.innerHeight;
+  return Math.ceil(introHold + budgetSum + ctaScroll + pinRunway + tail);
+}
+
+function syncScrollyHeight(scrolly: HTMLElement, pinH: number, count: number): void {
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (reduced) {
+    scrolly.style.height = "";
+    return;
+  }
+  const heightPx = totalScrollyHeightPx(scrolly, pinH, count);
+  scrolly.style.height = `${heightPx}px`;
+}
+
+function measureStackMetrics(scrolly: HTMLElement, count: number) {
+  const pin = scrolly.querySelector<HTMLElement>(".dqss-stack-pin");
+  const stackH = syncStackHeight(scrolly, count);
+  applyViewportFit(scrolly, count);
+  const pinH = pin?.getBoundingClientRect().height ?? Math.max(320, window.innerHeight - navHeightPx());
+  syncScrollyHeight(scrolly, pinH, count);
+  const pinHAfter = pin?.getBoundingClientRect().height ?? pinH;
+  const scrollable = Math.max(1, scrolly.offsetHeight - pinHAfter);
+  const hideOffset = stackH + 24;
+  const ctaHideOffset = libraryCtaHideOffsetPx(scrolly);
+  return { pinH: pinHAfter, scrollable, hideOffset, ctaHideOffset, stackH };
 }
 
 export function StrategySuite() {
@@ -456,7 +499,7 @@ export function StrategySuite() {
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     const updateFromScroll = () => {
-      const { scrollable, hideOffset } = measureStackMetrics(scrolly);
+      const { scrollable, hideOffset, ctaHideOffset } = measureStackMetrics(scrolly, count);
       const budgets = cardEnterBudgetsPx(scrolly, count);
       const ctaBudget = libraryCtaBudgetPx(scrolly);
       const rect = scrolly.getBoundingClientRect();
@@ -467,7 +510,7 @@ export function StrategySuite() {
         setIntroPhase(true);
         setActiveIndex(0);
         setCardOffsets(STRATEGIES.map(() => hideOffset));
-        setLibraryCtaOffset(hideOffset);
+        setLibraryCtaOffset(ctaHideOffset);
         return;
       }
 
@@ -479,7 +522,7 @@ export function StrategySuite() {
         setActiveIndex(idx);
         setCardOffsets(STRATEGIES.map((_, i) => (i <= idx ? 0 : hideOffset)));
         setLibraryCtaOffset(
-          scrolledPastHold >= totalCardBudgetPx(budgets) ? 0 : hideOffset,
+          scrolledPastHold >= totalCardBudgetPx(budgets) ? 0 : ctaHideOffset,
         );
         return;
       }
@@ -489,17 +532,69 @@ export function StrategySuite() {
         STRATEGIES.map((_, i) => stackCardOffsetY(i, scrolledPastHold, budgets, hideOffset)),
       );
       setLibraryCtaOffset(
-        libraryCtaOffsetY(scrolledPastHold, budgets, ctaBudget, hideOffset),
+        libraryCtaOffsetY(scrolledPastHold, budgets, ctaBudget, ctaHideOffset),
       );
     };
 
-    window.addEventListener("scroll", updateFromScroll, { passive: true });
-    window.addEventListener("resize", updateFromScroll, { passive: true });
+    const nudgeStrategiesHash = () => {
+      if (window.location.hash !== "#strategies") return;
+      const holdPx = introHoldPx(scrolly);
+      const { scrollable } = measureStackMetrics(scrolly, count);
+      const scrolled = clamp(-scrolly.getBoundingClientRect().top, 0, scrollable);
+      if (scrolled >= holdPx) return;
+      window.scrollTo({
+        top: window.scrollY + (holdPx - scrolled) + 1,
+        behavior: "instant",
+      });
+    };
+
+    const onScroll = () => {
+      updateFromScroll();
+    };
+
+    const onHashChange = () => {
+      requestAnimationFrame(() => {
+        nudgeStrategiesHash();
+        updateFromScroll();
+      });
+    };
+
+    const onViewportChange = () => {
+      updateFromScroll();
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onViewportChange, { passive: true });
+    window.addEventListener("hashchange", onHashChange);
+    window.visualViewport?.addEventListener("resize", onViewportChange);
+    window.visualViewport?.addEventListener("scroll", onViewportChange);
+
+    const col = scrolly.querySelector<HTMLElement>(".dqss-pin-col");
+    const stack = scrolly.querySelector<HTMLElement>(".dqss-stack");
+    const ro = new ResizeObserver(() => {
+      requestAnimationFrame(updateFromScroll);
+    });
+    if (col) ro.observe(col);
+    if (stack) ro.observe(stack);
+
     updateFromScroll();
+    requestAnimationFrame(() => {
+      nudgeStrategiesHash();
+      updateFromScroll();
+    });
+
+    const unsubCache = subscribeTearsheetCache(() => {
+      requestAnimationFrame(updateFromScroll);
+    });
 
     return () => {
-      window.removeEventListener("scroll", updateFromScroll);
-      window.removeEventListener("resize", updateFromScroll);
+      unsubCache();
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onViewportChange);
+      window.removeEventListener("hashchange", onHashChange);
+      window.visualViewport?.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("scroll", onViewportChange);
+      ro.disconnect();
     };
   }, [count]);
 
@@ -531,47 +626,46 @@ export function StrategySuite() {
               >
                 {STRATEGIES.map((entry, i) => {
                   const offset = cardOffsets[i] ?? 0;
-                  const notYetShown =
-                    introPhase || (offset > 8 && i !== activeIndex);
+                  const notYetShown = introPhase || (offset > 8 && i !== activeIndex);
                   return (
-                  <div
-                    key={entry.strategy}
-                    className="dqss-stack-card"
-                    data-stack-index={i}
-                    data-state={
-                      notYetShown
-                        ? "hidden"
-                        : i < activeIndex
-                          ? "buried"
-                          : i === activeIndex
-                            ? "top"
-                            : "below"
-                    }
-                    style={
-                      {
-                        "--stack-index": i,
-                        transform: `translate3d(0, ${offset}px, 0)`,
-                      } as CSSProperties
-                    }
-                    aria-hidden={introPhase || i > activeIndex}
-                  >
-                    <StrategyTearsheetCard entry={entry} />
-                  </div>
+                    <div
+                      key={entry.strategy}
+                      className="dqss-stack-card"
+                      data-stack-index={i}
+                      data-state={
+                        notYetShown
+                          ? "hidden"
+                          : i < activeIndex
+                            ? "buried"
+                            : i === activeIndex
+                              ? "top"
+                              : "below"
+                      }
+                      style={
+                        {
+                          "--stack-index": i,
+                          transform: `translate3d(0, ${offset}px, 0)`,
+                        } as CSSProperties
+                      }
+                      aria-hidden={introPhase || i > activeIndex}
+                    >
+                      <StrategyTearsheetCard entry={entry} />
+                    </div>
                   );
                 })}
               </div>
-              <div
-                className="dqss-library-cta"
-                data-state={introPhase || libraryCtaOffset > 8 ? "hidden" : "visible"}
-                style={{ transform: `translate3d(0, ${libraryCtaOffset}px, 0)` }}
-              >
-                <Link href="/strategies" className="dqss-library-pill">
-                  Full strategy library
-                  <span className="dqss-library-arrow" aria-hidden="true">
-                    →
-                  </span>
-                </Link>
-              </div>
+            </div>
+            <div
+              className="dqss-library-cta"
+              data-state={introPhase || libraryCtaOffset > 8 ? "hidden" : "visible"}
+              style={{ transform: `translate3d(0, ${libraryCtaOffset}px, 0)` }}
+            >
+              <Link href="/strategies" className="dqss-library-pill">
+                Full strategy library
+                <span className="dqss-library-arrow" aria-hidden="true">
+                  →
+                </span>
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Restores scroll-driven BTC → ETH → SOL card slide-in on the homepage strategy section
- Auto-scales the full peek stack + library CTA to fit the viewport (zoom-safe)
- Places the “Full strategy library” button below the card stack (no overlap)
- Fixes DqNav mobile portal hydration mismatch and contact section stacking

Fixes #1198

## Test plan
- [x] `npm run lint --workspace digiquant-web`
- [ ] Homepage: scroll `#strategies` — cards slide in from bottom
- [ ] End state: all 3 peek tabs + library button fully visible
- [ ] Browser zoom 110–125%: no clipping; contact section below strategies
- [ ] Mobile nav open/close; `/#strategies` hash lands on stack

Made with [Cursor](https://cursor.com)