### PR TITLE
perf(digiquant-web): StrategySuite on Motion useScroll — measure only on resize (epic #1329 phase 3)

### DIFF
--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -560,7 +560,9 @@ export function StrategySuite() {
     );
   };
   const applyScrollRef = useRef(applyScroll);
-  applyScrollRef.current = applyScroll;
+  useEffect(() => {
+    applyScrollRef.current = applyScroll;
+  });
 
   useMotionValueEvent(scrollYProgress, "change", () => applyScrollRef.current());
 

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -4,8 +4,16 @@
  *
  * Cards slide in from below as you scroll; the full stack + library CTA scale to
  * fit the viewport when zoom or content height would otherwise clip.
+ *
+ * Scroll handling (#1322): measurement (layout reads + height/scale writes) runs
+ * only when something can actually change size — mount, resize, visualViewport,
+ * ResizeObserver on the pin column/stack, tearsheet data landing — and caches
+ * its results in a ref. The per-scroll path is Motion's `useScroll` progress →
+ * pure math on the cached metrics → setState. Cards are memoized so scroll
+ * frames re-render only the transform wrappers, never the charts.
  */
 import {
+  memo,
   useEffect,
   useMemo,
   useRef,
@@ -14,6 +22,7 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
+import { useScroll, useMotionValueEvent } from "motion/react";
 import Link from "next/link";
 import { AssetLogoFor } from "@/components/tearsheet/asset-logo";
 import { CurrentPosition } from "@/components/tearsheet/current-position";
@@ -225,7 +234,11 @@ function Kpi({ label, value, className }: { label: string; value: ReactNode; cla
   );
 }
 
-function StrategyTearsheetCard({ entry }: { entry: StrategyIndexEntry }) {
+const StrategyTearsheetCard = memo(function StrategyTearsheetCard({
+  entry,
+}: {
+  entry: StrategyIndexEntry;
+}) {
   const cardRef = useRef<HTMLDivElement>(null);
   const cardWidth = useElementWidth(cardRef);
   const [mode, setMode] = useState<PreviewMode>("charts");
@@ -379,7 +392,7 @@ function StrategyTearsheetCard({ entry }: { entry: StrategyIndexEntry }) {
       </p>
     </div>
   );
-}
+});
 
 function navHeightPx(): number {
   const raw = getComputedStyle(document.documentElement).getPropertyValue("--dq-nav-h").trim();
@@ -480,90 +493,121 @@ function measureStackMetrics(scrolly: HTMLElement, count: number) {
   return { pinH: pinHAfter, scrollable, hideOffset, ctaHideOffset, stackH };
 }
 
+/** Everything the per-scroll math needs, produced by the measure pass only. */
+type StackMetrics = {
+  scrollable: number;
+  hideOffset: number;
+  ctaHideOffset: number;
+  budgets: number[];
+  ctaBudget: number;
+  holdPx: number;
+  /** Window-scroll distance the scrolly spans (height − viewport) — maps
+   *  Motion's 0..1 progress back to scrolled pixels. */
+  runway: number;
+};
+
 export function StrategySuite() {
   const scrollyRef = useRef<HTMLDivElement>(null);
+  const metricsRef = useRef<StackMetrics | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const [cardOffsets, setCardOffsets] = useState<number[]>(() => STRATEGIES.map(() => 9999));
   const [introPhase, setIntroPhase] = useState(true);
   const [libraryCtaOffset, setLibraryCtaOffset] = useState(9999);
   const count = STRATEGIES.length;
 
+  const { scrollYProgress } = useScroll({
+    target: scrollyRef,
+    offset: ["start start", "end end"],
+  });
+
   useEffect(() => {
     prefetchAllTearsheets(STRATEGIES.map((s) => s.strategy));
   }, []);
+
+  // Per-scroll path: pure math on cached metrics — zero layout reads or writes.
+  const applyScroll = () => {
+    const m = metricsRef.current;
+    if (!m) return;
+    const scrolled = clamp(scrollYProgress.get() * m.runway, 0, m.scrollable);
+
+    if (scrolled < m.holdPx) {
+      setIntroPhase(true);
+      setActiveIndex(0);
+      setCardOffsets(STRATEGIES.map(() => m.hideOffset));
+      setLibraryCtaOffset(m.ctaHideOffset);
+      return;
+    }
+
+    setIntroPhase(false);
+    const scrolledPastHold = scrolled - m.holdPx;
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      const idx = stackActiveIndex(scrolledPastHold, m.budgets);
+      setActiveIndex(idx);
+      setCardOffsets(STRATEGIES.map((_, i) => (i <= idx ? 0 : m.hideOffset)));
+      setLibraryCtaOffset(
+        scrolledPastHold >= totalCardBudgetPx(m.budgets) ? 0 : m.ctaHideOffset,
+      );
+      return;
+    }
+
+    setActiveIndex(stackActiveIndex(scrolledPastHold, m.budgets));
+    setCardOffsets(
+      STRATEGIES.map((_, i) => stackCardOffsetY(i, scrolledPastHold, m.budgets, m.hideOffset)),
+    );
+    setLibraryCtaOffset(
+      libraryCtaOffsetY(scrolledPastHold, m.budgets, m.ctaBudget, m.ctaHideOffset),
+    );
+  };
+  const applyScrollRef = useRef(applyScroll);
+  applyScrollRef.current = applyScroll;
+
+  useMotionValueEvent(scrollYProgress, "change", () => applyScrollRef.current());
 
   useEffect(() => {
     const scrolly = scrollyRef.current;
     if (!scrolly) return;
 
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
-    const updateFromScroll = () => {
+    // Measure pass: all layout reads + height/scale writes live here. Runs on
+    // mount, viewport changes, pin column / stack resizes, and tearsheet data
+    // landing — never on scroll (#1322).
+    const remeasure = () => {
       const { scrollable, hideOffset, ctaHideOffset } = measureStackMetrics(scrolly, count);
-      const budgets = cardEnterBudgetsPx(scrolly, count);
-      const ctaBudget = libraryCtaBudgetPx(scrolly);
-      const rect = scrolly.getBoundingClientRect();
-      const scrolled = clamp(-rect.top, 0, scrollable);
-      const holdPx = introHoldPx(scrolly);
-
-      if (scrolled < holdPx) {
-        setIntroPhase(true);
-        setActiveIndex(0);
-        setCardOffsets(STRATEGIES.map(() => hideOffset));
-        setLibraryCtaOffset(ctaHideOffset);
-        return;
-      }
-
-      setIntroPhase(false);
-      const scrolledPastHold = scrolled - holdPx;
-
-      if (reduced) {
-        const idx = stackActiveIndex(scrolledPastHold, budgets);
-        setActiveIndex(idx);
-        setCardOffsets(STRATEGIES.map((_, i) => (i <= idx ? 0 : hideOffset)));
-        setLibraryCtaOffset(
-          scrolledPastHold >= totalCardBudgetPx(budgets) ? 0 : ctaHideOffset,
-        );
-        return;
-      }
-
-      setActiveIndex(stackActiveIndex(scrolledPastHold, budgets));
-      setCardOffsets(
-        STRATEGIES.map((_, i) => stackCardOffsetY(i, scrolledPastHold, budgets, hideOffset)),
-      );
-      setLibraryCtaOffset(
-        libraryCtaOffsetY(scrolledPastHold, budgets, ctaBudget, ctaHideOffset),
-      );
+      metricsRef.current = {
+        scrollable,
+        hideOffset,
+        ctaHideOffset,
+        budgets: cardEnterBudgetsPx(scrolly, count),
+        ctaBudget: libraryCtaBudgetPx(scrolly),
+        holdPx: introHoldPx(scrolly),
+        runway: Math.max(1, scrolly.offsetHeight - window.innerHeight),
+      };
+      applyScrollRef.current();
     };
 
     const nudgeStrategiesHash = () => {
       if (window.location.hash !== "#strategies") return;
-      const holdPx = introHoldPx(scrolly);
-      const { scrollable } = measureStackMetrics(scrolly, count);
-      const scrolled = clamp(-scrolly.getBoundingClientRect().top, 0, scrollable);
-      if (scrolled >= holdPx) return;
+      const m = metricsRef.current;
+      if (!m) return;
+      const scrolled = clamp(-scrolly.getBoundingClientRect().top, 0, m.scrollable);
+      if (scrolled >= m.holdPx) return;
       window.scrollTo({
-        top: window.scrollY + (holdPx - scrolled) + 1,
+        top: window.scrollY + (m.holdPx - scrolled) + 1,
         behavior: "instant",
       });
     };
 
-    const onScroll = () => {
-      updateFromScroll();
-    };
-
     const onHashChange = () => {
       requestAnimationFrame(() => {
+        remeasure();
         nudgeStrategiesHash();
-        updateFromScroll();
       });
     };
 
     const onViewportChange = () => {
-      updateFromScroll();
+      remeasure();
     };
 
-    window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", onViewportChange, { passive: true });
     window.addEventListener("hashchange", onHashChange);
     window.visualViewport?.addEventListener("resize", onViewportChange);
@@ -572,30 +616,30 @@ export function StrategySuite() {
     const col = scrolly.querySelector<HTMLElement>(".dqss-pin-col");
     const stack = scrolly.querySelector<HTMLElement>(".dqss-stack");
     const ro = new ResizeObserver(() => {
-      requestAnimationFrame(updateFromScroll);
+      requestAnimationFrame(remeasure);
     });
     if (col) ro.observe(col);
     if (stack) ro.observe(stack);
 
-    updateFromScroll();
+    remeasure();
     requestAnimationFrame(() => {
+      remeasure();
       nudgeStrategiesHash();
-      updateFromScroll();
     });
 
     const unsubCache = subscribeTearsheetCache(() => {
-      requestAnimationFrame(updateFromScroll);
+      requestAnimationFrame(remeasure);
     });
 
     return () => {
       unsubCache();
-      window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onViewportChange);
       window.removeEventListener("hashchange", onHashChange);
       window.visualViewport?.removeEventListener("resize", onViewportChange);
       window.visualViewport?.removeEventListener("scroll", onViewportChange);
       ro.disconnect();
     };
+    // applyScrollRef is stable; remeasure closes over the current count.
   }, [count]);
 
   return (

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -50,6 +50,14 @@ type PreviewMode = "charts" | "tables";
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
+// Cached once — the per-scroll path must not re-query media state (#1322).
+let reducedMq: MediaQueryList | null = null;
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  reducedMq ??= window.matchMedia("(prefers-reduced-motion: reduce)");
+  return reducedMq.matches;
+}
+
 function easeInOutCubic(t: number): number {
   const x = clamp(t, 0, 1);
   return x < 0.5 ? 4 * x * x * x : 1 - (-2 * x + 2) ** 3 / 2;
@@ -541,7 +549,7 @@ export function StrategySuite() {
     setIntroPhase(false);
     const scrolledPastHold = scrolled - m.holdPx;
 
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    if (prefersReducedMotion()) {
       const idx = stackActiveIndex(scrolledPastHold, m.budgets);
       setActiveIndex(idx);
       setCardOffsets(STRATEGIES.map((_, i) => (i <= idx ? 0 : m.hideOffset)));

--- a/frontend/web/src/components/Terminal.tsx
+++ b/frontend/web/src/components/Terminal.tsx
@@ -27,7 +27,15 @@ export function Terminal({ title, lines }: { title: string; lines: TermLine[] })
   const started = useRef(false);
 
   useEffect(() => {
-    if (!safe || started.current) return;
+    // useMotionSafe resolves after mount (hydration-safe): reduced-motion
+    // users reach here with safe=false on the second pass — show everything
+    // instantly, even if the pre-resolution pass already "started" (its timer
+    // was cleaned up before ever ticking).
+    if (!safe) {
+      setN(lines.length);
+      return;
+    }
+    if (started.current) return;
     started.current = true;
     let i = 0;
     const tick = () => {

--- a/frontend/web/src/motion/primitives.tsx
+++ b/frontend/web/src/motion/primitives.tsx
@@ -12,14 +12,21 @@ import {
   type Variants,
   type Transition,
 } from "motion/react";
-import { type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 export const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
 export const baseTransition: Transition = { duration: 0.6, ease: EASE };
 
-/** True when motion is allowed (not reduced). */
+/** True when motion is allowed (not reduced). Hydration-safe: SSR cannot know
+ *  the media query, so the first client render reports motion-safe to match the
+ *  server markup, then resolves the real preference after mount. For reduced-
+ *  motion users the primitives swap to their static branch one effect-tick
+ *  later — no animation ever plays. */
 export function useMotionSafe(): boolean {
-  return !useReducedMotion();
+  const reduced = useReducedMotion();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted ? !reduced : true;
 }
 
 /** Wrap an app/tree once so `m.*` components have animation features (small bundle). */


### PR DESCRIPTION
Fixes #1322

Phase 3 of the frontend standardization epic (#1329): the flagship pin's scroll engine moves to Motion's `useScroll` — the same engine as the shared scrolly primitive — and the layout-thrash bug dies.

**Before**: every scroll event ran `measureStackMetrics` (multiple forced layout reads *and* height/scale style writes), three `getComputedStyle` calls, and re-rendered the three chart-bearing tearsheet cards.

**After**:
- Measurement runs only when something can actually change size (mount, resize, visualViewport, ResizeObserver on the pin column/stack, tearsheet data landing), cached in a ref.
- The per-scroll path is `useScroll` progress → pure math on cached metrics → setState. Zero layout reads or writes.
- `StrategyTearsheetCard` is memoized — scroll frames touch only the transform wrappers, never the charts.

Also fixes a **pre-existing hydration mismatch** in `@digithings/web`'s motion primitives: `useMotionSafe` now matches SSR on the first client render and resolves the real reduced-motion preference after mount (reduced-motion visitors tripped a dev hydration error on every Reveal/Stagger/HeroEntrance).

**Verified live** (worktree dev server, headless Chrome): scrub state machine at five depths including the designed mid-flight slide-in; zero state flapping across 8 samples at fixed scroll; the maintainer-ruled deck-at-rest reduced-motion behavior intact (all cards visible, grid same-cell stacking, uniform peeks, CTA in flow); hydration clean under reduced motion; reveals hidden below fold and firing in view.

Known pre-existing item recorded on #1329: Reveal SSRs its hidden initial style inline, so fully-JS-less visitors get invisible sections (law 06 tension) — separate fix, not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)