### PR TITLE
fix(digichat): treat explicit empty DIGICHAT_ENABLED_SERVICES as zero services

### DIFF
--- a/frontend/digichat/ARCHITECTURE.md
+++ b/frontend/digichat/ARCHITECTURE.md
@@ -713,7 +713,7 @@ Healthcheck: `curl -sf http://127.0.0.1:3000/api/health`.
 | `DIGIQUANT_INTERNAL_URL` | DigiQuant base URL (health probe) | Recommended |
 | `DIGISMITH_INTERNAL_URL` | DigiSmith base URL (health probe) | Recommended |
 | `DIGISEARCH_INTERNAL_URL` | DigiSearch base URL (health probe) | Optional |
-| `DIGICHAT_ENABLED_SERVICES` | Comma-separated active service IDs | Optional |
+| `DIGICHAT_ENABLED_SERVICES` | Comma-separated active service IDs; unset defaults to all four (`digigraph,digisearch,digiquant,digismith`), explicitly set to `""` to enable none | Optional |
 | `DIGICHAT_DATABASE_URL` | PostgreSQL connection URL | For server persistence |
 | `DIGICHAT_AUTO_MIGRATE` | Run Drizzle migrations on startup (`1` = on) | Docker recommended |
 | `DIGICHAT_BOOTSTRAP_API_KEY` | Static machine API key (env bootstrap) | For machine clients |

--- a/frontend/digichat/src/lib/capabilities.test.ts
+++ b/frontend/digichat/src/lib/capabilities.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getEnabledServiceIds, isServiceCapabilityEnabled } from "./capabilities";
+
+describe("getEnabledServiceIds", () => {
+  afterEach(() => {
+    delete process.env.DIGICHAT_ENABLED_SERVICES;
+  });
+
+  it("falls back to all four services when the env var is unset", () => {
+    delete process.env.DIGICHAT_ENABLED_SERVICES;
+    expect(getEnabledServiceIds()).toEqual([
+      "digigraph",
+      "digisearch",
+      "digiquant",
+      "digismith",
+    ]);
+  });
+
+  it("returns zero services when the env var is explicitly set to an empty string", () => {
+    process.env.DIGICHAT_ENABLED_SERVICES = "";
+    expect(getEnabledServiceIds()).toEqual([]);
+  });
+
+  it("returns zero services when the env var is whitespace only", () => {
+    process.env.DIGICHAT_ENABLED_SERVICES = "   ";
+    expect(getEnabledServiceIds()).toEqual([]);
+  });
+
+  it("parses an explicit comma-separated list", () => {
+    process.env.DIGICHAT_ENABLED_SERVICES = "digigraph, digismith";
+    expect(getEnabledServiceIds()).toEqual(["digigraph", "digismith"]);
+  });
+});
+
+describe("isServiceCapabilityEnabled", () => {
+  afterEach(() => {
+    delete process.env.DIGICHAT_ENABLED_SERVICES;
+  });
+
+  it("is false for every service when the env var is explicitly empty", () => {
+    process.env.DIGICHAT_ENABLED_SERVICES = "";
+    expect(isServiceCapabilityEnabled("digigraph")).toBe(false);
+    expect(isServiceCapabilityEnabled("digisearch")).toBe(false);
+    expect(isServiceCapabilityEnabled("digiquant")).toBe(false);
+    expect(isServiceCapabilityEnabled("digismith")).toBe(false);
+  });
+});

--- a/frontend/digichat/src/lib/capabilities.ts
+++ b/frontend/digichat/src/lib/capabilities.ts
@@ -3,9 +3,9 @@
  * Env: DIGICHAT_ENABLED_SERVICES=digigraph,digisearch,digiquant,digismith
  */
 export function getEnabledServiceIds(): string[] {
-  const raw = process.env.DIGICHAT_ENABLED_SERVICES?.trim();
+  const envVar = process.env.DIGICHAT_ENABLED_SERVICES;
   const fallback = "digigraph,digisearch,digiquant,digismith";
-  const s = raw || fallback;
+  const s = envVar === undefined ? fallback : envVar;
   return [...new Set(s.split(",").map((x) => x.trim()).filter(Boolean))];
 }
 


### PR DESCRIPTION
Fixes #1348

## What

`getEnabledServiceIds()` in `frontend/digichat/src/lib/capabilities.ts` used `const s = raw || fallback`. Since `raw` is derived from `process.env.DIGICHAT_ENABLED_SERVICES?.trim()`, an explicitly-set empty string is falsy and was indistinguishable from the variable being unset — both resolved to all four default services (`digigraph,digisearch,digiquant,digismith`). There was no way to express "disable every service" with a normal empty value.

Fix: only fall back to the default list when `process.env.DIGICHAT_ENABLED_SERVICES` is `undefined`. An explicit empty (or whitespace-only) string now parses to zero enabled services.

## Why

Found while working #1346/#1347 (health-route gating on `isServiceCapabilityEnabled`), where the tests had to use a placeholder value instead of `""` to express "no services enabled" — flagged there as a follow-up, filed as #1348.

## Testing

TDD: added `frontend/digichat/src/lib/capabilities.test.ts` (5 cases: unset fallback, explicit empty, whitespace-only, explicit list, `isServiceCapabilityEnabled` all-false-when-empty), confirmed RED against the old implementation, GREEN after the fix. Full digichat suite 138/138 passing, lint clean, `make score` 10/10 all dimensions.

Also updated `ARCHITECTURE.md`'s env var table to document the empty-string-means-none behavior.