### PR TITLE
feat(design): TrustStrip + reveal-up CSS-only utilities

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -212,11 +212,11 @@ Add to `tokens.css` when implementing primitives:
 | `BentoGrid` / `.bento` ✅ | 2×2 feature cells ([`site/README.md`](site/README.md#bentogrid-css-only-evolutionmd-phase-b)) | Cursor |
 | `ProductFrame` ✅ | CQ-scaled 800px UI embed ([`site/README.md`](site/README.md#productframe-css-only-evolutionmd-phase-b)) | Graphite, Cursor |
 | `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
-| `TrustStrip` | Logo / proof row | Cursor, Graphite |
+| `TrustStrip` ✅ | Logo / proof row ([`site/README.md`](site/README.md#truststrip-css-only-evolutionmd-phase-b)) | Cursor, Graphite |
 | `StatCounter` | Scroll-triggered metrics | xAI |
 | `CapabilityCard` | Mini UI + “Explore →” | xAI |
 | `ChangelogBand` | Dated release rows | Cursor |
-| `reveal-up` utility | Opacity + translate enter | Graphite |
+| `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
 
 **Implementation order:** `ProductFrame` → `BentoGrid` → `TrustStrip` → `ScrollyFeatures` refactor → `StatCounter`.
 
@@ -261,7 +261,7 @@ Add to `tokens.css` when implementing primitives:
 
 - [x] `ProductFrame` component + CSS
 - [x] `BentoGrid` layout CSS in `site/site.css`
-- [ ] `TrustStrip`, `reveal-up` utilities
+- [x] `TrustStrip`, `reveal-up` utilities
 
 ### Phase C — Landing realignment
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -6,7 +6,8 @@ sites (digithings.ai, digiquant.io). It supplies the primitives those apps'
 React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 `.kicker`/`.prompt`, the standalone `.hero-title`, the terminal block
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
-sections, **ProductFrame**, **BentoGrid**, `.principles`, and `.footer*`. Terminal-CLI /
+sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
+`.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -99,3 +100,49 @@ Cursor-style linked feature cells. Mobile-first: single column, 2×2 from
 | `.bento__cta` | Arrow-suffix link text (`Learn more →`); the `span[aria-hidden]` arrow translates on `.bento__cell:hover`, matching `.btn`'s hover idiom. |
 
 Works unscoped in both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `TrustStrip` (CSS-only, EVOLUTION.md Phase B)
+
+Cursor-style hero trust line — a muted row of proof items, text or logos.
+
+```html
+<div class="trust-strip">
+  <span class="trust-strip__item">open core · self-hosted</span>
+  <img class="trust-strip__item" src="/logos/partner.svg" alt="Partner" />
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.trust-strip` | Centered, wrapping flex row. |
+| `.trust-strip__item` | Text item (mono, `--ink-mute`) or `<img>` logo (28px height, grayscale + reduced opacity for visual parity across mixed-brand logos). |
+
+## `reveal-up` (CSS-only utility, EVOLUTION.md Phase B)
+
+Opacity + translate enter animation. **This is not the old `site/reveal.js`**
+(removed as dead code in #1240) — `.reveal-up` only owns the two visual
+states (`opacity`/`transform`/`transition`); something external toggles the
+visible class:
+
+```html
+<div class="reveal-up">Revealed on scroll or on mount.</div>
+```
+
+```js
+// Option A — vanilla pages: frontend/design/scroll-trigger.js
+import { initScrollTrigger } from '../scroll-trigger.js';
+initScrollTrigger({ activateSelector: '.reveal-up', activationLineRatio: 0.8 });
+// toggles .active on .reveal-up elements as they cross the scroll line
+
+// Option B — React: frontend/web/src/motion/primitives.tsx's <Reveal>
+// applies its own visibility state via className; pass className="reveal-up"
+// and toggle `is-visible` there instead of `.active`, or wire Reveal to add
+// `.active` for a single shared contract — either satisfies the CSS below.
+```
+
+| Class | Role |
+|-------|------|
+| `.reveal-up` | Initial state — `opacity: 0`, `translateY(1rem)`. |
+| `.reveal-up.is-visible` / `.reveal-up.active` | Visible state — both class names are wired to the same rule so either trigger mechanism (scroll-trigger's `.active` or a `.is-visible` convention) works without duplicating CSS. |
+
+`prefers-reduced-motion: reduce` shows the element immediately (no transition), consolidated in site.css's shared reduced-motion block.

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -143,6 +143,20 @@ a { color: inherit; text-decoration: none; }
   .bento { grid-template-columns: repeat(2, 1fr); }
 }
 
+/* ── trust strip (proof / logo row) ───────────────────────────────────── */
+.trust-strip { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: clamp(1.25rem, 4vw, 2.5rem); }
+.trust-strip__item { display: inline-flex; align-items: center; font-family: var(--font-mono); font-size: 0.85rem; color: var(--ink-mute); }
+.trust-strip__item img { height: 28px; width: auto; max-width: 140px; filter: grayscale(1); opacity: 0.7; }
+
+/* ── reveal-up (scroll-triggered enter) ────────────────────────────────
+   CSS-only: owns the two visual states only. Trigger it either with
+   ../scroll-trigger.js's `activateSelector` (toggles `.active` when the
+   element crosses the scroll line) or from the React `Reveal` component's
+   className (frontend/web/src/motion/primitives.tsx) — both are valid
+   drivers, so both class names are wired below. ───────────────────────── */
+.reveal-up { opacity: 0; transform: translateY(1rem); transition: opacity var(--duration-reveal) var(--ease-glide), transform var(--duration-reveal) var(--ease-glide); }
+.reveal-up.is-visible, .reveal-up.active { opacity: 1; transform: none; }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }
@@ -169,5 +183,6 @@ a { color: inherit; text-decoration: none; }
 @media (prefers-reduced-motion: reduce) {
   .glow { animation: none; }
   .term-cursor { animation: none; }
+  .reveal-up { opacity: 1 !important; transform: none !important; transition: none !important; }
   * { scroll-behavior: auto !important; }
 }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -146,12 +146,30 @@
     </div>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">trust-strip — text items shown; swap any item for an &lt;img&gt; logo</div>
+    <div class="trust-strip">
+      <span class="trust-strip__item">open core · self-hosted</span>
+      <span class="trust-strip__item">MIT licensed</span>
+      <span class="trust-strip__item">bring your own key</span>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
+    <div class="label">reveal-up — scroll down; driven by scroll-trigger.js's activateSelector (toggles .active)</div>
+    <div style="height:50vh; display:grid; place-items:center; color:var(--ink-mute); font-family:var(--font-mono); font-size:0.85rem;">scroll &darr;</div>
+    <div class="reveal-up" style="padding:1.5rem; border:1px solid var(--hair); border-radius:var(--r-lg); background:var(--surface);">
+      <strong>Revealed on scroll.</strong> <code>initScrollTrigger({ activateSelector: '.reveal-up' })</code> toggles <code>.active</code> when this crosses the scroll line.
+    </div>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';
     import { initTypographyMotion } from '../typography-motion/index.js';
     import { initTicker } from '../quant-native/ticker.js';
     import { initAppShell } from '../app-shell-terminal/index.js';
+    import { initScrollTrigger } from '../scroll-trigger.js';
 
     // Theme toggle for the site.css (Phase B) demos below. site/theme.js was
     // removed in #1240 (dead in production — apps use React ThemeProvider
@@ -216,6 +234,9 @@
         </div>`,
       mainSlot: '<p>Press <kbd>⌘K</kbd> for the palette. Type <code>/help</code> in the input.</p>',
     });
+
+    // reveal-up: driven by scroll-trigger's activateSelector/.active toggle
+    initScrollTrigger({ activateSelector: '.reveal-up', activationLineRatio: 0.8 });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds `.trust-strip`/`.trust-strip__item` to `frontend/design/site/site.css` — centered, wrapping proof/logo row.
- Adds `.reveal-up`/`.reveal-up.is-visible`/`.reveal-up.active` — opacity+translate enter utility, CSS-only (owns only the visual states).
- This issue's original acceptance criteria named the now-deleted `site/reveal.js` as the integration target (dead code removed in #1240) — corrected the issue body first, then implemented against the real target: `scroll-trigger.js`'s `activateSelector`/`.active` mechanism (confirmed live), with the CSS also wired to accept `.is-visible` so the React `Reveal` component (`frontend/web/src/motion/primitives.tsx`) can drive it too.
- Smoke demo wires the actual `initScrollTrigger({ activateSelector: '.reveal-up' })` call (not just static markup) to prove the trigger contract works.
- `prefers-reduced-motion` handled in site.css's existing consolidated reduced-motion block.
- Documents both in `frontend/design/site/README.md`; marks Phase B checkbox in `EVOLUTION.md`.

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Verified via direct HTTP: `.trust-strip`/`.reveal-up` present in site.css, smoke demo renders both, `scroll-trigger.js` serves correctly
- [ ] Browser preview tooling was unresponsive in this environment during development — CI's build-check workflows will exercise the real Next.js consumption path

Fixes #1204