### PR TITLE
fix(digiquant): Hermes shared-context digest-key gaps (H2/H3/H7)

### DIFF
--- a/digiquant/src/digiquant/olympus/hermes/phases/h2_market_thesis_exploration.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h2_market_thesis_exploration.py
@@ -39,7 +39,10 @@ def _run_h2_llm(state: HermesState) -> MarketThesisExplorationOutput:
             "thesis_review": state.phase_hermes.thesis_review,
             "meta": {"research_refs": []},
         },
-        context_keys=("digest",),
+        # Baseline runs publish `digest`, delta runs publish `digest-delta`
+        # (publish_phase.py) — both must be whitelisted or the prior digest
+        # silently drops out of context on whichever cadence is missing (#1270).
+        context_keys=("digest", "digest-delta"),
     )
     if exploration is None:
         return MarketThesisExplorationOutput()

--- a/digiquant/src/digiquant/olympus/hermes/phases/h3_thesis_vehicle_map.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h3_thesis_vehicle_map.py
@@ -39,7 +39,10 @@ def _run_h3_llm(state: HermesState) -> ThesisVehicleMapOutput:
             "market_thesis_exploration": state.phase_hermes.market_thesis_exploration,
             "meta": {"source_exploration_key": "market-thesis-exploration"},
         },
-        context_keys=("digest",),
+        # Baseline runs publish `digest`, delta runs publish `digest-delta`
+        # (publish_phase.py) — both must be whitelisted or the prior digest
+        # silently drops out of context on whichever cadence is missing (#1270).
+        context_keys=("digest", "digest-delta"),
     )
     if vehicle_map is None:
         return ThesisVehicleMapOutput()

--- a/digiquant/src/digiquant/olympus/hermes/phases/h7_pm_direction.py
+++ b/digiquant/src/digiquant/olympus/hermes/phases/h7_pm_direction.py
@@ -87,7 +87,11 @@ def _h7_node(state: HermesState) -> dict[str, Any]:
         phase_inputs=phase_inputs,
         shared_context=_shared_context(
             state,
-            context_keys=("pm-rebalance", "digest-delta", "digest-baseline"),
+            # `digest-baseline` is never written by anything — publish_phase.py
+            # writes plain `digest` on baseline runs, `digest-delta` on delta runs.
+            # The old tuple silently dropped the freshest baseline digest from
+            # context every Monday (#1270).
+            context_keys=("pm-rebalance", "digest", "digest-delta"),
             data_layer_scope="portfolio",
         ),
         output_model=PMDirectionMemo,

--- a/tests/dq/atlas/test_shared_context_digest_keys.py
+++ b/tests/dq/atlas/test_shared_context_digest_keys.py
@@ -1,0 +1,88 @@
+"""Regression coverage for #1270.
+
+`_shared_context`'s `context_keys` whitelist filters `prior_context.latest_segments`
+(one entry per literal `document_key` string) down to what a phase actually
+consumes. The digest is published as `digest` on baseline runs and `digest-delta`
+on delta runs (`atlas/phases/publish_phase.py`), so a whitelist missing either
+real key — or listing a key nothing ever writes, like the old `digest-baseline` —
+silently drops or keeps-stale the wrong digest instead of raising.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from datetime import date
+
+import pytest
+
+import digiquant.olympus.hermes.phases as hermes_phases_pkg
+from digiquant.olympus.atlas.phases._node_factory import _shared_context
+from digiquant.olympus.atlas.state import AtlasConfigBundle, AtlasResearchState, PriorContext
+
+
+def _state_with_latest_segments(latest_segments: dict) -> AtlasResearchState:
+    return AtlasResearchState(
+        run_type="delta",
+        run_date=date(2026, 6, 8),
+        config=AtlasConfigBundle(watchlist=["AAPL"]),
+        prior_context=PriorContext(latest_segments=latest_segments),
+    )
+
+
+@pytest.mark.unit
+def test_shared_context_keeps_both_digest_keys_when_whitelisted():
+    state = _state_with_latest_segments(
+        {
+            "digest": {"headline": "baseline digest"},
+            "digest-delta": {"headline": "delta digest"},
+            "pm-rebalance": {"actions": []},
+        }
+    )
+    ctx = _shared_context(state, context_keys=("pm-rebalance", "digest", "digest-delta"))
+    assert set(ctx["prior_context"]["latest_segments"]) == {
+        "digest",
+        "digest-delta",
+        "pm-rebalance",
+    }
+
+
+@pytest.mark.unit
+def test_shared_context_drops_digest_when_key_missing_from_whitelist():
+    """Reproduces the bug: a whitelist missing the real key silently loses that
+    digest, even when it's the freshest row in `latest_segments`."""
+    state = _state_with_latest_segments(
+        {
+            "digest": {"headline": "baseline digest"},
+            "digest-delta": {"headline": "stale digest-delta from last week"},
+        }
+    )
+    # The old H7 tuple: ("pm-rebalance", "digest-delta", "digest-baseline") —
+    # "digest-baseline" is never written by anything, so the day after a
+    # baseline run this kept the stale digest-delta row instead of the fresh
+    # baseline one.
+    buggy_ctx = _shared_context(
+        state, context_keys=("pm-rebalance", "digest-delta", "digest-baseline")
+    )
+    assert set(buggy_ctx["prior_context"]["latest_segments"]) == {"digest-delta"}
+
+    fixed_ctx = _shared_context(state, context_keys=("pm-rebalance", "digest", "digest-delta"))
+    assert set(fixed_ctx["prior_context"]["latest_segments"]) == {"digest", "digest-delta"}
+
+
+@pytest.mark.unit
+def test_live_h_phases_never_reference_dead_digest_baseline_key():
+    """`digest-baseline` is never published by anything. Guard against the typo
+    reappearing in the live H1-H9 phase modules. `phase7d_pm.py` is deliberately
+    excluded — confirmed unreachable from any production graph builder
+    (`hermes/graph.py::build_hermes_phases` aliases to the thesis-first graph,
+    never `phase7d_pm.build_phase7d_pm`), so it isn't fixed as part of #1270.
+    """
+    phases_dir = pathlib.Path(hermes_phases_pkg.__file__).parent
+    live_h_files = sorted(phases_dir.glob("h*.py"))
+    assert live_h_files, "expected to find the h1..h9 phase modules"
+
+    # Match the quoted string literal, not the bare phrase — code comments are
+    # free to *discuss* the dead key (as h7_pm_direction.py's now does) without
+    # tripping this guard; only an actual `"digest-baseline"` tuple element should.
+    offenders = [f.name for f in live_h_files if '"digest-baseline"' in f.read_text()]
+    assert offenders == []


### PR DESCRIPTION
## Summary

Backend counterpart to #1259 / PR #1266 (the Olympus Pipeline frontend fix), found while reviewing the frontend digest-key drift and checking for the same bug pattern on the backend.

`publish_phase.py` writes the digest as `document_key="digest"` on baseline runs (Sunday `refresh_scope=all`) and `document_key="digest-delta"` every other day. `_shared_context()` filters `prior_context.latest_segments` (most-recent-per-`document_key`, built by `load_prior_context`) down to a per-call `context_keys` whitelist. Three live H1-H9 call sites didn't cover both digest keys:

| File | Before | Bug |
|---|---|---|
| `h2_market_thesis_exploration.py` | `("digest",)` | loses the prior digest on delta days (6/7 days) |
| `h3_thesis_vehicle_map.py` | `("digest",)` | same |
| `h7_pm_direction.py` | `("pm-rebalance", "digest-delta", "digest-baseline")` | `digest-baseline` is never written by anything → every Monday, silently keeps a **stale week-old `digest-delta` row** instead of Sunday's fresh baseline digest |

`h1_thesis_review.py` already had it right (`("digest", "digest-delta")`) — that's the pattern applied here.

`phase7d_pm.py` has the identical typo at 3 sites but is confirmed unreachable from any production graph builder (`hermes/graph.py::build_hermes_phases` aliases straight to `build_hermes_phases_thesis`, never `phase7d_pm.build_phase7d_pm`) — left untouched. (Correction posted on the issue: it does have test coverage under `tests/dq/hermes/`/`tests/dq/atlas/`, contrary to my first pass — it's legacy-with-tests, not orphaned-and-untested, but still not production-reachable.)

## Test plan
- [x] New `tests/dq/atlas/test_shared_context_digest_keys.py`: reproduces the bug directly against `_shared_context` (old tuple silently drops the fresh digest; fixed tuple keeps it), plus a tripwire scanning the live `h*.py` phase modules for a `"digest-baseline"` string literal so the typo can't reappear.
- [x] `pytest -m unit tests/dq/atlas/ tests/dq/hermes/ tests/dq/learning/` — 925 passed (up from 924; my new file adds 3). The 27 remaining failures are pre-existing and environment-only (missing `OPENAI_API_KEY`/`OPENROUTER_API_KEY`, Supabase env config) — confirmed identical failure set with the fix reverted (`git stash`) on the same sandbox.
- [x] `ruff check` / `ruff format --check` on the touched files — clean.
- [x] `make score` — Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10.

Fixes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
