### PR TITLE
fix(design): Phase B hardening — code-sample-band ARIA + reveal-up no-JS

### DIFF
--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -227,9 +227,11 @@ Activation" pattern — keyboard-navigable, `aria-selected`, focus ring.
 
 ```html
 <div class="code-sample-band">
-  <div class="code-sample-band__tabs" role="tablist" aria-label="Install command">
-    <button class="code-sample-band__tab" role="tab" aria-selected="true" aria-controls="panel-curl" id="tab-curl">curl</button>
-    <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="panel-py" id="tab-py" tabindex="-1">Python</button>
+  <div class="code-sample-band__bar">
+    <div class="code-sample-band__tabs" role="tablist" aria-label="Install command">
+      <button class="code-sample-band__tab" role="tab" aria-selected="true" aria-controls="panel-curl" id="tab-curl">curl</button>
+      <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="panel-py" id="tab-py" tabindex="-1">Python</button>
+    </div>
     <button class="code-sample-band__copy" type="button" aria-label="Copy code">copy</button>
   </div>
   <div class="code-sample-band__panels">
@@ -239,6 +241,10 @@ Activation" pattern — keyboard-navigable, `aria-selected`, focus ring.
 </div>
 ```
 
+The copy button sits **outside** `role="tablist"` (inside `.code-sample-band__bar`
+alongside it) — a tablist owns only `role="tab"` children, so a non-tab button
+inside it is an ARIA structure violation.
+
 ```js
 import { initCodeSampleBand } from '../code-sample-band.js';
 initCodeSampleBand(); // wires every .code-sample-band on the page
@@ -247,7 +253,8 @@ initCodeSampleBand(); // wires every .code-sample-band on the page
 | Class | Role |
 |-------|------|
 | `.code-sample-band` | Dark panel, `--term-bg`/`--term-hair`. |
-| `.code-sample-band__tabs` | `role="tablist"` row. |
+| `.code-sample-band__bar` | Flex header row holding the tablist + the copy button as siblings (padding/fill/border). |
+| `.code-sample-band__tabs` | `role="tablist"` row — owns only `role="tab"` children. |
 | `.code-sample-band__tab` | `role="tab"` button; `[aria-selected="true"]` gets the active surface treatment; `:focus-visible` ring. |
 | `.code-sample-band__copy` | Copies the active panel's `textContent` via `navigator.clipboard`; `.is-ok` after a successful copy (2s, matches `.tl-ok`'s `--up` color). |
 | `.code-sample-band__panel` | `role="tabpanel"` `<pre><code>` block; Geist Mono, wraps long lines. |

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -156,6 +156,11 @@ a { color: inherit; text-decoration: none; }
    drivers, so both class names are wired below. ───────────────────────── */
 .reveal-up { opacity: 0; transform: translateY(1rem); transition: opacity var(--duration-reveal) var(--ease-glide), transform var(--duration-reveal) var(--ease-glide); }
 .reveal-up.is-visible, .reveal-up.active { opacity: 1; transform: none; }
+/* No-JS fallback: the visible state is only ever added by a JS trigger, so
+   without scripting .reveal-up content would be permanently hidden. Show it. */
+@media (scripting: none) {
+  .reveal-up { opacity: 1; transform: none; }
+}
 
 /* ── stat counter (xAI-style scroll-triggered metrics strip) ───────────
    No-fake-data policy (EVOLUTION.md §10 anti-pattern #2): stat-counter.js
@@ -190,7 +195,10 @@ a { color: inherit; text-decoration: none; }
    Always dark, reusing the terminal block's --term-* tokens regardless of
    page theme (matches .term). ───────────────────────────────────────────── */
 .code-sample-band { background: var(--term-bg); border: 1px solid var(--term-hair); border-radius: 14px; overflow: hidden; }
-.code-sample-band__tabs { display: flex; align-items: center; gap: 0.25rem; padding: 0.5rem 0.6rem; background: var(--term-fill); border-bottom: 1px solid var(--term-hair); }
+/* __bar holds the tablist + copy button as siblings — the copy button must NOT
+   live inside role="tablist" (a tablist owns only role="tab" children). */
+.code-sample-band__bar { display: flex; align-items: center; gap: 0.25rem; padding: 0.5rem 0.6rem; background: var(--term-fill); border-bottom: 1px solid var(--term-hair); }
+.code-sample-band__tabs { display: flex; align-items: center; gap: 0.25rem; }
 .code-sample-band__tab { font-family: var(--font-mono); font-size: 0.8rem; color: var(--term-mute); background: transparent; border: 1px solid transparent; border-radius: 7px; padding: 0.35rem 0.7rem; cursor: pointer; }
 .code-sample-band__tab[aria-selected="true"] { color: var(--term-ink); background: var(--term-bg); border-color: var(--term-hair); }
 .code-sample-band__tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -190,10 +190,12 @@
   <section class="smoke-section site-demo">
     <div class="label">code-sample-band — arrow keys move between tabs; click copy to test clipboard</div>
     <div class="code-sample-band">
-      <div class="code-sample-band__tabs" role="tablist" aria-label="Install command">
-        <button class="code-sample-band__tab" role="tab" aria-selected="true" aria-controls="csb-panel-curl" id="csb-tab-curl">curl</button>
-        <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="csb-panel-python" id="csb-tab-python" tabindex="-1">Python</button>
-        <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="csb-panel-ts" id="csb-tab-ts" tabindex="-1">TypeScript</button>
+      <div class="code-sample-band__bar">
+        <div class="code-sample-band__tabs" role="tablist" aria-label="Install command">
+          <button class="code-sample-band__tab" role="tab" aria-selected="true" aria-controls="csb-panel-curl" id="csb-tab-curl">curl</button>
+          <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="csb-panel-python" id="csb-tab-python" tabindex="-1">Python</button>
+          <button class="code-sample-band__tab" role="tab" aria-selected="false" aria-controls="csb-panel-ts" id="csb-tab-ts" tabindex="-1">TypeScript</button>
+        </div>
         <button class="code-sample-band__copy" type="button" aria-label="Copy code">copy</button>
       </div>
       <div class="code-sample-band__panels">


### PR DESCRIPTION
## Summary
Hardening pass over the shipped Phase B primitives (epic #1200). Two code-reviewable defects fixed; both verifiable without a browser.

1. **`code-sample-band` ARIA structure**: the `.code-sample-band__copy` button was a direct child of `role="tablist"`, which owns only `role="tab"` children — a structure violation that can make assistive tech miscount tabs / mishandle arrow-key nav. Moved it out into a new `.code-sample-band__bar` flex wrapper holding the tablist + copy button as siblings. `initCodeSampleBand()` is unchanged (it resolves `.code-sample-band__copy` and `[role="tab"]` as descendants of the `.code-sample-band` root, so the added wrapper doesn't affect it).
2. **`.reveal-up` no-JS fallback**: `opacity:0` with the visible state applied only by a JS trigger left content permanently hidden without scripting. Added `@media (scripting: none) { .reveal-up { opacity: 1; transform: none; } }`.

Updated the smoke demo + the documented pattern in `site/README.md` to match.

## Out of scope (noted in #1273, not fixed here)
- `PipelineScene` reduced-motion flow-layout fallback — pre-existing a11y gap in the live, untested Olympus scene; needs the #1205 scope/verification discussion (no in-browser QA available in this environment).

## Test plan
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [x] Parsed the served smoke HTML: `role="tablist"` owns exactly 3 `role="tab"` children, copy button is a sibling (not inside the tablist); `site.css` carries `__bar` + `@media (scripting: none)`
- [ ] Browser preview tooling unavailable in this environment — CI build-check workflows exercise the real Next.js consumption path

Fixes #1273