### PR TITLE
feat(design): HorizontalScrollBand (.h-scroll) primitive [#1221]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -218,6 +218,7 @@ Add to `tokens.css` when implementing primitives:
 | `ChangelogBand` ✅ | Dated release rows ([`site/README.md`](site/README.md#changelogband-css-only--data-shape-evolutionmd-phase-b)) | Cursor |
 | `CodeSampleBand` ✅ | Tabbed SDK / curl snippets ([`site/README.md`](site/README.md#codesampleband-css--code-sample-bandjs-evolutionmd-phase-b)) | xAI, Cursor |
 | `reveal-up` utility ✅ | Opacity + translate enter ([`site/README.md`](site/README.md#reveal-up-css-only-utility-evolutionmd-phase-b)) | Graphite |
+| `HorizontalScrollBand` / `.h-scroll` ✅ | Cursor-style horizontal snap row ([`site/README.md`](site/README.md#horizontalscrollband-css-only-evolutionmd-phase-e)) | Cursor |
 
 **Implementation order:** `ProductFrame` → `BentoGrid` → `TrustStrip` → `ScrollyFeatures` refactor → `StatCounter`.
 
@@ -292,6 +293,19 @@ Add to `tokens.css` when implementing primitives:
 - [ ] Olympus glass → surface migration
 - [ ] twelve-x mono header convention
 - [ ] DigiChat full token adoption (#240)
+
+### Phase E — Additional primitives & content-gated integration
+
+- [x] `HorizontalScrollBand` primitive (`.h-scroll`) — #1221
+- [ ] `ClosingCtaBand` primitive — #1222
+- [ ] `FaqAccordion` + `PricingMatrix` primitives — #1223
+- [ ] `HeroFeaturePicker` primitive — #1224
+- [ ] `AnnouncementBar` primitive (content-gated) — #1225
+- [ ] digiquant.io pricing FAQ + tier matrix — #1226
+- [ ] both landings closing CTA wiring — #1227
+- [ ] `TrustStrip` integration logo variant — #1229
+- [ ] `CaseStudyCard` primitive (P3, content-gated) — #1230
+- [ ] Olympus status dot → DigiSmith (P3) — #1231
 
 ---
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -8,7 +8,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
 **StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
-`.principles`, and `.footer*`. Terminal-CLI /
+**HorizontalScrollBand**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -293,3 +293,34 @@ inside a `.bento__cell`.
 | `.capability-card__cta` | `Explore →` arrow link; the `span[aria-hidden]` arrow translates on card hover, matching `.btn`/`.bento__cta`. |
 
 Works unscoped in both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `HorizontalScrollBand` (CSS-only, EVOLUTION.md Phase E)
+
+Cursor-style horizontal snap row for changelog cards, testimonial rows, and
+mobile overflow bands. CSS-only — no `horizontal-scroll.js` was needed:
+keyboard access comes from making `.h-scroll__track` a focusable
+(`tabindex="0"`) native scroll container, so arrow keys scroll it; wrap it in
+`role="group"` with an `aria-label` so the row is announced. `prefers-reduced-motion:
+reduce` collapses the row to a vertical stack, so every card stays reachable
+without a horizontal gesture.
+
+```html
+<div class="h-scroll">
+  <div class="h-scroll__track" tabindex="0" role="group" aria-label="Recent releases">
+    <article class="h-scroll__card"><!-- card content --></article>
+    <article class="h-scroll__card"><!-- card content --></article>
+    <article class="h-scroll__card"><!-- card content --></article>
+  </div>
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.h-scroll` | Positioning wrapper; applies an edge-fade `mask-image` on both inline edges (removed under reduced motion). |
+| `.h-scroll__track` | Focusable (`tabindex="0"`) flex scroll container — `scroll-snap-type: x mandatory`, hidden scrollbar, `:focus-visible` ring. Under `prefers-reduced-motion: reduce` it becomes a vertical column with no snap. |
+| `.h-scroll__card` | Snap child — fixed `262px` (Cursor changelog card width), flat `--surface` panel. Full-width when stacked under reduced motion. |
+
+CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+Content wiring (real changelog/testimonial data) is out of scope here — this
+primitive owns only the scroll/snap/masking contract, same division as
+TrustStrip and ChangelogBand.

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -225,6 +225,26 @@ a { color: inherit; text-decoration: none; }
   .capability-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
+/* ── horizontal scroll band (Cursor-style snap row) ─────────────────────
+   Overflow-x snap row for changelog cards, testimonial rows, and mobile
+   overflow bands. .h-scroll masks the edges; .h-scroll__track is the
+   focusable scroll container; .h-scroll__card are ~262px snap children
+   (Cursor changelog card width). CSS-only: keyboard access comes from the
+   track being a focusable (tabindex="0") native scroll container — arrow
+   keys scroll it — so no horizontal-scroll.js is needed (see site/README.md).
+   prefers-reduced-motion: reduce → cards stack vertically (no horizontal
+   scroll), so all content is reachable without horizontal gestures. ────── */
+.h-scroll { position: relative; -webkit-mask-image: linear-gradient(to right, transparent, #000 2.5rem, #000 calc(100% - 2.5rem), transparent); mask-image: linear-gradient(to right, transparent, #000 2.5rem, #000 calc(100% - 2.5rem), transparent); }
+.h-scroll__track { display: flex; gap: 1.25rem; overflow-x: auto; scroll-snap-type: x mandatory; scroll-padding-inline: 1.25rem; padding: 0.25rem 1.25rem; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+.h-scroll__track::-webkit-scrollbar { display: none; }
+.h-scroll__track:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-md); }
+.h-scroll__card { flex: 0 0 auto; min-width: 262px; max-width: 262px; scroll-snap-align: start; display: flex; flex-direction: column; gap: 0.5rem; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); padding: 1.5rem; }
+@media (prefers-reduced-motion: reduce) {
+  .h-scroll { -webkit-mask-image: none; mask-image: none; }
+  .h-scroll__track { flex-direction: column; overflow-x: visible; scroll-snap-type: none; padding-inline: 0; }
+  .h-scroll__card { min-width: 0; max-width: none; }
+}
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -32,6 +32,9 @@
       border-radius: var(--radius-md);
       padding: var(--space-4);
       background: rgba(10, 10, 10, 0.4);
+      /* grid items default to min-width:auto (won't shrink below content) —
+         set 0 so an .h-scroll inside actually scrolls instead of blowing out. */
+      min-width: 0;
     }
     .smoke-section > .label {
       font-family: var(--font-family-mono);
@@ -248,6 +251,44 @@ await client.chat.send("hello");</code></pre>
         <div class="capability-card__title">Quant research</div>
         <p class="capability-card__body">NautilusTrader-backed backtest, optimize, and live paths.</p>
         <a class="capability-card__cta" href="#" onclick="return false;">Explore <span aria-hidden="true">&rarr;</span></a>
+      </div>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
+    <div class="label">h-scroll — Cursor-style snap row; scroll horizontally (focus the row + arrow keys); reduced-motion stacks vertically</div>
+    <div class="h-scroll">
+      <div class="h-scroll__track" tabindex="0" role="group" aria-label="Horizontal scroll demo cards">
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 01</div>
+          <strong>Snap card one</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">Fixed ~262px width. Scroll the row horizontally; each card snaps to the start edge.</p>
+        </article>
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 02</div>
+          <strong>Snap card two</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">Edge fade masks hint at more content off-screen on both sides.</p>
+        </article>
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 03</div>
+          <strong>Snap card three</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">Under prefers-reduced-motion the row stacks vertically — no horizontal gesture needed.</p>
+        </article>
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 04</div>
+          <strong>Snap card four</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">More cards than fit the viewport, to exercise overflow scrolling.</p>
+        </article>
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 05</div>
+          <strong>Snap card five</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">Focus the row and press → to scroll one snap point at a time.</p>
+        </article>
+        <article class="h-scroll__card">
+          <div class="bento__kicker">// card 06</div>
+          <strong>Snap card six</strong>
+          <p style="color:var(--ink-soft); font-size:0.9rem; margin:0;">The scrollbar is hidden; the edge-fade masks signal more content.</p>
+        </article>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## HorizontalScrollBand (`.h-scroll`) — Phase E

Cursor-style horizontal snap row for changelog cards, testimonial rows, and mobile overflow bands. CSS-only, both themes, reduced-motion safe.

Fixes #1221

### What's here
- **`.h-scroll`** — positioning wrapper with an edge-fade `mask-image` on both inline edges (removed under reduced motion).
- **`.h-scroll__track`** — focusable (`tabindex="0"`, `role="group"`) flex scroll container: `scroll-snap-type: x mandatory`, hidden scrollbar, `:focus-visible` ring. Keyboard access comes from the native focusable scroll container (arrow keys scroll it) — **no `horizontal-scroll.js` needed** (documented rationale in `site/README.md`).
- **`.h-scroll__card`** — 262px (Cursor changelog card width) snap children on `--surface`.
- **`prefers-reduced-motion: reduce`** → cards stack vertically (no horizontal scroll), so all content stays reachable without a horizontal gesture.
- Smoke demo (6 cards), `site/README.md` section, `EVOLUTION.md` §6 table + new Phase E checklist.
- Smoke harness fix: `.smoke-section { min-width: 0 }` so an `.h-scroll` inside the `display:grid` page actually scrolls instead of blowing out the grid item (default `min-width:auto`). Container requirement documented for consumers.

### Live-reviewed (design-smoke, port 4030)
- 6 cards render; `scroll-snap-type: x mandatory`, `overflow-x: auto`, focusable track (`tabindex=0`/`role=group`/aria-label), cards `min-width: 262px` + `scroll-snap-align: start` — all confirmed.
- **Snap verified**: programmatic `scrollTo({left: 400})` landed at `282` (one card 262px + 20px gap) — snapped to card 2's start edge.
- Track overflows (`scrollWidth 1712 > clientWidth 750`) and scrolls; **no page-level horizontal overflow**.
- Edge-fade mask visible in screenshot (card 3 fading at the right edge).
- Reduced-motion vertical-stack rule confirmed by static inspection (preview can't emulate `prefers-reduced-motion`).

### Gates
- `score --staged`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10.
- `check_doc_links`: OK (212 files) — new EVOLUTION → README anchor validated.
- CI build-checks (`build-digithings.sh` / `build-digiquant.sh`) run on this PR; additive CSS/HTML/docs only, no live-page changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
