### PR TITLE
feat(design): FaqAccordion + PricingMatrix primitives [#1223]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -298,7 +298,7 @@ Add to `tokens.css` when implementing primitives:
 
 - [x] `HorizontalScrollBand` primitive (`.h-scroll`) — #1221
 - [x] `ClosingCtaBand` primitive (`.closing-cta`) — #1222. CSS-only centered pre-footer band (headline + primary `.btn` + optional mono secondary), `--section-y`/`--wrap-wide`, composes with `.reveal-up`. Copy slots + digithings/digiquant variants documented in `site/README.md`; smoke demo added. Landing wiring is #1227.
-- [ ] `FaqAccordion` + `PricingMatrix` primitives — #1223
+- [x] `FaqAccordion` + `PricingMatrix` primitives — #1223. FAQ = native `<details>`/`<summary>` (`.faq`/`.faq__item`/`.faq__q`/`.faq__a`), shared `name` → exclusive accordion, CSS chevron (reduced-motion safe). Pricing = `.pricing` grid + `.pricing__tier` (3 honest open-core tiers, featured variant) + optional `.pricing-table` (✓/— cells). Content shapes + smoke demo + `site/README.md` documented; honest-copy policy (no fake usage caps).
 - [ ] `HeroFeaturePicker` primitive — #1224
 - [ ] `AnnouncementBar` primitive (content-gated) — #1225
 - [ ] digiquant.io pricing FAQ + tier matrix — #1226

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -8,7 +8,8 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 (`.term*`/`.tl-*`, consumed by `frontend/web/src/components/Terminal.tsx`),
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
 **StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
-**HorizontalScrollBand**, **ClosingCtaBand**, `.principles`, and `.footer*`. Terminal-CLI /
+**HorizontalScrollBand**, **ClosingCtaBand**, **FaqAccordion**, **PricingMatrix**,
+`.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -371,5 +372,82 @@ tone follows [`../references/scans/copy-patterns.md`](../references/scans/copy-p
 | `.closing-cta__sub` | Muted one-line support, `max-width: 48ch`. |
 | `.closing-cta__actions` | Wrapping, centered row of the primary `.btn` + optional secondary. |
 | `.closing-cta__secondary` | Mono arrow-suffix link; hover tints `--ink` and nudges the arrow. |
+
+CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `FaqAccordion` (CSS-only, EVOLUTION.md Phase E)
+
+Graphite/Cursor pricing-page Q&A built on **native `<details>`/`<summary>`** — no
+JS. Give every `.faq__item` the **same `name`** to get a native "one open at a
+time" exclusive accordion (a modern-browser feature); omit `name` and each item
+toggles independently. The disclosure chevron rotates on `[open]`; its transition
+is dropped under `prefers-reduced-motion: reduce` (shared block). Keyboard access
+is native (`Tab` to the summary, `Enter`/`Space` to toggle).
+
+**Content shape** for a data-driven render (per site): `{ q, a }[]`.
+
+```html
+<div class="faq">
+  <details class="faq__item" name="pricing-faq" open>
+    <summary class="faq__q">Is DigiThings really open source?</summary>
+    <p class="faq__a">Yes — the core stack is MIT-licensed and self-hostable.</p>
+  </details>
+  <details class="faq__item" name="pricing-faq">
+    <summary class="faq__q">Do I need to bring my own model keys?</summary>
+    <p class="faq__a">For self-hosting, yes — any LiteLLM provider or a local model.</p>
+  </details>
+</div>
+```
+
+| Class | Role |
+|-------|------|
+| `.faq` | Column container, `max-width: 760px` for readable line length. |
+| `.faq__item` | One `<details>`; hairline divider below. Same `name` across items → exclusive accordion. |
+| `.faq__q` | The `<summary>` — flex row (label + chevron), default marker removed, `:focus-visible` ring. Rotating CSS chevron via `::after`. |
+| `.faq__a` | Answer body, `max-width: 60ch`, muted. |
+
+CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `PricingMatrix` (CSS-only, EVOLUTION.md Phase E)
+
+Open-core pricing tiers + optional comparison table. **Honest-copy policy**
+(EVOLUTION.md §10, anti-pattern #2): no invented usage caps or fake "limited AI
+requests" — the free self-hosted tier is genuinely the full MIT stack. Three
+tiers: **Self-hosted (MIT)** · **Managed (future)** · **Enterprise (contact)**.
+`.pricing__tier--featured` lifts one card with an `--accent` ring.
+
+**Content shape** (per site): `{ name, price, cadence?, desc, features: string[], cta: { label, href }, featured?: boolean }[]`.
+
+```html
+<div class="pricing">
+  <div class="pricing__tier">
+    <div class="pricing__name">Self-hosted</div>
+    <div class="pricing__price">Free <small>· MIT</small></div>
+    <p class="pricing__desc">Run the full stack on your own infrastructure.</p>
+    <ul class="pricing__features"><li>All core services</li><li>Bring your own key</li></ul>
+    <div class="pricing__cta"><a class="btn btn-ghost" href="/docs">Read the docs</a></div>
+  </div>
+  <div class="pricing__tier pricing__tier--featured"><!-- Managed --></div>
+  <div class="pricing__tier"><!-- Enterprise --></div>
+</div>
+
+<!-- optional feature × tier comparison -->
+<table class="pricing-table">
+  <thead><tr><th>Feature</th><th>Self-hosted</th><th>Managed</th><th>Enterprise</th></tr></thead>
+  <tbody>
+    <tr><th scope="row">Core services</th><td class="is-yes">✓</td><td class="is-yes">✓</td><td class="is-yes">✓</td></tr>
+    <tr><th scope="row">Managed upgrades</th><td class="is-no">—</td><td class="is-yes">✓</td><td class="is-yes">✓</td></tr>
+  </tbody>
+</table>
+```
+
+| Class | Role |
+|-------|------|
+| `.pricing` | Grid — 1 column below 768px, `repeat(3, 1fr)` at `min-width: 768px`; `max-width: var(--wrap-wide)`. |
+| `.pricing__tier` | Flat `--surface` card; `.pricing__cta .btn` pins to the bottom, full-width. |
+| `.pricing__tier--featured` | Highlighted tier — `--accent` border + ring. |
+| `.pricing__name` / `.pricing__price` / `.pricing__desc` | Mono tier label, display price (`<small>` for cadence/licence), muted blurb. |
+| `.pricing__features` | Check-bulleted list — `✓` in `--up` via `::before`. |
+| `.pricing-table` | Optional comparison grid; `.is-yes` (`--up`) / `.is-no` (`--ink-mute`) cells; first column left-aligned, tier columns centered. |
 
 CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -266,6 +266,55 @@ a { color: inherit; text-decoration: none; }
 .closing-cta__secondary span[aria-hidden] { transition: transform var(--duration-hover) var(--ease-glide); }
 .closing-cta__secondary:hover span[aria-hidden] { transform: translateX(3px); }
 
+/* ── FAQ accordion (Graphite/Cursor pricing-page Q&A) ───────────────────
+   Native <details>/<summary> — no JS. For an exclusive "one open at a time"
+   accordion, give every .faq__item the same name attribute
+   (<details class="faq__item" name="pricing-faq">) — a modern-browser native
+   exclusive-accordion feature; omit name and each item toggles independently.
+   The disclosure chevron rotates on [open]; its transition is dropped under
+   reduced motion (shared block below). Data-driven content shape (per site):
+   { q, a }[] — see site/README.md.
+   ───────────────────────────────────────────────────────────────────── */
+.faq { max-width: 760px; width: 100%; margin-inline: auto; }
+.faq__item { border-bottom: 1px solid var(--hair); }
+.faq__q { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1.15rem 0; font-size: 1rem; font-weight: 500; color: var(--ink); cursor: pointer; list-style: none; }
+.faq__q::-webkit-details-marker { display: none; }
+.faq__q::after { content: ""; flex: 0 0 auto; width: 0.55rem; height: 0.55rem; border-right: 1.5px solid var(--ink-mute); border-bottom: 1.5px solid var(--ink-mute); transform: rotate(45deg); transition: transform var(--duration-hover) var(--ease-glide); }
+.faq__item[open] .faq__q::after { transform: rotate(-135deg); }
+.faq__q:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: var(--r-sm); }
+.faq__a { max-width: 60ch; margin: 0; padding: 0 0 1.25rem; color: var(--ink-soft); font-size: 0.95rem; line-height: 1.6; }
+
+/* ── pricing matrix (open-core tiers + optional comparison table) ───────
+   3 honest open-core tiers — no invented usage caps or fake "limited AI
+   requests" (EVOLUTION.md §10, anti-pattern #2). Tier content shape (per
+   site): { name, price, cadence?, desc, features: string[], cta: {label, href},
+   featured?: bool }[] — see site/README.md. .pricing__tier--featured lifts one
+   card with an --accent ring. The optional .pricing-table gives a feature ×
+   tier comparison grid with ✓ (--up) / — (--ink-mute) cells.
+   ───────────────────────────────────────────────────────────────────── */
+.pricing { display: grid; grid-template-columns: 1fr; gap: 1.25rem; width: 100%; max-width: var(--wrap-wide); margin-inline: auto; }
+.pricing__tier { display: flex; flex-direction: column; gap: 0.9rem; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); padding: 1.75rem; }
+.pricing__tier--featured { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.pricing__name { font-family: var(--font-mono); font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
+.pricing__price { font-size: clamp(1.6rem, 3vw, 2.1rem); font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; }
+.pricing__price small { font-size: 0.9rem; font-weight: 400; color: var(--ink-mute); letter-spacing: 0; }
+.pricing__desc { font-size: 0.9rem; color: var(--ink-soft); line-height: 1.55; }
+.pricing__features { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; font-size: 0.9rem; color: var(--ink-soft); }
+.pricing__features li { display: flex; align-items: flex-start; gap: 0.55rem; }
+.pricing__features li::before { content: "✓"; flex: 0 0 auto; color: var(--up); font-weight: 600; line-height: 1.4; }
+.pricing__cta { margin-top: auto; }
+.pricing__cta .btn { width: 100%; justify-content: center; }
+@media (min-width: 768px) {
+  .pricing { grid-template-columns: repeat(3, 1fr); }
+}
+.pricing-table { width: 100%; max-width: var(--wrap-wide); margin-inline: auto; border-collapse: collapse; font-size: 0.9rem; }
+.pricing-table th, .pricing-table td { padding: 0.8rem 1rem; text-align: left; border-bottom: 1px solid var(--hair); }
+.pricing-table thead th { font-family: var(--font-mono); font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); font-weight: 500; }
+.pricing-table th + th, .pricing-table td + td { text-align: center; }
+.pricing-table tbody th { font-weight: 500; color: var(--ink); }
+.pricing-table .is-yes { color: var(--up); font-weight: 600; }
+.pricing-table .is-no { color: var(--ink-mute); }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }
@@ -293,5 +342,6 @@ a { color: inherit; text-decoration: none; }
   .glow { animation: none; }
   .term-cursor { animation: none; }
   .reveal-up { opacity: 1 !important; transform: none !important; transition: none !important; }
+  .faq__q::after { transition: none; }
   * { scroll-behavior: auto !important; }
 }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -294,6 +294,73 @@ await client.chat.send("hello");</code></pre>
   </section>
 
   <section class="smoke-section site-demo">
+    <div class="label">faq — native &lt;details&gt;/&lt;summary&gt; accordion; shared name="" = one open at a time; Tab + Enter/Space</div>
+    <div class="faq">
+      <details class="faq__item" name="smoke-faq" open>
+        <summary class="faq__q">Is DigiThings really open source?</summary>
+        <p class="faq__a">Yes — the core stack is MIT-licensed and self-hostable. Every service (orchestration, quant, RAG, chat) runs on your own infrastructure with your own keys.</p>
+      </details>
+      <details class="faq__item" name="smoke-faq">
+        <summary class="faq__q">Do I need to bring my own model keys?</summary>
+        <p class="faq__a">For self-hosting, yes — point the stack at any LiteLLM-supported provider or a local model. A managed option is planned.</p>
+      </details>
+      <details class="faq__item" name="smoke-faq">
+        <summary class="faq__q">Can I use it for live trading?</summary>
+        <p class="faq__a">Backtest and research paths are open. Live-trading paths require explicit configuration and human approval — they are never enabled by default.</p>
+      </details>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
+    <div class="label">pricing — 3 open-core tiers (honest copy, no fake usage caps); middle tier featured; + comparison table</div>
+    <div class="pricing">
+      <div class="pricing__tier">
+        <div class="pricing__name">Self-hosted</div>
+        <div class="pricing__price">Free <small>· MIT</small></div>
+        <p class="pricing__desc">Run the full stack on your own infrastructure with your own model keys.</p>
+        <ul class="pricing__features">
+          <li>All core services</li>
+          <li>Bring your own key</li>
+          <li>Community support</li>
+        </ul>
+        <div class="pricing__cta"><a class="btn btn-ghost" href="#" onclick="return false;">Read the docs</a></div>
+      </div>
+      <div class="pricing__tier pricing__tier--featured">
+        <div class="pricing__name">Managed</div>
+        <div class="pricing__price">Coming soon</div>
+        <p class="pricing__desc">Hosted DigiThings with managed upgrades and observability. In development.</p>
+        <ul class="pricing__features">
+          <li>Everything in Self-hosted</li>
+          <li>Managed upgrades</li>
+          <li>Hosted tracing (DigiSmith)</li>
+        </ul>
+        <div class="pricing__cta"><a class="btn btn-primary" href="#" onclick="return false;">Join the waitlist</a></div>
+      </div>
+      <div class="pricing__tier">
+        <div class="pricing__name">Enterprise</div>
+        <div class="pricing__price">Contact</div>
+        <p class="pricing__desc">Custom deployment, SLAs, and support for regulated environments.</p>
+        <ul class="pricing__features">
+          <li>Everything in Managed</li>
+          <li>SLA + priority support</li>
+          <li>Deployment assistance</li>
+        </ul>
+        <div class="pricing__cta"><a class="btn btn-ghost" href="#" onclick="return false;">Contact us</a></div>
+      </div>
+    </div>
+    <table class="pricing-table" style="margin-top: var(--space-4);">
+      <thead>
+        <tr><th scope="col">Feature</th><th scope="col">Self-hosted</th><th scope="col">Managed</th><th scope="col">Enterprise</th></tr>
+      </thead>
+      <tbody>
+        <tr><th scope="row">Core services</th><td class="is-yes">✓</td><td class="is-yes">✓</td><td class="is-yes">✓</td></tr>
+        <tr><th scope="row">Managed upgrades</th><td class="is-no">—</td><td class="is-yes">✓</td><td class="is-yes">✓</td></tr>
+        <tr><th scope="row">SLA + priority support</th><td class="is-no">—</td><td class="is-no">—</td><td class="is-yes">✓</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="smoke-section site-demo">
     <div class="label">closing-cta — pre-footer conversion band; two copy variants (digithings / digiquant); scroll down for the .reveal-up enter</div>
     <div class="closing-cta reveal-up">
       <div class="closing-cta__inner">


### PR DESCRIPTION
## Summary

Adds two shared Phase E primitives (epic #1200) for the digiquant.io pricing page
pattern — both **CSS-only**, in `frontend/design/site/site.css`:

**`FaqAccordion` (`.faq`)** — native `<details>`/`<summary>`, no JS. Every
`.faq__item` sharing the same `name` yields a native **one-open-at-a-time**
exclusive accordion; the CSS disclosure chevron rotates on `[open]` (transition
dropped under `prefers-reduced-motion`). Keyboard access is native.

**`PricingMatrix` (`.pricing`)** — responsive tier grid (1 col mobile → 3 from
768px), flat `--surface` `.pricing__tier` cards, a `--featured` accent-ring
variant, check-bulleted feature lists (`✓` in `--up`), plus an optional
`.pricing-table` feature × tier comparison (`.is-yes`/`.is-no`). **Honest
open-core copy** — three real tiers (Self-hosted MIT · Managed future ·
Enterprise contact), no invented usage caps (anti-pattern #2).

## Acceptance criteria

- [x] `.faq` > `.faq__item` with `<details>`/`<summary>` — one open at a time (native `name`)
- [x] `.pricing` grid + `.pricing__tier` cards (3 tiers)
- [x] Optional comparison table rows with ✓ checkmarks
- [x] Open-core honest copy — no fake "limited AI requests"
- [x] JSON content shape documented for FAQ + tiers (`site/README.md`)
- [x] `prefers-reduced-motion` respected on expand/collapse (chevron transition dropped)
- [x] Demo in smoke page (exclusive FAQ + 3-tier pricing + comparison table)
- [x] Document in `frontend/design/site/README.md`

**Note on the COPY_GUIDE.md §8 AC:** `frontend/design/COPY_GUIDE.md` does not
exist on `module/website`, so pricing voice is documented in `site/README.md`
(honest-copy policy) — flagging rather than fabricating the file.

## Verification

- `scripts/check_doc_links.py` → OK (212 files).
- `scripts/score.py --staged` → **10/10** all dimensions.
- `npm run build` → **both** digiquant-web and digithings-web build clean.
- Smoke page (static preview): exclusive accordion confirmed (opening item 2
  auto-closes item 1), default marker removed + chevron rendered; 3 tiers with 1
  featured; feature `✓` and table `.is-yes` both resolve to `--up`
  (`rgb(63,185,132)`); comparison table renders 3 rows.

## Out of scope

- digiquant.io landing wiring (#1226) — this PR ships the primitives + demo + docs.

Fixes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
