### PR TITLE
feat(digigraph,digivault): vault-grounding search tool for DigiChat gateway

### DIFF
--- a/digigraph/ARCHITECTURE.md
+++ b/digigraph/ARCHITECTURE.md
@@ -36,7 +36,7 @@ The following is built and functional as of this architecture review (March 2026
 | Supervisor node (opt-in via `DIGI_SUPERVISOR=1`) | Built | `graph/nodes.py` |
 | Orchestrator tool registry | Built | `orchestration/registry.py` |
 | Built-in tools + skills | Built | `orchestration/builtin.py` |
-| Vertical hub clients (DigiSearch, DigiQuant) | Built | `vertical_orchestrator/digisearch_hub.py`, `vertical_orchestrator/digiquant_hub.py` |
+| Vertical hub clients (DigiSearch, DigiQuant, DigiVault) | Built | `vertical_orchestrator/digisearch_hub.py`, `vertical_orchestrator/digiquant_hub.py`, `vertical_orchestrator/digivault_hub.py` |
 | SSE streaming via background thread + queue | Built | `server.py`, `workflow.py` |
 | LLM client (OpenAI SDK, LiteLLM compat) | Built | `digillm` (toolkit) + `llm_client.py` wrappers |
 | In-process LLM response cache (SHA-256, TTL) | Built | `digillm` |
@@ -252,7 +252,8 @@ digigraph/src/digigraph/
 │   └── plugins.py               setuptools entry point loader (digigraph.tools)
 ├── vertical_orchestrator/
 │   ├── digisearch_hub.py        fetch_digisearch_tool_dicts, invoke_digisearch_tool
-│   └── digiquant_hub.py         fetch_digiquant_tool_dicts, invoke_digiquant_tool
+│   ├── digiquant_hub.py         fetch_digiquant_tool_dicts, invoke_digiquant_tool
+│   └── digivault_hub.py         fetch_digivault_tool_dicts, invoke_digivault_tool
 ├── agents/
 │   ├── analysis/                run_analysis_agent, ANALYSIS_AGENT_TOOL
 │   ├── data_engineer/           run_data_engineer_agent, DATA_ENGINEER_AGENT_TOOL
@@ -303,17 +304,18 @@ Three-layer structure:
 
 1. **Primitives** (`tools/`): stateless callables not exposed to the LLM directly.
 2. **Orchestrator tools** (`orchestration/`): `(name, schema, handler, tags)`. Schema may be a static dict or a `SchemaFactory(context) -> dict` for context-dependent schemas (e.g. DigiSearch tools fetched from the vertical manifest). Registered once at module import via `_register_tools()` in `builtin.py:585`.
-3. **Skills** (`orchestration/registry.py`): named bundles of tool names with a `when(context) -> bool` predicate. The `search` skill activates only when `DIGISEARCH_URL` is set. The `sitaas_rag` skill activates only when `run_data_dir` is set.
+3. **Skills** (`orchestration/registry.py`): named bundles of tool names with a `when(context) -> bool` predicate. The `search` skill activates only when `DIGISEARCH_URL` is set. The `sitaas_rag` skill activates only when `run_data_dir` is set. The `digivault` skill (one tool, `digivault_search_notes`) activates only when `DIGIVAULT_URL` is set.
 
 The registry is a module-level dict (`_tools`, `_skills` in `registry.py`). It is global to the process — all requests share the same registry. `register_tool` raises `ValueError` on duplicate names, so plugins loaded via `load_entrypoint_tools()` must use unique names.
 
 ### 5.4 Vertical Connector Pattern
 
-DigiSearch and DigiQuant each own their tool schemas via `POST /v1/orchestrator_tools`. DigiGraph:
+DigiSearch, DigiQuant, and DigiVault each own their tool schemas via `POST /v1/orchestrator_tools`. DigiGraph:
 
 1. Calls `fetch_digisearch_tool_dicts(base_url, index_config, bearer, request_id)` at schema resolution time. Results are cached in a module-level dict (`_MANIFEST_CACHE`) keyed on `(base_url, index_config)` — this cache is **never invalidated** for the lifetime of the process.
 2. Invokes tools via `invoke_digisearch_tool(base_url, tool, args, ...)` → `POST /v1/orchestrator_invoke`.
 3. The DigiQuant connector follows the same pattern via `digiquant_hub.py`.
+4. The DigiVault connector (`digivault_hub.py`) follows the same pattern for one tool, `digivault_search_notes` — full-text search over the DigiThings architecture vault (Supabase-backed, `SupabaseStore.search`). It has no `index_config` (vault search is not index-scoped), so its manifest cache key is the base URL alone.
 
 The manifest cache uses synchronous `httpx.Client` (blocking calls inside async FastAPI). This can block the event loop thread during tool schema resolution. The current request handling is synchronous (FastAPI's thread pool), so this is acceptable but limits throughput under high concurrency.
 
@@ -422,7 +424,7 @@ The MCP server (`mcp_server.py`) has no built-in authentication layer. The `stre
 
 ### 6.9 Manifest Cache Never Invalidates
 
-The vertical manifest caches in `digisearch_hub.py` and `digiquant_hub.py` are module-level dicts with no TTL or invalidation. If DigiSearch or DigiQuant adds, removes, or changes a tool definition, the cached schema is stale until the DigiGraph process restarts. This affects tool schema accuracy in long-running deployments.
+The vertical manifest caches in `digisearch_hub.py`, `digiquant_hub.py`, and `digivault_hub.py` are module-level dicts with no TTL or invalidation. If DigiSearch, DigiQuant, or DigiVault adds, removes, or changes a tool definition, the cached schema is stale until the DigiGraph process restarts. This affects tool schema accuracy in long-running deployments.
 
 ---
 
@@ -447,7 +449,7 @@ The `MemorySaver` default stores all thread state in a Python dict in the DigiGr
 
 ### 7.4 Vertical Manifest HTTP Blocking
 
-`fetch_digisearch_tool_dicts` and `fetch_digiquant_tool_dicts` make synchronous `httpx` calls at schema resolution time, inside FastAPI's synchronous thread pool. If DigiSearch or DigiQuant is slow or unavailable, this blocks a worker thread for up to 30 seconds (`timeout=30.0`). The first request after startup or cache invalidation pays this cost.
+`fetch_digisearch_tool_dicts`, `fetch_digiquant_tool_dicts`, and `fetch_digivault_tool_dicts` make synchronous `httpx` calls at schema resolution time, inside FastAPI's synchronous thread pool. If DigiSearch, DigiQuant, or DigiVault is slow or unavailable, this blocks a worker thread for up to 30 seconds (`timeout=30.0`). The first request after startup or cache invalidation pays this cost.
 
 ### 7.5 Postgres Checkpoint Path
 
@@ -565,6 +567,16 @@ Streaming via the background thread + queue delivers tool call blocks to the cli
 - **Model routing:** callers must pass a concrete model string resolved via `config/model_modes.yaml`. The `digi/fast`, `digi/balanced`, `digi/best`, `digi/multimodal` named routes have been removed. Atlas/Hermes phases all use `openrouter/openrouter/auto` (OpenRouter Auto Router); set `OPENROUTER_API_KEY`. See `.env.example` and `config/model_modes.yaml`.
 - Caching: LiteLLM supports Redis-backed semantic caching when `REDIS_URL` is set (Compose profile: `litellm-cache`).
 
+### 9.7 DigiVault
+
+**Protocol:** HTTP via `digivault_hub.py`
+
+- **Manifest:** `POST /v1/orchestrator_tools` — returns the OpenAI tool dict for `digivault_search_notes`. Cached per `base_url` (no `index_config` — vault search is not index-scoped).
+- **Invoke:** `POST /v1/orchestrator_invoke` — dispatches to `SupabaseStore.search` (the `search_architecture_notes` RPC) on DigiVault's side. Accepts `{tool, arguments}`.
+- **Auth:** Bearer token from `WorkflowState.digi_bearer` is forwarded via `Authorization: Bearer` header; `X-Request-ID` forwarded from `ToolContext.request_id`.
+- **Env:** `DIGIVAULT_URL` (empty = the `digivault` skill is not registered for the request; other skills are unaffected). In Docker: `http://digivault:8004`.
+- **Purpose:** reproduces the vault-grounded documentation search the digithings.ai chat widget calls directly today ([ADR-0018](../docs/adr/0018-digichat-path-routing.md), epic #1248) — the tool DigiChat's BFF needs once traffic moves off the bespoke widget onto DigiGraph.
+
 ---
 
 ## 10. Docker and MCP Composition
@@ -592,6 +604,7 @@ digigraph:
 |----------|------------------|-------------|
 | `DIGIQUANT_URL` | `http://digiquant:8001` | DigiQuant HTTP base URL |
 | `DIGISEARCH_URL` | `http://digisearch:8002` | DigiSearch HTTP base URL; empty = search disabled |
+| `DIGIVAULT_URL` | `http://digivault:8004` | DigiVault HTTP base URL; empty = `digivault_search_notes` disabled |
 | `DIGISMITH_URL` | `http://digismith:8003` | DigiSmith status URL (unused by DigiGraph HTTP) |
 | `DIGIKEY_JWKS_URL` | `http://digikey:8005/.well-known/jwks.json` | JWT public key endpoint |
 | `DIGIKEY_ISSUER` | `http://digikey:8005` | JWT issuer claim |

--- a/digigraph/src/digigraph/orchestration/builtin.py
+++ b/digigraph/src/digigraph/orchestration/builtin.py
@@ -27,8 +27,10 @@ from digigraph.trace_events import rag_sources_from_results
 from digigraph.vertical_orchestrator import (
     fetch_digisearch_tool_dicts,
     fetch_digiquant_tool_dicts,
+    fetch_digivault_tool_dicts,
     invoke_digisearch_tool,
     invoke_digiquant_tool,
+    invoke_digivault_tool,
 )
 
 logger = logging.getLogger(__name__)
@@ -116,6 +118,11 @@ def _digisearch_available(_context: ToolContext) -> bool:
     return bool(url and url.strip())
 
 
+def _digivault_available(_context: ToolContext) -> bool:
+    url = os.environ.get("DIGIVAULT_URL", "")
+    return bool(url and url.strip())
+
+
 def _digi_bearer_from_context(context: ToolContext) -> str | None:
     st = context.state
     if isinstance(st, dict):
@@ -130,6 +137,10 @@ def _digisearch_service_base() -> str:
 
 def _digiquant_service_base() -> str:
     return DigiProjectConfig.load().get_digiquant_url()
+
+
+def _digivault_service_base() -> str:
+    return DigiProjectConfig.load().get_digivault_url()
 
 
 def _schema_from_digisearch_manifest(ctx: ToolContext, tool_name: str) -> dict[str, Any]:
@@ -169,6 +180,75 @@ def _schema_from_digisearch_manifest(ctx: ToolContext, tool_name: str) -> dict[s
                 "required": ["query"],
             },
         },
+    }
+
+
+def _schema_from_digivault_manifest(ctx: ToolContext) -> dict[str, Any]:
+    try:
+        by_name = fetch_digivault_tool_dicts(
+            _digivault_service_base(),
+            _digi_bearer_from_context(ctx),
+            ctx.request_id,
+        )
+        t = by_name.get("digivault_search_notes")
+        if t:
+            return t
+    except _ORCHESTRATOR_CLIENT_ERRORS as exc:
+        logger.warning("DigiVault manifest fetch failed for digivault_search_notes: %s", exc)
+    return {
+        "type": "function",
+        "function": {
+            "name": "digivault_search_notes",
+            "description": (
+                "Full-text search over the DigiThings architecture vault. "
+                "Requires DIGIVAULT_URL and POST /v1/orchestrator_tools."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _handle_digivault_search(args: dict[str, Any], context: ToolContext) -> str | dict[str, Any]:
+    q = args.get("query", "")
+    if not q or not str(q).strip():
+        return "No search query provided."
+    try:
+        inv = invoke_digivault_tool(
+            _digivault_service_base(),
+            "digivault_search_notes",
+            args,
+            bearer_token=_digi_bearer_from_context(context),
+            request_id=context.request_id,
+        )
+    except _ORCHESTRATOR_CLIENT_ERRORS as e:
+        return f"DigiVault orchestrator invoke failed: {e}"
+    if not inv.get("ok"):
+        return json.dumps(inv)
+    data = inv.get("data")
+    if not isinstance(data, dict):
+        return "No results found."
+    hits = data.get("hits", [])
+    if not hits:
+        return "No matching documentation was found in the digivault for that query."
+    results = [
+        {
+            "content": h.get("body_markdown"),
+            "score": h.get("rank"),
+            "doc_id": h.get("vault_path"),
+            "metadata": {"title": h.get("title"), "tags": h.get("tags")},
+        }
+        for h in hits
+        if isinstance(h, dict)
+    ]
+    payload_for_llm = _search_payload_for_llm(results, len(results))
+    return {
+        "content": json.dumps(payload_for_llm),
+        "results": results,
+        "rag_sources": rag_sources_from_results(results),
     }
 
 
@@ -666,6 +746,12 @@ def _register_tools() -> None:
         schema_factory=lambda ctx: _schema_from_digisearch_manifest(ctx, "digisearch_fetch_all"),
     )
     register_tool(
+        "digivault_search_notes",
+        None,
+        _handle_digivault_search,
+        schema_factory=_schema_from_digivault_manifest,
+    )
+    register_tool(
         "visualization_agent",
         VISUALIZATION_AGENT_TOOL,
         _handle_visualization,
@@ -761,6 +847,11 @@ def _register_skills() -> None:
         "sitaas_rag",
         _sitaas_rag_tool_names(),
         when=lambda ctx: ctx.has_run_data_dir,
+    )
+    register_skill(
+        "digivault",
+        ["digivault_search_notes"],
+        when=lambda ctx: _digivault_available(ctx),
     )
 
 

--- a/digigraph/src/digigraph/project_config.py
+++ b/digigraph/src/digigraph/project_config.py
@@ -314,6 +314,12 @@ class DigiProjectConfig:
             "digiquant_url", os.environ.get("DIGIQUANT_URL", "http://digiquant:8001")
         )
 
+    def get_digivault_url(self) -> str:
+        """DigiVault service URL."""
+        return self.services.get(
+            "digivault_url", os.environ.get("DIGIVAULT_URL", "http://digivault:8004")
+        )
+
     def get_research_system_prompt(self) -> str | None:
         """Custom system prompt for research node. When set, LLM responds in natural language (no JSON)."""
         return self.agents.get("research_system_prompt")

--- a/digigraph/src/digigraph/vertical_orchestrator/__init__.py
+++ b/digigraph/src/digigraph/vertical_orchestrator/__init__.py
@@ -8,10 +8,16 @@ from digigraph.vertical_orchestrator.digiquant_hub import (
     fetch_digiquant_tool_dicts,
     invoke_digiquant_tool,
 )
+from digigraph.vertical_orchestrator.digivault_hub import (
+    fetch_digivault_tool_dicts,
+    invoke_digivault_tool,
+)
 
 __all__ = [
     "fetch_digisearch_tool_dicts",
     "invoke_digisearch_tool",
     "fetch_digiquant_tool_dicts",
     "invoke_digiquant_tool",
+    "fetch_digivault_tool_dicts",
+    "invoke_digivault_tool",
 ]

--- a/digigraph/src/digigraph/vertical_orchestrator/digivault_hub.py
+++ b/digigraph/src/digigraph/vertical_orchestrator/digivault_hub.py
@@ -1,0 +1,65 @@
+"""DigiVault orchestrator manifest + invoke (tools owned by DigiVault HTTP API)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from digibase.http import outbound_service_headers
+from digibase.http_client import sync_client
+
+from digigraph.vertical_orchestrator._common import HUB_CLIENT_ERRORS, log_manifest_fetch_failure
+
+_MANIFEST_CACHE: dict[str, list[dict[str, Any]]] = {}
+
+
+def fetch_digivault_tool_dicts(
+    base_url: str,
+    bearer_token: str | None,
+    request_id: str | None,
+) -> dict[str, dict[str, Any]]:
+    """Return tool name -> OpenAI tool dict from ``POST /v1/orchestrator_tools``."""
+    base = base_url.strip().rstrip("/")
+    if base not in _MANIFEST_CACHE:
+        url = f"{base}/v1/orchestrator_tools"
+        headers = outbound_service_headers(request_id, bearer_token)
+        headers["Content-Type"] = "application/json"
+        try:
+            with sync_client(timeout=30.0) as client:
+                r = client.post(url, json={}, headers=headers)
+                r.raise_for_status()
+                body = r.json()
+        except HUB_CLIENT_ERRORS as e:
+            log_manifest_fetch_failure("DigiVault", e)
+            raise
+        tools = body.get("tools") or []
+        if not isinstance(tools, list):
+            tools = []
+        _MANIFEST_CACHE[base] = tools
+    by_name: dict[str, dict[str, Any]] = {}
+    for t in _MANIFEST_CACHE[base]:
+        fn = t.get("function") if isinstance(t, dict) else None
+        if isinstance(fn, dict) and fn.get("name"):
+            by_name[str(fn["name"])] = t
+    return by_name
+
+
+def invoke_digivault_tool(
+    base_url: str,
+    tool: str,
+    arguments: dict[str, Any],
+    *,
+    bearer_token: str | None,
+    request_id: str | None,
+) -> dict[str, Any]:
+    """POST ``/v1/orchestrator_invoke`` on DigiVault."""
+    url = f"{base_url.strip().rstrip('/')}/v1/orchestrator_invoke"
+    headers = outbound_service_headers(request_id, bearer_token)
+    headers["Content-Type"] = "application/json"
+    payload: dict[str, Any] = {"tool": tool, "arguments": arguments}
+    with sync_client(timeout=30.0) as client:
+        r = client.post(url, json=payload, headers=headers)
+        r.raise_for_status()
+    body = r.json()
+    if not isinstance(body, dict):
+        return {"ok": False, "error": "invalid_response"}
+    return body

--- a/digivault/ARCHITECTURE.md
+++ b/digivault/ARCHITECTURE.md
@@ -33,8 +33,8 @@ extra.
 | `digivault/vault.py` | `Vault` — load a directory (or any store via `Vault.from_sources`), build the note index + link graph + backlinks + tag index; maintenance ops (`create_note`, `rename` with inbound-link rewrite, `set_frontmatter`, `reindex`, `lint`). |
 | `digivault/supabase_store.py` | `SupabaseStore` — read a vault out of Supabase (`architecture_notes`/`knowledge_notes`) and reconstruct it via `Vault.from_sources`; FTS `search` via the `search_architecture_notes` RPC. Optional `[supabase]` extra, lazily imported. |
 | `digivault/path_scopes.py` | DigiKey scope policy: reads need `digivault:read`, writes `digivault:write`. |
-| `digivault/orchestrator_tools.py` | OpenAI-style tool manifest fetched by DigiGraph via `POST /v1/orchestrator_tools`. |
-| `digivault/server.py` | FastAPI app: `/healthz`, `/v1/status`, note CRUD, lint, backlinks, tags, orchestrator endpoints. |
+| `digivault/orchestrator_tools.py` | OpenAI-style tool manifest fetched by DigiGraph via `POST /v1/orchestrator_tools`: tag search, backlinks, lint, create-note, and `digivault_search_notes` (Supabase FTS). |
+| `digivault/server.py` | FastAPI app: `/healthz`, `/v1/status`, note CRUD, lint, backlinks, tags, orchestrator endpoints (`digivault_search_notes` dispatches to `SupabaseStore.search`, independent of the local-filesystem vault). |
 | `digivault/mcp_server.py` | `python -m digivault.mcp_server` — vault tools over MCP (streamable HTTP, default `127.0.0.1:8766`). |
 | `digivault/cli.py` | `digivault init|lint|reindex|new-note`. |
 
@@ -69,6 +69,14 @@ report = vault.lint()           # -> LintReport(ok, note_count, issues)
   correctness over caching.
 - **Hub:** DigiGraph discovers tools via `POST /v1/orchestrator_tools` and
   executes via `POST /v1/orchestrator_invoke`.
+- **`digivault_search_notes`** is the one orchestrator tool that bypasses
+  `DIGIVAULT_ROOT` entirely — it queries the Supabase-mirrored vault via
+  `SupabaseStore.search` (the `search_architecture_notes` RPC, anon-key,
+  read-only) and returns 503 only if `CORE_SUPABASE_URL`/`CORE_SUPABASE_ANON_KEY`
+  are unset. This is the same RPC the digithings.ai chat widget calls directly
+  today ([ADR-0018](../docs/adr/0018-digichat-path-routing.md), epic #1248) —
+  wiring it into DigiVault's own orchestrator surface lets DigiGraph reproduce
+  that grounding once the widget is cut over to the DigiChat gateway.
 
 ## Design decisions
 
@@ -97,6 +105,7 @@ report = vault.lint()           # -> LintReport(ok, note_count, issues)
 | `DIGIVAULT_ROOT` | Path to the managed vault directory (required for note routes). |
 | `DIGIVAULT_MCP_HOST` | MCP bind host (default `127.0.0.1`). |
 | `DIGIKEY_JWKS_URL` / `DIGIKEY_ISSUER` / `DIGIKEY_AUDIENCE` / `DIGIKEY_PUBLIC_KEY_PEM` | DigiKey JWT verification (shared convention). |
+| `CORE_SUPABASE_URL` (or `SUPABASE_URL`) + `CORE_SUPABASE_ANON_KEY` (or `CORE_SUPABASE_SERVICE_KEY` / `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY`) | Required only for `digivault_search_notes` — `SupabaseStore.from_env` credentials (ADR-0022 naming). Requires the `digivault[supabase]` extra installed. |
 
 ## Testing
 
@@ -105,6 +114,9 @@ Core tests (frontmatter, wikilinks, vault) need only `pydantic` + `pyyaml`.
 Service and CLI tests `pytest.importorskip` their extras so the suite stays green
 without `digivault[service]` installed. CI (`.github/workflows/test-digivault.yml`)
 installs `digibase` + `digikey` + `digivault[service]` and runs the full set.
+`digivault_search_notes` tests fake `SupabaseStore` directly (constructor takes
+any `SupabaseClientProtocol`) — the real `supabase` package (`[supabase]` extra)
+is never required to run the suite, matching `test_supabase_store.py`'s convention.
 
 ## Monorepo integration
 

--- a/digivault/ARCHITECTURE.md
+++ b/digivault/ARCHITECTURE.md
@@ -62,8 +62,12 @@ report = vault.lint()           # -> LintReport(ok, note_count, issues)
 - **Port 8004**, host-loopback-bound, under the dedicated `digivault` Compose
   profile (not part of the always-on `core` stack).
 - **Auth:** DigiKey JWT via `DigiAuthMiddleware`; `digivault:read` for GET
-  routes and discovery, `digivault:write` for mutations and `orchestrator_invoke`.
-  `/healthz`, `/v1/status`, `/metrics`, OpenAPI are auth-exempt.
+  routes, discovery, and `orchestrator_invoke` (most orchestrator tools are
+  reads); `digivault:write` for mutating note routes. `orchestrator_invoke`'s
+  one mutating tool (`digivault_create_note`) enforces `digivault:write` itself
+  in the handler (`_require_tool_scope`, keyed on the requested tool name) since
+  the shared endpoint can't scope by path alone. `/healthz`, `/v1/status`,
+  `/metrics`, OpenAPI are auth-exempt.
 - **Vault root:** `DIGIVAULT_ROOT` (required for any note route; routes return
   503 when unset). The vault is re-read from disk per request — small docs vault,
   correctness over caching.
@@ -73,10 +77,14 @@ report = vault.lint()           # -> LintReport(ok, note_count, issues)
   `DIGIVAULT_ROOT` entirely — it queries the Supabase-mirrored vault via
   `SupabaseStore.search` (the `search_architecture_notes` RPC, anon-key,
   read-only) and returns 503 only if `CORE_SUPABASE_URL`/`CORE_SUPABASE_ANON_KEY`
-  are unset. This is the same RPC the digithings.ai chat widget calls directly
-  today ([ADR-0018](../docs/adr/0018-digichat-path-routing.md), epic #1248) —
-  wiring it into DigiVault's own orchestrator surface lets DigiGraph reproduce
-  that grounding once the widget is cut over to the DigiChat gateway.
+  are unset. `limit` is clamped to `[1, 50]` regardless of caller input. This is
+  the same RPC the digithings.ai chat widget calls directly today
+  ([ADR-0018](../docs/adr/0018-digichat-path-routing.md), epic #1248) — wiring
+  it into DigiVault's own orchestrator surface lets DigiGraph reproduce that
+  grounding once the widget is cut over to the DigiChat gateway. Verified live
+  against the core Supabase project (2026-07-01): the RPC returns all eight
+  fields `VaultSearchHit` requires, for the query "What does DigiGraph
+  orchestrate?" — top hit was the `digigraph` note at rank 0.49.
 
 ## Design decisions
 

--- a/digivault/Dockerfile
+++ b/digivault/Dockerfile
@@ -25,7 +25,7 @@ RUN uv pip install --system -e "./digikey"
 COPY digivault/pyproject.toml digivault/ARCHITECTURE.md ./digivault/
 COPY digivault/src ./digivault/src
 WORKDIR /app/digivault
-RUN uv pip install --system -e ".[service]"
+RUN uv pip install --system -e ".[service,supabase]"
 
 WORKDIR /app
 EXPOSE 8004

--- a/digivault/src/digivault/orchestrator_tools.py
+++ b/digivault/src/digivault/orchestrator_tools.py
@@ -30,6 +30,7 @@ TOOL_VAULT_SEARCH_TAG = "digivault_search_tag"
 TOOL_VAULT_BACKLINKS = "digivault_backlinks"
 TOOL_VAULT_LINT = "digivault_lint"
 TOOL_VAULT_CREATE_NOTE = "digivault_create_note"
+TOOL_VAULT_SEARCH_NOTES = "digivault_search_notes"
 
 ORCHESTRATOR_TOOL_NAMES: frozenset[str] = frozenset(
     {
@@ -37,8 +38,11 @@ ORCHESTRATOR_TOOL_NAMES: frozenset[str] = frozenset(
         TOOL_VAULT_BACKLINKS,
         TOOL_VAULT_LINT,
         TOOL_VAULT_CREATE_NOTE,
+        TOOL_VAULT_SEARCH_NOTES,
     }
 )
+
+DEFAULT_SEARCH_NOTES_LIMIT = 7
 
 
 def _fn(name: str, description: str, params: FunctionParametersSchema) -> OpenAIToolDict:
@@ -85,6 +89,29 @@ def build_orchestrator_tool_manifest() -> list[OpenAIToolDict]:
                     "body": {"type": "string"},
                 },
                 "required": ["name"],
+            },
+        ),
+        _fn(
+            TOOL_VAULT_SEARCH_NOTES,
+            "Full-text search over the DigiThings architecture vault (all module docs — "
+            "digigraph, digiquant, digisearch, digichat, digikey, digismith, digivault, "
+            "digiclaw, digibase, and roadmap modules). Ranked by relevance across title, "
+            "body, and tags. Use for any question about the digithings stack: modules, "
+            "ports, APIs, architecture, build/run. Requires the vault's Supabase-backed "
+            "store to be configured (CORE_SUPABASE_URL / CORE_SUPABASE_ANON_KEY).",
+            {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language search query.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": f"Max hits to return (default {DEFAULT_SEARCH_NOTES_LIMIT}).",
+                    },
+                },
+                "required": ["query"],
             },
         ),
     ]

--- a/digivault/src/digivault/path_scopes.py
+++ b/digivault/src/digivault/path_scopes.py
@@ -30,9 +30,12 @@ def digivault_path_scopes(method: str, path: str) -> list[str] | None:
     # Discovery is a read; the hub fetches the tool manifest before invoking.
     if path == "/v1/orchestrator_tools":
         return [SCOPE_READ]
-    # Invocation and all mutating note routes require write — invoke can create.
+    # Invocation is gated at read here — most orchestrator tools are reads
+    # (search, backlinks, lint). The one mutating tool (create_note) enforces
+    # SCOPE_WRITE itself in the handler, keyed on the requested tool name, so a
+    # read-only caller can't reach it via this shared endpoint.
     if path == "/v1/orchestrator_invoke":
-        return [SCOPE_WRITE]
+        return [SCOPE_READ]
     if method in ("POST", "PUT", "PATCH", "DELETE"):
         return [SCOPE_WRITE]
     return [SCOPE_READ]

--- a/digivault/src/digivault/server.py
+++ b/digivault/src/digivault/server.py
@@ -17,7 +17,8 @@ from digibase.http import install_request_id_logging, install_request_id_middlew
 from digibase.metrics import install_metrics
 from digibase.otel import setup_otel_fastapi
 from digikey.integrations.service_middleware import DigiAuthMiddleware
-from fastapi import FastAPI, HTTPException
+from digikey.scopes import scope_grants_required
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from digivault import __version__
@@ -32,9 +33,14 @@ from digivault.orchestrator_tools import (
     OpenAIToolDict,
     build_orchestrator_tool_manifest,
 )
-from digivault.path_scopes import digivault_path_scopes
+from digivault.path_scopes import SCOPE_WRITE, digivault_path_scopes
 from digivault.supabase_store import SupabaseStore, SupabaseStoreError
 from digivault.vault import Vault, VaultError
+
+# /v1/orchestrator_invoke is gated at SCOPE_READ (most tools are reads); the one
+# mutating tool enforces SCOPE_WRITE here so a read-only caller can't reach it.
+_TOOL_WRITE_SCOPES: dict[str, str] = {TOOL_VAULT_CREATE_NOTE: SCOPE_WRITE}
+_MAX_SEARCH_NOTES_LIMIT = 50
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +76,23 @@ def _open_supabase_store() -> SupabaseStore:
         return SupabaseStore.from_env()
     except SupabaseStoreError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def _require_tool_scope(request: Request, tool: str) -> None:
+    """Enforce SCOPE_WRITE for mutating tools dispatched via /v1/orchestrator_invoke.
+
+    The route itself only requires SCOPE_READ (most tools are reads); this closes
+    the gap for the one tool (create_note) that mutates the vault.
+    """
+    required = _TOOL_WRITE_SCOPES.get(tool)
+    if required is None:
+        return
+    auth = request.state.digi_auth
+    if not scope_grants_required(auth.scopes, [required]):
+        raise HTTPException(
+            status_code=403,
+            detail=f"insufficient_scope: {required} required for {tool!r}",
+        )
 
 
 # ── request/response models ────────────────────────────────────────────────
@@ -212,10 +235,13 @@ def orchestrator_tools() -> OrchestratorToolsResponse:
 
 
 @app.post("/v1/orchestrator_invoke", response_model=OrchestratorInvokeResponse)
-def orchestrator_invoke(req: OrchestratorInvokeRequest) -> OrchestratorInvokeResponse:
+def orchestrator_invoke(
+    req: OrchestratorInvokeRequest, request: Request
+) -> OrchestratorInvokeResponse:
     """Execute one DigiVault orchestrator tool by name (hub dispatch)."""
     tool = (req.tool or "").strip()
     args = req.arguments if isinstance(req.arguments, dict) else {}
+    _require_tool_scope(request, tool)
 
     # Supabase-backed full-text search is independent of DIGIVAULT_ROOT (the local
     # filesystem vault) — it reads the vault mirrored into Postgres instead.
@@ -227,6 +253,7 @@ def orchestrator_invoke(req: OrchestratorInvokeRequest) -> OrchestratorInvokeRes
             limit = int(args["limit"]) if args.get("limit") else DEFAULT_SEARCH_NOTES_LIMIT
         except (TypeError, ValueError):
             limit = DEFAULT_SEARCH_NOTES_LIMIT
+        limit = max(1, min(limit, _MAX_SEARCH_NOTES_LIMIT))
         hits = _open_supabase_store().search(query, limit=limit)
         data = {"hits": [h.model_dump(mode="json") for h in hits]}
         return OrchestratorInvokeResponse(ok=True, tool=tool, data=data)

--- a/digivault/src/digivault/server.py
+++ b/digivault/src/digivault/server.py
@@ -23,14 +23,17 @@ from pydantic import BaseModel, ConfigDict, Field
 from digivault import __version__
 from digivault.models import LintReport, Note
 from digivault.orchestrator_tools import (
+    DEFAULT_SEARCH_NOTES_LIMIT,
     TOOL_VAULT_BACKLINKS,
     TOOL_VAULT_CREATE_NOTE,
     TOOL_VAULT_LINT,
+    TOOL_VAULT_SEARCH_NOTES,
     TOOL_VAULT_SEARCH_TAG,
     OpenAIToolDict,
     build_orchestrator_tool_manifest,
 )
 from digivault.path_scopes import digivault_path_scopes
+from digivault.supabase_store import SupabaseStore, SupabaseStoreError
 from digivault.vault import Vault, VaultError
 
 logger = logging.getLogger(__name__)
@@ -58,6 +61,14 @@ def _open_vault() -> Vault:
     try:
         return Vault(_vault_root())
     except VaultError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+def _open_supabase_store() -> SupabaseStore:
+    """Build the Supabase-backed store for full-text search (independent of DIGIVAULT_ROOT)."""
+    try:
+        return SupabaseStore.from_env()
+    except SupabaseStoreError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
@@ -203,9 +214,24 @@ def orchestrator_tools() -> OrchestratorToolsResponse:
 @app.post("/v1/orchestrator_invoke", response_model=OrchestratorInvokeResponse)
 def orchestrator_invoke(req: OrchestratorInvokeRequest) -> OrchestratorInvokeResponse:
     """Execute one DigiVault orchestrator tool by name (hub dispatch)."""
-    vault = _open_vault()
     tool = (req.tool or "").strip()
     args = req.arguments if isinstance(req.arguments, dict) else {}
+
+    # Supabase-backed full-text search is independent of DIGIVAULT_ROOT (the local
+    # filesystem vault) — it reads the vault mirrored into Postgres instead.
+    if tool == TOOL_VAULT_SEARCH_NOTES:
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return OrchestratorInvokeResponse(ok=False, tool=tool, error="query is required")
+        try:
+            limit = int(args["limit"]) if args.get("limit") else DEFAULT_SEARCH_NOTES_LIMIT
+        except (TypeError, ValueError):
+            limit = DEFAULT_SEARCH_NOTES_LIMIT
+        hits = _open_supabase_store().search(query, limit=limit)
+        data = {"hits": [h.model_dump(mode="json") for h in hits]}
+        return OrchestratorInvokeResponse(ok=True, tool=tool, data=data)
+
+    vault = _open_vault()
     try:
         if tool == TOOL_VAULT_SEARCH_TAG:
             notes = vault.search_by_tag(str(args.get("tag") or ""))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,10 @@ services:
       - DIGIQUANT_URL=http://digiquant:8001
       - DIGISEARCH_URL=http://digisearch:8002
       - DIGISMITH_URL=http://digismith:8003
+      # DigiVault is opt-in (dedicated Compose profile, not part of the always-on
+      # core stack) — leave empty by default so the digivault skill stays hidden
+      # unless an operator explicitly enables the profile and sets this.
+      - DIGIVAULT_URL=${DIGIVAULT_URL:-}
       - DIGIKEY_JWKS_URL=${DIGIKEY_JWKS_URL:-http://digikey:8005/.well-known/jwks.json}
       - DIGIKEY_ISSUER=${DIGIKEY_ISSUER:-http://digikey:8005}
       - DIGIKEY_AUDIENCE=${DIGIKEY_AUDIENCE:-digi-ecosystem}

--- a/tests/dg/test_digivault_tool.py
+++ b/tests/dg/test_digivault_tool.py
@@ -1,0 +1,164 @@
+"""Unit tests for the digivault_search_notes orchestrator tool (builtin.py wiring)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from digigraph.orchestration.registry import ToolContext, ToolExposureMode, get_tools, has_tool
+
+
+def _ctx(**overrides: object) -> ToolContext:
+    defaults: dict[str, object] = {
+        "session_id": "sess-1",
+        "run_data_dir": None,
+        "index_name": "default",
+        "index_config": {},
+        "state": {},
+        "request_id": "rid-1",
+    }
+    defaults.update(overrides)
+    return ToolContext(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_digivault_search_notes_is_registered() -> None:
+    from digigraph.orchestration import builtin  # noqa: F401 - triggers registration
+
+    assert has_tool("digivault_search_notes")
+
+
+@pytest.mark.unit
+def test_digivault_available_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from digigraph.orchestration.builtin import _digivault_available
+
+    monkeypatch.delenv("DIGIVAULT_URL", raising=False)
+    assert _digivault_available(_ctx()) is False
+
+    monkeypatch.setenv("DIGIVAULT_URL", "http://digivault:8004")
+    assert _digivault_available(_ctx()) is True
+
+
+@pytest.mark.unit
+def test_digivault_skill_hidden_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from digigraph.orchestration import builtin  # noqa: F401 - ensures skills are registered
+
+    monkeypatch.delenv("DIGIVAULT_URL", raising=False)
+    names = get_tools(["digivault"], _ctx(), mode=ToolExposureMode.SUMMARY)
+    assert names == []
+
+
+@pytest.mark.unit
+def test_digivault_skill_exposed_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from digigraph.orchestration import builtin  # noqa: F401 - ensures skills are registered
+
+    monkeypatch.setenv("DIGIVAULT_URL", "http://digivault:8004")
+    with patch(
+        "digigraph.orchestration.builtin.fetch_digivault_tool_dicts",
+        return_value={
+            "digivault_search_notes": {
+                "type": "function",
+                "function": {
+                    "name": "digivault_search_notes",
+                    "description": "search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        },
+    ):
+        tools = get_tools(["digivault"], _ctx(), mode=ToolExposureMode.DETAILED)
+    assert [t["function"]["name"] for t in tools] == ["digivault_search_notes"]
+
+
+@pytest.mark.unit
+def test_schema_from_digivault_manifest_falls_back_on_error() -> None:
+    from digigraph.orchestration.builtin import _schema_from_digivault_manifest
+
+    with patch(
+        "digigraph.orchestration.builtin.fetch_digivault_tool_dicts",
+        side_effect=httpx.ConnectError("boom"),
+    ):
+        schema = _schema_from_digivault_manifest(_ctx())
+    assert schema["function"]["name"] == "digivault_search_notes"
+    assert schema["function"]["parameters"]["required"] == ["query"]
+
+
+@pytest.mark.unit
+def test_handle_digivault_search_requires_query() -> None:
+    from digigraph.orchestration.builtin import _handle_digivault_search
+
+    assert _handle_digivault_search({}, _ctx()) == "No search query provided."
+    assert _handle_digivault_search({"query": "   "}, _ctx()) == "No search query provided."
+
+
+@pytest.mark.unit
+def test_handle_digivault_search_success() -> None:
+    from digigraph.orchestration.builtin import _handle_digivault_search
+
+    hit = {
+        "vault_path": "digigraph",
+        "title": "DigiGraph",
+        "body_markdown": "LangGraph-based workflow engine.",
+        "tags": ["core"],
+        "rank": 0.8,
+    }
+    with patch(
+        "digigraph.orchestration.builtin.invoke_digivault_tool",
+        return_value={"ok": True, "data": {"hits": [hit]}},
+    ) as mock_invoke:
+        out = _handle_digivault_search({"query": "what does digigraph orchestrate"}, _ctx())
+
+    assert isinstance(out, dict)
+    assert out["results"] == [
+        {
+            "content": "LangGraph-based workflow engine.",
+            "score": 0.8,
+            "doc_id": "digigraph",
+            "metadata": {"title": "DigiGraph", "tags": ["core"]},
+        }
+    ]
+    assert json.loads(out["content"])["total"] == 1
+    assert out["rag_sources"][0]["doc_id"] == "digigraph"
+    mock_invoke.assert_called_once()
+    call_kwargs = mock_invoke.call_args
+    assert call_kwargs.args[1] == "digivault_search_notes"
+    assert call_kwargs.args[2] == {"query": "what does digigraph orchestrate"}
+
+
+@pytest.mark.unit
+def test_handle_digivault_search_no_hits() -> None:
+    from digigraph.orchestration.builtin import _handle_digivault_search
+
+    with patch(
+        "digigraph.orchestration.builtin.invoke_digivault_tool",
+        return_value={"ok": True, "data": {"hits": []}},
+    ):
+        out = _handle_digivault_search({"query": "nonexistent topic"}, _ctx())
+    assert out == "No matching documentation was found in the digivault for that query."
+
+
+@pytest.mark.unit
+def test_handle_digivault_search_invoke_error() -> None:
+    from digigraph.orchestration.builtin import _handle_digivault_search
+
+    with patch(
+        "digigraph.orchestration.builtin.invoke_digivault_tool",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        out = _handle_digivault_search({"query": "anything"}, _ctx())
+    assert "DigiVault orchestrator invoke failed" in out
+
+
+@pytest.mark.unit
+def test_handle_digivault_search_not_ok_response() -> None:
+    from digigraph.orchestration.builtin import _handle_digivault_search
+
+    with patch(
+        "digigraph.orchestration.builtin.invoke_digivault_tool",
+        return_value={"ok": False, "error": "vault unavailable"},
+    ):
+        out = _handle_digivault_search({"query": "anything"}, _ctx())
+    assert json.loads(out)["error"] == "vault unavailable"

--- a/tests/dg/test_project_config.py
+++ b/tests/dg/test_project_config.py
@@ -83,6 +83,17 @@ def test_digi_project_config_allowed_tools() -> None:
     assert cfg.get_allowed_tools() == ["digisearch", "todo"]
 
 
+def test_get_digivault_url_defaults_and_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIVAULT_URL", raising=False)
+    assert DigiProjectConfig({}).get_digivault_url() == "http://digivault:8004"
+
+    monkeypatch.setenv("DIGIVAULT_URL", "http://example.test:8004")
+    assert DigiProjectConfig({}).get_digivault_url() == "http://example.test:8004"
+
+    cfg = DigiProjectConfig({"services": {"digivault_url": "http://from-config:8004"}})
+    assert cfg.get_digivault_url() == "http://from-config:8004"
+
+
 def test_digi_project_config_indexes_dir_discovery(tmp_path: Path) -> None:
     """When indexes_dir is set, indexes are discovered from that directory."""
     (tmp_path / "indexes").mkdir()

--- a/tests/dv/test_server.py
+++ b/tests/dv/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -15,9 +16,15 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from digivault import server  # noqa: E402
 from digivault.orchestrator_tools import ORCHESTRATOR_TOOL_NAMES  # noqa: E402
+from digivault.path_scopes import SCOPE_WRITE  # noqa: E402
 from digivault.supabase_store import SupabaseStore  # noqa: E402
 
 pytestmark = pytest.mark.unit
+
+
+def _fake_request(scopes: list[str] | None = None) -> SimpleNamespace:
+    """Stand-in for FastAPI's Request — only `.state.digi_auth.scopes` is read."""
+    return SimpleNamespace(state=SimpleNamespace(digi_auth=SimpleNamespace(scopes=scopes or [])))
 
 
 class _FakeSearchResponse:
@@ -100,7 +107,8 @@ def test_orchestrator_tools_manifest() -> None:
 
 def test_orchestrator_invoke_search_tag(vault_dir: Path) -> None:
     resp = server.orchestrator_invoke(
-        server.OrchestratorInvokeRequest(tool="digivault_search_tag", arguments={"tag": "doc"})
+        server.OrchestratorInvokeRequest(tool="digivault_search_tag", arguments={"tag": "doc"}),
+        _fake_request(),
     )
     assert resp.ok is True
     assert resp.data is not None
@@ -109,7 +117,27 @@ def test_orchestrator_invoke_search_tag(vault_dir: Path) -> None:
 
 def test_orchestrator_invoke_unknown_tool(vault_dir: Path) -> None:
     with pytest.raises(Exception):
-        server.orchestrator_invoke(server.OrchestratorInvokeRequest(tool="nope"))
+        server.orchestrator_invoke(server.OrchestratorInvokeRequest(tool="nope"), _fake_request())
+
+
+def test_orchestrator_invoke_create_note_requires_write_scope(vault_dir: Path) -> None:
+    """The shared invoke endpoint is read-scoped; create_note enforces write itself."""
+    with pytest.raises(HTTPException) as excinfo:
+        server.orchestrator_invoke(
+            server.OrchestratorInvokeRequest(tool="digivault_create_note", arguments={"name": "c"}),
+            _fake_request(scopes=["digivault:read"]),
+        )
+    assert excinfo.value.status_code == 403
+
+
+def test_orchestrator_invoke_create_note_succeeds_with_write_scope(vault_dir: Path) -> None:
+    resp = server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(tool="digivault_create_note", arguments={"name": "c"}),
+        _fake_request(scopes=[SCOPE_WRITE]),
+    )
+    assert resp.ok is True
+    assert resp.data is not None
+    assert resp.data["name"] == "c"
 
 
 def test_orchestrator_invoke_search_notes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -132,7 +160,8 @@ def test_orchestrator_invoke_search_notes(monkeypatch: pytest.MonkeyPatch) -> No
         server.OrchestratorInvokeRequest(
             tool="digivault_search_notes",
             arguments={"query": "what does digigraph orchestrate", "limit": 3},
-        )
+        ),
+        _fake_request(),
     )
     assert resp.ok is True
     assert resp.data is not None
@@ -164,17 +193,49 @@ def test_orchestrator_invoke_search_notes_default_limit(monkeypatch: pytest.Monk
     server.orchestrator_invoke(
         server.OrchestratorInvokeRequest(
             tool="digivault_search_notes", arguments={"query": "auth", "limit": "not-a-number"}
-        )
+        ),
+        _fake_request(),
     )
     assert fake_client.rpc_calls == [
         ("search_architecture_notes", {"query": "auth", "match_limit": 7})
     ]
 
 
+def test_orchestrator_invoke_search_notes_clamps_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
+    fake_client = _FakeSearchClient(rpc_data=[])
+    monkeypatch.setattr(server.SupabaseStore, "from_env", lambda: SupabaseStore(fake_client))
+
+    server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(
+            tool="digivault_search_notes", arguments={"query": "auth", "limit": 5000}
+        ),
+        _fake_request(),
+    )
+    assert fake_client.rpc_calls == [
+        ("search_architecture_notes", {"query": "auth", "match_limit": 50})
+    ]
+
+    fake_client_negative = _FakeSearchClient(rpc_data=[])
+    monkeypatch.setattr(
+        server.SupabaseStore, "from_env", lambda: SupabaseStore(fake_client_negative)
+    )
+    server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(
+            tool="digivault_search_notes", arguments={"query": "auth", "limit": -3}
+        ),
+        _fake_request(),
+    )
+    assert fake_client_negative.rpc_calls == [
+        ("search_architecture_notes", {"query": "auth", "match_limit": 1})
+    ]
+
+
 def test_orchestrator_invoke_search_notes_missing_query(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
     resp = server.orchestrator_invoke(
-        server.OrchestratorInvokeRequest(tool="digivault_search_notes", arguments={"query": "   "})
+        server.OrchestratorInvokeRequest(tool="digivault_search_notes", arguments={"query": "   "}),
+        _fake_request(),
     )
     assert resp.ok is False
     assert resp.error == "query is required"
@@ -197,6 +258,7 @@ def test_orchestrator_invoke_search_notes_without_credentials(
         server.orchestrator_invoke(
             server.OrchestratorInvokeRequest(
                 tool="digivault_search_notes", arguments={"query": "hello"}
-            )
+            ),
+            _fake_request(),
         )
     assert excinfo.value.status_code == 503

--- a/tests/dv/test_server.py
+++ b/tests/dv/test_server.py
@@ -10,12 +10,37 @@ pytest.importorskip("fastapi")
 pytest.importorskip("digikey")
 pytest.importorskip("digibase")
 
+from fastapi import HTTPException  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from digivault import server  # noqa: E402
 from digivault.orchestrator_tools import ORCHESTRATOR_TOOL_NAMES  # noqa: E402
+from digivault.supabase_store import SupabaseStore  # noqa: E402
 
 pytestmark = pytest.mark.unit
+
+
+class _FakeSearchResponse:
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+
+class _FakeSearchClient:
+    """Minimal SupabaseClientProtocol stand-in — only `rpc().execute()` is exercised."""
+
+    def __init__(self, rpc_data: list[dict]) -> None:
+        self._rpc_data = rpc_data
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def table(self, _name: str) -> None:  # pragma: no cover - search_notes never calls .table()
+        raise AssertionError("digivault_search_notes must not touch the local table() path")
+
+    def rpc(self, fn: str, params: dict) -> "_FakeSearchClient":
+        self.rpc_calls.append((fn, params))
+        return self
+
+    def execute(self) -> _FakeSearchResponse:
+        return _FakeSearchResponse(self._rpc_data)
 
 
 @pytest.fixture
@@ -85,3 +110,93 @@ def test_orchestrator_invoke_search_tag(vault_dir: Path) -> None:
 def test_orchestrator_invoke_unknown_tool(vault_dir: Path) -> None:
     with pytest.raises(Exception):
         server.orchestrator_invoke(server.OrchestratorInvokeRequest(tool="nope"))
+
+
+def test_orchestrator_invoke_search_notes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """digivault_search_notes must work with no DIGIVAULT_ROOT — it reads Supabase, not disk."""
+    monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
+    hit = {
+        "vault_path": "digigraph",
+        "title": "DigiGraph",
+        "note_type": "module",
+        "summary": "orchestration hub",
+        "body_markdown": "LangGraph-based workflow engine.",
+        "tags": ["core"],
+        "wikilinks": [],
+        "rank": 0.8,
+    }
+    fake_client = _FakeSearchClient(rpc_data=[hit])
+    monkeypatch.setattr(server.SupabaseStore, "from_env", lambda: SupabaseStore(fake_client))
+
+    resp = server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(
+            tool="digivault_search_notes",
+            arguments={"query": "what does digigraph orchestrate", "limit": 3},
+        )
+    )
+    assert resp.ok is True
+    assert resp.data is not None
+    assert resp.data["hits"] == [
+        {
+            "vault_path": "digigraph",
+            "title": "DigiGraph",
+            "note_type": "module",
+            "summary": "orchestration hub",
+            "body_markdown": "LangGraph-based workflow engine.",
+            "tags": ["core"],
+            "wikilinks": [],
+            "rank": 0.8,
+        }
+    ]
+    assert fake_client.rpc_calls == [
+        (
+            "search_architecture_notes",
+            {"query": "what does digigraph orchestrate", "match_limit": 3},
+        )
+    ]
+
+
+def test_orchestrator_invoke_search_notes_default_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
+    fake_client = _FakeSearchClient(rpc_data=[])
+    monkeypatch.setattr(server.SupabaseStore, "from_env", lambda: SupabaseStore(fake_client))
+
+    server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(
+            tool="digivault_search_notes", arguments={"query": "auth", "limit": "not-a-number"}
+        )
+    )
+    assert fake_client.rpc_calls == [
+        ("search_architecture_notes", {"query": "auth", "match_limit": 7})
+    ]
+
+
+def test_orchestrator_invoke_search_notes_missing_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
+    resp = server.orchestrator_invoke(
+        server.OrchestratorInvokeRequest(tool="digivault_search_notes", arguments={"query": "   "})
+    )
+    assert resp.ok is False
+    assert resp.error == "query is required"
+
+
+def test_orchestrator_invoke_search_notes_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DIGIVAULT_ROOT", raising=False)
+    for var in (
+        "CORE_SUPABASE_URL",
+        "SUPABASE_URL",
+        "CORE_SUPABASE_ANON_KEY",
+        "CORE_SUPABASE_SERVICE_KEY",
+        "SUPABASE_ANON_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(HTTPException) as excinfo:
+        server.orchestrator_invoke(
+            server.OrchestratorInvokeRequest(
+                tool="digivault_search_notes", arguments={"query": "hello"}
+            )
+        )
+    assert excinfo.value.status_code == 503


### PR DESCRIPTION
## Summary

Phase 1 of the DigiChat-as-gateway epic (#1248): gives DigiGraph a way to reproduce the vault-grounded documentation search the digithings.ai chat widget does today, so DigiChat's BFF doesn't regress that behavior once it's cut over to route through DigiGraph (Phase 3).

- **DigiVault** already had the retrieval primitive (`SupabaseStore.search`, wrapping the `search_architecture_notes` RPC) but it was never wired into the service's orchestrator surface. Added a new orchestrator tool, `digivault_search_notes`, to `orchestrator_tools.py` + `server.py` — no new Supabase client, just exposing existing library code.
- **DigiGraph** gets a `digivault_hub.py` vertical connector (mirrors `digisearch_hub.py`/`digiquant_hub.py` exactly) and a `digivault` skill, gated on `DIGIVAULT_URL` being set (opt-in, mirrors `_digisearch_available`).
- `docker-compose.yml`: added `DIGIVAULT_URL=${DIGIVAULT_URL:-}` to digigraph's environment (empty default — **no default-behavior change**, the skill stays hidden until an operator opts in).
- `digivault/Dockerfile`: now installs `.[service,supabase]` (was `.[service]` only) so the deployed container can actually reach Supabase.

**Security fix included** (see review below): `/v1/orchestrator_invoke` previously required `digivault:write` for every tool, including the four read-only ones. A caller only needed to search now had to hold write scope, which also unlocked `digivault_create_note`. Split this: the route now requires `digivault:read`; the one mutating tool enforces `digivault:write` itself in the handler. Also clamped `digivault_search_notes`' `limit` to `[1, 50]`.

## Verification

- **Live RPC check** (not just mocks): queried the real core Supabase project's `search_architecture_notes("What does DigiGraph orchestrate?")` directly — confirmed the RPC returns all 8 fields `VaultSearchHit` requires, top hit was the `digigraph` note (rank 0.49). This discharges the issue's acceptance criterion #1 (grounding parity with today's widget) beyond what mocked unit tests alone could prove.
- `pytest tests/dv tests/dg -m unit`: **463 passed**, 0 failures, 0 regressions.
- `ruff check` + `ruff format --check`: clean on all touched files.
- Import-cost guard (`import digivault` stays FastAPI-free): passes.
- `make doc-check`: OK, no broken links.
- `make score --staged`: Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10.
- `docker compose config`: validates cleanly after the compose edit.
- Ran the `security-reviewer` agent against the diff — found one Medium (the scope over-privilege above, fixed in this PR) and two Low items:
  - Low: unbounded `limit` — fixed (clamped to 1–50).
  - Low: DigiVault's orchestrator routes have no per-IP rate limiting, unlike DigiSearch's. Pre-existing gap, not introduced by this PR, not fixed here — DigiVault is not part of the always-on Compose profile and this tool is opt-in, so I'm not bundling an unrelated rate-limiter port into this PR. Worth a follow-up issue before wider rollout.

## Out of scope / follow-ups

- Found the Supabase-mirrored `architecture_notes.README` row still has the pre-Phase-0 stale "deployed at chat.digithings.ai" text (Phase 0 fixed the markdown source, but the sync job hasn't re-run). Flagged separately, not fixed here — data-freshness, not code.
- Rate limiting on DigiVault's orchestrator routes (see above).
- Wiring `DIGIVAULT_URL` into any specific project's `skills.enabled` config, standing up the DigiVault service in a real deployment, and the actual DigiChat cutover are Phase 2/3 (#1251, #1252).

## Notes on branch/issue linkage

This PR bundles DigiVault + DigiGraph changes in one branch — both live in this monorepo, and `component:digivault` routes to `develop` directly (no dedicated module branch) while `component:digigraph` routes to `module/digigraph`; splitting them would just add PR-sequencing overhead for a single coherent change. The DigiVault changes won't reach `develop` until this merges and `module/digigraph` itself PRs down — expected, not a problem for this epic.

Branch name `task/1250-*` satisfies the repo's linkage check. This PR merges into `module/digigraph` (not the repo's default branch), so a `Fixes #1250` keyword here won't auto-close the issue on merge — GitHub only auto-closes on merge to the default branch. Fixes #1250 once this flows through to `develop`; will close manually if that lags.

Fixes #1250