### PR TITLE
fix(digichat): make digigraph/digiquant/digismith health checks optional

### DIFF
--- a/frontend/digichat/ARCHITECTURE.md
+++ b/frontend/digichat/ARCHITECTURE.md
@@ -663,6 +663,16 @@ secret; only `DIGIKEY_BFF_TOKEN` is needed (a long-lived BFF credential).
 DigiGraph calls DigiSearch internally during workflow execution. The health badge
 in the Ecosystem sheet reflects connectivity only.
 
+DigiGraph and DigiQuant get the same `DIGICHAT_ENABLED_SERVICES` treatment (#1346):
+unlike `digisearchUrl`, `digigraphUrl`/`digiquantUrl`/`digismithUrl` in
+`EcosystemEndpoints` always have a default value (`ecosystem.ts`'s `DEFAULTS`), so
+the health route checks `isServiceCapabilityEnabled(...)` directly rather than URL
+presence — a deployment serving only `external-relay` embed tenants (no DigiGraph
+stack running at all) can omit them from `DIGICHAT_ENABLED_SERVICES` without
+`/api/health` reporting itself unhealthy. Note the `DIGICHAT_ENABLED_SERVICES=""`
+gotcha in `capabilities.ts`: an empty string falls back to the all-enabled default,
+so disabling every service requires a non-matching placeholder value instead.
+
 ### DigiQuant backtest result parsing
 
 DigiChat does not call DigiQuant directly. `BacktestResult`-shaped JSON appears in
@@ -673,9 +683,10 @@ using the extracted `run_id` and metrics.
 
 ### DigiSmith status endpoint
 
-`GET /api/health` probes `{DIGISMITH_INTERNAL_URL}/health`. DigiSmith is not called
-from the chat flow; tracing is handled by DigiGraph emitting `span` trace events in
-the SSE stream. The health badge confirms the tracing service is reachable.
+`GET /api/health` probes `{DIGISMITH_INTERNAL_URL}/health` when `digismith` is in
+`DIGICHAT_ENABLED_SERVICES`. DigiSmith is not called from the chat flow; tracing is
+handled by DigiGraph emitting `span` trace events in the SSE stream. The health
+badge confirms the tracing service is reachable.
 
 ---
 

--- a/frontend/digichat/src/app/api/health/route.test.ts
+++ b/frontend/digichat/src/app/api/health/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 vi.mock("@/db", () => ({
@@ -27,6 +27,10 @@ describe("GET /api/health", () => {
     );
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("returns 200 when upstream health checks pass", async () => {
     const res = await GET();
     expect(res.status).toBe(200);
@@ -44,5 +48,35 @@ describe("GET /api/health", () => {
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.ok).toBe(false);
+  });
+
+  it("skips digraph/digiquant/digismith checks and stays healthy when they're not in DIGICHAT_ENABLED_SERVICES (#external-relay-only deploy)", async () => {
+    // "" falls back to the all-enabled default in capabilities.ts (raw || fallback),
+    // so a non-matching placeholder is what actually disables every service.
+    vi.stubEnv("DIGICHAT_ENABLED_SERVICES", "none");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connection refused"))
+    );
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.checks.digraph).toBeUndefined();
+    expect(body.checks.digiquant).toBeUndefined();
+    expect(body.checks.digismith).toBeUndefined();
+  });
+
+  it("still requires digraph/digiquant/digismith when they are in DIGICHAT_ENABLED_SERVICES", async () => {
+    vi.stubEnv("DIGICHAT_ENABLED_SERVICES", "digigraph,digiquant,digismith");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connection refused"))
+    );
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.digraph).toBe("unreachable");
   });
 });

--- a/frontend/digichat/src/app/api/health/route.ts
+++ b/frontend/digichat/src/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "@/db";
 import { getEcosystemEndpoints } from "@/lib/ecosystem";
+import { isServiceCapabilityEnabled } from "@/lib/capabilities";
 
 async function pingHealth(base: string, label: string, checks: Record<string, string>) {
   try {
@@ -20,9 +21,18 @@ export async function GET() {
   };
 
   const eco = await getEcosystemEndpoints();
-  await pingHealth(eco.digigraphUrl, "digraph", checks);
-  await pingHealth(eco.digiquantUrl, "digiquant", checks);
-  await pingHealth(eco.digismithUrl, "digismith", checks);
+  // digigraph/digiquant/digismith always have a default URL (see ecosystem.ts
+  // DEFAULTS), unlike digisearchUrl, so URL presence alone can't signal
+  // "not deployed here" for them — check the capability flag directly.
+  if (isServiceCapabilityEnabled("digigraph")) {
+    await pingHealth(eco.digigraphUrl, "digraph", checks);
+  }
+  if (isServiceCapabilityEnabled("digiquant")) {
+    await pingHealth(eco.digiquantUrl, "digiquant", checks);
+  }
+  if (isServiceCapabilityEnabled("digismith")) {
+    await pingHealth(eco.digismithUrl, "digismith", checks);
+  }
   if (eco.digisearchUrl?.trim()) {
     await pingHealth(eco.digisearchUrl, "digisearch", checks);
   }
@@ -39,12 +49,15 @@ export async function GET() {
     checks.database = "skipped";
   }
 
+  const digraphOk = !isServiceCapabilityEnabled("digigraph") || checks.digraph === "ok";
+  const digiquantOk = !isServiceCapabilityEnabled("digiquant") || checks.digiquant === "ok";
+  const digismithOk = !isServiceCapabilityEnabled("digismith") || checks.digismith === "ok";
   const digisearchOk = !eco.digisearchUrl?.trim() || checks.digisearch === "ok";
 
   const ok =
-    checks.digraph === "ok" &&
-    checks.digiquant === "ok" &&
-    checks.digismith === "ok" &&
+    digraphOk &&
+    digiquantOk &&
+    digismithOk &&
     digisearchOk &&
     (checks.database === "ok" || checks.database === "skipped");
 


### PR DESCRIPTION
Fixes #1346

## What

`GET /api/health` unconditionally required `digigraph`/`digiquant`/`digismith` to respond healthy, returning 503 otherwise — only `digisearch` had "skip if not configured" treatment. Gated the other three on `isServiceCapabilityEnabled(...)` too, same as digisearch effectively already was.

## Why not just mirror digisearch's exact check

`digisearchUrl` in `EcosystemEndpoints` becomes genuinely absent when the digisearch capability is disabled. `digigraphUrl`/`digiquantUrl`/`digismithUrl` always carry a default (`ecosystem.ts`'s `DEFAULTS`), so checking URL truthiness on them is always true regardless of whether the service is actually deployed — had to check the capability flag directly instead.

## Context

Found while scoping a same-day digichat deployment for the datatapstream.com embed tenant, which only needs digichat + a small Postgres (for boot-time migrations) talking to DataTapStream's own already-deployed Azure relay (`external-relay` backend type) — no digigraph/digiquant/digismith/digisearch needed for that traffic at all. Without this fix the container would report itself unhealthy regardless.

## Testing

TDD: added 2 new tests (skip-when-disabled, still-required-when-enabled) confirmed RED against the old implementation, GREEN after the fix. Full suite 135/135 passing, lint clean, `make score` 10/10 all dimensions.

## Follow-up (not done here, flagged separately)

`DIGICHAT_ENABLED_SERVICES=""` doesn't actually disable everything — `capabilities.ts`'s `raw || fallback` treats empty string as unset and falls back to all-enabled. Worked around in the tests with a placeholder value; a real fix to that fallback logic is a separate task.