### PR TITLE
fix(web): law 06 — marketing apps render complete without JavaScript (epic #1329 phase 4)

### DIFF
--- a/frontend/design/site/site.css
+++ b/frontend/design/site/site.css
@@ -427,6 +427,17 @@ a { color: inherit; text-decoration: none; }
   .principles { grid-template-columns: 1fr; }
 }
 
+/* ── no-JS content-first (law 06) ───────────────────────────────────────
+   SSR ships html.no-js (removed pre-paint by an inline script in each app
+   layout). Motion primitives SSR their hidden initial styles inline, and
+   the [data-motion] children of a Stagger inherit variants — neutralize
+   all of it when scripts never run. */
+html.no-js [data-motion],
+html.no-js [data-motion] * {
+  opacity: 1 !important;
+  transform: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .glow { animation: none; }
   .term-cursor { animation: none; }

--- a/frontend/digiquant-web/app/globals.css
+++ b/frontend/digiquant-web/app/globals.css
@@ -587,6 +587,12 @@ html {
 .dqhero.loaded .dqhero-lede { opacity: 1; transform: none; }
 .dqhero-cta { display: flex; gap: 0.8rem; margin-top: 2.4rem; flex-wrap: wrap; justify-content: center; opacity: 0; transform: translateY(14px); transition: 0.8s var(--ease) 0.62s; }
 .dqhero.loaded .dqhero-cta { opacity: 1; transform: none; }
+
+/* no-JS (law 06): the entrance never gates content — html.no-js renders the
+   hero at rest. Keep in sync with the .loaded rules above. */
+html.no-js .dqhero-h1 .ln > span { transform: none; }
+html.no-js .dqhero-lede,
+html.no-js .dqhero-cta { opacity: 1; transform: none; }
 /* scroll cue: label + prominent vertical accent line (no primary CTA button) */
 .dqhero-scrollcue { flex-direction: column; align-items: center; gap: 0.85rem; margin-top: 2.6rem; }
 .dqhero-scroll-label { font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase; color: color-mix(in srgb, var(--accent) 78%, var(--ink-mute)); }
@@ -1061,6 +1067,14 @@ html {
   .dqss-library-cta { transform: none !important; visibility: visible; pointer-events: auto; }
   .dqss-chart-skeleton { animation: none; }
 }
+
+/* no-JS (law 06): without scripts the deck renders at rest — the same layout
+   as the reduced-motion block above (keep the two in sync). */
+html.no-js .dqss-scrolly { height: auto !important; }
+html.no-js .dqss-stack { height: auto !important; display: grid; padding-bottom: calc(var(--dqss-peek) * 2); }
+html.no-js .dqss-stack-card { position: relative !important; grid-area: 1 / 1; top: calc(var(--dqss-peek) * var(--stack-index, 0)); transform: none !important; }
+html.no-js .dqss-stack-card[data-state="hidden"] { visibility: visible; pointer-events: auto; }
+html.no-js .dqss-library-cta { transform: none !important; visibility: visible; pointer-events: auto; }
 
 /* ---- subsystem poster (canon §12) ----
    One poster per sub-graph hero: giant lowercase serif italic name, the

--- a/frontend/digiquant-web/app/layout.tsx
+++ b/frontend/digiquant-web/app/layout.tsx
@@ -43,9 +43,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   // suppressHydrationWarning: themeInitScript legitimately flips data-theme
   // pre-hydration for system-light visitors; scoped to this element only.
   return (
-    <html lang="en" data-theme="dark" suppressHydrationWarning className={`${GeistSans.variable} ${GeistMono.variable} ${fraunces.variable}`}>
+    <html lang="en" data-theme="dark" suppressHydrationWarning className={`${GeistSans.variable} ${GeistMono.variable} ${fraunces.variable} no-js`}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {/* Law 06 (content-first): SSR ships html.no-js so stylesheet rules can
+            neutralize JS-gated hiding (hero entrance, [data-motion] reveals,
+            the strategy deck); removed pre-paint when scripts run. */}
+        <script dangerouslySetInnerHTML={{ __html: "document.documentElement.classList.remove('no-js')" }} />
         {/* Single fallback; themeInitScript sets it to the active theme pre-paint. */}
         <meta name="theme-color" content="#0B0C0E" />
       </head>

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -683,11 +683,7 @@ export function StrategySuite() {
               </p>
             </div>
 
-            <div
-              className="dqss-stack-clip"
-              aria-hidden={hydrated ? introPhase : undefined}
-              suppressHydrationWarning
-            >
+            <div className="dqss-stack-clip" aria-hidden={hydrated ? introPhase : undefined}>
               <div
                 className="dqss-stack"
                 role="group"
@@ -718,7 +714,6 @@ export function StrategySuite() {
                         } as CSSProperties
                       }
                       aria-hidden={hydrated ? introPhase || i > activeIndex : undefined}
-                      suppressHydrationWarning
                     >
                       <StrategyTearsheetCard entry={entry} />
                     </div>

--- a/frontend/digiquant-web/components/landing/StrategySuite.tsx
+++ b/frontend/digiquant-web/components/landing/StrategySuite.tsx
@@ -18,6 +18,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type CSSProperties,
   type ReactNode,
   type RefObject,
@@ -49,6 +50,8 @@ const MIN_FIT_SCALE = 0.68;
 type PreviewMode = "charts" | "tables";
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+const emptySubscribe = () => () => {};
 
 // Cached once — the per-scroll path must not re-query media state (#1322).
 let reducedMq: MediaQueryList | null = null;
@@ -521,6 +524,15 @@ export function StrategySuite() {
   const [cardOffsets, setCardOffsets] = useState<number[]>(() => STRATEGIES.map(() => 9999));
   const [introPhase, setIntroPhase] = useState(true);
   const [libraryCtaOffset, setLibraryCtaOffset] = useState(9999);
+  // aria-hidden is a JS-driven visual-sync concern: SSR must not ship it, or
+  // no-JS screen-reader users lose the deck entirely (law 06). Applied only
+  // after hydration (the DqNav mount-gate idiom); the wrappers suppress the
+  // attribute-level mismatch.
+  const hydrated = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
   const count = STRATEGIES.length;
 
   const { scrollYProgress } = useScroll({
@@ -671,7 +683,11 @@ export function StrategySuite() {
               </p>
             </div>
 
-            <div className="dqss-stack-clip" aria-hidden={introPhase}>
+            <div
+              className="dqss-stack-clip"
+              aria-hidden={hydrated ? introPhase : undefined}
+              suppressHydrationWarning
+            >
               <div
                 className="dqss-stack"
                 role="group"
@@ -701,7 +717,8 @@ export function StrategySuite() {
                           transform: `translate3d(0, ${offset}px, 0)`,
                         } as CSSProperties
                       }
-                      aria-hidden={introPhase || i > activeIndex}
+                      aria-hidden={hydrated ? introPhase || i > activeIndex : undefined}
+                      suppressHydrationWarning
                     >
                       <StrategyTearsheetCard entry={entry} />
                     </div>

--- a/frontend/digithings-web/app/globals.css
+++ b/frontend/digithings-web/app/globals.css
@@ -284,6 +284,12 @@ html {
 .dqhero.loaded .dqhero-lede { opacity: 1; transform: none; }
 .dqhero-cta { display: flex; flex-direction: column; align-items: center; gap: 0.7rem; margin-top: 2.4rem; opacity: 0; transform: translateY(14px); transition: 0.8s var(--ease) 0.62s; }
 .dqhero.loaded .dqhero-cta { opacity: 1; transform: none; }
+
+/* no-JS (law 06): the entrance never gates content — html.no-js renders the
+   hero at rest. Keep in sync with the .loaded rules above. */
+html.no-js .dqhero-h1 .ln > span { transform: none; }
+html.no-js .dqhero-lede,
+html.no-js .dqhero-cta { opacity: 1; transform: none; }
 .dqhero-scroll-label { margin: 0; font-size: 0.72rem; font-weight: 500; letter-spacing: 0.14em; text-transform: uppercase; color: color-mix(in srgb, var(--accent) 78%, var(--ink)); }
 /* scroll-down cue: accent hairline with a pulse travelling down it */
 .dqhero-scroll { position: relative; width: 2px; height: 88px; overflow: hidden; border-radius: 1px; background: linear-gradient(color-mix(in srgb, var(--accent) 52%, var(--hair-2)), transparent); }

--- a/frontend/digithings-web/app/layout.tsx
+++ b/frontend/digithings-web/app/layout.tsx
@@ -38,9 +38,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   // legitimately flip data-theme + meta pre-hydration; scoped to this
   // element's attributes only.
   return (
-    <html lang="en" data-theme="dark" suppressHydrationWarning className={`${GeistSans.variable} ${GeistMono.variable} ${fraunces.variable}`}>
+    <html lang="en" data-theme="dark" suppressHydrationWarning className={`${GeistSans.variable} ${GeistMono.variable} ${fraunces.variable} no-js`}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {/* Law 06 (content-first): SSR ships html.no-js so stylesheet rules can
+            neutralize JS-gated hiding (hero entrance, [data-motion] reveals);
+            removed pre-paint when scripts run. */}
+        <script dangerouslySetInnerHTML={{ __html: "document.documentElement.classList.remove('no-js')" }} />
         {/* Single fallback; themeInitScript sets it to the active theme pre-paint. */}
         <meta name="theme-color" content="#0B0C0E" />
       </head>

--- a/frontend/web/src/motion/primitives.tsx
+++ b/frontend/web/src/motion/primitives.tsx
@@ -62,6 +62,7 @@ export function Reveal({
   return (
     <Comp
       className={className}
+      data-motion=""
       initial="hidden"
       whileInView="show"
       viewport={{ once: true, margin: "0px 0px -10% 0px" }}
@@ -79,6 +80,7 @@ export function Stagger({ children, className }: { children: ReactNode; classNam
   return (
     <m.div
       className={className}
+      data-motion=""
       initial="hidden"
       whileInView="show"
       viewport={{ once: true, margin: "0px 0px -10% 0px" }}
@@ -94,7 +96,7 @@ export function HeroEntrance({ children, className }: { children: ReactNode; cla
   const safe = useMotionSafe();
   if (!safe) return <div className={className}>{children}</div>;
   return (
-    <m.div className={className} initial="hidden" animate="show" variants={staggerParent}>
+    <m.div className={className} data-motion="" initial="hidden" animate="show" variants={staggerParent}>
       {children}
     </m.div>
   );


### PR DESCRIPTION
Fixes #1334

Phase 4 of the standardization epic (#1329). The audit item turned out worse than recorded — three separate JS-gates hid content with scripts off:

1. **Motion reveals** SSR their hidden initial styles inline (`opacity:0`, `translateY`)
2. **Both heroes** stay hidden until JS adds `.loaded`
3. **The strategy deck** SSRs cards translated 9999px away, with `aria-hidden` shipped to screen readers

**The `html.no-js` pattern fixes all three in regular CSS:** layouts SSR `html.no-js` (removed pre-paint by a static inline script, same pattern as `themeInitScript`); shared `site.css` neutralizes `[data-motion]` inline styles (the three primitives now carry the attribute); both apps get hero-at-rest rules beside their `.loaded` rules; digiquant gets an `html.no-js` mirror of the deck-at-rest block; and the deck's `aria-hidden` is applied only after hydration via the established `useSyncExternalStore` mount-gate idiom.

**Verified with scripts disabled on both apps**: heroes, reveals, module manifest, the at-rest deck (relative cards, no `aria-hidden`), and the colophon (already CSS-only) — all visible. **JS-on regression**: `no-js` removed pre-paint, hero entrance animates, below-fold reveals gate, the deck scrubs on its absolute layout, `aria-hidden` applies post-hydration. Lint clean on both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)