### PR TITLE
feat(digiquant-web): Pipeline·Strategies·Pricing feature bento [#1214]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -285,7 +285,7 @@ Add to `tokens.css` when implementing primitives:
 ### Phase C — Landing realignment
 
 - [x] digithings hero: trust-strip + ProductFrame (#1210); bento module grid — 4 primary modules, accent-coloured, real links, added *above* the retained interactive `digithings ps` manifest (hybrid, #1211)
-- [~] digiquant hero: literal CTAs (Open Olympus / Browse strategies) + trust-strip + real-value stat row (#1213). Bento feature grid (#1214) and Graphite progress on Olympus pin (#1215) still pending.
+- [~] digiquant hero: literal CTAs (Open Olympus / Browse strategies) + trust-strip + real-value stat row (#1213); additive Pipeline·Strategies·Pricing feature bento after the hero, teal accent, real links — kept **both** pinned scrollies (OlympusScene + StrategySuite) rather than the AC's "one pin" (avoids regressing the flagship + #1198; per sign-off) (#1214). Graphite progress on Olympus pin (#1215) still pending.
 - [ ] Changelog band (both sites) — #1212 **deferred**: no real releases source (no CHANGELOG.md / GitHub releases / tags); needs a data source + product call before shipping a public band (won't fabricate).
 
 ### Phase D — Dashboard flattening

--- a/frontend/design/demos/digiquant-landing/DESIGN_DECISIONS.md
+++ b/frontend/design/demos/digiquant-landing/DESIGN_DECISIONS.md
@@ -225,3 +225,15 @@ GENERAL: whole-page scrolling must be smooth/continuous (Apple-like), no pausing
 2. Run a dev server (preview_start) on each site, screenshot every page at desktop +
    mobile, diff against the Hermès/Linear bar. Capture concrete defects with shots.
 3. Triage homepage hero of each site first (highest-impact surface).
+
+## 2026-07-01 — feature bento (#1214): additive, not a demotion
+
+#1214's AC framed this as *demoting* scroll sections into a bento and keeping "only
+one pinned section." Against the live landing that was stale + risky: digiquant.io
+runs **two** intentional pinned scrollies — `OlympusScene` (the #1205 flagship, which
+#1215 then *enhances* with a progress rail) and `StrategySuite` (#1198). Demoting
+either regresses a good element. Per sign-off we went **additive**: a
+`Pipeline · Strategies · Pricing` `.bento` after the hero (teal marketing accent, real
+links to `#olympus` / `/strategies` / `#contact`), with **both** scrollies untouched.
+Two pins is not the anti-pattern (#4 targets *five*). ProductFrame tearsheet crops
+inside the cells remain a possible follow-up.

--- a/frontend/digiquant-web/app/page.tsx
+++ b/frontend/digiquant-web/app/page.tsx
@@ -65,6 +65,50 @@ export default function Home() {
           </div>
         </HeroMesh>
 
+        <section className="section" id="features">
+          <div className="wrap">
+            <Reveal className="section-head center">
+              <span className="kicker">{"// what's inside"}</span>
+              <h2>Research, execution, and the terms to run it.</h2>
+            </Reveal>
+            <Reveal className="bento">
+              <Link className="bento__cell" href="#olympus">
+                <div className="bento__kicker">{"// pipeline"}</div>
+                <div className="bento__title">Research → execution</div>
+                <p className="bento__body">
+                  Atlas researches, Hermes sizes the risk, Kairos executes — one live pipeline you can
+                  watch end to end.
+                </p>
+                <span className="bento__cta">
+                  See the pipeline <span aria-hidden="true">→</span>
+                </span>
+              </Link>
+              <Link className="bento__cell" href="/strategies">
+                <div className="bento__kicker">{"// strategies"}</div>
+                <div className="bento__title">Reference strategies</div>
+                <p className="bento__body">
+                  BTC, ETH, and SOL reference strategies with full backtest tearsheets — clone and run
+                  them yourself.
+                </p>
+                <span className="bento__cta">
+                  Browse strategies <span aria-hidden="true">→</span>
+                </span>
+              </Link>
+              <Link className="bento__cell bento__cell--span-2" href="#contact">
+                <div className="bento__kicker">{"// pricing"}</div>
+                <div className="bento__title">Own it, or have it hosted</div>
+                <p className="bento__body">
+                  Open core and free to self-host, or a managed Olympus runner with an SLA — the same
+                  engine either way.
+                </p>
+                <span className="bento__cta">
+                  See pricing <span aria-hidden="true">→</span>
+                </span>
+              </Link>
+            </Reveal>
+          </div>
+        </section>
+
         <ResearchPipeline />
 
         <OlympusScene />


### PR DESCRIPTION
## digiquant.io — Pipeline·Strategies·Pricing feature bento (Phase C, additive)

Adds a `Pipeline · Strategies · Pricing` feature bento after the hero (`frontend/digiquant-web/app/page.tsx`), adopting the shared `BentoGrid`.

Fixes #1214

### Approach: additive (keep both scrollies) — reviewed + chosen
#1214's AC framed this as *demoting* scroll sections into a bento and keeping "only one pinned section." Against the live landing that was stale and risky: digiquant.io runs **two** intentional pinned scrollies — `OlympusScene` (the #1205 flagship, which #1215 then *enhances*) and `StrategySuite` (#1198). Demoting either regresses a good element. Per sign-off, this is **additive**:

- A `Pipeline · Strategies · Pricing` `.bento` (3 cells, pricing spanning full width) after the hero.
- **Teal marketing accent** (the default `--accent`), per the AC's "teal on marketing, module green only inside quant UI previews."
- **Real links** (via `next/link`, lint-clean): `#olympus` (the Olympus scene, anchor confirmed), `/strategies` (real route), `#contact` (holds the pricing `price-card`s).
- Honest copy: Atlas/Hermes/Kairos, BTC/ETH/SOL reference strategies, open-core-vs-managed pricing.
- **Both pinned scrollies untouched** → no regression to the Olympus scene or the StrategySuite scroll animation (#1198). Two pins is not the anti-pattern (#4 targets *five*).

ProductFrame tearsheet crops inside the cells are a possible follow-up (kept the first pass clean).

### Live-reviewed (worktree dev server, port 4015)
- 3 teal-accented cells render after the hero; `#olympus` + `#contact` anchors exist; `/strategies` resolves.
- Scrollies (OlympusScene, StrategySuite) unchanged below.

### Gates
- **`web / lint`: 0 errors** (ran locally this time — used `next/link` for internal routes; the 6 remaining warnings are pre-existing `no-img-element`/`exhaustive-deps`)
- `score --staged`: 10 / 10 / 10 / 10
- `check_doc_links`: OK
- Production `next build` of digiquant-web: pass
- Docs: EVOLUTION.md Phase C + DESIGN_DECISIONS.md (additive-vs-demotion rationale) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
