### PR TITLE
feat(digithings-web): adopt trust-strip + ProductFrame in landing [#1210]

### DIFF
--- a/frontend/digithings-web/app/page.tsx
+++ b/frontend/digithings-web/app/page.tsx
@@ -30,10 +30,70 @@ export default function Home() {
             Self-hosted, BYOK, audit-on by default. No vendor lock-in, no opaque pipelines.
           </p>
           <div className="dqhero-cta">
+            <div className="trust-strip" style={{ marginBottom: "0.4rem" }}>
+              <span className="trust-strip__item">open core · self-hosted</span>
+              <span className="trust-strip__item">BYOK · keys never stored</span>
+              <span className="trust-strip__item">audit-on by default</span>
+            </div>
             <p className="dqhero-scroll-label">Scroll to explore</p>
             <div className="dqhero-scroll" aria-hidden="true" />
           </div>
         </HeroMesh>
+
+        <section className="section" id="product">
+          <div className="wrap">
+            <Reveal className="product-frame">
+              <div className="product-frame__surface">
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.6em",
+                    paddingBottom: "0.75em",
+                    borderBottom: "1px solid var(--hair)",
+                    marginBottom: "0.9em",
+                  }}
+                >
+                  <span
+                    style={{
+                      width: "0.7em",
+                      height: "0.7em",
+                      borderRadius: "50%",
+                      background: "var(--up)",
+                      display: "inline-block",
+                    }}
+                  />
+                  <strong>digithings · supervisor</strong>
+                  <span
+                    style={{
+                      marginLeft: "auto",
+                      color: "var(--ink-mute)",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.8em",
+                    }}
+                  >
+                    audit-on
+                  </span>
+                </div>
+                <pre
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    margin: 0,
+                    color: "var(--ink-soft)",
+                    lineHeight: 1.75,
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {`$ export ANTHROPIC_API_KEY=sk-…   # BYOK — forwarded, never stored
+$ digithings chat "summarize the latest filings"
+supervisor → routes across research · retrieval · chat
+✓ answered · correlation id logged · PII redacted before disk`}
+                </pre>
+              </div>
+            </Reveal>
+            <p className="product-frame__caption">One supervisor routes every request — your keys, audited by default.</p>
+          </div>
+        </section>
 
         <section className="section section-architecture" id="architecture">
           <div className="wrap">


### PR DESCRIPTION
## digithings.ai landing — adopt shared primitives (Phase C, slice 1)

First live-page adoption of the shared Phase B primitives into the digithings.ai landing (`frontend/digithings-web/app/page.tsx`). This is the exemplar that validates the shared vocabulary against the current v7 design language — reviewed live and signed off before replicating across other surfaces.

Fixes #1210

### What changed
- **Hero trust-strip** — a `.trust-strip` proof row ("open core · self-hosted", "BYOK · keys never stored", "audit-on by default") inside the hero CTA block, so it inherits the staggered reveal. Restates the lede's factual claims — no invented content.
- **ProductFrame band** — a `.product-frame` after the hero (the Graphite/Cursor "hero → product shot" pattern), showing a supervisor-routing / BYOK / audit surface. Content is deliberately *non-module-enumerating* so it complements (rather than echoes) the "Ten modules" manifest directly below it. No fabricated metrics (EVOLUTION.md anti-pattern #2).
- **Hero CTA left as scroll-cue** — the hero intentionally has no literal buttons (anti-pattern #1, "generic AI hero"); kept per sign-off.

### Grounding note
Both marketing sites already import `@digithings/design/site/site.css`, where these primitives live — this PR is the first to *consume* them in a live page (they were previously dormant, only exercised on the smoke harness). The primitives use the shared `[data-theme]` tokens, so the adoption is theme-safe with zero per-primitive theming.

### Live-reviewed (worktree dev server, faithful `@digithings/*` resolution)
- Hero trust-strip renders as a mono proof line under the lede, consistent with the v7 hero.
- ProductFrame is a flat `--surface` panel, hairline border, honoring "atmospheric outside, surgical inside."
- **Theme-safe** — verified in both dark and light (surface/ink/accent flip via tokens; digithings monochrome accent respected).
- No new console errors from these changes (the pre-existing DigiNav hydration warning is unrelated — tracked separately).

### Gates
- `score --staged`: Security 10 / Quality 10 / Optimization 10 / Accuracy 10
- Production `next build` of digithings-web: pass
- CI build-checks (`build-digithings.sh` / `build-digiquant.sh`) run on this PR.

Follow-ups on this landing: #1211 (bento module grid), #1212 (changelog band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
