### PR TITLE
feat(design): ClosingCtaBand primitive (.closing-cta) [#1222]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -297,7 +297,7 @@ Add to `tokens.css` when implementing primitives:
 ### Phase E — Additional primitives & content-gated integration
 
 - [x] `HorizontalScrollBand` primitive (`.h-scroll`) — #1221
-- [ ] `ClosingCtaBand` primitive — #1222
+- [x] `ClosingCtaBand` primitive (`.closing-cta`) — #1222. CSS-only centered pre-footer band (headline + primary `.btn` + optional mono secondary), `--section-y`/`--wrap-wide`, composes with `.reveal-up`. Copy slots + digithings/digiquant variants documented in `site/README.md`; smoke demo added. Landing wiring is #1227.
 - [ ] `FaqAccordion` + `PricingMatrix` primitives — #1223
 - [ ] `HeroFeaturePicker` primitive — #1224
 - [ ] `AnnouncementBar` primitive (content-gated) — #1225

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -8,7 +8,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
 **StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
-**HorizontalScrollBand**, `.principles`, and `.footer*`. Terminal-CLI /
+**HorizontalScrollBand**, **ClosingCtaBand**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -324,3 +324,52 @@ CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
 Content wiring (real changelog/testimonial data) is out of scope here — this
 primitive owns only the scroll/snap/masking contract, same division as
 TrustStrip and ChangelogBand.
+
+## `ClosingCtaBand` (CSS-only, EVOLUTION.md Phase E)
+
+Graphite/Cursor **pre-footer conversion band** — a full-width centered section
+placed directly above the footer: one literal headline, one primary `.btn`, and
+an optional mono secondary link. Compose with `.reveal-up` (above) for a
+scroll-in enter; reduced motion is already honored by the shared block. Copy
+tone follows [`../references/scans/copy-patterns.md`](../references/scans/copy-patterns.md)
+(literal verbs, no hype). Landing-page wiring is [#1227](https://github.com/digithings-ai/digithings/issues/1227) — this primitive owns only the markup/CSS contract.
+
+```html
+<section class="closing-cta reveal-up">
+  <div class="closing-cta__inner">
+    <h2 class="closing-cta__title">Build your agent stack in the open.</h2>
+    <p class="closing-cta__sub">Open-core orchestration, quant, RAG, and chat.</p>
+    <div class="closing-cta__actions">
+      <a class="btn btn-primary" href="https://github.com/digithings-ai">Start building</a>
+      <a class="closing-cta__secondary" href="/architecture">Read the architecture <span aria-hidden="true">&rarr;</span></a>
+    </div>
+  </div>
+</section>
+```
+
+**Copy slots** (fill from the consuming app; keep labels literal):
+
+| Slot | Content | Notes |
+|------|---------|-------|
+| `.closing-cta__title` | Headline | Literal, reads best ≤ ~20ch. |
+| `.closing-cta__sub` | Optional one-line support | ≤ ~48ch; omit for a bare title. |
+| `.closing-cta__actions` → `.btn.btn-primary` | Primary label + `href` | The single, literal action (e.g. "Start building", "Open Olympus"). |
+| `.closing-cta__secondary` | Optional secondary label + `href` | Mono, arrow-suffix; the `span[aria-hidden]` translates on hover, matching `.btn`/`.bento__cta`. |
+
+**Copy variants** (shown in `frontend/design/smoke/index.html`):
+
+| Surface | Title | Primary | Secondary |
+|---------|-------|---------|-----------|
+| digithings.ai | "Build your agent stack in the open." | Start building | Read the architecture → |
+| digiquant.io | "One graph, research to execution." | Open Olympus | Browse strategies → |
+
+| Class | Role |
+|-------|------|
+| `.closing-cta` | Full-width band — `padding-block: var(--section-y)`, centered text. |
+| `.closing-cta__inner` | `max-width: var(--wrap-wide)` centered column (title / sub / actions), gap-stacked. |
+| `.closing-cta__title` | Clamped display headline, `max-width: 20ch`. |
+| `.closing-cta__sub` | Muted one-line support, `max-width: 48ch`. |
+| `.closing-cta__actions` | Wrapping, centered row of the primary `.btn` + optional secondary. |
+| `.closing-cta__secondary` | Mono arrow-suffix link; hover tints `--ink` and nudges the arrow. |
+
+CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -245,6 +245,27 @@ a { color: inherit; text-decoration: none; }
   .h-scroll__card { min-width: 0; max-width: none; }
 }
 
+/* ── closing CTA band (Graphite/Cursor pre-footer conversion) ───────────
+   Full-width centered band placed directly above the footer: one headline,
+   one literal primary .btn, and an optional mono secondary link. Compose
+   with .reveal-up (above) for a scroll-in enter — reduced-motion is already
+   honored there. Copy slots (see site/README.md for digithings + digiquant
+   variants and references/scans/copy-patterns.md for tone):
+     .closing-cta__title      headline — literal, ≤ ~20ch reads best
+     .closing-cta__sub        optional one-line support — ≤ ~48ch
+     .closing-cta__actions    primary:  <a class="btn btn-primary" href>label</a>
+     .closing-cta__secondary  optional: <a href>label <span aria-hidden>&rarr;</span></a>
+   ───────────────────────────────────────────────────────────────────── */
+.closing-cta { padding-block: var(--section-y); text-align: center; }
+.closing-cta__inner { max-width: var(--wrap-wide); margin-inline: auto; display: flex; flex-direction: column; align-items: center; gap: 1.1rem; }
+.closing-cta__title { font-size: clamp(1.8rem, 4vw, 2.75rem); font-weight: 600; letter-spacing: -0.03em; line-height: 1.1; max-width: 20ch; }
+.closing-cta__sub { font-size: 1rem; color: var(--ink-soft); max-width: 48ch; line-height: 1.6; }
+.closing-cta__actions { display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 1rem; margin-top: 0.4rem; }
+.closing-cta__secondary { display: inline-flex; align-items: center; gap: 0.4rem; font-family: var(--font-mono); font-size: 0.88rem; color: var(--ink-soft); }
+.closing-cta__secondary:hover { color: var(--ink); }
+.closing-cta__secondary span[aria-hidden] { transition: transform var(--duration-hover) var(--ease-glide); }
+.closing-cta__secondary:hover span[aria-hidden] { transform: translateX(3px); }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -293,6 +293,30 @@ await client.chat.send("hello");</code></pre>
     </div>
   </section>
 
+  <section class="smoke-section site-demo">
+    <div class="label">closing-cta — pre-footer conversion band; two copy variants (digithings / digiquant); scroll down for the .reveal-up enter</div>
+    <div class="closing-cta reveal-up">
+      <div class="closing-cta__inner">
+        <h2 class="closing-cta__title">Build your agent stack in the open.</h2>
+        <p class="closing-cta__sub">Open-core orchestration, quant, RAG, and chat — self-hosted or bring your own key.</p>
+        <div class="closing-cta__actions">
+          <a class="btn btn-primary" href="#" onclick="return false;">Start building</a>
+          <a class="closing-cta__secondary" href="#" onclick="return false;">Read the architecture <span aria-hidden="true">&rarr;</span></a>
+        </div>
+      </div>
+    </div>
+    <div class="closing-cta reveal-up">
+      <div class="closing-cta__inner">
+        <h2 class="closing-cta__title">One graph, research to execution.</h2>
+        <p class="closing-cta__sub">Backtest, optimize, and route strategies on NautilusTrader with Atlas and Hermes.</p>
+        <div class="closing-cta__actions">
+          <a class="btn btn-primary" href="#" onclick="return false;">Open Olympus</a>
+          <a class="closing-cta__secondary" href="#" onclick="return false;">Browse strategies <span aria-hidden="true">&rarr;</span></a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <script type="module">
     import { initDiagram } from '../living-architecture/index.js';
     import { initTerminal } from '../terminal/index.js';


### PR DESCRIPTION
## Summary

Adds the shared **`ClosingCtaBand`** primitive (`.closing-cta`) — a Graphite/Cursor
**pre-footer conversion band**: centered headline + one literal primary `.btn` +
optional mono secondary link. Phase E, epic #1200.

- **CSS-only**, in `frontend/design/site/site.css` (consumed by digithings.ai and
  digiquant.io via `@import "@digithings/design/site/site.css"`).
- Uses `--section-y` rhythm and the `--wrap-wide` container; composes with
  `.reveal-up` for a scroll-in enter (reduced motion already honored by the shared block).
- **Copy slots documented** (headline / sub / primary label+href / secondary
  label+href) in the site.css header comment and `site/README.md`, with
  **digithings + digiquant copy variants**.
- **Smoke demo** added to `frontend/design/smoke/index.html` (both variants, `.reveal-up`).

## Acceptance criteria

- [x] CSS `.closing-cta` — centered h2 + `.btn` primary + optional secondary link
- [x] Uses `--section-y` rhythm and `--wrap-wide` container
- [x] Copy slots documented (headline, primary label+href, secondary label+href)
- [x] `reveal-up` enter on scroll (respects reduced motion via the shared block)
- [x] Demo in smoke page with digithings + digiquant copy variants
- [x] Document in `frontend/design/site/README.md`

**Note on the COPY_GUIDE.md ACs:** `frontend/design/COPY_GUIDE.md` does not exist
on `module/website`, so the "reference primitive in COPY_GUIDE.md" doc item is
satisfied in `site/README.md` instead (with a tone pointer to the existing
`references/scans/copy-patterns.md`). Flagging rather than fabricating the file.

## Verification

- `scripts/check_doc_links.py` → OK (212 files).
- `scripts/score.py --staged` → **10/10** Security / Quality / Optimization / Accuracy.
- `npm run build` → **both** digithings-web and digiquant-web build clean.
- Smoke page (static preview): computed styles correct — `padding-block` = `--section-y`
  (64px floor), title clamp → 1.8rem/600/-0.03em, `max-width` 20ch, `--ink` color,
  `.closing-cta__actions` `display:flex; justify-content:center`; both variants render.
  (A pixel screenshot wasn't meaningful — this preview window reports a 0-width
  viewport — so verification is via resolved computed styles + structure.)

## Out of scope

- Landing-page wiring (#1227) — this PR ships the primitive + demo + docs only.

Fixes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
