### PR TITLE
feat(design): TrustStrip integration-logo variant (.trust-strip--logos) [#1229]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -303,7 +303,7 @@ Add to `tokens.css` when implementing primitives:
 - [x] `AnnouncementBar` primitive (content-gated) — #1225. 48px full-width `.announcement` bar + `announcement.js`; renders only for enabled content (empty/`{enabled:false}` → nothing, so OFF by default), stretched-link when `href` set (scheme-guarded), dismiss persists per-`id` in localStorage, escaped text. No animation (reduced-motion safe). `announcement-example.json` shape + smoke demo + `site/README.md` (enable procedure). React landing wiring deferred (content-driven).
 - [ ] digiquant.io pricing FAQ + tier matrix — #1226
 - [ ] both landings closing CTA wiring — #1227
-- [ ] `TrustStrip` integration logo variant — #1229
+- [x] `TrustStrip` integration logo variant (`.trust-strip--logos`) — #1229. x.ai-style integration-mark row (real stack: NautilusTrader · LangGraph · LiteLLM · Polars), grayscale/muted default → color on hover, composes on the base strip. Smoke demo (text wordmarks; production uses real logo `<img>` + `alt`) + `site/README.md`. No stock/fabricated logos.
 - [ ] `CaseStudyCard` primitive (P3, content-gated) — #1230
 - [ ] Olympus status dot → DigiSmith (P3) — #1231
 

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -119,6 +119,28 @@ Cursor-style hero trust line — a muted row of proof items, text or logos.
 | `.trust-strip` | Centered, wrapping flex row. |
 | `.trust-strip__item` | Text item (mono, `--ink-mute`) or `<img>` logo (28px height, grayscale + reduced opacity for visual parity across mixed-brand logos). |
 
+### `--logos` integration variant (EVOLUTION.md Phase E, #1229)
+
+`.trust-strip--logos` turns the strip into an x.ai-style **integration mark row**
+for the real stack (NautilusTrader · LangGraph · LiteLLM · Polars). Marks are
+muted/grayscale by default and lift to full color on hover; it composes on top of
+the base `.trust-strip` and coexists with the text friction variant. **Real
+integrations only — no stock/generic or fabricated customer logos.**
+
+```html
+<div class="trust-strip trust-strip--logos">
+  <span class="trust-strip__item"><img src="/logos/nautilustrader.svg" alt="NautilusTrader" /></span>
+  <span class="trust-strip__item"><img src="/logos/langgraph.svg" alt="LangGraph" /></span>
+  <!-- decorative-only marks use alt="" -->
+</div>
+```
+
+Wrap each logo as `<span class="trust-strip__item"><img alt="…"></span>` so the
+base `.trust-strip__item img` sizing (28px) applies; give every logo real `alt`
+text (or `alt=""` when purely decorative). The smoke page demos the layout with
+the four integration **names as text wordmarks** — production drops in the real
+logo assets. Contrast holds in both themes (grayscale marks over `--surface`).
+
 ## `reveal-up` (CSS-only utility, EVOLUTION.md Phase B)
 
 Opacity + translate enter animation. **This is not the old `site/reveal.js`**

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -147,6 +147,16 @@ a { color: inherit; text-decoration: none; }
 .trust-strip { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: clamp(1.25rem, 4vw, 2.5rem); }
 .trust-strip__item { display: inline-flex; align-items: center; font-family: var(--font-mono); font-size: 0.85rem; color: var(--ink-mute); }
 .trust-strip__item img { height: 28px; width: auto; max-width: 140px; filter: grayscale(1); opacity: 0.7; }
+/* --logos: integration-mark row (x.ai partner-mark pattern, #1229). Real
+   integrations only — no stock/generic logos. Marks are muted/grayscale by
+   default and lift to full color on hover; wrap each logo as
+   <span class="trust-strip__item"><img alt="Name"></span> (decorative-only
+   logos use alt=""). Works alongside the base text friction variant. */
+.trust-strip--logos { gap: clamp(1.5rem, 4vw, 2.75rem); }
+.trust-strip--logos .trust-strip__item { font-size: 0.95rem; color: var(--ink-soft); }
+.trust-strip--logos .trust-strip__item img { transition: filter var(--duration-hover) var(--ease-glide), opacity var(--duration-hover) var(--ease-glide); }
+.trust-strip--logos .trust-strip__item:hover { color: var(--ink); }
+.trust-strip--logos .trust-strip__item:hover img { filter: grayscale(0); opacity: 1; }
 
 /* ── reveal-up (scroll-triggered enter) ────────────────────────────────
    CSS-only: owns the two visual states only. Trigger it either with

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -159,6 +159,16 @@
   </section>
 
   <section class="smoke-section site-demo">
+    <div class="label">trust-strip--logos — real integration marks; text wordmarks here (production uses real logo &lt;img&gt; with alt); muted default, hover to color</div>
+    <div class="trust-strip trust-strip--logos">
+      <span class="trust-strip__item">NautilusTrader</span>
+      <span class="trust-strip__item">LangGraph</span>
+      <span class="trust-strip__item">LiteLLM</span>
+      <span class="trust-strip__item">Polars</span>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
     <div class="label">reveal-up — scroll down; driven by scroll-trigger.js's activateSelector (toggles .active)</div>
     <div style="height:50vh; display:grid; place-items:center; color:var(--ink-mute); font-family:var(--font-mono); font-size:0.85rem;">scroll &darr;</div>
     <div class="reveal-up" style="padding:1.5rem; border:1px solid var(--hair); border-radius:var(--r-lg); background:var(--surface);">


### PR DESCRIPTION
## Summary

Extends **`TrustStrip`** (#1204) with the **`.trust-strip--logos`** integration
variant (Phase E, epic #1200) — an x.ai-style partner-mark row for the **real
stack** (NautilusTrader · LangGraph · LiteLLM · Polars). Marks are muted/grayscale
by default and lift to full color on hover; the variant composes on the base
`.trust-strip` and coexists with the text friction variant.

## Acceptance criteria

- [x] `.trust-strip--logos` — horizontal integration-logo row (~28px marks via base sizing), muted/grayscale default, hover color
- [x] Real integrations only — no stock/generic logos
- [x] Accessible: `alt` per logo; decorative-only logos use `alt=""` (documented)
- [x] Works alongside the text friction variant (`.trust-strip`)
- [x] Demo in smoke page with 4 integration marks
- [x] Document usage in `site/README.md`

**Notes:** `frontend/design/COPY_GUIDE.md` §10 doesn't exist on `module/website`,
so usage is documented in `site/README.md`. The smoke demo uses the four
integration **names as text wordmarks** (I won't fabricate or fetch brand SVGs);
production drops in real logo `<img>` assets — the README documents the
`<span class="trust-strip__item"><img alt="…"></span>` form so base 28px sizing applies.

## Verification

- `scripts/check_doc_links.py` → OK. `scripts/score.py --staged` → **10/10**.
- `npm run build` → **both** digithings-web and digiquant-web build clean.
- Smoke page (static preview): 4 real integration marks; the variant applies
  distinct styling — `--ink-soft` idle color (vs base `--ink-mute`) and `0.95rem`
  (vs base `0.85rem`) — while the base text strip is unchanged.

## Out of scope

- Fake enterprise customer logos; case-study quotes (#1230); digithings.ai wiring (C1 follow-up).

Fixes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
