### PR TITLE
fix(olympus): wire up the Pipeline page (deep links, digest-delta, dead chip state)

### DIFF
--- a/frontend/olympus/app/pipeline/page.tsx
+++ b/frontend/olympus/app/pipeline/page.tsx
@@ -1,11 +1,16 @@
+import { Suspense } from 'react';
 import PipelineClient from '@/components/pipeline/PipelineClient';
+import AtlasLoader from '@/components/AtlasLoader';
 
 /**
  * Pipeline hub (Surface 1) — zoomable/pannable graph of the daily decision
  * pipeline (Inputs → Research → Synthesis → Selection → Decision).
  *
  * Deep-link grammar: ?date=YYYY-MM-DD&stage=<stage>&node=<document_key>
- * Replaces the /why redirect placeholder.
+ * Replaces the /why redirect placeholder. `PipelineClient` reads the params
+ * itself via `useSearchParams()` (this is a static export — no server-side
+ * `searchParams` prop is available), which is why it must be Suspense-wrapped
+ * here, same as `/why` (`components/why/why-client.tsx`).
  */
 export default function PipelinePage() {
   return (
@@ -26,7 +31,9 @@ export default function PipelinePage() {
       </header>
 
       {/* Client shell */}
-      <PipelineClient />
+      <Suspense fallback={<AtlasLoader fullScreen={false} />}>
+        <PipelineClient />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/olympus/components/command-palette.tsx
+++ b/frontend/olympus/components/command-palette.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import { useDashboard } from '@/lib/dashboard-context';
 import { useAppShell } from '@/components/app-shell-context';
-import { buildPipelineHref } from '@/lib/pipeline-links';
+import { buildPipelineHref, DIGEST_DOCUMENT_KEYS } from '@/lib/pipeline-links';
 import { buildDocumentSearchItems } from '@/lib/document-search';
 import type { Doc } from '@/lib/types';
 
@@ -116,8 +116,17 @@ export function buildCommandItems(data: ReturnType<typeof useDashboard>['data'])
     icon: Brain,
   }));
 
-  // Recent run dates: up to 5 most recent unique dates with a digest
-  const recentDates = [...new Set(docs.filter((d) => d.path === 'digest' || d.path === 'Digest').map((d) => d.date))]
+  // Recent run dates: up to 5 most recent unique dates with a digest. `path` is
+  // the raw `document_key` (see queries.ts) — baseline days publish `digest`,
+  // delta days (the majority) publish `digest-delta`; both must match here or
+  // this list silently drops every non-baseline day.
+  const recentDates = [
+    ...new Set(
+      docs
+        .filter((d) => (DIGEST_DOCUMENT_KEYS as readonly string[]).includes(d.path))
+        .map((d) => d.date),
+    ),
+  ]
     .sort()
     .reverse()
     .slice(0, 5);

--- a/frontend/olympus/components/pipeline/PipelineClient.tsx
+++ b/frontend/olympus/components/pipeline/PipelineClient.tsx
@@ -1,23 +1,20 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { buildPipelineDayData, fanoutIdForKey } from '@/lib/pipeline-graph-data';
 import type { PipelineDayData } from '@/lib/pipeline-graph-data';
 import { PIPELINE_TOPOLOGY } from '@/lib/pipeline-topology';
 import type { PipelineStageId } from '@/lib/pipeline-topology';
 import type { ExpansionState, LaidOutNode } from '@/lib/pipeline-layout';
 import type { PipelineStage } from '@/lib/pipeline-links';
-import { parsePipelineParams } from '@/lib/pipeline-links';
-import type { RegimeChip } from './PipelineSummaryStrip';
+import { DIGEST_DOCUMENT_KEYS, parsePipelineParams, resolvePresentDigestKey } from '@/lib/pipeline-links';
+import type { RegimeChip } from '@/lib/render-pipeline-payloads';
+import { regimeChipsFromMacroPayload, summarizeRecommendedPortfolio } from '@/lib/render-pipeline-payloads';
 import PipelineSummaryStrip from './PipelineSummaryStrip';
 import PipelineDaySelector from './PipelineDaySelector';
 import PipelineCanvas from './PipelineCanvas';
 import PipelineNodeDetail from './PipelineNodeDetail';
-
-export interface PipelineClientProps {
-  /** Initial URL search params (passed from the server page) */
-  searchParams?: Record<string, string>;
-}
 
 function today(): string {
   return new Date().toISOString().slice(0, 10);
@@ -54,11 +51,16 @@ function buildInitialExpansion(
   return { expandedStages, expandedFanouts };
 }
 
-export default function PipelineClient({ searchParams = {} }: PipelineClientProps) {
+export default function PipelineClient() {
+  // Static export (`output: 'export'`) — there is no server to hand this page a
+  // `searchParams` prop, so deep links (`?date=&stage=&node=`) must be read
+  // client-side, same as `/why` (`components/why/why-client.tsx`). Must be
+  // Suspense-wrapped by the caller (`app/pipeline/page.tsx`) per Next.js's rules
+  // for `useSearchParams`.
+  const searchParams = useSearchParams();
   const params = useMemo(
-    () => parsePipelineParams(new URLSearchParams(new URLSearchParams(searchParams).toString())),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    () => parsePipelineParams(searchParams),
+    [searchParams],
   );
 
   const [selectedDate, setSelectedDate] = useState(params.date ?? today());
@@ -71,7 +73,7 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
 
   // Summary strip state
   const [headline, setHeadline] = useState<string | null>(null);
-  const [regimeChips] = useState<RegimeChip[]>([]);
+  const [regimeChips, setRegimeChips] = useState<RegimeChip[]>([]);
   const [decision, setDecision] = useState<string | null>(null);
 
   // Node detail
@@ -88,6 +90,13 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
     let cancelled = false;
 
     void (async () => {
+      // Reset before the fetch, not just on success — otherwise switching to a
+      // date with no digest/rebalance/macro doc silently keeps showing the
+      // PREVIOUS date's headline/decision/chips.
+      setHeadline(null);
+      setDecision(null);
+      setRegimeChips([]);
+
       try {
         const { createClient } = await import('@supabase/supabase-js');
         const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -95,53 +104,65 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
         if (!url || !key) return;
 
         const supabase = createClient(url, key);
+        const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
-        // Load available dates (last 30 days of pipeline runs)
-        const { data: dateRows } = await supabase
-          .from('documents')
-          .select('date')
-          .gte('date', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10))
-          .order('date', { ascending: false });
+        // Independent reads — run them together instead of one round-trip at a time.
+        const [datesRes, docsRes, digestRes, rebalanceRes, macroRes] = await Promise.all([
+          supabase
+            .from('documents')
+            .select('date')
+            .gte('date', thirtyDaysAgo)
+            .order('date', { ascending: false }),
+          supabase.from('documents').select('document_key').eq('date', selectedDate),
+          // The digest is published as `digest` on baseline days, `digest-delta`
+          // on delta days (the majority of days) — see DIGEST_DOCUMENT_KEYS.
+          supabase
+            .from('documents')
+            .select('payload')
+            .in('document_key', DIGEST_DOCUMENT_KEYS)
+            .eq('date', selectedDate)
+            .maybeSingle(),
+          supabase
+            .from('documents')
+            .select('payload')
+            .eq('document_key', 'pm-rebalance')
+            .eq('date', selectedDate)
+            .maybeSingle(),
+          supabase
+            .from('documents')
+            .select('payload')
+            .eq('document_key', 'macro')
+            .eq('date', selectedDate)
+            .maybeSingle(),
+        ]);
 
-        if (!cancelled && dateRows) {
-          const uniqueDates = [...new Set((dateRows as { date: string }[]).map((r) => r.date))].sort().reverse();
+        if (cancelled) return;
+
+        if (datesRes.data) {
+          const uniqueDates = [...new Set((datesRes.data as { date: string }[]).map((r) => r.date))]
+            .sort()
+            .reverse();
           if (uniqueDates.length > 0) setAvailableDates(uniqueDates);
         }
 
-        // Load documents for the selected date
-        const { data: docs } = await supabase
-          .from('documents')
-          .select('document_key')
-          .eq('date', selectedDate);
-
-        if (!cancelled && docs) {
-          const built = buildPipelineDayData(docs as { document_key: string }[]);
-          setDayData(built);
+        if (docsRes.data) {
+          setDayData(buildPipelineDayData(docsRes.data as { document_key: string }[]));
         }
 
-        // Try to fetch digest headline
-        const { data: digestRow } = await supabase
-          .from('documents')
-          .select('content')
-          .eq('document_key', 'digest')
-          .eq('date', selectedDate)
-          .maybeSingle();
+        // Headline comes from the digest's structured `headline` field — pipeline
+        // documents leave `documents.content` empty and carry everything in `payload`.
+        const digestPayload = digestRes.data?.payload as Record<string, unknown> | undefined;
+        const headlineText = typeof digestPayload?.headline === 'string' ? digestPayload.headline.trim() : '';
+        if (headlineText) setHeadline(headlineText);
 
-        if (!cancelled && digestRow?.content) {
-          const firstLine = (digestRow.content as string).split('\n').find((l: string) => l.trim().length > 10);
-          if (firstLine) setHeadline(firstLine.replace(/^#+\s*/, '').trim());
+        // Decision chip: summarize the day's PM rebalance book (target weights),
+        // not decision_log (a per-ticker analyst-call audit trail, not a per-day summary).
+        const summary = summarizeRecommendedPortfolio(rebalanceRes.data?.payload);
+        if (summary) {
+          setDecision(`${summary.holdingsCount} holdings · ${summary.investedPct.toFixed(0)}% invested`);
         }
 
-        // Try to fetch decision summary
-        const { data: decisionRow } = await supabase
-          .from('decision_log')
-          .select('summary')
-          .eq('date', selectedDate)
-          .maybeSingle();
-
-        if (!cancelled && decisionRow?.summary) {
-          setDecision(decisionRow.summary as string);
-        }
+        setRegimeChips(regimeChipsFromMacroPayload(macroRes.data?.payload));
       } catch {
         // Supabase not configured or no data — degrade gracefully
       }
@@ -149,6 +170,15 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
 
     return () => { cancelled = true; };
   }, [selectedDate]);
+
+  // A '?node=digest' deep link (from Overview / the command palette, which don't
+  // know today's baseline-vs-delta cadence) is a sentinel, not necessarily this
+  // day's real key — derive the actual key to fetch/highlight once the day's
+  // documents load, rather than storing it (avoids a setState-in-effect).
+  const resolvedActiveDocumentKey = useMemo(() => {
+    if (activeDocumentKey !== 'digest') return activeDocumentKey;
+    return resolvePresentDigestKey(dayData) ?? activeDocumentKey;
+  }, [activeDocumentKey, dayData]);
 
   const handleNodeActivate = useCallback((node: LaidOutNode) => {
     setActiveDocumentKey(node.documentKey ?? null);
@@ -177,13 +207,13 @@ export default function PipelineClient({ searchParams = {} }: PipelineClientProp
         <PipelineCanvas
           day={dayData}
           initialExpansion={initialExpansion}
-          selectedNodeId={activeDocumentKey ?? undefined}
+          selectedNodeId={resolvedActiveDocumentKey ?? undefined}
           onNodeActivate={handleNodeActivate}
         />
 
-        {activeDocumentKey !== null && (
+        {resolvedActiveDocumentKey !== null && (
           <PipelineNodeDetail
-            documentKey={activeDocumentKey}
+            documentKey={resolvedActiveDocumentKey}
             date={selectedDate}
             onClose={() => setActiveDocumentKey(null)}
           />

--- a/frontend/olympus/components/pipeline/PipelineNode.test.tsx
+++ b/frontend/olympus/components/pipeline/PipelineNode.test.tsx
@@ -52,4 +52,64 @@ describe('PipelineNode', () => {
     const rawBlue = 'rgba(' + '59,130,246';
     expect(html).not.toContain(rawBlue);
   });
+
+  describe('inert nodes (#1259 follow-up)', () => {
+    const leafNoData: LaidOutNode = {
+      id: 'selection:thesis',
+      kind: 'substep',
+      stageId: 'selection',
+      label: 'Thesis framing',
+      x: 0,
+      y: 0,
+      width: 160,
+      height: 48,
+      // no documentKey — never resolves, nothing to expand
+    };
+
+    it('renders a leaf substep with no documentKey as visibly inert', () => {
+      const html = renderToStaticMarkup(
+        createElement(PipelineNode, {
+          node: leafNoData,
+          expandable: false,
+          expanded: false,
+          onActivate: () => {},
+        }),
+      );
+      expect(html).toContain('cursor-default');
+      expect(html).toContain('aria-disabled="true"');
+      expect(html).toContain('No output for this step on this day');
+      expect(html).not.toContain('cursor-pointer');
+      // Inline style, not a Tailwind class — the `.glass-card.reveal-in` mount
+      // animation rule (app/globals.css) sets `opacity:1` with higher CSS
+      // specificity than an `opacity-50` utility class would have.
+      expect(html).toContain('opacity:0.5');
+    });
+
+    it('does not render a fanout-parent substep as inert even without a documentKey', () => {
+      const html = renderToStaticMarkup(
+        createElement(PipelineNode, {
+          node: fanoutNode,
+          expandable: true,
+          expanded: false,
+          onActivate: () => {},
+        }),
+      );
+      expect(html).toContain('cursor-pointer');
+      expect(html).not.toContain('cursor-default');
+      expect(html).not.toContain('aria-disabled');
+    });
+
+    it('does not render a leaf substep with a real documentKey as inert', () => {
+      const html = renderToStaticMarkup(
+        createElement(PipelineNode, {
+          node: { ...leafNoData, documentKey: 'macro' },
+          expandable: false,
+          expanded: false,
+          onActivate: () => {},
+        }),
+      );
+      expect(html).toContain('cursor-pointer');
+      expect(html).not.toContain('cursor-default');
+    });
+  });
 });

--- a/frontend/olympus/components/pipeline/PipelineNode.tsx
+++ b/frontend/olympus/components/pipeline/PipelineNode.tsx
@@ -22,17 +22,24 @@ export default function PipelineNode({
 }: PipelineNodeProps) {
   const isBranch = node.kind === 'fanout-branch';
 
+  // A leaf substep/branch with no documentKey and nothing to expand can never
+  // open anything (PipelineCanvas.handleNodeClick no-ops on a missing
+  // documentKey) — render it visibly inert instead of looking identical to a
+  // real, clickable node (#1259 follow-up: a PM couldn't tell "no data today"
+  // from "broken").
+  const isInert = !expandable && !node.documentKey;
+
   // Branches read as nested cards: recessed inset + tighter 6px radius. Standard
   // nodes use the shared .glass-card primitive (flat panel, 8px radius, hover
   // border-glow). Decision is NOT special-cased (F5 — no green chrome).
   const cardClass = [
-    'absolute cursor-pointer',
+    'absolute',
     'transition-[border-color,box-shadow,transform] duration-150',
-    'hover:-translate-y-px',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fin-blue/60',
-    isBranch
-      ? 'rounded-md border border-border-subtle bg-bg-secondary hover:border-border-glow'
-      : 'glass-card',
+    isBranch ? 'rounded-md border border-border-subtle bg-bg-secondary' : 'glass-card',
+    isInert
+      ? 'cursor-default'
+      : `cursor-pointer hover:-translate-y-px${isBranch ? ' hover:border-border-glow' : ''}`,
     selected ? 'border-fin-blue/60 shadow-[0_0_0_1px_var(--color-fin-blue)]' : '',
   ]
     .filter(Boolean)
@@ -41,23 +48,34 @@ export default function PipelineNode({
   return (
     <div
       role="button"
-      tabIndex={0}
+      tabIndex={isInert ? -1 : 0}
+      aria-disabled={isInert || undefined}
       aria-expanded={expandable ? expanded : undefined}
       aria-label={node.label}
+      title={isInert ? 'No output for this step on this day' : undefined}
       className={cardClass}
       style={{
         left: node.x,
         top: node.y,
         width: node.width,
         height: node.height,
+        // Inline, not a Tailwind class — `.glass-card.reveal-in` (the mount
+        // reveal-animation rule, app/globals.css) sets `opacity: 1` with
+        // higher specificity than a plain utility class, so `opacity-50`
+        // would get silently overridden once the reveal transition settles.
+        opacity: isInert ? 0.5 : undefined,
       }}
-      onClick={onActivate}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onActivate();
-        }
-      }}
+      onClick={isInert ? undefined : onActivate}
+      onKeyDown={
+        isInert
+          ? undefined
+          : (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onActivate();
+              }
+            }
+      }
     >
       <div className="flex items-center gap-1.5 px-3 h-full">
         {/* status pip — calm cyan recipe (F5): active when expanded, else

--- a/frontend/olympus/components/pipeline/PipelineSummaryStrip.tsx
+++ b/frontend/olympus/components/pipeline/PipelineSummaryStrip.tsx
@@ -1,10 +1,6 @@
-export type RegimeChipColor = 'green' | 'red' | 'amber' | 'blue' | 'muted';
+import type { RegimeChip, RegimeChipColor } from '@/lib/render-pipeline-payloads';
 
-export interface RegimeChip {
-  label: string;
-  value: string;
-  color: RegimeChipColor;
-}
+export type { RegimeChip, RegimeChipColor };
 
 export interface PipelineSummaryStripProps {
   headline: string | null;

--- a/frontend/olympus/components/today/today-summaries.tsx
+++ b/frontend/olympus/components/today/today-summaries.tsx
@@ -84,7 +84,7 @@ export function TodaySummaries({
       <Doorway
         title="The read"
         cta="Read"
-        href={buildPipelineHref({ date: asOfDate, node: 'digest' })}
+        href={buildPipelineHref({ date: asOfDate, stage: 'synthesis', node: 'digest' })}
         icon={BookOpen}
       >
         <p className="line-clamp-3 text-sm leading-snug text-text-secondary">

--- a/frontend/olympus/components/today/what-to-watch.tsx
+++ b/frontend/olympus/components/today/what-to-watch.tsx
@@ -34,7 +34,7 @@ export function WhatToWatch({ actionables, risks, asOfDate }: WhatToWatchProps) 
           </h2>
         </div>
         <Link
-          href={buildPipelineHref({ date: asOfDate, node: 'digest' })}
+          href={buildPipelineHref({ date: asOfDate, stage: 'synthesis', node: 'digest' })}
           className="text-[10px] font-medium text-accent hover:underline"
         >
           see the full read →

--- a/frontend/olympus/lib/pipeline-layout.test.ts
+++ b/frontend/olympus/lib/pipeline-layout.test.ts
@@ -88,4 +88,19 @@ describe('layoutPipeline', () => {
     expect(byId('selection:thesis')?.documentKey).toBeUndefined();
     expect(byId('selection:screener')?.documentKey).toBeUndefined();
   });
+
+  it('#1259: digest node resolves via digest-delta on a delta day (no plain `digest` key)', () => {
+    const day: PipelineDayData = {
+      fanoutCounts: {},
+      fanoutKeys: {},
+      presentKeys: new Set(['digest-delta', 'macro']),
+    };
+    const exp: ExpansionState = {
+      expandedStages: new Set(['synthesis']),
+      expandedFanouts: new Set(),
+    };
+    const l = layoutPipeline(day, exp);
+    const byId = (id: string) => l.nodes.find((n) => n.id === id);
+    expect(byId('synthesis:digest')?.documentKey).toBe('digest-delta');
+  });
 });

--- a/frontend/olympus/lib/pipeline-layout.ts
+++ b/frontend/olympus/lib/pipeline-layout.ts
@@ -1,7 +1,7 @@
 import { PIPELINE_TOPOLOGY } from './pipeline-topology';
 import type { PipelineStageId } from './pipeline-topology';
 import type { PipelineDayData } from './pipeline-graph-data';
-import { leafDocumentKey } from './pipeline-links';
+import { leafDocumentKey, resolvePresentDigestKey } from './pipeline-links';
 
 export interface LaidOutNode {
   id: string;
@@ -39,12 +39,17 @@ const BASE_Y = 0;
  * Resolve a leaf sub-step's document_key, honouring the golden rule: only
  * return a key that is actually present in this day's documents. `commit` is
  * special-cased — there can be several `commit-run/{run_id}` keys per day, so
- * we pick the present ones and default to the lexicographically-last.
+ * we pick the present ones and default to the lexicographically-last. `digest`
+ * is special-cased too — it's published as `digest` on baseline days and
+ * `digest-delta` on delta days (see `resolvePresentDigestKey`).
  */
 function resolveLeafDocumentKey(subStepId: string, day: PipelineDayData): string | undefined {
   if (subStepId === 'commit') {
     const runs = [...day.presentKeys].filter((k) => k.startsWith('commit-run/')).sort();
     return runs.length > 0 ? runs[runs.length - 1] : undefined;
+  }
+  if (subStepId === 'digest') {
+    return resolvePresentDigestKey(day);
   }
   const key = leafDocumentKey(subStepId);
   return key && day.presentKeys.has(key) ? key : undefined;

--- a/frontend/olympus/lib/pipeline-links.test.ts
+++ b/frontend/olympus/lib/pipeline-links.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { buildPipelineHref, stageForDocumentKey, parsePipelineParams, leafDocumentKey } from './pipeline-links';
+import {
+  buildPipelineHref,
+  stageForDocumentKey,
+  parsePipelineParams,
+  leafDocumentKey,
+  resolvePresentDigestKey,
+} from './pipeline-links';
+import { buildPipelineDayData } from './pipeline-graph-data';
 
 describe('buildPipelineHref (LOCKED deep-link grammar)', () => {
   it('emits /pipeline?date=&stage=&node= keyed off document_key', () => {
@@ -13,12 +20,30 @@ describe('buildPipelineHref (LOCKED deep-link grammar)', () => {
   });
   it('infers stage from a document_key when the caller has none', () => {
     expect(stageForDocumentKey('digest')).toBe('synthesis');
+    // Delta runs (the majority of days) publish `digest-delta`, not `digest` —
+    // #1259 regression: the stage resolver must recognize both.
+    expect(stageForDocumentKey('digest-delta')).toBe('synthesis');
     expect(stageForDocumentKey('analyst/IJR')).toBe('selection');
     expect(stageForDocumentKey('deliberation/EWT')).toBe('selection');
     expect(stageForDocumentKey('pm-rebalance')).toBe('selection');
     expect(stageForDocumentKey('sector-energy')).toBe('research');
     expect(stageForDocumentKey('commit-run/28041585974')).toBe('decision');
     expect(stageForDocumentKey('unknown-thing')).toBeNull();
+  });
+});
+
+describe('resolvePresentDigestKey (#1259 — digest vs digest-delta drift)', () => {
+  it('resolves to `digest` on a baseline day', () => {
+    const day = buildPipelineDayData([{ document_key: 'digest' }, { document_key: 'macro' }]);
+    expect(resolvePresentDigestKey(day)).toBe('digest');
+  });
+  it('resolves to `digest-delta` on a delta day', () => {
+    const day = buildPipelineDayData([{ document_key: 'digest-delta' }, { document_key: 'macro' }]);
+    expect(resolvePresentDigestKey(day)).toBe('digest-delta');
+  });
+  it('returns undefined when neither key is present', () => {
+    const day = buildPipelineDayData([{ document_key: 'macro' }]);
+    expect(resolvePresentDigestKey(day)).toBeUndefined();
   });
 });
 

--- a/frontend/olympus/lib/pipeline-links.ts
+++ b/frontend/olympus/lib/pipeline-links.ts
@@ -1,3 +1,5 @@
+import type { PipelineDayData } from './pipeline-graph-data';
+
 /**
  * LOCKED deep-link grammar for the Pipeline hub (Surface 1).
  * `/pipeline?date=YYYY-MM-DD&stage=<stage>&node=<document_key>`
@@ -5,6 +7,22 @@
  * legacy `path` field. Six consumers depend on this exact shape; do not drift.
  */
 export type PipelineStage = 'inputs' | 'research' | 'synthesis' | 'selection' | 'decision';
+
+/**
+ * The digest is published under different `document_key`s depending on
+ * `run_type` (`publish_phase.py`): baseline runs (the Sunday `refresh_scope=all`
+ * cron) write `digest`; every other day (the `delta` cadence — the majority of
+ * days) writes `digest-delta`. Callers that don't know today's cadence (Overview
+ * "See the full read" links, the command palette) should treat `'digest'` as a
+ * generic sentinel and resolve it against a day's real `presentKeys` via
+ * `resolvePresentDigestKey`, not assume it is the literal key on every day.
+ */
+export const DIGEST_DOCUMENT_KEYS = ['digest', 'digest-delta'] as const;
+
+/** Whichever digest key is actually present for a given day, if any. */
+export function resolvePresentDigestKey(day: PipelineDayData): string | undefined {
+  return DIGEST_DOCUMENT_KEYS.find((k) => day.presentKeys.has(k));
+}
 
 export function buildPipelineHref(opts: {
   date?: string | null;
@@ -51,7 +69,7 @@ export function leafDocumentKey(subStepId: string, branch?: string): string | nu
 /** Map a `document_key` to the stage that owns it (per the spec topology table). */
 export function stageForDocumentKey(documentKey: string): PipelineStage | null {
   const k = documentKey.toLowerCase();
-  if (k === 'digest') return 'synthesis';
+  if ((DIGEST_DOCUMENT_KEYS as readonly string[]).includes(k)) return 'synthesis';
   if (k.startsWith('analyst/') || k.startsWith('deliberation/')) return 'selection';
   if (k === 'pm-direction-memo' || k === 'pm-rebalance' || k === 'risk-debate') return 'selection';
   if (k.startsWith('commit-run/')) return 'decision';

--- a/frontend/olympus/lib/render-pipeline-payloads.test.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.test.ts
@@ -19,6 +19,7 @@ import {
   renderRebalanceMarkdown,
   renderRiskDebateMarkdown,
   renderSegmentReportMarkdown,
+  regimeChipsFromMacroPayload,
   summarizeRecommendedPortfolio,
 } from './render-pipeline-payloads';
 import { digestItemsToStrings, extractDigestContextBullets } from './snapshot-context';
@@ -389,6 +390,35 @@ describe('renderDigestMarkdownFromSnapshot shape routing', () => {
     const md = renderDigestMarkdownFromSnapshot(V1_SNAPSHOT as never);
     expect(md).toContain('# DIGEST — 2026-04-27');
     expect(md).toContain('## Sector Scorecard');
+  });
+});
+
+describe('regimeChipsFromMacroPayload (#1259 — Pipeline summary strip)', () => {
+  it('builds one chip per 4-factor field with the expected label/value/color', () => {
+    const chips = regimeChipsFromMacroPayload({
+      segment: 'macro',
+      growth: 'slowing',
+      inflation: 'cooling',
+      policy: 'easing',
+      risk_appetite: 'mixed',
+    });
+    expect(chips).toEqual([
+      { label: 'Growth', value: 'slowing', color: 'amber' },
+      { label: 'Inflation', value: 'cooling', color: 'green' },
+      { label: 'Policy', value: 'easing', color: 'green' },
+      { label: 'Risk appetite', value: 'mixed', color: 'amber' },
+    ]);
+  });
+
+  it('drops missing factors and defaults unknown tokens to muted (never throws)', () => {
+    expect(regimeChipsFromMacroPayload({ growth: 'expanding' })).toEqual([
+      { label: 'Growth', value: 'expanding', color: 'green' },
+    ]);
+    expect(regimeChipsFromMacroPayload({ growth: 'sideways' })).toEqual([
+      { label: 'Growth', value: 'sideways', color: 'muted' },
+    ]);
+    expect(regimeChipsFromMacroPayload(null)).toEqual([]);
+    expect(regimeChipsFromMacroPayload(undefined)).toEqual([]);
   });
 });
 

--- a/frontend/olympus/lib/render-pipeline-payloads.ts
+++ b/frontend/olympus/lib/render-pipeline-payloads.ts
@@ -437,6 +437,74 @@ export function renderSegmentReportMarkdown(payload: unknown): string {
   return `${out.join('\n').trim()}\n`;
 }
 
+/* ── Macro regime chips (Pipeline summary strip) ─────────────────────────── */
+
+export type RegimeChipColor = 'green' | 'red' | 'amber' | 'blue' | 'muted';
+
+export interface RegimeChip {
+  label: string;
+  value: string;
+  color: RegimeChipColor;
+}
+
+// Directional read for risk assets: green = supportive, red = headwind, amber =
+// transitional/mixed, blue = steady-state neutral. Values are the `MacroRegimeReport`
+// Literal enums (`digiquant/olympus/atlas/phases/phase3_macro.py`).
+const GROWTH_CHIP_COLOR: Record<string, RegimeChipColor> = {
+  expanding: 'green',
+  slowing: 'amber',
+  contracting: 'red',
+};
+const INFLATION_CHIP_COLOR: Record<string, RegimeChipColor> = {
+  cooling: 'green',
+  cold: 'blue',
+  hot: 'red',
+};
+const POLICY_CHIP_COLOR: Record<string, RegimeChipColor> = {
+  easing: 'green',
+  neutral: 'blue',
+  tightening: 'red',
+};
+const RISK_APPETITE_CHIP_COLOR: Record<string, RegimeChipColor> = {
+  risk_on: 'green',
+  mixed: 'amber',
+  risk_off: 'red',
+};
+
+/**
+ * Build the Pipeline summary strip's regime chips from the `macro` segment
+ * document's 4-factor breakdown (`growth`/`inflation`/`policy`/`risk_appetite`
+ * — each a short Literal token, not a nested object). Unknown/future token
+ * values still render (as a `muted` chip) rather than being dropped.
+ */
+export function regimeChipsFromMacroPayload(payload: unknown): RegimeChip[] {
+  const p = asObj(payload);
+  if (!p) return [];
+  const chips: RegimeChip[] = [];
+
+  const growth = s(p.growth).trim();
+  if (growth) chips.push({ label: 'Growth', value: growth, color: GROWTH_CHIP_COLOR[growth] ?? 'muted' });
+
+  const inflation = s(p.inflation).trim();
+  if (inflation) {
+    chips.push({ label: 'Inflation', value: inflation, color: INFLATION_CHIP_COLOR[inflation] ?? 'muted' });
+  }
+
+  const policy = s(p.policy).trim();
+  if (policy) chips.push({ label: 'Policy', value: policy, color: POLICY_CHIP_COLOR[policy] ?? 'muted' });
+
+  const riskAppetite = s(p.risk_appetite).trim();
+  if (riskAppetite) {
+    chips.push({
+      label: 'Risk appetite',
+      value: riskAppetite.replace(/_/g, '-'),
+      color: RISK_APPETITE_CHIP_COLOR[riskAppetite] ?? 'muted',
+    });
+  }
+
+  return chips;
+}
+
 /* ── Analyst specialist report (Phase 7C) ────────────────────────────────── */
 
 /**


### PR DESCRIPTION
## Summary

End-to-end review + fix for "the Pipeline page doesn't function" (#1259). Two independent root causes, both confirmed against real production Supabase data, not guessed:

- **`app/pipeline/page.tsx` never forwarded the URL's search params to `PipelineClient`.** It's a static export (`output: 'export'`), so there's no server to hand a page a `searchParams` prop — params must be read client-side via `useSearchParams()`, exactly like `/why` does (`components/why/why-client.tsx`, `<Suspense>`-wrapped by its page). Pipeline's page never did this, so **every deep link** from Overview ("See the full read"), the command palette, thesis pages, and library search landed on "today, fully collapsed, nothing selected" regardless of `?date=&stage=&node=` in the URL.
- **The digest is published under different `document_key`s depending on run type** (`digiquant/.../publish_phase.py`): baseline runs (the Sunday `refresh_scope=all` cron) write `digest`; every other day (`delta` — 6 of 7 days) writes `digest-delta`. The frontend hardcoded `'digest'` in three places (`pipeline-links.ts`, `PipelineClient.tsx`, and the two Overview "See the full read" links), so the Synthesis → "Daily digest" node was permanently non-clickable and the headline banner stuck on "Loading digest…" on the vast majority of days.

Also found and fixed while in there (all in `PipelineClient.tsx`):
- The headline read `documents.content`, which the pipeline never populates (it writes `payload` JSON only, `content` stays `NULL`) — now reads `payload.headline`.
- The "Decision" chip queried `decision_log.summary`/`.date` — neither column exists (real columns: `thesis`/`run_date`; the table is one row per ticker per day, so `.maybeSingle()` was also wrong). Now summarizes the day's `pm-rebalance` book via the existing `summarizeRecommendedPortfolio()` helper → `"7 holdings · 90% invested"`.
- `regimeChips` was dead state (`useState` with no setter ever called). Now renders the `macro` segment's 4-factor breakdown (growth/inflation/policy/risk_appetite) with a directional green/amber/red/blue color map.
- The command palette's "recent run dates with a digest" filter had the same `digest`-only blind spot.
- Stale headline/decision/chips no longer carry over silently when switching days via the date selector (state wasn't reset before re-fetching).

## Test plan
- [x] `npx vitest run` — 549/549 tests pass (added coverage for `resolvePresentDigestKey`, `digest-delta` layout resolution, `regimeChipsFromMacroPayload`)
- [x] `npx tsc --noEmit` — clean (2 pre-existing unrelated errors in untouched files)
- [x] `npm run lint` — clean
- [x] `make score` — Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10
- [x] **Live-verified against real production Supabase data** (not just unit tests): loaded `/pipeline?date=2026-06-30&stage=synthesis&node=digest` (a real delta day) — Synthesis stage auto-expanded, "Daily digest" node resolved to the real `digest-delta` doc and rendered its full structured content in the side panel, and "The read" populated with the real headline. Loaded `/pipeline?date=2026-06-24` — regime chips (`Growth: slowing`, `Inflation: cooling`, `Policy: neutral`, `Risk appetite: mixed`) and the decision chip (`7 holdings · 90% invested`) both rendered from real data.

Fixes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
