### PR TITLE
chore(process): lighten frontend/design iteration overhead [#1310]

### DIFF
--- a/.github/workflows/agent-claude-review.yml
+++ b/.github/workflows/agent-claude-review.yml
@@ -24,6 +24,10 @@ on:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
+      # Presentation-only surfaces — /code-review rarely adds value on CSS /
+      # shared design system, and design iteration pushes frequently (#1310).
+      - 'frontend/design/**'
+      - '**.css'
 
 concurrency:
   # Cancel in-flight review when the PR is updated — avoids stacking reviews

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
               - 'digismith/**'
               - 'digikey/**'
               - 'digivault/**'
-              - 'frontend/**'
               - 'scripts/**'
               - 'tests/**'
               - 'agents.yml'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@ Run `make score` on staged changes before every PR. All dimensions must pass.
 
 Rubrics live in `docs/scoring/` (10 criteria each).
 
+**Exception — presentation-only frontend** (`frontend/design/**`, `**.css`, static
+marketing pages): `make score` does **not** apply — its rubrics are Python-oriented
+and misfire on CSS/JS. `frontend/**` is excluded from the `score` CI filter and
+`frontend/design/` is in `score.py`'s skip list. Iterate design on **one branch off
+`develop`** with a live preview (`.claude/launch.json` dev servers) and open a
+single PR when the look is approved. Gates that still apply: gitleaks (secrets),
+app builds, the digithings deploy build-check. (See #1310.)
+
 ## Human gate (always requires human review)
 
 - Auth, JWT, or crypto changes (`digikey/`)
@@ -61,6 +69,8 @@ main ← develop ← module/<component> ← task/<N>-slug
 ```
 
 Use `make task ISSUE=N` to create a `task/N-slug` branch from the right module branch. Task branches PR into their module branch; module branches PR into develop. Never do module-specific work on `develop` directly.
+
+**Frontend is one-hop (#1310).** `component:website`, `component:digiquant-web`, and `component:design-system` route **straight to `develop`** (see `scripts/project_routing.json`), skipping the `module/website` hop — frontend/marketing has no auth/live-trading surface to isolate, and the module hop was the source of the redesign epic's sync/conflict churn. Task branches for these still PR into `develop` directly. The two-hop model still applies to backend modules (`module/digiquant`, `module/digikey`, `module/digigraph`, etc.).
 
 **Sync the module branch with develop *before* you branch off it.** Module branches drift behind `develop` fast because we iterate on develop constantly — and a task branch cut from a stale module branch edits dead code. (Real incident, 2026-06-17: `module/digiquant` was ~2 months / ~400 commits behind, predating the `apps/digiquant-atlas → digiquant/src/digiquant/olympus` migration; backend PRs cut from it touched files that no longer exist on develop.) `make task ISSUE=N` does **not** sync for you — check first:
 

--- a/scripts/ci_paths.yaml
+++ b/scripts/ci_paths.yaml
@@ -75,7 +75,9 @@ score:
   - digismith/**
   - digikey/**
   - digivault/**
-  - frontend/**
+  # frontend/** intentionally excluded from scoring (#1310): score.py is a
+  # Python-oriented anti-pattern heuristic that misfires on CSS/JS; gitleaks
+  # still runs on frontend PRs for secrets, and app builds still gate breakage.
   - scripts/**
   - tests/**
   - agents.yml

--- a/scripts/project_routing.json
+++ b/scripts/project_routing.json
@@ -24,9 +24,9 @@
     "component:digiclaw": "module/digiclaw",
     "component:digibase": "module/digibase",
     "component:digivault": "develop",
-    "component:website": "module/website",
-    "component:digiquant-web": "module/website",
-    "component:design-system": "module/website",
+    "component:website": "develop",
+    "component:digiquant-web": "develop",
+    "component:design-system": "develop",
     "component:root": "develop",
     "default": "develop"
   }

--- a/scripts/score.py
+++ b/scripts/score.py
@@ -72,6 +72,11 @@ SCORE_SKIP_PATH_FRAGMENTS: tuple[str, ...] = (
     "docs/reviews/",
     "digigraph/docs/SECURITY.md",
     "digigraph/src/digigraph/tools/analytics/execute_python.py",
+    # Shared design system (CSS/JS presentation) — score.py's anti-pattern
+    # heuristics are Python-oriented and misfire on CSS/JS (eval/exec/TODO scans
+    # hit all files). This is the source-of-truth design dir we iterate heavily;
+    # secrets are still covered by gitleaks. See #1310.
+    "frontend/design/",
 )
 
 # ── Anti-pattern definitions ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Lightens the engineering-process overhead for **frontend/design/marketing**
iteration, which the round-1 redesign postmortem showed dominated effort (~13 PRs
+ a `module/website`→`develop` sync merge on largely-CSS work). **For your review —
these touch guardrails, so I did not merge.** Backed by the workflow audit (#1310).

## Changes

| # | Change | File(s) |
|---|--------|---------|
| 1 | **Frontend one-hop routing** — `component:website` / `digiquant-web` / `design-system` route straight to `develop` (skip the `module/website` hop that caused the sync/conflict churn) | `scripts/project_routing.json` |
| 2 | **Score exemption** — drop `frontend/**` from the `score` CI filter + add `frontend/design/` to `score.py`'s skip list (`score.py` misfires on CSS/JS — eval/exec/TODO scans hit all files) | `scripts/ci_paths.yaml`, `.github/workflows/ci.yml` (regenerated), `scripts/score.py` |
| 3 | **Review-bot exemption** — `agent-claude-review` skips `frontend/design/**` + `**.css` | `.github/workflows/agent-claude-review.yml` |
| 4 | **Docs** — CLAUDE.md documents the presentation-only lightweight lane (one branch off `develop` + live preview, single PR when the look is approved) + the one-hop note | `CLAUDE.md` |

## Kept unchanged (still protect correctness)

gitleaks on every non-md PR · app build checks · the digithings deploy build-check ·
all auth/JWT/live-trading **human gates** · `Require Fixes` linkage · branch-name
rules · the Claude PreToolUse/PostToolUse hooks.

## For you to weigh

- **Tradeoff:** frontend PRs (including digichat/olympus *app logic*, not just CSS)
  no longer trigger the advisory `score` job. gitleaks + the auth/crypto human gate
  still apply. If you'd rather keep score on digichat/olympus TS, say so and I'll
  narrow the exemption to `frontend/design/**` + the marketing apps only.
- **Follow-up (NOT in this PR):** a `design_only` CI lane so one `frontend/design/**`
  edit doesn't rebuild digichat + olympus + web separately. It's a bigger change with
  more risk of missing a cross-app breakage — better done on its own once this lands.
- **Verify before relying on it:** the `module-branch-protection` required-checks
  list lives only on origin (not in the repo); confirm `score` isn't a *required*
  check there.

Fixes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
