### PR TITLE
feat(design): HeroFeaturePicker primitive (.hero-picker + hero-picker.js) [#1224]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -299,7 +299,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `HorizontalScrollBand` primitive (`.h-scroll`) — #1221
 - [x] `ClosingCtaBand` primitive (`.closing-cta`) — #1222. CSS-only centered pre-footer band (headline + primary `.btn` + optional mono secondary), `--section-y`/`--wrap-wide`, composes with `.reveal-up`. Copy slots + digithings/digiquant variants documented in `site/README.md`; smoke demo added. Landing wiring is #1227.
 - [x] `FaqAccordion` + `PricingMatrix` primitives — #1223. FAQ = native `<details>`/`<summary>` (`.faq`/`.faq__item`/`.faq__q`/`.faq__a`), shared `name` → exclusive accordion, CSS chevron (reduced-motion safe). Pricing = `.pricing` grid + `.pricing__tier` (3 honest open-core tiers, featured variant) + optional `.pricing-table` (✓/— cells). Content shapes + smoke demo + `site/README.md` documented; honest-copy policy (no fake usage caps).
-- [ ] `HeroFeaturePicker` primitive — #1224
+- [x] `HeroFeaturePicker` primitive (`.hero-picker` + `hero-picker.js`) — #1224. WAI-ARIA icon-tab row (53×53px) swapping `.hero-picker__panel` ProductFrame previews; roving tabindex (←/→/Home/End), `aria-controls`/`aria-selected`, static crops only. Smoke demo (Olympus · Strategies · Pipeline) + `site/README.md`. React hero wiring is a follow-up (#1213).
 - [ ] `AnnouncementBar` primitive (content-gated) — #1225
 - [ ] digiquant.io pricing FAQ + tier matrix — #1226
 - [ ] both landings closing CTA wiring — #1227

--- a/frontend/design/hero-picker.js
+++ b/frontend/design/hero-picker.js
@@ -1,0 +1,59 @@
+/**
+ * DigiThings hero-picker — accessible icon-tab row that swaps a ProductFrame
+ * preview below the hero (Graphite "feature picker" pattern; WAI-ARIA "Tabs
+ * with Automatic Activation").
+ *
+ * Markup contract: a `.hero-picker` containing one `[role="tablist"]` of
+ * `[role="tab"]` icon buttons (each `aria-controls` -> a panel id) and matching
+ * `[role="tabpanel"]` `.hero-picker__panel` regions (each typically wrapping a
+ * `.product-frame`). The active tab gets `aria-selected="true"` + `tabindex 0`;
+ * inactive panels get the `hidden` attribute.
+ *
+ * Usage:
+ *   import { initHeroPicker } from './hero-picker.js';
+ *   initHeroPicker({ selector: '.hero-picker' });
+ *
+ * Keyboard: ArrowLeft/ArrowRight move focus and activate (roving tabindex),
+ * Home/End jump to the first/last tab — same model as code-sample-band.js.
+ */
+export function initHeroPicker({ selector = '.hero-picker' } = {}) {
+  const pickers = document.querySelectorAll(selector);
+
+  pickers.forEach((root) => {
+    const tabs = Array.from(root.querySelectorAll('[role="tab"]'));
+    if (!tabs.length) return;
+    const panels = tabs.map((tab) => document.getElementById(tab.getAttribute('aria-controls')));
+
+    const activate = (index, focus = true) => {
+      tabs.forEach((tab, i) => {
+        const active = i === index;
+        tab.setAttribute('aria-selected', String(active));
+        tab.tabIndex = active ? 0 : -1;
+        if (panels[i]) panels[i].hidden = !active;
+      });
+      if (focus) tabs[index].focus();
+    };
+
+    tabs.forEach((tab, i) => {
+      tab.addEventListener('click', () => activate(i));
+      tab.addEventListener('keydown', (e) => {
+        let next = null;
+        if (e.key === 'ArrowRight') next = (i + 1) % tabs.length;
+        else if (e.key === 'ArrowLeft') next = (i - 1 + tabs.length) % tabs.length;
+        else if (e.key === 'Home') next = 0;
+        else if (e.key === 'End') next = tabs.length - 1;
+        if (next !== null) {
+          e.preventDefault();
+          activate(next);
+        }
+      });
+    });
+
+    // Normalize from the tab marked aria-selected (default first) without
+    // stealing focus on page load.
+    const initial = tabs.findIndex((t) => t.getAttribute('aria-selected') === 'true');
+    activate(initial >= 0 ? initial : 0, false);
+  });
+
+  return { stop() {} };
+}

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -9,7 +9,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
 **StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
 **HorizontalScrollBand**, **ClosingCtaBand**, **FaqAccordion**, **PricingMatrix**,
-`.principles`, and `.footer*`. Terminal-CLI /
+**HeroFeaturePicker**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -451,3 +451,56 @@ tiers: **Self-hosted (MIT)** · **Managed (future)** · **Enterprise (contact)**
 | `.pricing-table` | Optional comparison grid; `.is-yes` (`--up`) / `.is-no` (`--ink-mute`) cells; first column left-aligned, tier columns centered. |
 
 CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `HeroFeaturePicker` (CSS + `hero-picker.js`, EVOLUTION.md Phase E)
+
+Graphite-style **icon-tab row** below the hero that swaps which `ProductFrame`
+(#1202) preview shows — e.g. Olympus / Strategies / Pipeline on digiquant.io.
+**Static UI crops only** (no video swap — lighter weight per the design spec).
+Follows the WAI-ARIA "Tabs" pattern; each panel wraps a `.product-frame`, so it
+inherits the container-query sizing and never clips at browser zoom. Tabs are
+icon-only (`~53×53px`, Graphite reference) — give each an `aria-label`.
+
+```html
+<div class="hero-picker">
+  <div class="hero-picker__tabs" role="tablist" aria-label="Preview context">
+    <button class="hero-picker__tab" role="tab" id="hp-tab-olympus"
+            aria-controls="hp-panel-olympus" aria-selected="true" aria-label="Olympus">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><!-- icon --></svg>
+    </button>
+    <button class="hero-picker__tab" role="tab" id="hp-tab-strategies"
+            aria-controls="hp-panel-strategies" aria-selected="false" tabindex="-1" aria-label="Strategies">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><!-- icon --></svg>
+    </button>
+  </div>
+  <div class="hero-picker__panels">
+    <div class="hero-picker__panel" role="tabpanel" id="hp-panel-olympus" aria-labelledby="hp-tab-olympus">
+      <div class="product-frame"><div class="product-frame__surface"><!-- Olympus crop --></div></div>
+    </div>
+    <div class="hero-picker__panel" role="tabpanel" id="hp-panel-strategies" aria-labelledby="hp-tab-strategies" hidden>
+      <div class="product-frame"><div class="product-frame__surface"><!-- Strategies crop --></div></div>
+    </div>
+  </div>
+</div>
+```
+
+```js
+import { initHeroPicker } from '../hero-picker.js';
+initHeroPicker(); // wires every .hero-picker on the page
+```
+
+| Class | Role |
+|-------|------|
+| `.hero-picker` | Centered column — icon tablist above, swapped panels below. |
+| `.hero-picker__tabs` | `role="tablist"` row of icon buttons. |
+| `.hero-picker__tab` | `role="tab"` icon button, `53×53px`; `[aria-selected="true"]` tints `--accent`; `:focus-visible` ring. Icon-only → needs `aria-label`. |
+| `.hero-picker__panels` / `.hero-picker__panel` | `role="tabpanel"` regions; inactive ones carry the `hidden` attribute. Each wraps a `.product-frame`. |
+
+`hero-picker.js`'s `initHeroPicker()` wires click + keyboard (`ArrowLeft`/`ArrowRight`/
+`Home`/`End`, roving `tabindex`) on every `[role="tab"]`, toggling the matching
+`[role="tabpanel"]`'s `hidden` — the same tab model as `code-sample-band.js`. It
+normalizes the initial state from the `aria-selected` tab without stealing focus
+on load. No network calls, pure DOM. `prefers-reduced-motion` needs no special
+handling — the swap is an instant `hidden` toggle, not an animation.
+
+CSS-only styling, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -315,6 +315,24 @@ a { color: inherit; text-decoration: none; }
 .pricing-table .is-yes { color: var(--up); font-weight: 600; }
 .pricing-table .is-no { color: var(--ink-mute); }
 
+/* ── hero feature picker (Graphite icon-tab row swapping a ProductFrame) ─
+   Icon tablist below the hero that swaps which ProductFrame preview shows
+   (e.g. Olympus / Strategies / Pipeline). WAI-ARIA tabs — wire with
+   hero-picker.js (roving tabindex, ArrowLeft/Right/Home/End). Static UI crops
+   only (no video). Each panel wraps a .product-frame, so it inherits the
+   CQ-scaled sizing and never clips at browser zoom. Icon buttons are ~53×53px
+   (Graphite reference); use aria-label per button since they are icon-only.
+   ───────────────────────────────────────────────────────────────────── */
+.hero-picker { display: flex; flex-direction: column; align-items: center; gap: 1.5rem; width: 100%; }
+.hero-picker__tabs { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.6rem; }
+.hero-picker__tab { display: inline-flex; align-items: center; justify-content: center; width: 53px; height: 53px; padding: 0; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-md); color: var(--ink-soft); cursor: pointer; transition: color var(--duration-hover) var(--ease-glide), border-color var(--duration-hover) var(--ease-glide); }
+.hero-picker__tab:hover { color: var(--ink); border-color: var(--hair-2); }
+.hero-picker__tab[aria-selected="true"] { color: var(--accent); border-color: var(--accent); }
+.hero-picker__tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.hero-picker__tab svg { width: 22px; height: 22px; }
+.hero-picker__panels { width: 100%; display: flex; justify-content: center; }
+.hero-picker__panel[hidden] { display: none; }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -294,6 +294,58 @@ await client.chat.send("hello");</code></pre>
   </section>
 
   <section class="smoke-section site-demo">
+    <div class="label">hero-picker — icon tabs swap the ProductFrame preview; click or focus + &larr;/&rarr;/Home/End; aria-controls panels</div>
+    <div class="hero-picker">
+      <div class="hero-picker__tabs" role="tablist" aria-label="Preview context">
+        <button class="hero-picker__tab" role="tab" id="hp-tab-olympus" aria-controls="hp-panel-olympus" aria-selected="true" aria-label="Olympus dashboard">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+        </button>
+        <button class="hero-picker__tab" role="tab" id="hp-tab-strategies" aria-controls="hp-panel-strategies" aria-selected="false" tabindex="-1" aria-label="Strategies">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4v16h16"/><path d="M7 15l3.5-4 3 2.5L20 7"/></svg>
+        </button>
+        <button class="hero-picker__tab" role="tab" id="hp-tab-pipeline" aria-controls="hp-panel-pipeline" aria-selected="false" tabindex="-1" aria-label="Pipeline">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="5" cy="12" r="2.4"/><circle cx="19" cy="6" r="2.4"/><circle cx="19" cy="18" r="2.4"/><path d="M7.2 11l9.6-4.2M7.2 13l9.6 4.2"/></svg>
+        </button>
+      </div>
+      <div class="hero-picker__panels">
+        <div class="hero-picker__panel" role="tabpanel" id="hp-panel-olympus" aria-labelledby="hp-tab-olympus">
+          <div class="product-frame">
+            <div class="product-frame__surface">
+              <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.6em; border-bottom:1px solid var(--hair); margin-bottom:0.6em;">
+                <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--accent); display:inline-block;"></span>
+                <strong>olympus · portfolio</strong>
+              </div>
+              <code style="font-family:var(--font-mono);">exposure · pnl · signals</code>
+            </div>
+          </div>
+        </div>
+        <div class="hero-picker__panel" role="tabpanel" id="hp-panel-strategies" aria-labelledby="hp-tab-strategies" hidden>
+          <div class="product-frame">
+            <div class="product-frame__surface">
+              <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.6em; border-bottom:1px solid var(--hair); margin-bottom:0.6em;">
+                <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--up); display:inline-block;"></span>
+                <strong>strategies · tearsheet</strong>
+              </div>
+              <code style="font-family:var(--font-mono);">sharpe · drawdown · turnover</code>
+            </div>
+          </div>
+        </div>
+        <div class="hero-picker__panel" role="tabpanel" id="hp-panel-pipeline" aria-labelledby="hp-tab-pipeline" hidden>
+          <div class="product-frame">
+            <div class="product-frame__surface">
+              <div style="display:flex; align-items:center; gap:0.6em; padding-bottom:0.6em; border-bottom:1px solid var(--hair); margin-bottom:0.6em;">
+                <span style="width:0.7em; height:0.7em; border-radius:50%; background:var(--accent-digiquant); display:inline-block;"></span>
+                <strong>pipeline · run</strong>
+              </div>
+              <code style="font-family:var(--font-mono);">atlas.route -&gt; hermes.plan -&gt; execute</code>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
     <div class="label">faq — native &lt;details&gt;/&lt;summary&gt; accordion; shared name="" = one open at a time; Tab + Enter/Space</div>
     <div class="faq">
       <details class="faq__item" name="smoke-faq" open>
@@ -394,6 +446,7 @@ await client.chat.send("hello");</code></pre>
     import { initScrollTrigger } from '../scroll-trigger.js';
     import { escapeHtml } from '../html-escape.js';
     import { initCodeSampleBand } from '../code-sample-band.js';
+    import { initHeroPicker } from '../hero-picker.js';
 
     // Theme toggle for the site.css (Phase B) demos below. site/theme.js was
     // removed in #1240 (dead in production — apps use React ThemeProvider
@@ -484,6 +537,9 @@ await client.chat.send("hello");</code></pre>
 
     // code-sample-band: WAI-ARIA tabs + copy-to-clipboard
     initCodeSampleBand();
+
+    // hero-picker: icon tabs swap the ProductFrame preview panel
+    initHeroPicker();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds the shared **`HeroFeaturePicker`** primitive (`.hero-picker` + `hero-picker.js`),
Phase E, epic #1200 — a Graphite-style icon-tab row below the hero that swaps
which `ProductFrame` (#1202) preview shows (e.g. Olympus / Strategies / Pipeline
on digiquant.io). **Static UI crops only** (no video swap — lighter per spec).

- **CSS** in `frontend/design/site/site.css`: `.hero-picker__tab` icon buttons
  `~53×53px` (Graphite reference), `[aria-selected="true"]` tints `--accent`,
  `:focus-visible` ring; `.hero-picker__panel` regions wrap a `.product-frame` so
  they inherit its container-query sizing and never clip at browser zoom.
- **`hero-picker.js`**: WAI-ARIA tabs, roving tabindex (`ArrowLeft/Right/Home/End`
  + click), toggles panel `hidden`; mirrors `code-sample-band.js`'s model.
  Normalizes initial state from `aria-selected` without stealing focus on load.

## Acceptance criteria

- [x] CSS `.hero-picker` > buttons with `[aria-selected]` + panel region for swapping frame children
- [x] Icon buttons `~53×53px` (Graphite reference)
- [x] Static UI crops only — no video swap
- [x] Keyboard accessible: arrow keys / Home / End; `aria-controls` on panels
- [x] 3 tabs in demo: Olympus · Strategies · Pipeline
- [x] Integrates with `ProductFrame` (#1202) — panels wrap `.product-frame`, CQ-scaled, no zoom clipping
- [x] Document in `frontend/design/site/README.md` + `EVOLUTION.md`

## Verification

- `scripts/check_doc_links.py` → OK. `scripts/score.py --staged` → **10/10**.
- `npm run build` → **both** digiquant-web and digithings-web build clean.
- Smoke page (static preview): 3 tabs at exactly `53×53`; clicking a tab flips
  `aria-selected`, roving `tabindex` (`0`/`-1`), and panel `hidden` correctly;
  `aria-controls` → panel ids all match; the load-settled selected tab computes
  `border`/`color` = `--accent` (`rgb(61,214,196)`). *(A read taken immediately
  after `.click()` returns the transition start frame — measured the settled tab
  instead.)*

## Out of scope

- React digiquant hero wiring (#1213) — this PR ships the primitive + demo + docs.

Fixes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
