### PR TITLE
fix(ci): raise provider-review agent max-turns to 100

### DIFF
--- a/.github/workflows/pipeline-provider-review.yml
+++ b/.github/workflows/pipeline-provider-review.yml
@@ -126,8 +126,13 @@ jobs:
           # search results by fetching the actual page content, which is a separate tool/grant.
           # git checkout/push (issue #1243) let STEP F land its commit on a bot/ branch instead
           # of the protected develop ref it checks out on.
+          # --max-turns 40 was too low once tool access actually worked: a verification run
+          # hit error_max_turns at 41 turns / $7.14 doing real WebSearch+WebFetch research
+          # across ~20 providers, without ever reaching STEP E/F. Raised to 100 to give STEP
+          # A's per-provider research (search + fetch, ~2-3 turns each) headroom to finish
+          # alongside STEP B-F. Raises the per-run cost estimate to roughly $15-20/week.
           claude_args: >-
-            --max-turns 40
+            --max-turns 100
             --allowedTools "Read,Glob,Grep,WebSearch,WebFetch,Write,Edit,Bash(python scripts/provider_review/generate_docs.py:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
           prompt: |
             You are performing the weekly LLM provider review for the DigiThings project.


### PR DESCRIPTION
## Summary
- Follow-up to #1242 (merged). That PR fixed the agent-mode tool-permission gap (`permission_denials_count: 8` → the agent silently did nothing). A live post-merge verification run confirmed permissions now work — the agent did 41 turns of real `WebSearch`/`WebFetch`/`Read` work across ~20 providers, with only 6 denials remaining (the deliberately-unaddressed `deep-research` skill invocation attempts) — but it hit **`--max-turns 40`** before ever reaching STEP E (`findings.json`) or STEP F (commit/PR):
  ```
  "subtype": "error_max_turns",
  "is_error": true,
  "duration_ms": 751544,
  "num_turns": 41,
  "total_cost_usd": 7.140426199999999,
  "permission_denials_count": 6
  ```
- Extrapolating from turn/tool usage across verification runs (~18 `WebSearch` calls consumed ~29 turns in an earlier partial run before `WebFetch` was even granted), a full pass across ~20 providers with `WebSearch`+`WebFetch` research, then writing 20 YAML files, rewriting the catalog doc, and STEP F's git+PR flow, needs roughly double the current budget.
- Raises `--max-turns` from 40 to 100. Estimated cost impact: roughly $15-20/week instead of ~$7 for a run that doesn't finish.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] `python3 scripts/score.py --diff HEAD~1` — Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10
- [ ] Next scheduled/dispatched run completes through STEP F (commit landed on a `bot/provider-review-*` branch, PR opened) without hitting `error_max_turns`

Fixes #1241