### PR TITLE
chore(root): add release-please + GHCR publish pipeline for digichat

### DIFF
--- a/.github/workflows/publish-digichat-image.yml
+++ b/.github/workflows/publish-digichat-image.yml
@@ -1,0 +1,59 @@
+# Publishes the digichat image only once a version has actually reached main
+# (passed make score + the promotion PR), decoupled on purpose from when
+# release-please-digichat.yml cuts the tag on module/digichat (see #1343).
+name: "Publish: digichat image"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/digichat/**"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-digichat-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read digichat version
+        id: version
+        run: echo "version=$(jq -r .version frontend/digichat/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if this version is already published
+        id: check
+        env:
+          IMAGE_TAG: "ghcr.io/digithings-ai/digichat:v${{ steps.version.outputs.version }}"
+        run: |
+          if docker manifest inspect "$IMAGE_TAG" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/digichat/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/digithings-ai/digichat:v${{ steps.version.outputs.version }}
+            ghcr.io/digithings-ai/digichat:latest

--- a/.github/workflows/release-please-digichat.yml
+++ b/.github/workflows/release-please-digichat.yml
@@ -1,0 +1,33 @@
+# Tracks digichat's version and changelog from Conventional Commits on
+# module/digichat (not main: some develop -> main promotions land as a single
+# squashed "chore: promote develop to main (...)" commit, which would look like
+# a no-op to a Conventional Commits parser and swallow the real feat/fix signal
+# that module/digichat still has, see #1343).
+name: "Release please: digichat"
+
+on:
+  push:
+    branches:
+      - module/digichat
+    paths:
+      - "frontend/digichat/**"
+      - "release-please-config.json"
+      - ".release-please-manifest.json"
+
+concurrency:
+  group: release-please-digichat
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          target-branch: module/digichat
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "frontend/digichat": "0.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    "frontend/digichat": {
+      "release-type": "node",
+      "component": "digichat",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1343

## What

- `release-please-config.json` / `.release-please-manifest.json` — `release-type: node`, tag format `digichat-vX.Y.Z`, scoped to `frontend/digichat`.
- `.github/workflows/release-please-digichat.yml` — runs on push to `module/digichat`. Opens/updates a Release PR that bumps `package.json` + `CHANGELOG.md` from Conventional Commits; merging it cuts the tag.
- `.github/workflows/publish-digichat-image.yml` — runs on push to `main` touching `frontend/digichat/**`. Reads the version already in `package.json`, checks `ghcr.io/digithings-ai/digichat` for that tag, and if missing builds + pushes `:v<version>` and `:latest`.

## Why module/digichat, not main

`module/digichat` preserves individual `feat(digichat): ...` / `fix(digichat): ...` commits from task-branch merges. Some `develop -> main` promotions squash the whole batch into one `chore: promote develop to main (...)` commit, which would read as a no-op to a Conventional Commits parser and swallow the real signal. Publishing is intentionally a separate, later trigger gated on the code actually reaching `main` — the version is *decided* on the module branch, but not shipped to customers until it clears the same promotion gate everything else does.

## Human review required

Per `CLAUDE.md`'s human-gate rules, this is both a new external service dependency (GHCR) and a novel architecture decision not covered by any existing `ARCHITECTURE.md` — flagging for explicit review rather than relying on `make score` alone (10/10 all dimensions).

## Follow-ups (not done here, need your call)

- First push will auto-create the `ghcr.io/digithings-ai/digichat` package as **private** by default — if self-hosting customers should `docker pull` without a digithings-issued credential, someone needs to flip it to public in the package settings after the first publish (can't be done before it exists).
- First release-please run will scan all of `frontend/digichat`'s history since it has no prior `digichat-v*` tag to anchor on — expect a larger-than-normal initial version bump and changelog.
- Same pattern extends to digikey/digigraph/etc. later by adding another entry to the `packages` map — not scoped here.