### PR TITLE
feat(design): ProductFrame CQ-scaled primitive

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -48,6 +48,12 @@
       "runtimeExecutable": "/Users/chrisstefan/Code/digithings/.venv/bin/python",
       "runtimeArgs": ["-m", "http.server", "4020", "--directory", "frontend/design/demos/digiquant-landing"],
       "port": 4020
+    },
+    {
+      "name": "design-smoke-local",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "4030", "--directory", "frontend/design"],
+      "port": 4030
     }
   ]
 }

--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -202,7 +202,7 @@ Add to `tokens.css` when implementing primitives:
 | Primitive | Purpose | References |
 |-----------|---------|------------|
 | `BentoGrid` / `.bento` | 2×2 feature cells | Cursor |
-| `ProductFrame` | CQ-scaled 800px UI embed | Graphite, Cursor |
+| `ProductFrame` ✅ | CQ-scaled 800px UI embed ([`site/README.md`](site/README.md#productframe-css-only-evolutionmd-phase-b)) | Graphite, Cursor |
 | `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
 | `TrustStrip` | Logo / proof row | Cursor, Graphite |
 | `StatCounter` | Scroll-triggered metrics | xAI |
@@ -251,7 +251,7 @@ Add to `tokens.css` when implementing primitives:
 
 ### Phase B — Shared primitives
 
-- [ ] `ProductFrame` component + CSS
+- [x] `ProductFrame` component + CSS
 - [ ] `BentoGrid` layout CSS in `site/site.css`
 - [ ] `TrustStrip`, `reveal-up` utilities
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -28,7 +28,7 @@ on the same origin, so a chosen theme follows the user across surfaces.
 
 | File | Export | Purpose |
 |------|--------|---------|
-| `site.css` | — | Component layer: nav, buttons, hero, sections, cards, **terminal block**, **connected graph**, pills/stage, principles, footer, `.reveal`. |
+| `site.css` | — | Component layer: nav, buttons, hero, sections, cards, **product frame**, **terminal block**, **connected graph**, pills/stage, principles, footer, `.reveal`. |
 | `theme.js` | `initTheme()`, `applyTheme()` | Toggle (`#theme-toggle`), persistence, OS-follow, and theme-aware asset swap for any element with `data-src-dark` / `data-src-light` (QR mark, favicon). |
 | `ui.js` | `initNav()`, `initCopy()` | Sticky-nav glass, mobile nav, and `[data-copy]` / `[data-copy-target]` copy buttons. |
 | `reveal.js` | `initReveal()` | Scroll reveal for `.reveal` with per-grid stagger. |
@@ -37,6 +37,37 @@ on the same origin, so a chosen theme follows the user across surfaces.
 
 All modules are progressive enhancement (a JS-off page is fully visible/static)
 and honor `prefers-reduced-motion`.
+
+## `ProductFrame` (CSS-only, EVOLUTION.md Phase B)
+
+CQ-scaled ~800px UI embed for marketing pages — Graphite artboard / Cursor
+product-screenshot pattern. No JS: markup two nested elements and let the
+container query handle scaling.
+
+```html
+<div class="product-frame">
+  <div class="product-frame__surface">
+    <!-- screenshot <img>, terminal snippet, or arbitrary UI markup -->
+  </div>
+</div>
+<p class="product-frame__caption">Fig. 1 — caption text</p>
+```
+
+| Class | Role |
+|-------|------|
+| `.product-frame` | Sizing wrapper — `max-width: var(--product-frame-w)` (800px), establishes a `container-type: inline-size` query container. |
+| `.product-frame__surface` | Flat panel — `--surface` background, 1px `--hair` border, `--r-lg` radius. Font size scales in `cqi` (container-query inline units), clamped, so content shrinks with the *frame's* width rather than the viewport. |
+| `.product-frame__caption` | Optional mono caption below the frame. |
+
+**Atmosphere rule:** no mesh/glow/grain inside `.product-frame__surface` —
+those effects belong to the page background around the frame, never on
+the simulated UI itself (EVOLUTION.md §7, "atmospheric outside, surgical
+inside").
+
+Works unscoped in both `[data-theme="light"]` and `[data-theme="dark"]`. A
+React wrapper is deferred until [#1195](https://github.com/digithings-ai/digithings/issues/1195)
+(landing-primitive package location) resolves — the CSS classes are usable
+directly from any JSX/TSX today.
 
 ## JSON-driven detail pages
 

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -161,6 +161,21 @@ code.snippet, .card code { font-family: var(--font-mono); font-size: 0.74rem; co
 .card-link { font-size: 0.8rem; color: var(--accent); margin-top: 0.55rem; font-weight: 500; }
 .card-link:hover { text-decoration: underline; }
 
+/* ── product frame (Graphite artboard / Cursor product screenshot) ────
+   Flat, CQ-scaled UI embed for marketing pages. "Atmospheric outside,
+   surgical inside" (EVOLUTION.md §7) — no mesh/glow/grain on the surface
+   itself; those live on the page background around the frame.
+   CQ scaling: `container-type: inline-size` on .product-frame turns its
+   own box into a query container, and .product-frame__surface sizes its
+   type in `cqi` (container-query inline-size units) clamped between a
+   floor and ceiling. That means UI text inside the frame shrinks with
+   the *frame's* width (e.g. a narrower column on mobile), not the
+   viewport — a screenshot-like embed stays legible without overflowing
+   at any breakpoint. ────────────────────────────────────────────────── */
+.product-frame { width: 100%; max-width: var(--product-frame-w); margin-inline: auto; container-type: inline-size; }
+.product-frame__surface { background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); overflow: hidden; padding: clamp(0.85rem, 4cqi, 1.6rem); font-size: clamp(0.72rem, 2.4cqi, 1rem); line-height: 1.5; }
+.product-frame__caption { margin-top: 0.75rem; font-family: var(--font-mono); font-size: 0.78rem; color: var(--ink-mute); text-align: center; }
+
 /* ── capability pills / stage ───────────────────────────────────────── */
 .pills { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin: 1.2rem 0 1.8rem; }
 .pill { font-family: var(--font-mono); font-size: 0.85rem; padding: 0.5rem 1rem; border-radius: 999px; border: 1px solid var(--hair); background: var(--surface); color: var(--ink-soft); cursor: pointer; transition: 0.2s var(--ease); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -10,7 +10,13 @@
   <link rel="stylesheet" href="../typography-motion/styles.css" />
   <link rel="stylesheet" href="../quant-native/styles.css" />
   <link rel="stylesheet" href="../app-shell-terminal/styles.css" />
+  <link rel="stylesheet" href="../site/site.css" />
   <style>
+    /* Phase B (site.css) demos render inside .site-demo so the legacy
+       primitives above are unaffected by the [data-theme] font/color layer. */
+    .site-demo { font-family: var(--font-sans); color: var(--ink); }
+    .site-demo .label { color: var(--ink-mute); }
+    #smoke-theme-toggle { position: fixed; top: var(--space-4); right: var(--space-4); z-index: 10; }
     body {
       margin: 0;
       padding: var(--space-5);
@@ -58,6 +64,7 @@
   </style>
 </head>
 <body>
+  <button id="smoke-theme-toggle" class="btn btn-sm btn-ghost" type="button">toggle theme</button>
   <h1>design smoke</h1>
   <p>Minimal isolated examples of each new primitive. Review each section.</p>
 
@@ -99,12 +106,33 @@
     <div id="appshell-host"></div>
   </section>
 
+  <h1 style="font-family: var(--font-sans, inherit);">Phase B — site.css primitives</h1>
+
+  <section class="smoke-section site-demo">
+    <div class="label">product-frame — resize the window; UI text scales with the frame, not the viewport</div>
+    <div class="product-frame">
+      <div class="product-frame__surface">
+        <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.75em; border-bottom:1px solid var(--hair); margin-bottom:0.75em;">
+          <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--up); display:inline-block;"></span>
+          <strong>olympus · pipeline</strong>
+        </div>
+        <p style="color:var(--ink-soft); margin:0 0 0.6em;">Sample UI content standing in for a real screenshot or embedded product frame. Font size below is container-query scaled.</p>
+        <code style="font-family:var(--font-mono);">atlas.route(intent) -&gt; hermes.plan()</code>
+      </div>
+    </div>
+    <p class="product-frame__caption">Fig. 1 — Atlas → Hermes routing (placeholder)</p>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';
     import { initTypographyMotion } from '../typography-motion/index.js';
     import { initTicker } from '../quant-native/ticker.js';
     import { initAppShell } from '../app-shell-terminal/index.js';
+    import { initTheme } from '../site/theme.js';
+
+    // Theme toggle for the site.css (Phase B) demos below
+    initTheme('smoke-theme-toggle');
 
     // Living architecture
     initDiagram({


### PR DESCRIPTION
## Summary
- Adds `.product-frame` / `.product-frame__surface` / `.product-frame__caption` to `frontend/design/site/site.css` — a CSS-only, container-query-scaled 800px UI-embed primitive (Graphite artboard / Cursor product-screenshot pattern). No JS.
- Documents the primitive in `frontend/design/site/README.md` (markup, class table, atmosphere rule, React-wrapper note deferring to #1195).
- Adds a smoke-test demo section to `frontend/design/smoke/index.html` with a theme toggle.
- Marks `ProductFrame` done in `EVOLUTION.md` Phase B checklist and primitives table.
- Adds a portable `design-smoke-local` entry to `.claude/launch.json` for local testing.

## Test plan
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Visual check via smoke page in both `data-theme="dark"` and `"light"`
- [x] Confirmed no dependency on any dead/superseded `site.css` classes (verified via architecture audit — this primitive is additive only)

Fixes #1202