### PR TITLE
feat(digiquant-web): hero CTAs + trust-strip + stat row [#1213]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -285,8 +285,8 @@ Add to `tokens.css` when implementing primitives:
 ### Phase C — Landing realignment
 
 - [x] digithings hero: trust-strip + ProductFrame (#1210); bento module grid — 4 primary modules, accent-coloured, real links, added *above* the retained interactive `digithings ps` manifest (hybrid, #1211)
-- [ ] digiquant hero CTA + bento; Graphite progress on Olympus pin only
-- [ ] Changelog band (both sites)
+- [~] digiquant hero: literal CTAs (Open Olympus / Browse strategies) + trust-strip + real-value stat row (#1213). Bento feature grid (#1214) and Graphite progress on Olympus pin (#1215) still pending.
+- [ ] Changelog band (both sites) — #1212 **deferred**: no real releases source (no CHANGELOG.md / GitHub releases / tags); needs a data source + product call before shipping a public band (won't fabricate).
 
 ### Phase D — Dashboard flattening
 

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Footer, Reveal } from "@digithings/web";
 import { DQ_FOOTER, DQ_FOOTER_META } from "./_nav";
 import {
@@ -35,9 +36,32 @@ export default function Home() {
             researches, <b>Hermes</b> sizes the risk, <b>Kairos</b> executes. Open-source and
             self-hosted, so a fund that once needed a team now runs for one.
           </p>
-          <div className="dqhero-cta dqhero-scrollcue">
-            <span className="dqhero-scroll-label">Scroll to explore</span>
-            <div className="dqhero-scroll" aria-hidden="true" />
+          <div className="dqhero-cta">
+            <Link className="btn btn-primary" href="/#olympus">
+              Open Olympus <span aria-hidden="true">→</span>
+            </Link>
+            <Link className="btn btn-ghost" href="/strategies">
+              Browse strategies
+            </Link>
+          </div>
+          <div className="trust-strip" style={{ marginTop: "1.7rem" }}>
+            <span className="trust-strip__item">NautilusTrader</span>
+            <span className="trust-strip__item">open core</span>
+            <span className="trust-strip__item">Atlas · Hermes · Kairos</span>
+          </div>
+          {/* Real values (no placeholders): 3 reference strategies (BTC/ETH/SOL,
+              public/strategies/index.json) and the 3 specialist agents named in
+              the lede. Static render — the count-up is the vanilla stat-counter.js
+              path (dead in React); a React count-up is a follow-up, not wired here. */}
+          <div className="stat-counter-row" style={{ marginTop: "2.1rem" }}>
+            <div className="stat-counter">
+              <span className="stat-counter__value">3</span>
+              <span className="stat-counter__label">reference strategies</span>
+            </div>
+            <div className="stat-counter">
+              <span className="stat-counter__value">3</span>
+              <span className="stat-counter__label">specialist agents</span>
+            </div>
           </div>
         </HeroMesh>
 


### PR DESCRIPTION
## digiquant.io hero — literal CTAs + trust-strip + stat row (Phase C)

Upgrades the digiquant.io hero (`frontend/digiquant-web/app/page.tsx`) with literal product CTAs, a trust-strip, and a real-value stat row — adopting the shared primitives.

Fixes #1213

### What changed
- **Literal CTAs** (replace the scroll-cue): primary **Open Olympus** → `/#olympus` (the in-page Olympus scene, matching DqNav's Olympus button) + ghost **Browse strategies** → `/strategies` (the real library route). Product-appropriate, not a generic two-button hero.
- **TrustStrip**: `NautilusTrader · open core · Atlas · Hermes · Kairos` — factual (the engine, licence model, and the three specialist agents named in the hero lede).
- **StatCounter row** — **real values only** (anti-pattern #2): `3` reference strategies (BTC/ETH/SOL, from `public/strategies/index.json`) and `3` specialist agents (Atlas/Hermes/Kairos, per the lede). Rendered static — the count-up is the vanilla `stat-counter.js` path (dead in React); a React count-up is a documented follow-up, **not** faked.
- **Fraunces hero display retained**; no price ticker.

### Editorial calls for your review
- The two stats are both `3` (distinct labels). digiquant.io has thin *aggregate* numeric data — these are the honest options. Happy to swap for other real metrics or drop the stat row if you'd prefer.
- Kept the trust-strip wording close to the AC's example but added Kairos (the lede names all three agents).

### Live-reviewed (worktree dev server, port 4015)
- CTAs resolve (`/#olympus`, `/strategies`); trust-strip + stat row render; Fraunces headline intact; mesh hero unaffected.
- Dark theme shown; primitives are theme-safe via shared tokens (verified previously).

### Gates
- `score --staged`: 10 / 10 / 10 / 10
- `check_doc_links`: OK
- Production `next build` of digiquant-web: pass
- EVOLUTION.md Phase C updated.

Note: **#1212 (changelog band) is deferred** — no real releases source exists (no CHANGELOG.md / GitHub releases / tags); it needs a data source + a product decision before a public band, which I won't fabricate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
