### PR TITLE
docs(#1215): Olympus progress rail satisfied by existing PipelineScene rail

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -285,7 +285,7 @@ Add to `tokens.css` when implementing primitives:
 ### Phase C — Landing realignment
 
 - [x] digithings hero: trust-strip + ProductFrame (#1210); bento module grid — 4 primary modules, accent-coloured, real links, added *above* the retained interactive `digithings ps` manifest (hybrid, #1211)
-- [~] digiquant hero: literal CTAs (Open Olympus / Browse strategies) + trust-strip + real-value stat row (#1213); additive Pipeline·Strategies·Pricing feature bento after the hero, teal accent, real links — kept **both** pinned scrollies (OlympusScene + StrategySuite) rather than the AC's "one pin" (avoids regressing the flagship + #1198; per sign-off) (#1214). Graphite progress on Olympus pin (#1215) still pending.
+- [~] digiquant hero: literal CTAs (Open Olympus / Browse strategies) + trust-strip + real-value stat row (#1213); additive Pipeline·Strategies·Pricing feature bento after the hero, teal accent, real links — kept **both** pinned scrollies (OlympusScene + StrategySuite) rather than the AC's "one pin" (avoids regressing the flagship + #1198; per sign-off) (#1214). Graphite progress rail on the Olympus pin (#1215) — **satisfied by the existing `PipelineScene`**: `.dqp-rail` already renders a scroll-synced fill + engine nodes in `--accent` cyan, reduced-motion-safe, mobile-simplified at 820px (verified live: 55% scroll → 54.99% fill). Refactoring onto the shared `ScrollyFeatures` primitive would be pure regression risk, so left as-is.
 - [ ] Changelog band (both sites) — #1212 **deferred**: no real releases source (no CHANGELOG.md / GitHub releases / tags); needs a data source + product call before shipping a public band (won't fabricate).
 
 ### Phase D — Dashboard flattening

--- a/frontend/digiquant-web/components/landing/PipelineScene.tsx
+++ b/frontend/digiquant-web/components/landing/PipelineScene.tsx
@@ -226,6 +226,11 @@ export function OlympusScene() {
             <div className="dqp-scene-title">A hedge fund in a box.</div>
           </div>
 
+          {/* Graphite-style progress rail (#1215): scroll-synced .dqp-fill + engine
+              nodes lit in --accent as `gp` advances (see applyState). Reduced-motion-safe
+              (discrete state is scroll-driven, not rAF-gated) and mobile-simplified at the
+              820px breakpoint — #1215 is satisfied here, not via a separate ScrollyFeatures
+              refactor of this hand-tuned scene. */}
           <div className="dqp-rail">
             <div className="dqp-fill" ref={railFillRef} />
             {NODES.map(([num, label], i) => (


### PR DESCRIPTION
Fixes #1215

**Satisfied-by-existing.** The Graphite progress rail #1215 specifies already lives in `PipelineScene` (`.dqp-rail`): a scroll-synced `.dqp-fill` + three engine nodes lit in `--accent` cyan, reduced-motion-safe (discrete state is scroll-driven), mobile-simplified at the 820px breakpoint, no new pinned sections.

**Verified live** (worktree dev server): at 55% scroll into the Olympus pin, fill = 54.99%, Atlas+Hermes nodes lit, active head = Hermes, current step = "Screener". Fill color = `rgb(61,214,196)` (`--accent`).

Refactoring this hand-tuned 286-line scene onto the shared `ScrollyFeatures` primitive would be pure regression risk for no visual gain, so this PR **documents the existing rail as the deliverable** (a code comment in PipelineScene + an EVOLUTION.md Phase C note) rather than rebuilding it.

Gates: lint 0 errors · score 10/10/10/10 · doc-links OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)