### PR TITLE
docs(#1217): twelve-x xAI polish — audit confirms already applied

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -291,7 +291,7 @@ Add to `tokens.css` when implementing primitives:
 ### Phase D — Dashboard flattening
 
 - [x] Olympus glass → surface migration (#1216) — **audit: already flat**. `.glass-card` is a legacy *name* for a flat `--surface` panel (1px `--hair` border, subtle intentional depth shadow, not glass); `backdrop-blur` is confined to sticky/overlay chrome (nav, mobile app bar, command palette, sidebar), never content. Surface system documented in `frontend/olympus/app/globals.css` (Olympus has no ARCHITECTURE.md/AGENTS.md to update). No visual change — anti-pattern #8 already satisfied.
-- [ ] twelve-x mono header convention
+- [x] twelve-x xAI utility polish (#1217) — **audit: already there**. Section/table headers use `uppercase tracking-wider` mono-style labels (`ConsensusDataTable`, `IntelligenceTab`, `MoversStrip`); metrics use `font-mono tabular-nums`; chips/panels are flat (`.glass-card` = flat panel, per #1216); `MoversStrip` is already a real-data headline FX metric strip. No mesh/serif/scrolly. Forcing the shared `StatCounter` over the working `MoversStrip` would be churn — left as-is.
 - [ ] DigiChat full token adoption (#240)
 
 ### Phase E — Additional primitives & content-gated integration


### PR DESCRIPTION
Fixes #1217

**Audit-and-close.** twelve-x already embodies the xAI utility aesthetic the AC asks for:
- **Mono uppercase headers**: `ConsensusDataTable`, `IntelligenceTab`, `MoversStrip` use `uppercase tracking-wider` label styling; metrics render `font-mono tabular-nums`.
- **Flat chips/pills**: `.glass-card` is a flat panel (confirmed #1216); no filled glass chips.
- **Headline FX metric strip**: `MoversStrip` already is one (real movers data, mono tabular values, uppercase label).
- No mesh / serif / scroll storytelling; tab bar unchanged.

The only literal gap is the *shared* `StatCounter` primitive vs the bespoke `MoversStrip` — but MoversStrip is the working, real-data equivalent, so swapping it would be churn/regression risk for no visual gain.

Deliverable: EVOLUTION.md Phase D updated with the audit finding (docs-only; no visual change). Gates: score 10/10/10/10 · doc-links OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)