### PR TITLE
feat(design): BentoGrid CSS-only feature-cell primitive

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -1,11 +1,19 @@
 # DigiThings design evolution
 
-**Status:** Living document · **Last updated:** 2026-06-29
+**Status:** Living document · **Last updated:** 2026-07-01
 
 This file synthesizes three external north stars — [Graphite](references/graphite.com.md),
 [Cursor](references/cursor.com.md), [x.ai](references/x.ai.md) — with our current
-implementation (`tokens.css`, `site/site.css`, v7 landings) and sets **evolution
-paths** per surface.
+implementation and sets **evolution paths** per surface. "Current implementation"
+is two layers: `tokens.css` + `site/site.css` (shared CSS foundation — brand,
+buttons, terminal block, sections, and the CSS-only primitives built here in
+Phase B) consumed directly by the v7 landings (`frontend/digithings-web`,
+`frontend/digiquant-web`), plus `@digithings/web` (the React component layer —
+nav, hero layout, `Reveal` motion, connected graph) that those same apps import
+for everything with real interaction/state. Vanilla-JS equivalents of the
+latter (`site/theme.js`, `ui.js`, `reveal.js`, `terminal.js`, `graph.js`) were
+removed as dead code in #1240 once an import-graph audit confirmed neither
+landing referenced them.
 
 **Deep audits:** [`references/scans/`](references/scans/INDEX.md) — page-by-page,
 components, mobile nav (Playwright), copy patterns.
@@ -201,7 +209,7 @@ Add to `tokens.css` when implementing primitives:
 
 | Primitive | Purpose | References |
 |-----------|---------|------------|
-| `BentoGrid` / `.bento` | 2×2 feature cells | Cursor |
+| `BentoGrid` / `.bento` ✅ | 2×2 feature cells ([`site/README.md`](site/README.md#bentogrid-css-only-evolutionmd-phase-b)) | Cursor |
 | `ProductFrame` ✅ | CQ-scaled 800px UI embed ([`site/README.md`](site/README.md#productframe-css-only-evolutionmd-phase-b)) | Graphite, Cursor |
 | `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
 | `TrustStrip` | Logo / proof row | Cursor, Graphite |
@@ -252,7 +260,7 @@ Add to `tokens.css` when implementing primitives:
 ### Phase B — Shared primitives
 
 - [x] `ProductFrame` component + CSS
-- [ ] `BentoGrid` layout CSS in `site/site.css`
+- [x] `BentoGrid` layout CSS in `site/site.css`
 - [ ] `TrustStrip`, `reveal-up` utilities
 
 ### Phase C — Landing realignment

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -6,7 +6,7 @@ sites (digithings.ai, digiquant.io). It supplies the primitives those apps'
 React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 `.kicker`/`.prompt`, the standalone `.hero-title`, the terminal block
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
-sections, **ProductFrame**, `.principles`, and `.footer*`. Terminal-CLI /
+sections, **ProductFrame**, **BentoGrid**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -69,3 +69,33 @@ Works unscoped in both `[data-theme="light"]` and `[data-theme="dark"]`. A
 React wrapper is deferred until [#1195](https://github.com/digithings-ai/digithings/issues/1195)
 (landing-primitive package location) resolves — the CSS classes are usable
 directly from any JSX/TSX today.
+
+## `BentoGrid` (CSS-only, EVOLUTION.md Phase B)
+
+Cursor-style linked feature cells. Mobile-first: single column, 2×2 from
+768px. Flat `--surface` panels — no glass morphism (anti-pattern #8).
+
+```html
+<div class="bento">
+  <a class="bento__cell" href="/modules/digigraph">
+    <div class="bento__kicker">// orchestration</div>
+    <div class="bento__title">Supervisor graph</div>
+    <p class="bento__body">One line of what this module does.</p>
+    <span class="bento__cta">Learn more <span aria-hidden="true">&rarr;</span></span>
+  </a>
+  <div class="bento__cell bento__cell--static bento__cell--span-2">
+    <!-- non-linked, wide cell -->
+  </div>
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.bento` | Grid container — 1 column below 768px, `repeat(2, 1fr)` at `min-width: 768px`; `max-width: var(--wrap-wide)`. |
+| `.bento__cell` | Cell surface — `<a>` for a linked cell (hover lift via `--duration-hover`/`--ease-glide`) or any element with `.bento__cell--static` for a non-interactive cell (no hover, no cursor pointer). |
+| `.bento__cell--span-2` | Optional wide cell spanning both columns. |
+| `.bento__kicker` / `.bento__title` / `.bento__body` | Mono eyebrow, heading, body copy. |
+| `.bento__thumb` | Optional image/thumbnail slot — rounds to `--r-md`, clips overflow. |
+| `.bento__cta` | Arrow-suffix link text (`Learn more →`); the `span[aria-hidden]` arrow translates on `.bento__cell:hover`, matching `.btn`'s hover idiom. |
+
+Works unscoped in both themes. Same deferred-React-wrapper note as ProductFrame (#1195).

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -124,6 +124,25 @@ a { color: inherit; text-decoration: none; }
 .product-frame__surface { background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); overflow: hidden; padding: clamp(0.85rem, 4cqi, 1.6rem); font-size: clamp(0.72rem, 2.4cqi, 1rem); line-height: 1.5; }
 .product-frame__caption { margin-top: 0.75rem; font-family: var(--font-mono); font-size: 0.78rem; color: var(--ink-mute); text-align: center; }
 
+/* ── bento grid (Cursor-style linked feature cells) ───────────────────
+   Mobile-first: single column, 2×2 from 768px. Flat --surface panels,
+   no glass morphism (EVOLUTION.md §10 anti-pattern #8). ─────────────── */
+.bento { display: grid; grid-template-columns: 1fr; gap: 1.25rem; width: 100%; max-width: var(--wrap-wide); margin-inline: auto; }
+.bento__cell { display: flex; flex-direction: column; gap: 0.5rem; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); padding: 1.5rem; transition: transform var(--duration-hover) var(--ease-glide), border-color var(--duration-hover) var(--ease-glide); }
+.bento__cell:not(.bento__cell--static):hover { transform: translateY(-3px); border-color: var(--hair-2); }
+.bento__cell--static { cursor: default; }
+.bento__cell--span-2 { grid-column: span 2; }
+.bento__thumb { border-radius: var(--r-md); overflow: hidden; }
+.bento__kicker { font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 0.02em; color: var(--accent); }
+.bento__title { font-size: 1.1rem; font-weight: 600; letter-spacing: -0.02em; }
+.bento__body { font-size: 0.9rem; color: var(--ink-soft); line-height: 1.5; }
+.bento__cta { margin-top: auto; padding-top: 0.5rem; display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; color: var(--accent); font-weight: 500; }
+.bento__cta span[aria-hidden] { transition: transform var(--duration-hover) var(--ease-glide); }
+.bento__cell:hover .bento__cta span[aria-hidden] { transform: translateX(3px); }
+@media (min-width: 768px) {
+  .bento { grid-template-columns: repeat(2, 1fr); }
+}
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -123,6 +123,29 @@
     <p class="product-frame__caption">Fig. 1 — Atlas → Hermes routing (placeholder)</p>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">bento — 2×2 from 768px, single column below</div>
+    <div class="bento">
+      <a class="bento__cell" href="#" onclick="return false;">
+        <div class="bento__kicker">// orchestration</div>
+        <div class="bento__title">Supervisor graph</div>
+        <p class="bento__body">LangGraph supervisor routes intents across sub-graphs with typed handoffs.</p>
+        <span class="bento__cta">Learn more <span aria-hidden="true">&rarr;</span></span>
+      </a>
+      <a class="bento__cell" href="#" onclick="return false;">
+        <div class="bento__kicker">// quant</div>
+        <div class="bento__title">Atlas + Hermes</div>
+        <p class="bento__body">Tiered research and execution sub-graphs inside DigiQuant.</p>
+        <span class="bento__cta">Learn more <span aria-hidden="true">&rarr;</span></span>
+      </a>
+      <div class="bento__cell bento__cell--static bento__cell--span-2">
+        <div class="bento__kicker">// static example</div>
+        <div class="bento__title">bento__cell--span-2</div>
+        <p class="bento__body">A non-linked, wide cell — no hover lift, no CTA arrow.</p>
+      </div>
+    </div>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';


### PR DESCRIPTION
## Summary
- Adds `.bento`/`.bento__cell`/`.bento__cell--static`/`.bento__cell--span-2`/`.bento__kicker`/`.bento__title`/`.bento__body`/`.bento__thumb`/`.bento__cta` to `frontend/design/site/site.css` — mobile-first (1 col below 768px, 2×2 at `min-width: 768px`), flat `--surface` panels, hover lift via `--duration-hover`/`--ease-glide`. No JS.
- Documents the primitive in `frontend/design/site/README.md`.
- Adds a 3-cell demo (2 linked + 1 static span-2) to `frontend/design/smoke/index.html`.
- Marks `BentoGrid` done in `EVOLUTION.md`.
- Corrects `EVOLUTION.md`'s header, which still described `site.css` as the sole "current implementation" after #1240 split the foundation into shared-CSS (`tokens.css`+`site.css`) vs. React behavior layer (`@digithings/web`).

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Verified via direct HTTP against the built site.css/smoke page (`.bento` present, demo renders 4 `bento__cell` elements)
- [ ] Browser preview tooling was unresponsive in this environment during development — CI's build-check workflows will exercise the real Next.js consumption path

Fixes #1203