### PR TITLE
feat(website): motion & layout tokens for design evolution

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -246,7 +246,7 @@ Add to `tokens.css` when implementing primitives:
 
 - [x] Reference scans in `references/`
 - [x] This evolution doc
-- [ ] Add `--ease-glide`, `--section-y`, `--product-frame-w` to `tokens.css`
+- [x] Add `--ease-glide`, `--section-y`, `--product-frame-w` to `tokens.css`
 - [ ] Update `README.md` typography table (Geist, not Inter)
 
 ### Phase B — Shared primitives

--- a/frontend/design/README.md
+++ b/frontend/design/README.md
@@ -67,6 +67,12 @@ Tokens `--space-1` … `--space-9` (0.25rem, 0.5rem, 1rem, 1.5rem, 2rem,
 3rem, 4rem, 6rem, 8rem). `--spacing-base` (1.5rem) remains as the
 container gutter.
 
+**Redesign layer (`[data-theme]`, EVOLUTION.md §5):** `--wrap: 1180px`
+(default container), `--wrap-wide: 1280px` (marketing/bento sections),
+`--product-frame-w: 800px` (Graphite/Cursor-style CQ-scaled UI embed),
+`--section-y: clamp(4rem, 8vw, 7rem)` / `--section-y-tight:
+clamp(2.5rem, 5vw, 4rem)` (section vertical rhythm).
+
 ### Radius
 
 `--radius-sm: 6px`, `--radius-md: 8px`, `--radius-lg: 12px`.
@@ -74,6 +80,11 @@ container gutter.
 ### Motion
 
 `--transition-speed: 0.8s`, `--transition-ease: cubic-bezier(0.2, 0.8, 0.2, 1)`.
+
+**Redesign layer (`[data-theme]`, EVOLUTION.md §5):** `--ease-glide:
+cubic-bezier(0.22, 1, 0.36, 1)` (same curve as `--ease`, named
+separately for reveal-on-scroll consumers per the primitives in Phase
+B), `--duration-reveal: 0.6s`, `--duration-hover: 0.18s`.
 
 ---
 

--- a/frontend/design/tokens.css
+++ b/frontend/design/tokens.css
@@ -172,6 +172,8 @@
   --font-display: "Instrument Serif", Georgia, serif;
 
   --wrap: 1180px;
+  --wrap-wide: 1280px;
+  --product-frame-w: 800px;
   --gutter: clamp(1.25rem, 4vw, 3.25rem);
 
   --r-sm: 8px;
@@ -179,4 +181,11 @@
   --r-lg: 16px;
 
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* Graphite-inspired section rhythm + reveal motion (EVOLUTION.md §5). */
+  --section-y: clamp(4rem, 8vw, 7rem);
+  --section-y-tight: clamp(2.5rem, 5vw, 4rem);
+  --ease-glide: cubic-bezier(0.22, 1, 0.36, 1);
+  --duration-reveal: 0.6s;
+  --duration-hover: 0.18s;
 }


### PR DESCRIPTION
## Summary
- Adds `--wrap-wide`, `--product-frame-w`, `--section-y`, `--section-y-tight`, `--ease-glide`, `--duration-reveal`, `--duration-hover` to the `[data-theme]` redesign layer of `frontend/design/tokens.css`, per [EVOLUTION.md §5](../../blob/develop/frontend/design/EVOLUTION.md).
- Purely additive — `--transition-speed` / `--transition-ease` (legacy layer) unchanged, no existing consumer touched.
- Documents the new tokens in `README.md` Motion + Spacing sections and checks off the Phase A tokens item in `EVOLUTION.md`.

## Test plan
- [x] `cd frontend/digithings-web && npm run build` — passes
- [x] `cd frontend/digiquant-web && npm run build` — passes
- [x] `python3 scripts/score.py --staged` — 10/10/10/10

Fixes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)