### PR TITLE
docs(#1216): Olympus glass→flat — audit confirms already migrated

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -290,7 +290,7 @@ Add to `tokens.css` when implementing primitives:
 
 ### Phase D — Dashboard flattening
 
-- [ ] Olympus glass → surface migration
+- [x] Olympus glass → surface migration (#1216) — **audit: already flat**. `.glass-card` is a legacy *name* for a flat `--surface` panel (1px `--hair` border, subtle intentional depth shadow, not glass); `backdrop-blur` is confined to sticky/overlay chrome (nav, mobile app bar, command palette, sidebar), never content. Surface system documented in `frontend/olympus/app/globals.css` (Olympus has no ARCHITECTURE.md/AGENTS.md to update). No visual change — anti-pattern #8 already satisfied.
 - [ ] twelve-x mono header convention
 - [ ] DigiChat full token adoption (#240)
 

--- a/frontend/olympus/app/globals.css
+++ b/frontend/olympus/app/globals.css
@@ -119,7 +119,14 @@ html.motion-on [data-reveal].reveal-in {
   html.motion-on [data-reveal] { opacity: 1 !important; transform: none !important; transition: none !important; }
 }
 
-/* ── Panel (formerly glass-card; flattened for a terminal/TradingView feel) ── */
+/* ── Surface system (x.ai-style flat — EVOLUTION.md §3 Olympus / §10 · #1216) ──
+   Olympus is FLAT: no glass morphism on content (anti-pattern #8). Panels use
+   `--surface` (via `--color-bg-glass`) + a 1px `--hair` border (`--color-border-
+   subtle`), hover to `--hair-2` (`--color-border-glow`). `--shadow-glass` is a
+   deliberately subtle depth cue for the terminal/TradingView feel, not a decorative
+   drop shadow. `backdrop-blur` is used ONLY on sticky/overlay chrome (nav, mobile
+   app bar, command palette, sidebar) — never on content cards. `.glass-card` is a
+   legacy *name* for this flat panel; new components should read as flat surfaces. */
 .glass-card {
   background: var(--color-bg-glass);
   border: 1px solid var(--color-border-subtle);


### PR DESCRIPTION
Fixes #1216

**Audit-and-close.** The Olympus dashboard has already migrated to x.ai-style flat surfaces:
- `.glass-card` is a legacy *name* for a **flat** panel — `background: var(--color-bg-glass)` where `--color-bg-glass: var(--surface)`, a 1px `--hair` border, hover to `--hair-2`. The comment at its definition already reads *"formerly glass-card; flattened for a terminal/TradingView feel."*
- The subtle `--shadow-glass` is a deliberate depth cue, not glass morphism.
- All 10 `backdrop-blur` uses are on **sticky/overlay chrome** (nav, mobile app bar, command palette, sidebar, subpage tab bar) — the accepted pattern, not content cards.

So anti-pattern #8 (glass on new components) is already satisfied. Refactoring/renaming the working flat dashboard would be pure churn + regression risk.

**Deliverable (docs, no visual change):**
- Surface-system doc comment in `frontend/olympus/app/globals.css` (Olympus has no ARCHITECTURE.md/AGENTS.md to update)
- EVOLUTION.md Phase D marked done with the audit finding

Gates: score 10/10/10/10 · doc-links OK · (CSS-comment + markdown only — no logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)