### PR TITLE
docs(website): typography README aligned to Geist, not Inter

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -247,7 +247,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] Reference scans in `references/`
 - [x] This evolution doc
 - [ ] Add `--ease-glide`, `--section-y`, `--product-frame-w` to `tokens.css`
-- [ ] Update `README.md` typography table (Geist, not Inter)
+- [x] Update `README.md` typography table (Geist, not Inter)
 
 ### Phase B — Shared primitives
 

--- a/frontend/design/README.md
+++ b/frontend/design/README.md
@@ -49,10 +49,35 @@ DigiChat and the marketing site render at identical contrast.
 
 ### Typography
 
+**Canonical fonts (all surfaces), per [`EVOLUTION.md` §4](EVOLUTION.md#4-typography-direction):**
+
+| Role                    | Font                             | Weight  | Token(s)                       |
+| ------------------------ | -------------------------------- | ------- | ------------------------------- |
+| Marketing hero display    | Fraunces *or* Instrument Serif   | 400     | `--font-display`                |
+| Dashboard display         | Instrument Serif                 | 400     | `--font-display`                |
+| Body                      | Geist Sans                       | 400–500 | `--font-sans`                   |
+| Labels / eyebrows         | Geist Mono, uppercase, tracked   | 400     | `--font-mono`                   |
+| Data / metrics            | Geist Mono, tabular nums         | 400–600 | `--font-mono` + `qn-metric`     |
+| Code                      | Geist Mono                       | 400     | `--font-mono`                   |
+
+`--font-sans`, `--font-mono`, `--font-display` are declared in the
+`[data-theme]` redesign layer of `tokens.css` and are already loaded in
+every Next.js app. **Rule:** serif is display-only on marketing pages;
+dashboards and twelve-x use sans + mono exclusively.
+
+**Deprecated:** `--font-family` (`'Inter', …`) and `--font-family-mono`
+(`'JetBrains Mono', …`) are the legacy `:root` tokens — still resolved
+by pages that haven't adopted `[data-theme]` yet, but no longer the
+documented default. New and migrating components should reference
+`--font-sans` / `--font-mono` / `--font-display` instead of these two.
+
+| Token (legacy, deprecated) | Value                                 |
+| --------------------------- | ------------------------------------- |
+| `--font-family`             | `'Inter', system-ui, …`               |
+| `--font-family-mono`        | `'JetBrains Mono', 'Fira Code', …`    |
+
 | Token                      | Value                                 |
 | -------------------------- | ------------------------------------- |
-| `--font-family`            | `'Inter', system-ui, …`               |
-| `--font-family-mono`       | `'JetBrains Mono', 'Fira Code', …`    |
 | `--font-size-h1`           | `clamp(3rem, 6vw, 4.5rem)`            |
 | `--font-size-h2`           | `2.5rem`                              |
 | `--font-size-h3`           | `1.5rem`                              |


### PR DESCRIPTION
## Summary
- Replaces the Inter/JetBrains-first typography table in `frontend/design/README.md` with a role table (display / body / label / data / code) matching [EVOLUTION.md §4](../../blob/develop/frontend/design/EVOLUTION.md#4-typography-direction).
- Marks legacy `--font-family` / `--font-family-mono` as deprecated with a migration note to `--font-sans` / `--font-mono` / `--font-display` (the `[data-theme]` redesign-layer tokens, already loaded in every Next.js app).
- Docs-only — no `@font-face` / font-loading code changed.

## Test plan
- [x] `make doc-check` — OK (212 markdown files scanned)
- [x] `python3 scripts/score.py --staged` — 10/10/10/10

Fixes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)