### PR TITLE
feat(digichat): per-IP rate limiting on the anonymous /embed chat path

### DIFF
--- a/frontend/digichat/ARCHITECTURE.md
+++ b/frontend/digichat/ARCHITECTURE.md
@@ -143,6 +143,8 @@ probe).
 - Response: Server-Sent Events (AI SDK UI message stream) — text deltas plus optional `data-digigraphTrace` parts.
 - The route resolves upstream auth, builds a `createDigiGraphClient`, then either (a) calls `createDigigraphTraceStreamResponse` for the trace path or (b) calls `streamText` with `smoothStream` for the legacy path.
 - `maxDuration = 120` (Vercel/Next.js edge timeout).
+- **Rate limiting (two layers):** every request hits a shared per-`{tenantSlug}:{ownerUserSub}` sliding-window check (`checkBffRateLimit`, `DIGICHAT_CHAT_RATE_LIMIT_MAX`/`_WINDOW_MS`, default 30/min). Unauthenticated `/embed` requests all resolve to the *same* `ownerUserSub` (`embed:anonymous`, see below), so they'd share one bucket — a per-IP check (`checkEmbedIpRateLimit`, `DIGICHAT_EMBED_IP_RATE_LIMIT_MAX`/`_WINDOW_MS`, default 10/min) runs first for that case, so one visitor can't exhaust the shared quota for everyone (#1251). **Invariant:** the per-IP default must stay below the shared default, or the shared bucket's ceiling binds first and the per-IP layer becomes a no-op (caught in review on the first cut of #1251, which shipped 60 against a shared default of 30 — see the regression test in `embed-ip-rate-limit.test.ts`). IP is read from `cf-connecting-ip`, falling back to the first `X-Forwarded-For` hop — both are spoofable by the client unless a proxy in front strips/overwrites them (true of Cloudflare in the ADR-0018 production deployment, not guaranteed elsewhere). DigiGraph closed the equivalent gap with a `DIGI_TRUSTED_PROXIES` allowlist (`digigraph/ARCHITECTURE.md` §12.8, REM-027); DigiChat has no equivalent yet — acceptable for now since this is a rate-limiting decision, not an authorization one, but tracked as a follow-up.
+- **Anonymous `/embed` requests** (`resolveEmbedChatTenant` in `embed-chat-tenant.ts`) resolve to `{ tenantSlug: "embed", ownerUserSub: "embed:anonymous" }` when `DIGICHAT_EMBED_ENABLED=1` or a valid `X-Embed-Token` is presented; otherwise 503. This path never touches `conversations-repo` — no server-side persistence call exists in this route for any caller (persistence, when it happens, is client-initiated via the separate `/api/conversations` endpoints below, which require a real session).
 
 ### Conversations
 
@@ -352,6 +354,13 @@ mutation. It first creates the conversation row if `remote: false`, then issues 
 with the full message array. This is a full-replace strategy — not an append — so it
 re-sends the entire conversation on every flush. For long threads this may be
 non-trivial in payload size.
+
+This entire dual-path is inapplicable to the anonymous `/embed` surface: `src/app/embed/page.tsx`
+calls only `useChat` against `POST /api/chat` — it never imports `saveLocalThreads`,
+`flushServerSave`, or anything from `conversations-repo`. Even if it did, every
+`/api/conversations*` route calls `requireDigiChatAuth()` first, which 401s a bare
+anonymous request before any read/write — so no Postgres row can be created for
+`ownerUserSub: "embed:anonymous"` (verified by inspection for #1251, not assumed).
 
 ---
 
@@ -655,6 +664,10 @@ Healthcheck: `curl -sf http://127.0.0.1:3000/api/health`.
 | `DIGICHAT_MODEL` | DigiGraph model name (default: `sitaas-rag`) | Optional |
 | `DIGICHAT_OPENWEBUI_FORMAT` | Enable OpenWebUI format flag (default: `1`) | Optional |
 | `DIGICHAT_ENDPOINT_HOST_ALLOWLIST` | Comma-separated hosts for SSRF guard | Security hardening |
+| `DIGICHAT_EMBED_ENABLED` | Enable the unauthenticated `/embed` chat surface (`1` = on) | For public embed |
+| `DIGICHAT_EMBED_TOKEN` | Alternative to `DIGICHAT_EMBED_ENABLED`: gate `/embed` on `X-Embed-Token` instead | Optional |
+| `DIGICHAT_CHAT_RATE_LIMIT_MAX` / `_WINDOW_MS` | Shared per-`{tenantSlug}:{ownerUserSub}` chat rate limit (default 30/60000ms) | Optional |
+| `DIGICHAT_EMBED_IP_RATE_LIMIT_MAX` / `_WINDOW_MS` | Per-IP chat rate limit for anonymous `/embed` requests, in front of the shared bucket above (default 10/60000ms — must stay below `DIGICHAT_CHAT_RATE_LIMIT_MAX`) | Optional |
 | `DIGICHAT_POSTGRES_PASSWORD` | Postgres password (Compose default: `digichat`) | Change in production |
 | `DIGICHAT_VERSION` | Version string returned in health response | Optional |
 | `NEXTAUTH_SECRET` | Legacy Auth.js secret alias (same value as `AUTH_SECRET`) | If using legacy env |
@@ -743,12 +756,24 @@ UI is momentarily empty between submit and first response. Optimistically append
 user message to the local display before the server confirms improves perceived
 responsiveness significantly.
 
-### (d) Add rate limiting on `POST /api/chat` at BFF layer (before DigiGraph)
+### (d) ~~Add rate limiting on `POST /api/chat` at BFF layer~~ — done; extend to distributed storage
 
-DigiGraph rate-limits by caller IP, but behind the BFF all browser requests share the
-BFF's egress IP. A per-user rate limit at the BFF (keyed on `ownerUserSub` + a sliding
-window counter in Redis or in-memory with token bucket) would prevent a single user
-from saturating DigiGraph. This is especially important before any public deployment.
+Per-user/per-tenant rate limiting at the BFF (`checkBffRateLimit`, in-memory sliding
+window) shipped, and #1251 added a per-IP layer in front of it specifically for the
+shared anonymous `embed:anonymous` bucket (`checkEmbedIpRateLimit`). Both are
+in-process (`BoundedTTLMap`), so — like DigiGraph's and DigiSearch's own limiters —
+multiple DigiChat replicas would each enforce independently, multiplying the effective
+limit by replica count. Moving to Redis-backed counters remains open if DigiChat scales
+to multiple instances behind a load balancer.
+
+The new `embed_ip:*` keys share the same 10,000-entry bounded map (`MAX_RATE_LIMIT_KEYS`
+in `bff-rate-limit.ts`) as every other rate-limit key, including authenticated
+`chat:*` buckets, and eviction is FIFO by insertion order (not LRU). An attacker who
+can mint many distinct client IPs (only realistic when not actually behind Cloudflare —
+see the trust-boundary note above) could cycle through enough of them to evict
+legitimate entries, resetting their windows early. Impact is limiter degradation, not
+an auth bypass; segmenting the two key spaces into separate bounded maps would close
+this if it becomes a real concern.
 
 ### (e) Add streaming cancellation (AbortController from client to DigiGraph SSE disconnect)
 

--- a/frontend/digichat/src/app/api/chat/route.test.ts
+++ b/frontend/digichat/src/app/api/chat/route.test.ts
@@ -14,6 +14,10 @@ vi.mock("@/lib/bff-rate-limit", () => ({
   checkBffRateLimit: vi.fn(() => ({ allowed: true, retryAfterSec: 0 })),
 }));
 
+vi.mock("@/lib/embed-ip-rate-limit", () => ({
+  checkEmbedIpRateLimit: vi.fn(() => ({ allowed: true, retryAfterSec: 0 })),
+}));
+
 vi.mock("@/lib/digigraph-upstream", () => ({
   resolveDigigraphUpstreamAuth: vi.fn(),
   DigigraphUpstreamAuthError: class DigigraphUpstreamAuthError extends Error {},
@@ -50,6 +54,7 @@ vi.mock("ai", () => ({
 import { requireDigiChatAuth } from "@/lib/request-auth";
 import { resolveChatTenantContext } from "@/lib/chat-route-context";
 import { checkBffRateLimit } from "@/lib/bff-rate-limit";
+import { checkEmbedIpRateLimit } from "@/lib/embed-ip-rate-limit";
 import { resolveDigigraphUpstreamAuth } from "@/lib/digigraph-upstream";
 import { streamText } from "ai";
 
@@ -65,6 +70,7 @@ describe("POST /api/chat", () => {
       litellmProxyApiKey: null,
     });
     vi.mocked(checkBffRateLimit).mockReturnValue({ allowed: true, retryAfterSec: 0 });
+    vi.mocked(checkEmbedIpRateLimit).mockReturnValue({ allowed: true, retryAfterSec: 0 });
   });
 
   afterEach(() => {
@@ -140,6 +146,43 @@ describe("POST /api/chat", () => {
       })
     );
     expect(res.status).toBe(429);
+  });
+
+  it("returns 429 when the anonymous embed IP limiter blocks", async () => {
+    process.env.DIGICHAT_EMBED_ENABLED = "1";
+    vi.mocked(requireDigiChatAuth).mockResolvedValue(unauthorizedResponse);
+    vi.mocked(checkBffRateLimit).mockClear();
+    vi.mocked(checkEmbedIpRateLimit).mockReturnValue({ allowed: false, retryAfterSec: 45 });
+    const res = await POST(
+      new Request("http://localhost/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-embed-host": "https://digithings.ai",
+        },
+        body: JSON.stringify({ messages: [{ id: "1", role: "user", parts: [] }] }),
+      })
+    );
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("rate_limit_exceeded");
+    // The IP gate short-circuits before the shared embed:anonymous bucket check.
+    expect(checkBffRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke the embed IP limiter for authenticated non-embed requests", async () => {
+    vi.mocked(checkEmbedIpRateLimit).mockClear();
+    const res = await POST(
+      new Request("http://localhost/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(checkEmbedIpRateLimit).not.toHaveBeenCalled();
   });
 
   it("routes OpenRouter BYOK through DigiGraph with BYOK headers", async () => {

--- a/frontend/digichat/src/app/api/chat/route.ts
+++ b/frontend/digichat/src/app/api/chat/route.ts
@@ -16,6 +16,7 @@ import { createDigigraphTraceStreamResponse } from "@/lib/stream-digigraph-trace
 import { requireDigiChatAuth } from "@/lib/request-auth";
 import { getEcosystemEndpoints } from "@/lib/ecosystem";
 import { checkBffRateLimit } from "@/lib/bff-rate-limit";
+import { checkEmbedIpRateLimit } from "@/lib/embed-ip-rate-limit";
 import { resolveChatTenantContext } from "@/lib/chat-route-context";
 import {
   isEmbedChatRequest,
@@ -23,6 +24,19 @@ import {
 } from "@/lib/embed-chat-tenant";
 
 export const maxDuration = 120;
+
+function rateLimitResponse(message: string, retryAfterSec: number): Response {
+  return new Response(
+    JSON.stringify({ error: "rate_limit_exceeded", message }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": String(retryAfterSec),
+      },
+    }
+  );
+}
 
 export async function POST(req: Request) {
   const authResult = await requireDigiChatAuth(req);
@@ -35,22 +49,23 @@ export async function POST(req: Request) {
   }
   const { tenantSlug, ownerUserSub } = tenantCtx;
 
+  // Anonymous embed requests all share one bucket below (tenantSlug=embed,
+  // ownerUserSub=embed:anonymous) — gate per-IP first so one visitor can't
+  // exhaust it for everyone (#1251).
+  if (ownerUserSub === "embed:anonymous") {
+    const ipRate = checkEmbedIpRateLimit(req);
+    if (!ipRate.allowed) {
+      return rateLimitResponse(
+        "Too many requests from this address. Try again shortly.",
+        ipRate.retryAfterSec
+      );
+    }
+  }
+
   const rateKey = `chat:${tenantSlug}:${ownerUserSub}`;
   const rate = checkBffRateLimit(rateKey);
   if (!rate.allowed) {
-    return new Response(
-      JSON.stringify({
-        error: "rate_limit_exceeded",
-        message: "Too many chat requests. Try again shortly.",
-      }),
-      {
-        status: 429,
-        headers: {
-          "content-type": "application/json",
-          "retry-after": String(rate.retryAfterSec),
-        },
-      }
-    );
+    return rateLimitResponse("Too many chat requests. Try again shortly.", rate.retryAfterSec);
   }
 
   let body: { messages?: UIMessage[] };

--- a/frontend/digichat/src/lib/bff-rate-limit.ts
+++ b/frontend/digichat/src/lib/bff-rate-limit.ts
@@ -12,7 +12,7 @@ const windows = new BoundedTTLMap<string, Window>(MAX_RATE_LIMIT_KEYS, 60 * 60_0
  * numeric separators are a literal-only syntax — and a NaN window made the
  * cutoff filter drop every timestamp, silently disabling the limiter (#675).
  */
-function envPositiveInt(name: string, fallback: number): number {
+export function envPositiveInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number(raw);
@@ -23,7 +23,7 @@ function envPositiveInt(name: string, fallback: number): number {
   return parsed;
 }
 
-const DEFAULT_MAX = envPositiveInt("DIGICHAT_CHAT_RATE_LIMIT_MAX", 30);
+export const DEFAULT_MAX = envPositiveInt("DIGICHAT_CHAT_RATE_LIMIT_MAX", 30);
 const DEFAULT_WINDOW_MS = envPositiveInt("DIGICHAT_CHAT_RATE_LIMIT_WINDOW_MS", 60_000);
 
 export function checkBffRateLimit(

--- a/frontend/digichat/src/lib/embed-ip-rate-limit.test.ts
+++ b/frontend/digichat/src/lib/embed-ip-rate-limit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MAX as SHARED_BUCKET_MAX } from "@/lib/bff-rate-limit";
+import {
+  checkEmbedIpRateLimit,
+  clientIpForRateLimit,
+  EMBED_IP_MAX,
+} from "@/lib/embed-ip-rate-limit";
+
+function reqWithHeaders(headers: Record<string, string>): Request {
+  return new Request("http://localhost/api/chat", { headers });
+}
+
+describe("clientIpForRateLimit", () => {
+  it("prefers cf-connecting-ip", () => {
+    const req = reqWithHeaders({
+      "cf-connecting-ip": "198.51.100.1",
+      "x-forwarded-for": "203.0.113.9",
+    });
+    expect(clientIpForRateLimit(req)).toBe("198.51.100.1");
+  });
+
+  it("falls back to the first X-Forwarded-For hop", () => {
+    const req = reqWithHeaders({ "x-forwarded-for": "203.0.113.9, 10.0.0.1" });
+    expect(clientIpForRateLimit(req)).toBe("203.0.113.9");
+  });
+
+  it("returns 'unknown' when neither header is present", () => {
+    expect(clientIpForRateLimit(reqWithHeaders({}))).toBe("unknown");
+  });
+});
+
+describe("checkEmbedIpRateLimit", () => {
+  it("blocks one IP after its limit without affecting another IP", () => {
+    // DIGICHAT_EMBED_IP_RATE_LIMIT_MAX is read once at module import time, so
+    // this exercises the real default (EMBED_IP_MAX) rather than overriding it.
+    const ipA = `198.51.100.${Date.now() % 200}`;
+    const ipB = `198.51.100.${(Date.now() % 200) + 1}`;
+    const reqA = reqWithHeaders({ "cf-connecting-ip": ipA });
+    const reqB = reqWithHeaders({ "cf-connecting-ip": ipB });
+
+    for (let i = 0; i < EMBED_IP_MAX; i++) {
+      expect(checkEmbedIpRateLimit(reqA).allowed).toBe(true);
+    }
+    const blockedA = checkEmbedIpRateLimit(reqA);
+    const allowedB = checkEmbedIpRateLimit(reqB);
+
+    expect(blockedA.allowed).toBe(false);
+    expect(allowedB.allowed).toBe(true);
+  });
+
+  it("keeps the per-IP default below the shared bucket default (regression: caught in review, #1251)", () => {
+    // If EMBED_IP_MAX >= SHARED_BUCKET_MAX, a single visitor hits the *shared*
+    // embed:anonymous bucket's ceiling before ever tripping this per-IP one —
+    // the per-IP layer becomes a no-op and the abuse #1251 exists to prevent
+    // (one visitor exhausting the shared quota) still happens. The first cut
+    // of this file shipped EMBED_IP_MAX=60 against a shared default of 30.
+    expect(EMBED_IP_MAX).toBeLessThan(SHARED_BUCKET_MAX);
+  });
+});

--- a/frontend/digichat/src/lib/embed-ip-rate-limit.ts
+++ b/frontend/digichat/src/lib/embed-ip-rate-limit.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-IP sliding-window limiter for the anonymous /embed chat surface (#1251).
+ *
+ * `checkBffRateLimit`'s shared bucket keys on `chat:embed:embed:anonymous` —
+ * every unauthenticated embed visitor combined. This sits in front of that
+ * check so one visitor can't exhaust the shared quota for everyone, mirroring
+ * `frontend/digithings-web/functions/api/chat.ts`'s per-IP `rateLimit()`.
+ *
+ * INVARIANT: the per-IP max here must stay below `DIGICHAT_CHAT_RATE_LIMIT_MAX`
+ * (the shared bucket's cap, default 30/min in bff-rate-limit.ts). If it isn't,
+ * one visitor hits the *shared* bucket's ceiling before ever tripping this
+ * per-IP one — the per-IP layer becomes a no-op and the exact abuse this
+ * exists to prevent (one visitor exhausting the shared quota) still happens.
+ * A caught-in-review regression (#1251): the first cut of this file defaulted
+ * to 60/min here against the shared default of 30/min.
+ */
+
+import { checkBffRateLimit, envPositiveInt } from "@/lib/bff-rate-limit";
+
+export const EMBED_IP_MAX = envPositiveInt("DIGICHAT_EMBED_IP_RATE_LIMIT_MAX", 10);
+const EMBED_IP_WINDOW_MS = envPositiveInt("DIGICHAT_EMBED_IP_RATE_LIMIT_WINDOW_MS", 60_000);
+
+/**
+ * Best-effort client IP for rate-limiting only — never treat this as an
+ * identity signal. `cf-connecting-ip` is set authoritatively by Cloudflare's
+ * edge (DigiChat's deployment target per ADR-0018) and can't be spoofed by
+ * the client when actually behind Cloudflare. Falls back to the first
+ * `X-Forwarded-For` hop for non-Cloudflare setups (dev, other proxies) — that
+ * header, and `cf-connecting-ip` itself outside Cloudflare, CAN be spoofed
+ * absent a proxy that strips/overwrites them. DigiGraph closed the equivalent
+ * gap in its own rate limiter via a `DIGI_TRUSTED_PROXIES` allowlist
+ * (digigraph/ARCHITECTURE.md §12.8, REM-027); this module has no equivalent
+ * yet (tracked as a follow-up) — acceptable only because this is a
+ * rate-limiting decision, not an authorization one.
+ */
+export function clientIpForRateLimit(req: Request): string {
+  const cf = req.headers.get("cf-connecting-ip")?.trim();
+  if (cf) return cf;
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return "unknown";
+}
+
+/** Per-IP check for the shared anonymous /embed chat bucket. */
+export function checkEmbedIpRateLimit(
+  req: Request
+): { allowed: true } | { allowed: false; retryAfterSec: number } {
+  const ip = clientIpForRateLimit(req);
+  return checkBffRateLimit(`embed_ip:${ip}`, EMBED_IP_MAX, EMBED_IP_WINDOW_MS);
+}


### PR DESCRIPTION
## Summary

Phase 2 of the DigiChat-as-gateway epic (#1248): hardens DigiChat's unauthenticated `/embed` chat surface so it can safely absorb public digithings.ai traffic before that traffic starts routing through it (Phase 3, #1252).

Every anonymous `/embed` visitor resolves to the same identity (`{ tenantSlug: "embed", ownerUserSub: "embed:anonymous" }`), so the existing shared BFF rate limiter (`checkBffRateLimit`, 30 req/min default) gives **all public visitors combined** one bucket — one abusive visitor exhausts it for everyone. Adds `checkEmbedIpRateLimit`, a per-IP sliding-window check that runs in front of the shared bucket specifically for that case, reusing the existing `checkBffRateLimit` primitive (new key prefix, no new algorithm). IP source: `cf-connecting-ip` (authoritative behind the Cloudflare Route deployment target, ADR-0018), falling back to the first `X-Forwarded-For` hop.

## Security review caught a real bug before merge

A security-reviewer pass on this diff found the first cut shipped the per-IP default (60/min) **higher** than the shared bucket's default (30/min) — meaning a visitor would hit the shared bucket's ceiling before ever tripping the per-IP one, making the new layer a no-op for the exact abuse it exists to prevent. Fixed: per-IP default is now 10/min, with a new regression test (`embed-ip-rate-limit.test.ts`) that directly asserts `EMBED_IP_MAX < SHARED_BUCKET_MAX` so this can't silently regress again.

Two Low findings from the same review, documented in `ARCHITECTURE.md` and tracked as a follow-up rather than bundled here (per the review's own framing — both are rate-limiting-hardening, not authorization, decisions):
- IP headers (`cf-connecting-ip`/`X-Forwarded-For`) are spoofable outside an actual Cloudflare deployment. DigiGraph already solved this for its own limiter via a `DIGI_TRUSTED_PROXIES` allowlist (REM-027); DigiChat has no equivalent yet.
- The new `embed_ip:*` keys share the same 10,000-entry bounded map (FIFO eviction) as authenticated `chat:*` keys — an IP-cycling attacker could evict legitimate entries early.

Follow-up filed: #1279.

## Other Phase 2 acceptance criteria — verified, not assumed

- **No Postgres writes for `embed:anonymous`:** `src/app/embed/page.tsx` only calls `useChat` against `POST /api/chat` — it never imports anything from `conversations-repo` or calls `/api/conversations*`. Even if it did, every `/api/conversations*` route handler calls `requireDigiChatAuth()` first, which 401s a bare anonymous caller before any DB read/write. Confirmed by reading both code paths, not inferred.
- **ADR-0018 env wiring against the embed flow specifically** (not just the top-level `/chat` → login redirect ADR-0018 already verified): `src/lib/base-path.ts`'s `p()` helper is already correctly used in the embed transport (`api: p("/api/chat")`); `next.config.ts`'s CSP `headers()` rules for `/embed*` get Next's automatic `basePath` prefixing since none opt out via `basePath: false`; `AUTH_URL` isn't meaningfully exercised by the passive anonymous session check the embed path takes. No gap found.

## Verification

- `npx vitest run`: **100 passed** (22 files), 0 failures, 0 regressions.
- `npm run lint`: clean.
- `npm run build`: compiles, type-checks, and generates all routes including `/embed` and `/api/chat` successfully.
- `make doc-check`: OK.
- `make score --staged`: Security 10/10, Quality 10/10, Optimization 10/10, Accuracy 10/10 (post-fix; the pre-fix diff scored 7/10 on Security per the reviewer's own estimate, which would have failed the gate).

## Notes

Branch based on `module/digichat`, which was 898 commits behind `develop` — synced first via #1276 per CLAUDE.md's module-branch-sync rule before cutting this task branch.

The security reviewer noted this touches an unauthenticated public-embed surface and its rate-limiting posture, and suggested it may warrant human review under CLAUDE.md's network-exposure human-gate bullet regardless of score. For the record: the `/embed` surface itself is pre-existing (not new exposure), and this change only adds a limiter in front of it — the originating issue's own scoping call was "no new network exposure, no human gate required," which I agree with, but flagging the reviewer's caution here so a human reviewer can make the final call rather than me asserting it unilaterally.

Fixes #1251