### PR TITLE
fix(digiquant-web): gate DqNav portal on mount to fix hydration mismatch

### DIFF
--- a/frontend/digiquant-web/components/landing/DqNav.tsx
+++ b/frontend/digiquant-web/components/landing/DqNav.tsx
@@ -4,12 +4,17 @@
  * Wide: brand · inline links · theme + GitHub.
  * Narrow: brand · theme + GitHub + hamburger — links + Olympus CTA live in a full-height sheet.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import Link from "next/link";
 import { ThemeToggle } from "@digithings/web";
 import { Brand, DQ_NAV_PRIMARY } from "@/app/_nav";
 import { OlympusMark } from "./OlympusMark";
+
+// Mount gate: server + first (hydration) client render read `false`; the client
+// re-reads `true` post-hydration. Keeps the portal out of the SSR/hydration tree
+// so it can't cause a mismatch — without a setState-in-effect cascade.
+const emptySubscribe = () => () => {};
 
 function GitHubGlyph() {
   return (
@@ -47,7 +52,11 @@ function NavLinks({
 export function DqNav() {
   const navRef = useRef<HTMLElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
-  const portalReady = typeof window !== "undefined";
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -84,7 +93,7 @@ export function DqNav() {
   }, [menuOpen, closeMenu]);
 
   const menuOverlay =
-    portalReady &&
+    mounted &&
     createPortal(
       <>
         <div


### PR DESCRIPTION
## Summary

`DqNav` (digiquant.io top nav) is a structural twin of `DigiNav` and carried the
**identical** hydration mismatch that #1291 fixed for digithings.ai. Its
`createPortal` overlay was gated by a render-body `typeof window !== "undefined"`
check — on the client's first (hydration) render `window` is already defined, so
it portaled `.dqnav-backdrop` + `.dqnav-sheet` into `document.body` (DOM the server
never emitted) → React hydration mismatch on **every digiquant.io page load**.

Replaced it with the same `useSyncExternalStore` mount-gate #1291 uses: server and
first client render both read `false` (no overlay → matches SSR), then the client
re-reads `true` post-hydration and mounts the portal with no diff. Open / Escape /
backdrop handlers are unchanged — only *when* the portal first mounts changed.

## Audit — swept every `createPortal` across the frontends

While reconciling #1291 I checked all four `createPortal` call sites; this was the
**last** unfixed instance:

| Call site | Gating | Status |
|-----------|--------|--------|
| `digithings-web/DigiNav.tsx` | `useSyncExternalStore` mount-gate | fixed (#1291) ✅ |
| `olympus/sidebar-settings.tsx` | `useClientMounted()` | already correct ✅ |
| `olympus/subpage-tab-bar.tsx` | `open` state (starts `false`) | no mismatch ✅ |
| `digiquant-web/DqNav.tsx` | render-body `typeof window` | **this fix** ❌→✅ |

## Verification

- `make score` (`scripts/score.py --staged`) → **10/10** Security / Quality / Optimization / Accuracy.
- `eslint components/landing/DqNav.tsx` → clean.
- `npm run build --workspace frontend/digiquant-web` → all 12 routes prerender.
- SSR HTML emits **0** `.dqnav-backdrop` (the `aria-controls="dqnav-sheet"` on the
  hamburger button remains — that's the button, not the portal).
- Client console after load: no "Hydration failed", DevTools + `[HMR] connected` only.

Fixes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
