### PR TITLE
feat(web): useScrollyFeatures primitive (pinned + progress rail)

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -211,7 +211,7 @@ Add to `tokens.css` when implementing primitives:
 |-----------|---------|------------|
 | `BentoGrid` / `.bento` ✅ | 2×2 feature cells ([`site/README.md`](site/README.md#bentogrid-css-only-evolutionmd-phase-b)) | Cursor |
 | `ProductFrame` ✅ | CQ-scaled 800px UI embed ([`site/README.md`](site/README.md#productframe-css-only-evolutionmd-phase-b)) | Graphite, Cursor |
-| `ScrollyFeatures` | Pinned section + progress rail + N slides | Graphite |
+| `ScrollyFeatures` ✅ | Pinned section + progress rail + N slides — React hook `useScrollyFeatures` in `@digithings/web` (`frontend/web/src/motion/scrolly.tsx`); live `PipelineScene` adoption deferred (see below) | Graphite |
 | `TrustStrip` ✅ | Logo / proof row ([`site/README.md`](site/README.md#truststrip-css-only-evolutionmd-phase-b)) | Cursor, Graphite |
 | `StatCounter` ✅ | Scroll-triggered metrics ([`site/README.md`](site/README.md#statcounter-css--stat-counterjs-evolutionmd-phase-b)) | xAI |
 | `CapabilityCard` ✅ | Mini UI + “Explore →” ([`site/README.md`](site/README.md#capabilitycard-css-only-evolutionmd-phase-b)) | xAI |
@@ -220,6 +220,18 @@ Add to `tokens.css` when implementing primitives:
 | `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
 
 **Implementation order:** `ProductFrame` → `BentoGrid` → `TrustStrip` → `ScrollyFeatures` refactor → `StatCounter`.
+
+> **ScrollyFeatures landed as a React hook, not vanilla `frontend/design/`.** #1205's
+> original spec ("shared module JS+CSS under `frontend/design/`, built on
+> `scroll-trigger.js`") predated the finding that the vanilla `frontend/design/site/*.js`
+> layer + `scroll-trigger.js` are dead (removed in #1240; zero importers) and both live
+> marketing sites are React. The only two hand-rolled scrollies —
+> `ScrollyGraph` (`@digithings/web`) and digiquant-web's `PipelineScene` — are React, so
+> the primitive is a React hook `useScrollyFeatures` (+ `ScrollyRail`, pure math in
+> `scrolly-core.ts`) in `@digithings/web`. **Refactoring the live `PipelineScene` to consume
+> it is deferred to a follow-up** — its acceptance criterion is "no visual regression" via
+> manual scroll QA at 100%/125% zoom, which needs a working in-browser preview (unavailable
+> when the primitive was built). See [#1205](https://github.com/digithings-ai/digithings/issues/1205).
 
 ---
 
@@ -267,6 +279,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `ChangelogBand` component + CSS
 - [x] `CodeSampleBand` component + CSS
 - [x] `CapabilityCard` component + CSS
+- [x] `ScrollyFeatures` primitive (`useScrollyFeatures` hook in `@digithings/web`); live `PipelineScene` adoption deferred to a browser-QA follow-up (#1205)
 
 ### Phase C — Landing realignment
 

--- a/frontend/web/src/index.ts
+++ b/frontend/web/src/index.ts
@@ -1,5 +1,14 @@
 export { ThemeProvider, ThemeToggle, useTheme, themeInitScript } from "./components/ThemeProvider";
 export { MotionProvider, Reveal, Stagger, HeroEntrance, useMotionSafe, m, EASE } from "./motion/primitives";
+export {
+  useScrollyFeatures,
+  ScrollyRail,
+  progressToIndex,
+  scrollyTrackHeightVh,
+  STEPPER_MEDIA_QUERY,
+  type ScrollyFeatures,
+  type UseScrollyFeaturesOptions,
+} from "./motion/scrolly";
 export { Emblem, emblems } from "./components/emblems";
 export { StackLogo, StackRow } from "./components/StackLogo";
 export { ScrollyGraph, GraphSVG } from "./components/graph";

--- a/frontend/web/src/motion/scrolly-core.test.ts
+++ b/frontend/web/src/motion/scrolly-core.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { progressToIndex, scrollyTrackHeightVh, STEPPER_MEDIA_QUERY } from "./scrolly-core";
+
+describe("progressToIndex", () => {
+  it("maps progress into equal per-slide dwells", () => {
+    expect(progressToIndex(0, 3)).toBe(0);
+    expect(progressToIndex(0.2, 3)).toBe(0);
+    expect(progressToIndex(0.34, 3)).toBe(1);
+    expect(progressToIndex(0.67, 3)).toBe(2);
+  });
+
+  it("maps progress exactly at 1 to the last slide (not out of range)", () => {
+    expect(progressToIndex(1, 3)).toBe(2);
+    expect(progressToIndex(1, 5)).toBe(4);
+  });
+
+  it("clamps out-of-range progress", () => {
+    expect(progressToIndex(-0.5, 4)).toBe(0);
+    expect(progressToIndex(1.5, 4)).toBe(3);
+  });
+
+  it("is safe for degenerate slide counts", () => {
+    expect(progressToIndex(0.5, 0)).toBe(0);
+    expect(progressToIndex(0.5, 1)).toBe(0);
+    expect(progressToIndex(0.9, -2)).toBe(0);
+  });
+});
+
+describe("scrollyTrackHeightVh", () => {
+  it("derives the budget from slide count (content), not a fixed multiple", () => {
+    expect(scrollyTrackHeightVh(3)).toBe(270);
+    expect(scrollyTrackHeightVh(5)).toBe(450);
+  });
+
+  it("honors a custom per-slide dwell", () => {
+    expect(scrollyTrackHeightVh(4, 120)).toBe(480);
+  });
+
+  it("floors at one slide of budget", () => {
+    expect(scrollyTrackHeightVh(0)).toBe(90);
+    expect(scrollyTrackHeightVh(-3, 100)).toBe(100);
+  });
+});
+
+describe("STEPPER_MEDIA_QUERY", () => {
+  it("triggers the flow fallback on small viewports and reduced-motion", () => {
+    expect(STEPPER_MEDIA_QUERY).toContain("max-width");
+    expect(STEPPER_MEDIA_QUERY).toContain("prefers-reduced-motion: reduce");
+  });
+});

--- a/frontend/web/src/motion/scrolly-core.ts
+++ b/frontend/web/src/motion/scrolly-core.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure logic for the ScrollyFeatures primitive (pinned section + progress rail).
+ * Framework-free and side-effect-free so it can be unit-tested without a DOM —
+ * the React hook in `./scrolly.tsx` wraps these with `useScroll` + `matchMedia`.
+ *
+ * Generalizes the scroll→slide mapping that `ScrollyGraph` (components/graph.tsx)
+ * and digiquant-web's `PipelineScene` both hand-roll.
+ */
+
+/**
+ * Map a 0..1 scroll progress to an active slide index, clamped to
+ * `[0, slideCount - 1]`. `floor(progress * slideCount)` gives each slide an
+ * equal dwell; progress exactly at 1 maps to the last slide (not out of range).
+ */
+export function progressToIndex(progress: number, slideCount: number): number {
+  if (slideCount <= 0) return 0;
+  const raw = Math.floor(progress * slideCount);
+  return Math.max(0, Math.min(slideCount - 1, raw));
+}
+
+/**
+ * Vertical scroll budget (in `vh`) for a pinned scrolly: one dwell per slide.
+ * Derived from the slide count (content) rather than a hardcoded viewport
+ * multiple — the #1198 lesson (a pin's scroll budget must track its content so
+ * the next section can't overlap the pin and it holds up under browser zoom).
+ * Consumers with tall/variable slides can pass a larger `vhPerSlide`.
+ */
+export function scrollyTrackHeightVh(slideCount: number, vhPerSlide = 90): number {
+  return Math.max(1, slideCount) * vhPerSlide;
+}
+
+/**
+ * Media query that forces the flow-layout fallback: small viewport OR
+ * reduced-motion. When it matches, consumers render every slide in normal flow
+ * (no pinning) — satisfying `prefers-reduced-motion: reduce` by showing all
+ * slides, and giving small screens a static stepper.
+ */
+export const STEPPER_MEDIA_QUERY = "(max-width: 860px), (prefers-reduced-motion: reduce)";

--- a/frontend/web/src/motion/scrolly.tsx
+++ b/frontend/web/src/motion/scrolly.tsx
@@ -1,0 +1,95 @@
+"use client";
+/**
+ * ScrollyFeatures — shared pinned-section + progress-rail primitive (Graphite
+ * pattern). Desktop: a `position: sticky` pin whose active slide advances with
+ * scroll. Small viewport / reduced-motion: consumers render every slide in flow
+ * (see `stepper`). Generalizes the scroll→slide logic that `ScrollyGraph`
+ * (components/graph.tsx) and digiquant-web's `PipelineScene` hand-roll.
+ *
+ * The hook owns state only; markup + CSS stay with the consumer (the
+ * `scrolly-*` classes in styles/web-theme.css are the reference skin). Pure math
+ * lives in ./scrolly-core (unit-tested).
+ *
+ * Usage:
+ *   const trackRef = useRef<HTMLDivElement>(null);
+ *   const { activeIndex, stepper } = useScrollyFeatures(trackRef, { slideCount: slides.length });
+ *   if (stepper) return <FlowStepper slides={slides} />;   // all slides, no pin
+ *   return (
+ *     <div ref={trackRef} className="scrolly-track"
+ *          style={{ height: `${scrollyTrackHeightVh(slides.length)}vh` }}>
+ *       <div className="scrolly-pin">…active slide…<ScrollyRail count={slides.length} activeIndex={activeIndex} /></div>
+ *     </div>
+ *   );
+ *
+ * Docs note (EVOLUTION.md §9): **max one pinned section per page.**
+ */
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { useScroll, useMotionValueEvent } from "framer-motion";
+import { progressToIndex, STEPPER_MEDIA_QUERY } from "./scrolly-core";
+
+export { progressToIndex, scrollyTrackHeightVh, STEPPER_MEDIA_QUERY } from "./scrolly-core";
+
+export interface ScrollyFeatures {
+  /** Scroll-driven active slide index, clamped to the slide range. */
+  activeIndex: number;
+  /** True on small viewport OR reduced-motion — render all slides in flow, unpinned. */
+  stepper: boolean;
+}
+
+export interface UseScrollyFeaturesOptions {
+  slideCount: number;
+  /** Fired once per active-slide change (not per scroll frame). */
+  onSlideChange?: (index: number) => void;
+}
+
+export function useScrollyFeatures(
+  trackRef: RefObject<HTMLElement | null>,
+  { slideCount, onSlideChange }: UseScrollyFeaturesOptions,
+): ScrollyFeatures {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [stepper, setStepper] = useState(false);
+  const prevIndex = useRef(0);
+
+  useEffect(() => {
+    if (typeof matchMedia !== "function") return;
+    const mq = matchMedia(STEPPER_MEDIA_QUERY);
+    const apply = () => setStepper(mq.matches);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, []);
+
+  const { scrollYProgress } = useScroll({ target: trackRef, offset: ["start start", "end end"] });
+  useMotionValueEvent(scrollYProgress, "change", (p) => {
+    const i = progressToIndex(p, slideCount);
+    if (i !== prevIndex.current) {
+      prevIndex.current = i;
+      setActiveIndex(i);
+      onSlideChange?.(i);
+    }
+  });
+
+  return { activeIndex, stepper };
+}
+
+/**
+ * Progress rail — one tick per slide, `.on` at the active index. Decorative
+ * (`aria-hidden`); slide state is conveyed by the slide content itself.
+ */
+export function ScrollyRail({
+  count,
+  activeIndex,
+  className = "scrolly-rail",
+}: {
+  count: number;
+  activeIndex: number;
+  className?: string;
+}) {
+  return (
+    <div className={className} aria-hidden="true">
+      {Array.from({ length: count }, (_, i) => (
+        <span key={i} className={`scrolly-tick${i === activeIndex ? " on" : ""}`} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/web/src/styles/web-theme.css
+++ b/frontend/web/src/styles/web-theme.css
@@ -116,3 +116,23 @@ body {
 .dg-graph-mini { max-width: 360px; margin-inline: auto; }
 @media (min-width: 720px) { .dg-step { grid-template-columns: 1fr 1.2fr; align-items: center; } }
 @media (max-width: 900px) { .dg-stage-grid { grid-template-columns: 1fr; } .dg-rail { display: none; } }
+
+/* ── ScrollyFeatures (useScrollyFeatures reference skin) ────────────────────
+   Pinned section + progress rail (Graphite pattern). The hook owns state; this
+   is the reference CSS. Track height comes from scrollyTrackHeightVh() inline.
+   Small-viewport/reduced-motion consumers render .scrolly-stepper instead (all
+   slides in flow — the hook signals this via `stepper`). ────────────────── */
+.scrolly-track { position: relative; }
+.scrolly-pin { position: sticky; top: 0; min-height: 100svh; display: flex; flex-direction: column; justify-content: center; }
+.scrolly-rail { position: absolute; right: clamp(1rem, 3vw, 2rem); top: 50%; transform: translateY(-50%); display: flex; flex-direction: column; gap: 8px; }
+.scrolly-tick { width: 6px; height: 6px; border-radius: 50%; background: var(--hair-2); transition: background .2s var(--ease), transform .2s var(--ease); }
+.scrolly-tick.on { background: var(--accent); transform: scale(1.5); }
+.scrolly-stepper { display: flex; flex-direction: column; gap: 2rem; max-width: var(--wrap); margin-inline: auto; padding-inline: var(--gutter); }
+
+@media (prefers-reduced-motion: reduce) {
+  /* Belt-and-suspenders: even if a consumer keeps the pinned track mounted,
+     drop the sticky pin so slides read as a static stack. The hook's `stepper`
+     flag is the primary path (renders .scrolly-stepper); this is the fallback. */
+  .scrolly-pin { position: static; min-height: 0; }
+  .scrolly-tick { transition: none; }
+}


### PR DESCRIPTION
## Summary
Shared **ScrollyFeatures** primitive (epic #1200 Phase B), landed as a React hook in `@digithings/web`. Generalizes the scroll→slide logic that both `ScrollyGraph` (`@digithings/web`) and digiquant-web's `PipelineScene` hand-roll.

- **`frontend/web/src/motion/scrolly-core.ts`** — pure, unit-tested math: `progressToIndex` (clamped per-slide dwell), `scrollyTrackHeightVh` (content-derived scroll budget — the #1198 lesson, not a hardcoded `vh`), `STEPPER_MEDIA_QUERY`.
- **`frontend/web/src/motion/scrolly.tsx`** — `useScrollyFeatures(trackRef, { slideCount, onSlideChange? })` wrapping Framer `useScroll` + `matchMedia`; returns `{ activeIndex, stepper }`. `stepper` (small-viewport **or** reduced-motion) signals the flow-layout fallback so consumers render all slides unpinned — satisfies the reduced-motion AC ("show all slides in flow layout"). Plus `ScrollyRail` (decorative `aria-hidden` progress rail).
- **`frontend/web/src/styles/web-theme.css`** — reference `.scrolly-*` skin (pin/track/rail/tick/stepper) + a reduced-motion static-pin fallback.
- Exported from the `@digithings/web` barrel; documented in `EVOLUTION.md`.

## Why a React hook, not vanilla `frontend/design/` (as #1205's text says)
#1205's original spec ("shared module JS+CSS under `frontend/design/`, built on `scroll-trigger.js`") predates the #1240 finding that the vanilla `frontend/design/site/*.js` layer + `scroll-trigger.js` are **dead** (zero importers) and both live marketing sites are React. The only two real scrollies are React. Full reasoning in the [#1205 thread](https://github.com/digithings-ai/digithings/issues/1205#issuecomment-4856475501) and the `EVOLUTION.md` note added here.

## Deferred (not in this PR)
**Refactoring the live `PipelineScene` to consume this hook.** Its acceptance criterion is "no visual regression," verified by manual scroll QA at 100%/125% zoom — which needs a working in-browser preview (unavailable in the environment where this was built). This PR is purely **additive** (a new, unconsumed primitive); it changes nothing on the live digiquant.io landing. A follow-up adopts it with proper browser QA.

## Test plan
- [x] `@digithings/web` vitest: **12/12 pass** (8 new `scrolly-core` + 4 existing `hashScroll`)
- [x] `tsc -p frontend/web/tsconfig.json --noEmit` — clean
- [x] `python3 scripts/check_doc_links.py` — OK
- [x] `python3 scripts/score.py --staged` — Security 10, Quality 10, Optimization 10, Accuracy 10
- [ ] In-browser visual QA — deferred with the `PipelineScene` adoption (see above)

Note: `test-web.yml` is lint-only, so the new vitest suite isn't gated in CI (pre-existing gap — `hashScroll.test.ts` isn't either); the barrel re-export means the Next build-check still type-checks this module.

Fixes #1205