### PR TITLE
feat(digithings-web): 4-module bento grid above manifest [#1211]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -284,7 +284,7 @@ Add to `tokens.css` when implementing primitives:
 
 ### Phase C — Landing realignment
 
-- [ ] digithings hero + bento modules
+- [x] digithings hero: trust-strip + ProductFrame (#1210); bento module grid — 4 primary modules, accent-coloured, real links, added *above* the retained interactive `digithings ps` manifest (hybrid, #1211)
 - [ ] digiquant hero CTA + bento; Graphite progress on Olympus pin only
 - [ ] Changelog band (both sites)
 

--- a/frontend/digithings-web/app/page.tsx
+++ b/frontend/digithings-web/app/page.tsx
@@ -102,6 +102,44 @@ supervisor → routes across research · retrieval · chat
               <h2>Ten modules, wired into one.</h2>
               <p>A supervisor at the centre routes every request to the right module — chat, quant research, or retrieval. Each one self-hosted, audited, and swappable.</p>
             </Reveal>
+            <div style={{ margin: "2.75rem 0 3.25rem" }}>
+              <Reveal className="bento">
+                <a
+                  className="bento__cell accent-digigraph"
+                  href="https://github.com/digithings-ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div className="bento__kicker">{"// orchestration"}</div>
+                  <div className="bento__title">digigraph</div>
+                  <p className="bento__body">One supervisor decides which specialist runs. Every time.</p>
+                  <span className="bento__cta">Source <span aria-hidden="true">→</span></span>
+                </a>
+                <a
+                  className="bento__cell accent-digiquant"
+                  href="https://digiquant.io"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div className="bento__kicker">{"// quant engine"}</div>
+                  <div className="bento__title">digiquant</div>
+                  <p className="bento__body">Strategy research that ends in an order, not a markdown file.</p>
+                  <span className="bento__cta">digiquant.io <span aria-hidden="true">→</span></span>
+                </a>
+                <a className="bento__cell accent-digisearch" href="https://github.com/digithings-ai" target="_blank" rel="noopener noreferrer">
+                  <div className="bento__kicker">{"// retrieval"}</div>
+                  <div className="bento__title">digisearch</div>
+                  <p className="bento__body">Production RAG without a stack rewrite when you switch vector DB.</p>
+                  <span className="bento__cta">Source <span aria-hidden="true">→</span></span>
+                </a>
+                <a className="bento__cell accent-digichat" href="/chat">
+                  <div className="bento__kicker">{"// chat"}</div>
+                  <div className="bento__title">digichat</div>
+                  <p className="bento__body">Talk to your stack with your keys, your models, your audit log.</p>
+                  <span className="bento__cta">Ask digichat <span aria-hidden="true">→</span></span>
+                </a>
+              </Reveal>
+            </div>
             <ModuleManifest />
           </div>
         </section>


### PR DESCRIPTION
## digithings.ai — bento module grid (Phase C, slice 2 · hybrid)

Adds a **4-module bento "start here" grid** to the architecture section, adopting `BentoGrid` with per-module accent colours and real links.

Fixes #1211

### Approach: hybrid (keep manifest, add bento) — reviewed + chosen
The AC framed this as replacing a "long architecture-only scroll," but the live section is already a compact **interactive** `ModuleManifest` (`digithings ps` — click a module, its description types out; all 10 modules). Rather than regress that distinctive element, this PR (per sign-off) **keeps the interactive manifest** and adds a focused bento **above** it:

- 4 primary modules (DigiGraph / DigiQuant / DigiSearch / DigiChat) as `.bento__cell` links.
- Correct `--accent-*` treatment via the `.accent-<id>` utility classes: digigraph gold, digiquant green, digisearch blue, digichat purple (verified computed colours).
- **Real hrefs, no `#`:** GitHub Source, `https://digiquant.io`, and `/chat` (Ask digichat) — sourced from the shared `modules` data `links`.
- Body copy is each module's real `tagline` from `modules.ts` (no invented content).

**Principles 4-up:** retained as-is (not merged into the bento) — it answers a different question ("why", not "what"), so folding it in would muddy both. Documented here per AC.

### Live-reviewed (worktree dev server, port 4014)
- 4 accent-coloured bento cells render above the retained manifest (all 10 modules still present).
- Accent colours confirmed: `#e5b765 / #4fa37a / #5aa3c4 / #9d8fc9`.
- Real hrefs resolve (external Source/digiquant.io open in new tab; `/chat` internal).
- 2×2 at ≥768px, single column below (shared `.bento` rule).

### Gates
- `score --staged`: 10 / 10 / 10 / 10
- `check_doc_links`: OK (212 files)
- Production `next build` of digithings-web: pass
- EVOLUTION.md Phase C checklist updated.

Next on this landing: #1212 (changelog/releases band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
