### PR TITLE
feat(design): CaseStudyCard primitive (.case-study) [#1230]

### DIFF
--- a/frontend/design/EVOLUTION.md
+++ b/frontend/design/EVOLUTION.md
@@ -304,7 +304,7 @@ Add to `tokens.css` when implementing primitives:
 - [ ] digiquant.io pricing FAQ + tier matrix — #1226
 - [ ] both landings closing CTA wiring — #1227
 - [x] `TrustStrip` integration logo variant (`.trust-strip--logos`) — #1229. x.ai-style integration-mark row (real stack: NautilusTrader · LangGraph · LiteLLM · Polars), grayscale/muted default → color on hover, composes on the base strip. Smoke demo (text wordmarks; production uses real logo `<img>` + `alt`) + `site/README.md`. No stock/fabricated logos.
-- [ ] `CaseStudyCard` primitive (P3, content-gated) — #1230
+- [x] `CaseStudyCard` primitive (P3, content-gated) — #1230. `.case-study` flat card (`{org} × digithings` label, quote, attribution + optional logo), composes in bento/capability-grid/`.h-scroll`. Content-gated — ships dormant, `.case-study--example` watermark for demos only, real attribution required in production. Smoke demo (watermarked example row) + `site/README.md` content shape.
 - [ ] Olympus status dot → DigiSmith (P3) — #1231
 
 ---

--- a/frontend/design/site/README.md
+++ b/frontend/design/site/README.md
@@ -9,7 +9,7 @@ React components still reach for by class name: `.wrap`, `.brand*`, buttons,
 sections, **ProductFrame**, **BentoGrid**, **TrustStrip**, **reveal-up**,
 **StatCounter**, **ChangelogBand**, **CodeSampleBand**, **CapabilityCard**,
 **HorizontalScrollBand**, **ClosingCtaBand**, **FaqAccordion**, **PricingMatrix**,
-**HeroFeaturePicker**, **AnnouncementBar**, `.principles`, and `.footer*`. Terminal-CLI /
+**HeroFeaturePicker**, **AnnouncementBar**, **CaseStudyCard**, `.principles`, and `.footer*`. Terminal-CLI /
 utilitarian aesthetic, light **and** dark, reduced-motion safe. Consumes the
 `[data-theme]` semantic tokens in [`../tokens.css`](../tokens.css).
 
@@ -571,3 +571,40 @@ re-show the bar after users have dismissed a previous one.
 | `.announcement__dismiss` | Optional close button — sits above the overlay (`z-index`), persists dismissal by `id`. |
 
 CSS + `announcement.js`, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+
+## `CaseStudyCard` (CSS-only, EVOLUTION.md Phase E · P3)
+
+Graphite `{org} × product` social-proof card — a flat `--surface` panel (same
+sizing family as `.bento__cell`/`.capability-card`) with a mono `{org} × digithings`
+label, a quote, and an attribution row with an optional logo slot. Drop it into a
+`.bento`, `.capability-grid`, or an `.h-scroll` track (for a horizontal row).
+
+**Content-gated (anti-pattern #2 — no fabricated testimonials).** Ship dormant:
+no card renders until a real quote exists. **Production requires real attribution**
+— a name, title, company, or a public GitHub/OSS reference. Use
+`.case-study--example` for a watermarked placeholder in demos/docs **only**.
+
+**Content shape** (per site): `{ org, quote, name, title?, href?, logo? }`.
+
+```html
+<article class="case-study">
+  <div class="case-study__label">Acme × digithings</div>
+  <blockquote class="case-study__quote">A real, attributable quote.</blockquote>
+  <div class="case-study__attr">
+    <img class="case-study__logo" src="/logos/acme.svg" alt="Acme" />
+    <span><strong>Jane Dev</strong> · Staff Engineer, Acme</span>
+  </div>
+</article>
+```
+
+| Class | Role |
+|-------|------|
+| `.case-study` | Flat `--surface` card, `--hair` border, `--r-lg`; column layout, quote grows to push attribution to the bottom. |
+| `.case-study__label` | Mono `{org} × digithings` eyebrow. |
+| `.case-study__quote` | The quote (`<blockquote>`), `--ink`. |
+| `.case-study__attr` | Attribution row — name (`<strong>`) + title/company, optional `.case-study__logo`. |
+| `.case-study__logo` | Optional 24px grayscale logo (real assets only, with `alt`). |
+| `.case-study--example` | Adds an "EXAMPLE" watermark — demos/docs only, never production. |
+
+CSS-only, both themes. Same deferred-React-wrapper note as ProductFrame (#1195).
+**P3** — defer content until real quotes or OSS adopter stories exist.

--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -363,6 +363,24 @@ a { color: inherit; text-decoration: none; }
 .announcement__dismiss:hover { color: var(--ink); }
 .announcement__dismiss:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
+/* ── case-study card (Graphite {org} × product social proof) ────────────
+   Flat --surface card (same sizing family as .bento__cell / .capability-card):
+   a mono "{org} × digithings" label, a quote block, and an attribution row with
+   an optional logo slot. Drop into a .bento, .capability-grid, or an .h-scroll
+   track for a horizontal row. CONTENT-GATED (anti-pattern #2): ship dormant —
+   no fabricated testimonials. Real attribution required in production (name,
+   title, company, or a public GitHub/OSS reference). Add .case-study--example
+   for a watermarked placeholder in demos/docs only. Content shape (per site):
+   { org, quote, name, title?, href?, logo? } — see site/README.md.
+   ───────────────────────────────────────────────────────────────────── */
+.case-study { position: relative; display: flex; flex-direction: column; gap: 1rem; background: var(--surface); border: 1px solid var(--hair); border-radius: var(--r-lg); padding: 1.75rem; }
+.case-study__label { font-family: var(--font-mono); font-size: 0.78rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-mute); }
+.case-study__quote { margin: 0; font-size: 1.05rem; line-height: 1.55; color: var(--ink); }
+.case-study__attr { display: flex; align-items: center; gap: 0.6rem; margin-top: auto; font-size: 0.85rem; color: var(--ink-soft); }
+.case-study__attr strong { color: var(--ink); font-weight: 600; }
+.case-study__logo { height: 24px; width: auto; max-width: 120px; filter: grayscale(1); opacity: 0.8; }
+.case-study--example::after { content: "EXAMPLE"; position: absolute; top: 0.85rem; right: 0.85rem; font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.12em; color: var(--ink-mute); border: 1px solid var(--hair-2); border-radius: var(--r-sm); padding: 0.15rem 0.4rem; }
+
 /* ── principles ─────────────────────────────────────────────────────── */
 .principles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1.5rem; }
 .principle { padding-top: 1.4rem; border-top: 1px solid var(--hair-2); }

--- a/frontend/design/smoke/index.html
+++ b/frontend/design/smoke/index.html
@@ -428,6 +428,24 @@ await client.chat.send("hello");</code></pre>
   </section>
 
   <section class="smoke-section site-demo">
+    <div class="label">case-study — content-gated social-proof card (watermarked EXAMPLE; no real quotes shipped); shown in an h-scroll row</div>
+    <div class="h-scroll">
+      <div class="h-scroll__track" tabindex="0" role="group" aria-label="Example case studies">
+        <article class="h-scroll__card case-study case-study--example" style="min-width:320px; max-width:320px;">
+          <div class="case-study__label">Example org × digithings</div>
+          <blockquote class="case-study__quote">Placeholder quote — real attribution required before this ships. No fabricated testimonials.</blockquote>
+          <div class="case-study__attr"><strong>Example Maintainer</strong> · Example OSS project</div>
+        </article>
+        <article class="h-scroll__card case-study case-study--example" style="min-width:320px; max-width:320px;">
+          <div class="case-study__label">Example org × digithings</div>
+          <blockquote class="case-study__quote">Second placeholder card — production content comes from a real name, title, company, or public GitHub/OSS reference.</blockquote>
+          <div class="case-study__attr"><strong>Example Contributor</strong> · Example Labs</div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="smoke-section site-demo">
     <div class="label">closing-cta — pre-footer conversion band; two copy variants (digithings / digiquant); scroll down for the .reveal-up enter</div>
     <div class="closing-cta reveal-up">
       <div class="closing-cta__inner">


### PR DESCRIPTION
## Summary

Adds the shared **`CaseStudyCard`** primitive (`.case-study`), Phase E · P3, epic
#1200 — a Graphite `{org} × product` social-proof card: flat `--surface` panel
(same sizing family as `.bento__cell`/`.capability-card`) with a mono
`{org} × digithings` label, a quote block, and an attribution row with an optional
logo slot. Composes in a `.bento`, `.capability-grid`, or an `.h-scroll` track.

**Content-gated (anti-pattern #2 — no fabricated testimonials):** ships dormant,
no card until a real quote exists. Real attribution required in production
(name/title/company or a public GitHub/OSS reference). `.case-study--example`
adds an "EXAMPLE" watermark for demos/docs only.

## Acceptance criteria

- [x] CSS `.case-study` — `{org} × digithings` label, quote block, logo slot; bento-family sizing
- [x] Content-gated — no placeholder fake quotes; demo uses `.case-study--example` watermark only
- [x] Optional horizontal scroll via `HorizontalScrollBand` (`.h-scroll`) — demoed
- [x] Real attribution documented as a production requirement
- [x] Document content shape in `site/README.md`

**Note:** `frontend/design/COPY_GUIDE.md` §12 doesn't exist on `module/website`,
so the anti-pattern/attribution guidance is documented in `site/README.md`.

## Verification

- `scripts/check_doc_links.py` → OK. `scripts/score.py --staged` → **10/10**.
- `npm run build` → **both** digithings-web and digiquant-web build clean.
- Smoke page (static preview): two `.case-study--example` cards render inside an
  `.h-scroll` row with the `::after` "EXAMPLE" watermark, correct structure
  (label/quote/attr), flat `--surface` + `--r-lg` — no real attribution shipped.

## Out of scope

- Fabricated enterprise testimonials; automated quote ingestion; social-proof band
  wiring (content-dependent).

Fixes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
