### PR TITLE
docs(agent-backlog): add design evolution theme row to INDEX.md

### DIFF
--- a/docs/agent-backlog/INDEX.md
+++ b/docs/agent-backlog/INDEX.md
@@ -7,6 +7,7 @@ Update this file when themes start/complete. Link **GitHub Issues** (not bare TO
 | Theme | Status | Primary issues | Notes / ADRs |
 |-------|--------|----------------|--------------|
 | Agent ops & doc hygiene | in_progress | _(add GitHub issue URLs)_ | [ADR template](../adr/0000-template.md) |
+| Design evolution (Graphite/Cursor/xAI primitives) | in_progress | [#1200](https://github.com/digithings-ai/digithings/issues/1200) (epic), #1201–#1231 | [`frontend/design/EVOLUTION.md`](../../frontend/design/EVOLUTION.md) |
 | _(example) DigiGraph hub mode_ | todo |  | |
 
 ## Quick links


### PR DESCRIPTION
## Summary
- Epic #1200's acceptance criteria checkbox claims `docs/agent-backlog/INDEX.md` already has a "Design evolution" theme row — it doesn't (verified via grep, and no commit on any branch ever added it).
- Adds the row now that Phase A work (#1201, #1219) has actually started, per this file's own instruction: "Update this file when themes start."

## Test plan
- [x] `make doc-check` — OK (212 markdown files scanned)
- [x] `python3 scripts/score.py --staged` — 10/10/10/10

Refs #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)