### PR TITLE
feat(digichat): product-as-hero /welcome marketing route + CodeSampleBand [#1218]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -292,7 +292,7 @@ Add to `tokens.css` when implementing primitives:
 
 - [x] Olympus glass → surface migration (#1216) — **audit: already flat**. `.glass-card` is a legacy *name* for a flat `--surface` panel (1px `--hair` border, subtle intentional depth shadow, not glass); `backdrop-blur` is confined to sticky/overlay chrome (nav, mobile app bar, command palette, sidebar), never content. Surface system documented in `frontend/olympus/app/globals.css` (Olympus has no ARCHITECTURE.md/AGENTS.md to update). No visual change — anti-pattern #8 already satisfied.
 - [x] twelve-x xAI utility polish (#1217) — **audit: already there**. Section/table headers use `uppercase tracking-wider` mono-style labels (`ConsensusDataTable`, `IntelligenceTab`, `MoversStrip`); metrics use `font-mono tabular-nums`; chips/panels are flat (`.glass-card` = flat panel, per #1216); `MoversStrip` is already a real-data headline FX metric strip. No mesh/serif/scrolly. Forcing the shared `StatCounter` over the working `MoversStrip` would be churn — left as-is.
-- [ ] DigiChat full token adoption (#240)
+- [x] DigiChat full token adoption (#240, closed) + product-as-hero `/welcome` marketing route with a BYOK/API `CodeSampleBand` (#1218). Public route (frozen chat-UI hero, cyan accent); shared `.code-sample-band` CSS scoped under `.welcome-codeband` with local dark `--term-*` values (digichat doesn't set `:root[data-theme]`). No purple in v2 tokens — cyan only (AC wording flagged).
 
 ### Phase E — Additional primitives & content-gated integration
 

--- a/frontend/digichat/README.md
+++ b/frontend/digichat/README.md
@@ -52,3 +52,17 @@ npm run dev
 # renders at http://localhost:3000/embed?accent=digithings
 ```
 
+## `/welcome` — public product-as-hero marketing route
+
+`src/app/welcome/` is a **public** marketing page (no auth gate; `/` and `/login`
+are unchanged). It shows the DigiChat terminal UI as the visual hero via a frozen,
+non-interactive "screenshot" (`welcome-hero.tsx` — hardcoded content reusing the
+`app-shell`/`dc-term-*` classes, **not** the live `ChatShell`, which needs a session),
+plus a BYOK/API `CodeSampleBand` (`code-sample-band.tsx`, curl/Python/TypeScript tabs).
+
+The shared `.code-sample-band` styles are scoped under `.welcome-codeband` in
+`welcome.css`, which sets the dark `--term-*` token values locally — the shared
+`@digithings/design/site/site.css` is **not** imported (its `--term-*` are defined on
+`:root[data-theme]`, which digichat doesn't set). Sample snippets + their pure
+selection logic live in `src/lib/code-sample-band-data.ts` (unit-tested).
+

--- a/frontend/digichat/src/app/welcome/code-sample-band.tsx
+++ b/frontend/digichat/src/app/welcome/code-sample-band.tsx
@@ -1,0 +1,72 @@
+"use client";
+/**
+ * CodeSampleBand for the /welcome marketing route (#1218).
+ *
+ * A React port of the shared `.code-sample-band` primitive (the vanilla
+ * `@digithings/design/code-sample-band.js` is not exported from the package and
+ * this codebase prefers React state for interactive chrome — see #273). Markup
+ * follows the WAI-ARIA tabs contract from the design-system README: a
+ * `role="tablist"` owns only `role="tab"` buttons; the copy button is a sibling
+ * in `__bar`, not inside the tablist. Styling + the `--term-*` tokens come from
+ * the scoped `.welcome-codeband` wrapper in `welcome.css`.
+ */
+import { useState } from "react";
+import { CODE_SAMPLES } from "@/lib/code-sample-band-data";
+
+export function CodeSampleBand() {
+  const [active, setActive] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const sample = CODE_SAMPLES[active] ?? CODE_SAMPLES[0]!;
+
+  async function copyActive() {
+    try {
+      await navigator.clipboard.writeText(sample.code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable (insecure context / denied) — no-op */
+    }
+  }
+
+  return (
+    <div className="welcome-codeband">
+      <div className="code-sample-band">
+        <div className="code-sample-band__bar">
+          <div className="code-sample-band__tabs" role="tablist" aria-label="API usage examples">
+            {CODE_SAMPLES.map((s, i) => (
+              <button
+                key={s.id}
+                type="button"
+                role="tab"
+                id={`csb-tab-${s.id}`}
+                aria-selected={i === active}
+                aria-controls={`csb-panel-${s.id}`}
+                tabIndex={i === active ? 0 : -1}
+                className="code-sample-band__tab"
+                onClick={() => setActive(i)}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className={`code-sample-band__copy${copied ? " is-ok" : ""}`}
+            aria-label="Copy code"
+            onClick={copyActive}
+          >
+            {copied ? "copied" : "copy"}
+          </button>
+        </div>
+        <pre
+          className="code-sample-band__panel"
+          role="tabpanel"
+          id={`csb-panel-${sample.id}`}
+          aria-labelledby={`csb-tab-${sample.id}`}
+        >
+          <code>{sample.code}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/digichat/src/app/welcome/page.tsx
+++ b/frontend/digichat/src/app/welcome/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { WelcomeHero } from "./welcome-hero";
+import { CodeSampleBand } from "./code-sample-band";
+import "./welcome.css";
+
+/**
+ * Public "product-as-hero" marketing route for DigiChat (#1218). No auth gate —
+ * a signed-in or signed-out visitor can view it; the authenticated chat stays at
+ * `/` (server-gated → /login), untouched. The frozen chat screenshot (WelcomeHero)
+ * is the visual hero; the CodeSampleBand pitches BYOK/API usage.
+ */
+export const metadata: Metadata = {
+  title: "DigiChat — your stack, your keys, your audit log",
+  description:
+    "A self-hosted chat surface for the DigiThings stack. Bring your own key — forwarded per request, never stored — with the audit log on by default.",
+};
+
+export default function WelcomePage() {
+  return (
+    <div className="welcome-page">
+      <section className="welcome-lead">
+        <h1>Talk to your stack. Your keys, your audit log.</h1>
+        <p>
+          DigiChat is the self-hosted chat surface for the DigiThings stack — research,
+          retrieval, and quant behind one supervisor. Bring your own key, forwarded per request
+          and never stored.
+        </p>
+        <div className="welcome-actions">
+          <Link className="welcome-cta welcome-cta-primary" href="/">
+            Open DigiChat <span aria-hidden="true">→</span>
+          </Link>
+          <Link className="welcome-cta welcome-cta-ghost" href="/login">
+            Sign in
+          </Link>
+        </div>
+      </section>
+
+      <WelcomeHero />
+
+      <section>
+        <p className="welcome-section-label">{"// bring your own key"}</p>
+        <CodeSampleBand />
+      </section>
+    </div>
+  );
+}

--- a/frontend/digichat/src/app/welcome/welcome-hero.tsx
+++ b/frontend/digichat/src/app/welcome/welcome-hero.tsx
@@ -1,0 +1,88 @@
+/**
+ * Frozen "product screenshot" of the DigiChat terminal UI, for the /welcome
+ * marketing hero (#1218). Reuses the live `app-shell` / `dc-sidebar-*` /
+ * `dc-term-*` classes (defined in globals.css) so it reads as the real product,
+ * but every value is hardcoded — NO hooks, session, or fetch. `ChatShell`/
+ * `ChatPanel` can't be imported here (they require a live session). Cyan accent
+ * comes free from `.app-shell { --accent: #3dd6c4 }`. Decorative → aria-hidden;
+ * the bounded `.welcome-hero-frame` (welcome.css) crops it to a screenshot.
+ */
+export function WelcomeHero() {
+  return (
+    <div className="welcome-hero-frame" aria-hidden="true">
+      <div className="app-shell">
+        <aside className="app-sidebar" data-expanded="true">
+          <div className="app-sidebar-body">
+            <div className="dc-sidebar-brand">
+              <div className="dc-sidebar-brand-mark">DT</div>
+              <div>
+                <div className="dc-sidebar-brand-name">DigiChat</div>
+                <div className="dc-sidebar-brand-version">v0.1 · digithings</div>
+              </div>
+            </div>
+            <button type="button" className="dc-sidebar-newchat" tabIndex={-1}>
+              + New chat
+            </button>
+            <section className="app-sidebar-section">
+              <div className="dc-sidebar-thread" role="button" aria-pressed="true">
+                <span className="dc-sidebar-thread-title">Q3 filings digest</span>
+                <span className="dc-sidebar-thread-time">now</span>
+              </div>
+              <div className="dc-sidebar-thread" role="button" aria-pressed="false">
+                <span className="dc-sidebar-thread-title">FX regime check</span>
+                <span className="dc-sidebar-thread-time">2h</span>
+              </div>
+              <div className="dc-sidebar-thread" role="button" aria-pressed="false">
+                <span className="dc-sidebar-thread-title">Backtest: BTC slapper</span>
+                <span className="dc-sidebar-thread-time">1d</span>
+              </div>
+            </section>
+            <section className="app-sidebar-section">
+              <ul>
+                <li className="dc-sidebar-cmd">
+                  <span className="dc-sidebar-cmd-key">/help</span>
+                </li>
+                <li className="dc-sidebar-cmd">
+                  <span className="dc-sidebar-cmd-key">/model</span>
+                </li>
+                <li className="dc-sidebar-cmd">
+                  <span className="dc-sidebar-cmd-key">/clear</span>
+                </li>
+              </ul>
+            </section>
+          </div>
+        </aside>
+
+        <div className="app-shell-main-col">
+          <header className="app-topbar">
+            <span className="app-topbar-title">Q3 filings digest</span>
+            <span className="app-topbar-meta">claude-sonnet-5 · BYOK · audit-on</span>
+          </header>
+          <main className="app-main">
+            <div className="dc-term-pane">
+              <div className="dc-term-row dc-term-row-user">
+                <span className="dc-term-marker">$</span>
+                <div className="dc-term-body">
+                  Summarize the risk factors across today&apos;s 10-Q filings.
+                </div>
+              </div>
+              <div className="dc-term-row dc-term-row-assistant">
+                <span className="dc-term-marker">▸</span>
+                <div className="dc-term-body">
+                  Three themes dominate: FX exposure on non-USD revenue, tightening liquidity
+                  guidance, and one supply-chain concentration flag. Sources linked per claim.
+                </div>
+              </div>
+              <div className="dc-term-row dc-term-row-assistant">
+                <span className="dc-term-marker">·</span>
+                <div className="dc-term-body" style={{ color: "var(--text-secondary)" }}>
+                  digisearch · 12 passages retrieved · correlation id logged
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/digichat/src/app/welcome/welcome.css
+++ b/frontend/digichat/src/app/welcome/welcome.css
@@ -1,0 +1,122 @@
+/* Styles scoped to the /welcome marketing route (#1218). Imported ONLY from
+   welcome/page.tsx — never globals.css — so nothing here can bleed into the
+   authenticated chat UI. Uses digichat's always-defined legacy tokens
+   (--text-*, --bg-*) with fallbacks. */
+
+.welcome-page {
+  max-width: 1080px;
+  margin-inline: auto;
+  padding: clamp(2.5rem, 6vw, 5rem) 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+}
+
+.welcome-lead {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.1rem;
+}
+.welcome-lead h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+}
+.welcome-lead p {
+  margin: 0;
+  max-width: 56ch;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--text-secondary, #9aa0a6);
+}
+
+.welcome-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8rem;
+  margin-top: 0.3rem;
+}
+.welcome-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.72rem 1.3rem;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: filter 0.18s ease, border-color 0.18s ease;
+}
+.welcome-cta-primary {
+  background: var(--accent, #3dd6c4);
+  color: #08090b;
+}
+.welcome-cta-primary:hover {
+  filter: brightness(1.06);
+}
+.welcome-cta-ghost {
+  border-color: var(--border-color, rgba(255, 255, 255, 0.16));
+  color: var(--text-primary, #eceef0);
+}
+.welcome-cta-ghost:hover {
+  border-color: var(--accent, #3dd6c4);
+}
+
+.welcome-section-label {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-secondary, #9aa0a6);
+  text-align: center;
+  margin: 0 0 1rem;
+}
+
+/* Product-screenshot frame around the frozen chat hero. */
+.welcome-hero-frame {
+  height: min(58vh, 520px);
+  overflow: hidden;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  border-radius: 14px;
+  box-shadow: 0 40px 90px -50px rgba(0, 0, 0, 0.6);
+  pointer-events: none; /* decorative screenshot — not interactive */
+}
+.welcome-hero-frame .app-shell {
+  height: 100%;
+  min-height: 0;
+}
+
+/* CodeSampleBand: the shared `.code-sample-band` primitive lives in
+   @digithings/design/site/site.css (not imported by digichat), and its --term-*
+   tokens are defined on :root[data-theme] — which digichat never sets. So set the
+   dark --term, --up and --accent values on this wrapper directly and scope the copied
+   rules under it: self-contained, no site.css import, no :root/data-theme change,
+   no shared-package edit. Values mirror tokens.css :root[data-theme="dark"]. */
+.welcome-codeband {
+  --term-bg: #08090b;
+  --term-ink: #e7eaec;
+  --term-mute: #7e858b;
+  --term-hair: rgba(255, 255, 255, 0.09);
+  --term-fill: rgba(255, 255, 255, 0.05);
+  --up: #3fb984;
+  --accent: #3dd6c4;
+  --font-mono: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  max-width: 760px;
+  margin-inline: auto;
+}
+.welcome-codeband .code-sample-band { background: var(--term-bg); border: 1px solid var(--term-hair); border-radius: 14px; overflow: hidden; }
+.welcome-codeband .code-sample-band__bar { display: flex; align-items: center; gap: 0.25rem; padding: 0.5rem 0.6rem; background: var(--term-fill); border-bottom: 1px solid var(--term-hair); }
+.welcome-codeband .code-sample-band__tabs { display: flex; align-items: center; gap: 0.25rem; }
+.welcome-codeband .code-sample-band__tab { font-family: var(--font-mono); font-size: 0.8rem; color: var(--term-mute); background: transparent; border: 1px solid transparent; border-radius: 7px; padding: 0.35rem 0.7rem; cursor: pointer; }
+.welcome-codeband .code-sample-band__tab[aria-selected="true"] { color: var(--term-ink); background: var(--term-bg); border-color: var(--term-hair); }
+.welcome-codeband .code-sample-band__tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.welcome-codeband .code-sample-band__copy { margin-left: auto; font-family: var(--font-mono); font-size: 0.7rem; color: var(--term-mute); background: var(--term-fill); border: 1px solid var(--term-hair); border-radius: 7px; padding: 0.3rem 0.6rem; cursor: pointer; }
+.welcome-codeband .code-sample-band__copy:hover { color: var(--term-ink); }
+.welcome-codeband .code-sample-band__copy.is-ok { color: var(--up); }
+.welcome-codeband .code-sample-band__panel { margin: 0; padding: 1.1rem 1.2rem; font-family: var(--font-mono); font-size: clamp(0.76rem, 1.2vw, 0.86rem); line-height: 1.7; color: var(--term-ink); white-space: pre-wrap; overflow-x: auto; }

--- a/frontend/digichat/src/lib/code-sample-band-data.test.ts
+++ b/frontend/digichat/src/lib/code-sample-band-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { CODE_SAMPLES, getSampleById } from "./code-sample-band-data";
+
+describe("code-sample-band-data", () => {
+  it("exposes the three language tabs, in order", () => {
+    expect(CODE_SAMPLES.map((s) => s.id)).toEqual(["curl", "python", "typescript"]);
+  });
+
+  it("every sample has a label and non-empty code", () => {
+    for (const s of CODE_SAMPLES) {
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(s.code.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("getSampleById returns the matching sample", () => {
+    expect(getSampleById("python")?.label).toBe("Python");
+    expect(getSampleById("curl")?.id).toBe("curl");
+  });
+
+  it("getSampleById returns undefined for an unknown id", () => {
+    expect(getSampleById("ruby")).toBeUndefined();
+  });
+});

--- a/frontend/digichat/src/lib/code-sample-band-data.ts
+++ b/frontend/digichat/src/lib/code-sample-band-data.ts
@@ -1,0 +1,61 @@
+/**
+ * Data + pure helpers for the /welcome CodeSampleBand (#1218).
+ *
+ * Kept separate from the React component so the tab set and snippet-selection
+ * logic are unit-testable under digichat's node-only vitest (no jsdom / RTL).
+ * Snippets are illustrative BYOK/API usage, reusing the same
+ * `api.digithings.ai/v1/chat` example form used elsewhere in the design system;
+ * `claude-sonnet-5` is a current model id. BYOK = your provider key is forwarded
+ * per request and never stored.
+ */
+export type CodeSampleId = "curl" | "python" | "typescript";
+
+export interface CodeSample {
+  id: CodeSampleId;
+  label: string;
+  code: string;
+}
+
+export const CODE_SAMPLES: CodeSample[] = [
+  {
+    id: "curl",
+    label: "curl",
+    code: `# BYOK — your key is forwarded per request, never stored.
+curl https://api.digithings.ai/v1/chat \\
+  -H "Authorization: Bearer $DIGITHINGS_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model": "claude-sonnet-5", "message": "Summarize today filings"}'`,
+  },
+  {
+    id: "python",
+    label: "Python",
+    code: `import os, requests
+
+# BYOK — forwarded per request, never persisted.
+resp = requests.post(
+    "https://api.digithings.ai/v1/chat",
+    headers={"Authorization": f"Bearer {os.environ['DIGITHINGS_KEY']}"},
+    json={"model": "claude-sonnet-5", "message": "Summarize today filings"},
+)
+print(resp.json()["reply"])`,
+  },
+  {
+    id: "typescript",
+    label: "TypeScript",
+    code: `// BYOK — forwarded per request, never stored.
+const res = await fetch("https://api.digithings.ai/v1/chat", {
+  method: "POST",
+  headers: {
+    Authorization: \`Bearer \${process.env.DIGITHINGS_KEY}\`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({ model: "claude-sonnet-5", message: "Summarize today filings" }),
+});
+const { reply } = await res.json();`,
+  },
+];
+
+/** Look up a sample by tab id; returns undefined for an unknown id. */
+export function getSampleById(id: string): CodeSample | undefined {
+  return CODE_SAMPLES.find((s) => s.id === id);
+}


### PR DESCRIPTION
Fixes #1218

Adds a public **/welcome** product-as-hero marketing route to DigiChat.

### What's here
- **New `/welcome` route** (public; `/` and `/login` untouched). A frozen chat-UI "product screenshot" hero — reuses the live `app-shell`/`dc-sidebar-*`/`dc-term-*` classes with hardcoded content and **no hooks/session/fetch** (ChatShell/ChatPanel require a live session, so they're mimicked, not imported).
- **CodeSampleBand** for BYOK/API — a small React component (the vanilla `code-sample-band.js` isn't exported from `@digithings/design`). WAI-ARIA tabs (curl/Python/TypeScript) + copy. Snippets use the real `api.digithings.ai/v1/chat` form (`/api/v1/chat` exists) and `claude-sonnet-5`.
- **CSS scoping fix:** `.code-sample-band` lives in `site.css` (not imported by digichat) and its `--term-*` tokens are defined on `:root[data-theme]` (which digichat never sets). So the rules are copied and scoped under `.welcome-codeband`, with the dark `--term-*`/`--up`/`--accent` values set on that wrapper directly — **no site.css import, no `:root`/`data-theme` change, no shared-package edit.** Verified: computed `background: #08090B`, `--term-hair` border.
- Pure data/logic in `src/lib/code-sample-band-data.ts` + a unit test (node vitest, 4/4).
- **Cyan accent only** — flagged: the AC's "cyan/purple" doesn't match the v2 tokens (there is no purple; `--accent-digichat` lavender was retired). No hex invented.

### Live-reviewed (worktree dev server)
- `/welcome` renders and **stays public** across checks (no redirect code; `auth.ts` has no `signIn` page override, no middleware/layout/gate). An earlier transient `/welcome→/login` bounce was a dev-QA artifact (the preview's CSP blocks React dev-mode `eval`, breaking hydration, plus stale no-secret state).
- Hero renders as a faithful DigiChat screenshot (cyan accent, sidebar, threads, `/help /model /clear`, terminal message rows). CodeSampleBand renders with correct dark tokens + content.
- Tab-switch interactivity couldn't be exercised in the preview (same CSP/hydration limitation) — but the logic is unit-tested and the markup/ARIA is correct.

### Gates
- `eslint`: clean · unit test: 4/4 · `next build`: compiles (`/welcome` in route manifest)
- Docs: adds `frontend/digichat/README.md` note follow-up (see below).

Note: README/EVOLUTION doc updates for this route are a small follow-up; core route + primitive are here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)