### PR TITLE
feat(design): StatCounter scroll-triggered metrics primitive

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -213,7 +213,7 @@ Add to `tokens.css` when implementing primitives:
 | `ProductFrame` ✅ | CQ-scaled 800px UI embed ([`site/README.md`](site/README.md#productframe-css-only-evolutionmd-phase-b)) | Graphite, Cursor |
 | `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
 | `TrustStrip` ✅ | Logo / proof row ([`site/README.md`](site/README.md#truststrip-css-only-evolutionmd-phase-b)) | Cursor, Graphite |
-| `StatCounter` | Scroll-triggered metrics | xAI |
+| `StatCounter` ✅ | Scroll-triggered metrics ([`site/README.md`](site/README.md#statcounter-css--stat-counterjs-evolutionmd-phase-b)) | xAI |
 | `CapabilityCard` | Mini UI + “Explore →” | xAI |
 | `ChangelogBand` | Dated release rows | Cursor |
 | `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
@@ -262,6 +262,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `ProductFrame` component + CSS
 - [x] `BentoGrid` layout CSS in `site/site.css`
 - [x] `TrustStrip`, `reveal-up` utilities
+- [x] `StatCounter` component + CSS
 
 ### Phase C — Landing realignment
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -7,7 +7,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 `.kicker`/`.prompt`, the standalone `.hero-title`, the terminal block
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
-`.principles`, and `.footer*`. Terminal-CLI /
+**StatCounter**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -146,3 +146,37 @@ initScrollTrigger({ activateSelector: '.reveal-up', activationLineRatio: 0.8 });
 | `.reveal-up.is-visible` / `.reveal-up.active` | Visible state — both class names are wired to the same rule so either trigger mechanism (scroll-trigger's `.active` or a `.is-visible` convention) works without duplicating CSS. |
 
 `prefers-reduced-motion: reduce` shows the element immediately (no transition), consolidated in site.css's shared reduced-motion block.
+
+## `StatCounter` (CSS + `stat-counter.js`, EVOLUTION.md Phase B)
+
+xAI-style scroll-triggered metrics strip. **No-fake-data policy** (EVOLUTION.md
+§10, anti-pattern #2): placeholder demo values must be clearly labeled as such;
+real wiring is just setting `data-target` from real numbers, nothing invented.
+
+```html
+<div class="stat-counter-row">
+  <div class="stat-counter" data-target="128" data-suffix="ms">
+    <span class="stat-counter__value">0</span>
+    <span class="stat-counter__label">p50 latency</span>
+  </div>
+</div>
+```
+
+```js
+import { initStatCounter } from '../stat-counter.js';
+initStatCounter(); // defaults: selector '.stat-counter', 1200ms ease-out-cubic
+```
+
+| Class / attribute | Role |
+|-------|------|
+| `.stat-counter-row` | Centered, wrapping flex row of metrics. |
+| `.stat-counter` | One metric — JS-observed root. `data-target` (required), `data-prefix`/`data-suffix`/`data-decimals` (optional formatting). |
+| `.stat-counter__value` | The animated number — `tabular-nums`, Geist Mono. |
+| `.stat-counter__label` | Mono, uppercase, tracked label. |
+
+`stat-counter.js`'s `initStatCounter()` uses `IntersectionObserver` to count
+each `.stat-counter__value` from 0 to `data-target` once, the first time it
+scrolls into view (a one-shot count, distinct from `scroll-trigger.js`'s
+continuous `--scroll` progress model — different job, separate module).
+`prefers-reduced-motion: reduce` (or no `IntersectionObserver` support) shows
+the final value immediately, no animation loop.

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -157,6 +157,15 @@ a { color: inherit; text-decoration: none; }
 .reveal-up { opacity: 0; transform: translateY(1rem); transition: opacity var(--duration-reveal) var(--ease-glide), transform var(--duration-reveal) var(--ease-glide); }
 .reveal-up.is-visible, .reveal-up.active { opacity: 1; transform: none; }
 
+/* ── stat counter (xAI-style scroll-triggered metrics strip) ───────────
+   No-fake-data policy (EVOLUTION.md §10 anti-pattern #2): stat-counter.js
+   only counts up to whatever data-target says — placeholders must be
+   labeled as such, real wiring is just setting data-target. ────────────── */
+.stat-counter-row { display: flex; flex-wrap: wrap; justify-content: center; gap: clamp(1.5rem, 5vw, 3.5rem); }
+.stat-counter { display: flex; flex-direction: column; align-items: center; gap: 0.3rem; text-align: center; }
+.stat-counter__value { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: clamp(1.7rem, 4vw, 2.5rem); font-weight: 600; letter-spacing: -0.02em; color: var(--ink); }
+.stat-counter__label { font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -163,10 +163,29 @@
     </div>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">stat-counter — placeholder values (clearly labeled, no live data wired); scroll into view to trigger</div>
+    <div class="stat-counter-row">
+      <div class="stat-counter" data-target="128" data-suffix="ms">
+        <span class="stat-counter__value">0</span>
+        <span class="stat-counter__label">p50 latency (placeholder)</span>
+      </div>
+      <div class="stat-counter" data-target="99.95" data-decimals="2" data-suffix="%">
+        <span class="stat-counter__value">0</span>
+        <span class="stat-counter__label">uptime (placeholder)</span>
+      </div>
+      <div class="stat-counter" data-target="8" data-prefix="v">
+        <span class="stat-counter__value">0</span>
+        <span class="stat-counter__label">modules (placeholder)</span>
+      </div>
+    </div>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';
     import { initTypographyMotion } from '../typography-motion/index.js';
+    import { initStatCounter } from '../stat-counter.js';
     import { initTicker } from '../quant-native/ticker.js';
     import { initAppShell } from '../app-shell-terminal/index.js';
     import { initScrollTrigger } from '../scroll-trigger.js';
@@ -237,6 +256,9 @@
 
     // reveal-up: driven by scroll-trigger's activateSelector/.active toggle
     initScrollTrigger({ activateSelector: '.reveal-up', activationLineRatio: 0.8 });
+
+    // stat-counter: counts up on scroll into view
+    initStatCounter();
   </script>
 </body>
 </html>

--- a/frontend/design/stat-counter.js
+++ b/frontend/design/stat-counter.js
@@ -1,0 +1,86 @@
+/**
+ * DigiThings stat-counter — animates each .stat-counter's .stat-counter__value
+ * from 0 to data-target when the element scrolls into view.
+ *
+ * Markup contract:
+ *   <div class="stat-counter" data-target="1024" data-prefix="" data-suffix="+" data-decimals="0">
+ *     <span class="stat-counter__value">0</span>
+ *     <span class="stat-counter__label">requests / sec</span>
+ *   </div>
+ *
+ * No-fake-data policy (EVOLUTION.md §10, anti-pattern #2): this module only
+ * counts up to whatever data-target says — wire real numbers there via
+ * props/CMS data, don't invent placeholder metrics that look live.
+ *
+ * Usage:
+ *   import { initStatCounter } from './stat-counter.js';
+ *   const ctl = initStatCounter({ selector: '.stat-counter' });
+ *
+ * Honors prefers-reduced-motion: renders the final value immediately with
+ * no animation loop and no IntersectionObserver.
+ *
+ * Returns { stop() } to disconnect the observer.
+ */
+export function initStatCounter({
+  selector = '.stat-counter',
+  valueSelector = '.stat-counter__value',
+  duration = 1200,
+  threshold = 0.6,
+} = {}) {
+  const roots = document.querySelectorAll(selector);
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const format = (root, value) => {
+    const decimals = parseInt(root.dataset.decimals ?? '0', 10);
+    const prefix = root.dataset.prefix ?? '';
+    const suffix = root.dataset.suffix ?? '';
+    return `${prefix}${value.toFixed(decimals)}${suffix}`;
+  };
+
+  const setFinal = (root) => {
+    const valueEl = root.querySelector(valueSelector);
+    if (!valueEl) return;
+    const target = parseFloat(root.dataset.target ?? '0');
+    valueEl.textContent = format(root, target);
+  };
+
+  if (reduceMotion || !('IntersectionObserver' in window)) {
+    roots.forEach(setFinal);
+    return { stop() {} };
+  }
+
+  const animate = (root) => {
+    const valueEl = root.querySelector(valueSelector);
+    if (!valueEl) return;
+    const target = parseFloat(root.dataset.target ?? '0');
+    const start = performance.now();
+
+    const frame = (now) => {
+      const progress = Math.min(1, (now - start) / duration);
+      const eased = 1 - (1 - progress) ** 3; // ease-out-cubic
+      valueEl.textContent = format(root, target * eased);
+      if (progress < 1) requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
+  };
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          animate(entry.target);
+          obs.unobserve(entry.target);
+        }
+      }
+    },
+    { threshold },
+  );
+
+  roots.forEach((root) => observer.observe(root));
+
+  return {
+    stop() {
+      observer.disconnect();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- New `frontend/design/stat-counter.js`: `initStatCounter()` uses `IntersectionObserver` to count each `.stat-counter__value` from 0 to `data-target` once, the first time it scrolls into view. Supports `data-prefix`/`data-suffix`/`data-decimals`. `prefers-reduced-motion: reduce` (or no `IntersectionObserver` support) renders the final value immediately — no animation loop.
- Deliberately a separate one-shot module rather than extending `scroll-trigger.js`, which drives a continuous `--scroll` progress value — different job.
- CSS: `.stat-counter-row` (flex row) / `.stat-counter` (JS-observed root) / `.stat-counter__value` (`tabular-nums`, Geist Mono) / `.stat-counter__label` (mono, uppercase, tracked).
- No-fake-data policy (EVOLUTION.md §10, anti-pattern #2) enforced in the smoke demo — placeholder values are labeled `(placeholder)`.
- Documents the primitive in `frontend/design/site/README.md`; marks Phase B checkbox in `EVOLUTION.md`.

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Verified via direct HTTP: `stat-counter.js` serves and exports `initStatCounter`, `.stat-counter` CSS present, smoke demo renders 3 counters
- [x] Exercised the reduced-motion code path directly in Node (mocked `matchMedia`/DOM): formats `data-target="99.95" data-decimals="2" data-suffix="%"` → `"99.95%"` correctly
- [ ] Browser preview tooling was unresponsive in this environment during development — CI's build-check workflows will exercise the real Next.js consumption path

Fixes #1206