### PR TITLE
feat(design): ChangelogBand CSS-only primitive

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -215,7 +215,7 @@ Add to `tokens.css` when implementing primitives:
 | `TrustStrip` ✅ | Logo / proof row ([`site/README.md`](site/README.md#truststrip-css-only-evolutionmd-phase-b)) | Cursor, Graphite |
 | `StatCounter` ✅ | Scroll-triggered metrics ([`site/README.md`](site/README.md#statcounter-css--stat-counterjs-evolutionmd-phase-b)) | xAI |
 | `CapabilityCard` | Mini UI + “Explore →” | xAI |
-| `ChangelogBand` | Dated release rows | Cursor |
+| `ChangelogBand` ✅ | Dated release rows ([`site/README.md`](site/README.md#changelogband-css-only--data-shape-evolutionmd-phase-b)) | Cursor |
 | `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
 
 **Implementation order:** `ProductFrame` → `BentoGrid` → `TrustStrip` → `ScrollyFeatures` refactor → `StatCounter`.
@@ -263,6 +263,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `BentoGrid` layout CSS in `site/site.css`
 - [x] `TrustStrip`, `reveal-up` utilities
 - [x] `StatCounter` component + CSS
+- [x] `ChangelogBand` component + CSS
 
 ### Phase C — Landing realignment
 

--- a/frontend/design/changelog-example.json
+++ b/frontend/design/changelog-example.json
@@ -1,0 +1,22 @@
+[
+  {
+    "date": "2026-06-29",
+    "version": "v7.2",
+    "title": "Example release entry — replace with a CHANGELOG.md excerpt or GitHub Releases feed",
+    "href": "#",
+    "tag": "release"
+  },
+  {
+    "date": "2026-06-17",
+    "title": "Example fix entry",
+    "href": "#",
+    "tag": "fix"
+  },
+  {
+    "date": "2026-06-01",
+    "version": "v7.0",
+    "title": "Example release entry",
+    "href": "#",
+    "tag": "release"
+  }
+]

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -7,7 +7,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 `.kicker`/`.prompt`, the standalone `.hero-title`, the terminal block
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
-**StatCounter**, `.principles`, and `.footer*`. Terminal-CLI /
+**StatCounter**, **ChangelogBand**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -180,3 +180,39 @@ scrolls into view (a one-shot count, distinct from `scroll-trigger.js`'s
 continuous `--scroll` progress model — different job, separate module).
 `prefers-reduced-motion: reduce` (or no `IntersectionObserver` support) shows
 the final value immediately, no animation loop.
+
+## `ChangelogBand` (CSS-only + data shape, EVOLUTION.md Phase B)
+
+Cursor-style dated release rows. Mobile: stacked. Desktop (`min-width: 640px`):
+fixed date column + title row. CSS-only — rendering the data shape into
+markup is left to the consumer (vanilla template string or React `.map()`),
+same division of responsibility as TrustStrip.
+
+**Data shape** (`{ date, version?, title, href, tag? }[]`) — see
+[`../changelog-example.json`](../changelog-example.json) for a worked
+example and `frontend/design/smoke/index.html` for a vanilla-JS renderer.
+Source of truth for real content is whatever the consuming app already has
+(a `CHANGELOG.md` excerpt, the GitHub Releases API, or a CMS) — this
+primitive doesn't fetch or own data, only the markup/CSS contract.
+
+```html
+<div class="changelog-band">
+  <div class="changelog-row">
+    <div class="changelog-row__date">2026-06-29 &middot; v7.2</div>
+    <div class="changelog-row__title">
+      <a href="/releases/v7.2">Shared design primitives shipped</a>
+      <span class="changelog-row__tag">release</span>
+    </div>
+  </div>
+</div>
+<p class="changelog-band__footer"><a href="/releases">View all releases &rarr;</a></p>
+```
+
+| Class | Role |
+|-------|------|
+| `.changelog-band` | Column container, `max-width: var(--wrap-wide)`. |
+| `.changelog-row` | One entry — 1 column below 640px, `8rem 1fr` grid (date / title) at `min-width: 640px`. Hairline divider between rows. |
+| `.changelog-row__date` | Mono date (+ optional version). |
+| `.changelog-row__title` | Title, linked; hover tints `--accent`. |
+| `.changelog-row__tag` | Optional pill (`release`, `fix`, etc.). |
+| `.changelog-band__footer` | "View all releases →" link pattern. |

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -166,6 +166,25 @@ a { color: inherit; text-decoration: none; }
 .stat-counter__value { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: clamp(1.7rem, 4vw, 2.5rem); font-weight: 600; letter-spacing: -0.02em; color: var(--ink); }
 .stat-counter__label { font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); }
 
+/* ── changelog band (Cursor-style dated release rows) ───────────────────
+   Mobile: stacked (date above title). Desktop: fixed date column + title
+   row, from 640px. Data shape: { date, version?, title, href, tag? }[] —
+   see site/README.md for the documented contract and rendering is left to
+   the consumer (vanilla or React), same as TrustStrip. ─────────────────── */
+.changelog-band { display: flex; flex-direction: column; max-width: var(--wrap-wide); margin-inline: auto; }
+.changelog-row { display: grid; grid-template-columns: 1fr; gap: 0.3rem; padding: 1.1rem 0; border-bottom: 1px solid var(--hair); }
+.changelog-row:last-child { border-bottom: none; }
+.changelog-row__date { font-family: var(--font-mono); font-size: 0.78rem; color: var(--ink-mute); }
+.changelog-row__title { font-size: 0.98rem; color: var(--ink); }
+.changelog-row__title a { color: inherit; }
+.changelog-row__title a:hover { color: var(--accent); }
+.changelog-row__tag { display: inline-flex; align-items: center; margin-left: 0.6rem; padding: 0.15rem 0.5rem; border-radius: 999px; border: 1px solid var(--hair-2); font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-soft); }
+.changelog-band__footer { margin-top: 1.2rem; text-align: center; }
+.changelog-band__footer a { font-family: var(--font-mono); font-size: 0.85rem; color: var(--accent); }
+@media (min-width: 640px) {
+  .changelog-row { grid-template-columns: 8rem 1fr; align-items: baseline; gap: 1.5rem; }
+}
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -181,6 +181,12 @@
     </div>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">changelog-band — rendered from ../changelog-example.json (data shape: date/version?/title/href/tag?)</div>
+    <div class="changelog-band" id="changelog-demo"></div>
+    <p class="changelog-band__footer"><a href="#">View all releases &rarr;</a></p>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';
@@ -189,6 +195,7 @@
     import { initTicker } from '../quant-native/ticker.js';
     import { initAppShell } from '../app-shell-terminal/index.js';
     import { initScrollTrigger } from '../scroll-trigger.js';
+    import { escapeHtml } from '../html-escape.js';
 
     // Theme toggle for the site.css (Phase B) demos below. site/theme.js was
     // removed in #1240 (dead in production — apps use React ThemeProvider
@@ -259,6 +266,23 @@
 
     // stat-counter: counts up on scroll into view
     initStatCounter();
+
+    // changelog-band: render from the documented data shape (see
+    // site/README.md) — { date, version?, title, href, tag? }[]
+    fetch('../changelog-example.json')
+      .then((r) => r.json())
+      .then((entries) => {
+        const host = document.getElementById('changelog-demo');
+        host.innerHTML = entries.map((e) => `
+          <div class="changelog-row">
+            <div class="changelog-row__date">${escapeHtml(e.date)}${e.version ? ' &middot; ' + escapeHtml(e.version) : ''}</div>
+            <div class="changelog-row__title">
+              <a href="${escapeHtml(e.href)}">${escapeHtml(e.title)}</a>
+              ${e.tag ? `<span class="changelog-row__tag">${escapeHtml(e.tag)}</span>` : ''}
+            </div>
+          </div>
+        `).join('');
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds `.changelog-band`/`.changelog-row`/`.changelog-row__date`/`.changelog-row__title`/`.changelog-row__tag`/`.changelog-band__footer` to `frontend/design/site/site.css` — mobile stacked, desktop (`min-width: 640px`) fixed date column + title row.
- CSS-only, same division of responsibility as TrustStrip: this primitive owns markup/CSS; rendering the documented data shape (`{ date, version?, title, href, tag? }[]`) into that markup is left to the consumer.
- `frontend/design/changelog-example.json` — worked example of the data shape.
- Smoke demo actually `fetch()`es and renders the example JSON (escaping via the existing `html-escape.js`) to prove the contract works, not just static markup.
- Documents the primitive + data shape in `frontend/design/site/README.md`; marks Phase B checkbox in `EVOLUTION.md`.

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Verified via direct HTTP: `changelog-example.json` is valid JSON and serves, `.changelog-band`/`.changelog-row` CSS present, smoke demo wires the fetch+render
- [ ] Browser preview tooling was unresponsive in this environment during development — CI's build-check workflows will exercise the real Next.js consumption path

Fixes #1207