### PR TITLE
feat(design): CapabilityCard CSS-only primitive

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -214,7 +214,7 @@ Add to `tokens.css` when implementing primitives:
 | `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
 | `TrustStrip` ✅ | Logo / proof row ([`site/README.md`](site/README.md#truststrip-css-only-evolutionmd-phase-b)) | Cursor, Graphite |
 | `StatCounter` ✅ | Scroll-triggered metrics ([`site/README.md`](site/README.md#statcounter-css--stat-counterjs-evolutionmd-phase-b)) | xAI |
-| `CapabilityCard` | Mini UI + “Explore →” | xAI |
+| `CapabilityCard` ✅ | Mini UI + “Explore →” ([`site/README.md`](site/README.md#capabilitycard-css-only-evolutionmd-phase-b)) | xAI |
 | `ChangelogBand` ✅ | Dated release rows ([`site/README.md`](site/README.md#changelogband-css-only--data-shape-evolutionmd-phase-b)) | Cursor |
 | `CodeSampleBand` ✅ | Tabbed SDK / curl snippets ([`site/README.md`](site/README.md#codesampleband-css--code-sample-bandjs-evolutionmd-phase-b)) | xAI, Cursor |
 | `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
@@ -266,6 +266,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `StatCounter` component + CSS
 - [x] `ChangelogBand` component + CSS
 - [x] `CodeSampleBand` component + CSS
+- [x] `CapabilityCard` component + CSS
 
 ### Phase C — Landing realignment
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -7,8 +7,8 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 `.kicker`/`.prompt`, the standalone `.hero-title`, the terminal block
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
-**StatCounter**, **ChangelogBand**, **CodeSampleBand**, `.principles`, and
-`.footer*`. Terminal-CLI /
+**StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
+`.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -256,3 +256,33 @@ initCodeSampleBand(); // wires every .code-sample-band on the page
 (`ArrowLeft`/`ArrowRight`/`Home`/`End`, roving `tabindex`) on every
 `[role="tab"]` inside the matched root, and toggles the matching
 `[role="tabpanel"]`'s `hidden` attribute — no network calls, pure DOM.
+
+## `CapabilityCard` (CSS-only, EVOLUTION.md Phase B)
+
+xAI-style mini-UI preview + "Explore →" link. Flat `--surface` panel, hairline
+border — no decorative eyebrow pills without an action (anti-pattern #3).
+Composes standalone in a `.capability-grid`, or drop a single `.capability-card`
+inside a `.bento__cell`.
+
+```html
+<div class="capability-grid">
+  <div class="capability-card">
+    <div class="capability-card__preview">
+      <!-- <img>, a .product-frame child, or a .term snippet -->
+    </div>
+    <div class="capability-card__title">Orchestration</div>
+    <p class="capability-card__body">One line of what this capability does.</p>
+    <a class="capability-card__cta" href="/modules/digigraph">Explore <span aria-hidden="true">&rarr;</span></a>
+  </div>
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.capability-grid` | Grid container — 1 column below 768px, `repeat(2, 1fr)` at `min-width: 768px`; `max-width: var(--wrap-wide)`. |
+| `.capability-card` | Flat card surface with hover lift (`--duration-hover`/`--ease-glide`). |
+| `.capability-card__preview` | Optional media slot — takes an `<img>`, a `.product-frame` child, or a `.term` snippet; rounds to `--r-md`, clips overflow. |
+| `.capability-card__title` / `.capability-card__body` | Heading + body copy. |
+| `.capability-card__cta` | `Explore →` arrow link; the `span[aria-hidden]` arrow translates on card hover, matching `.btn`/`.bento__cta`. |
+
+Works unscoped in both themes. Same deferred-React-wrapper note as ProductFrame (#1195).

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -199,6 +199,24 @@ a { color: inherit; text-decoration: none; }
 .code-sample-band__copy.is-ok { color: var(--up); }
 .code-sample-band__panel { margin: 0; padding: 1.1rem 1.2rem; font-family: var(--font-mono); font-size: clamp(0.76rem, 1.2vw, 0.86rem); line-height: 1.7; color: var(--term-ink); white-space: pre-wrap; overflow-x: auto; }
 
+/* ── capability card (xAI-style mini-UI preview + "Explore →") ──────────
+   Flat --surface panel, hairline border — no decorative eyebrow pills
+   (EVOLUTION.md §10 anti-pattern #3). Composes standalone (.capability-grid),
+   or drop a .capability-card inside a .bento__cell. The __preview slot takes
+   an <img>, a .product-frame child, or a .term snippet. ─────────────────── */
+.capability-grid { display: grid; grid-template-columns: 1fr; gap: 1.25rem; width: 100%; max-width: var(--wrap-wide); margin-inline: auto; }
+.capability-card { display: flex; flex-direction: column; gap: 0.6rem; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); padding: 1.5rem; transition: transform var(--duration-hover) var(--ease-glide), border-color var(--duration-hover) var(--ease-glide); }
+.capability-card:hover { transform: translateY(-3px); border-color: var(--hair-2); }
+.capability-card__preview { border-radius: var(--r-md); overflow: hidden; margin-bottom: 0.4rem; }
+.capability-card__title { font-size: 1.1rem; font-weight: 600; letter-spacing: -0.02em; }
+.capability-card__body { font-size: 0.9rem; color: var(--ink-soft); line-height: 1.5; }
+.capability-card__cta { margin-top: auto; padding-top: 0.5rem; display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; color: var(--accent); font-weight: 500; }
+.capability-card__cta span[aria-hidden] { transition: transform var(--duration-hover) var(--ease-glide); }
+.capability-card:hover .capability-card__cta span[aria-hidden] { transform: translateX(3px); }
+@media (min-width: 768px) {
+  .capability-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -212,6 +212,44 @@ await client.chat.send("hello");</code></pre>
     </div>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">capability-card — 2 cards with ProductFrame previews (also composable inside a bento__cell)</div>
+    <div class="capability-grid">
+      <div class="capability-card">
+        <div class="capability-card__preview">
+          <div class="product-frame">
+            <div class="product-frame__surface">
+              <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.6em; border-bottom:1px solid var(--hair); margin-bottom:0.6em;">
+                <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--accent); display:inline-block;"></span>
+                <strong>digigraph · supervisor</strong>
+              </div>
+              <code style="font-family:var(--font-mono);">graph.route(intent) -&gt; agent</code>
+            </div>
+          </div>
+        </div>
+        <div class="capability-card__title">Orchestration</div>
+        <p class="capability-card__body">LangGraph supervisor routes intents across typed sub-graphs.</p>
+        <a class="capability-card__cta" href="#" onclick="return false;">Explore <span aria-hidden="true">&rarr;</span></a>
+      </div>
+      <div class="capability-card">
+        <div class="capability-card__preview">
+          <div class="product-frame">
+            <div class="product-frame__surface">
+              <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.6em; border-bottom:1px solid var(--hair); margin-bottom:0.6em;">
+                <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--up); display:inline-block;"></span>
+                <strong>digiquant · atlas</strong>
+              </div>
+              <code style="font-family:var(--font-mono);">atlas.backtest(strategy)</code>
+            </div>
+          </div>
+        </div>
+        <div class="capability-card__title">Quant research</div>
+        <p class="capability-card__body">NautilusTrader-backed backtest, optimize, and live paths.</p>
+        <a class="capability-card__cta" href="#" onclick="return false;">Explore <span aria-hidden="true">&rarr;</span></a>
+      </div>
+    </div>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';


### PR DESCRIPTION
## Summary
- Adds `.capability-grid`/`.capability-card`/`.capability-card__preview`/`__title`/`__body`/`__cta` to `frontend/design/site/site.css` — xAI-style mini-UI preview + "Explore →" link.
- Flat `--surface` panel, hairline border, hover lift (`--duration-hover`/`--ease-glide`) — no decorative eyebrow pills without an action (EVOLUTION.md §10 anti-pattern #3).
- Composes standalone in a `.capability-grid` (1-col mobile, 2-col from 768px) or as a single `.capability-card` inside a `.bento__cell` (#1203).
- `__preview` slot takes an `<img>`, a `.product-frame` child (#1202), or a `.term` snippet.
- Smoke demo: 2 cards with ProductFrame previews (per acceptance criteria).
- Documents the primitive in `frontend/design/site/README.md`; marks Phase B checkbox + primitives-table row in `EVOLUTION.md`.

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Verified via direct HTTP: `.capability-card`/`.capability-grid` CSS present, smoke demo renders both cards with ProductFrame previews
- [ ] Browser preview tooling was unresponsive in this environment during development — CI's build-check workflows will exercise the real Next.js consumption path

Fixes #1208