### PR TITLE
chore: promote develop to main (embed hosts/secret split)

### DIFF
--- a/frontend/digichat/ARCHITECTURE.md
+++ b/frontend/digichat/ARCHITECTURE.md
@@ -369,10 +369,23 @@ per-host `slug`, `backend` (`digigraph` | `external-relay` + https URL),
 `gateMode` (`turn_limited` | `ungated`), `theme` (`dark` | `light`),
 optional `accent` hex pair, `attribution` flag, `aliases`, and a required
 `token`. Parsed fail-fast in `src/lib/embed-tenants.ts`; the same registry
-feeds `/api/chat` tenant resolution (`src/lib/embed-chat-tenant.ts`), the
-client-safe `GET /api/embed/tenant-config` endpoint, and the `/embed`
-CSP frame-ancestors (`src/lib/security-headers.ts` — which means the env
-var must be present at build time, not just runtime).
+feeds `/api/chat` tenant resolution (`src/lib/embed-chat-tenant.ts`) and the
+client-safe `GET /api/embed/tenant-config` endpoint — both runtime-only,
+reading `process.env.DIGICHAT_EMBED_TENANTS` fresh per request.
+
+The `/embed` CSP frame-ancestors (`src/lib/security-headers.ts`) is
+different: Next.js evaluates `next.config.ts`'s `headers()` during `next
+build` and bakes the result into the routes manifest, so whatever feeds it
+must be present at **build** time, not just container runtime. `embedFrameAncestors()`
+never reads anything but the registry's hostnames — never the token — so
+it's driven by a separate, non-secret `DIGICHAT_EMBED_HOSTS` env var (plain
+comma-separated hostnames) instead, preferred over deriving hosts from the
+full `DIGICHAT_EMBED_TENANTS` registry when both are set (#1360). This
+matters because a Docker build-arg persists in image layer history and
+cloud-build logs (e.g. `az acr build`) — passing the full token-bearing
+registry there for a value the build never actually reads would leak every
+tenant's token. `DIGICHAT_EMBED_TENANTS` itself stays runtime-only (a
+container env var, never a build-arg).
 
 `external-relay` tenants bypass DigiGraph entirely: `/api/chat` proxies to
 the configured relay via `src/lib/external-relay-stream.ts`, translating
@@ -736,7 +749,8 @@ Healthcheck: `curl -sf http://127.0.0.1:3000/api/health`.
 | `DIGICHAT_ENDPOINT_HOST_ALLOWLIST` | Comma-separated hosts for SSRF guard | Security hardening |
 | `DIGICHAT_EMBED_ENABLED` | Enable the unauthenticated `/embed` chat surface (`1` = on) | For public embed |
 | `DIGICHAT_EMBED_TOKEN` | Alternative to `DIGICHAT_EMBED_ENABLED`: gate `/embed` on `X-Embed-Token` instead | Optional |
-| `DIGICHAT_EMBED_TENANTS` | Optional JSON registry of embed tenants (see "Embed tenant registry & external backends"). Unset = no external embed tenants; first-party embeds behave exactly as before. Must be present at build time for CSP frame-ancestors derivation. Each entry requires a `token` — the embed snippet passes it back as `?token=` / `X-Embed-Token`; a registered host alone is not sufficient authorization (#1339). | Optional |
+| `DIGICHAT_EMBED_TENANTS` | Optional JSON registry of embed tenants (see "Embed tenant registry & external backends"). Unset = no external embed tenants; first-party embeds behave exactly as before. Runtime-only — never pass as a Docker build-arg, it carries every tenant's secret `token` and build-args persist in image layer history / cloud-build logs (#1360). Each entry requires a `token` — the embed snippet passes it back as `?token=` / `X-Embed-Token`; a registered host alone is not sufficient authorization (#1339). | Optional |
+| `DIGICHAT_EMBED_HOSTS` | Plain comma-separated embed-tenant hostnames, no secrets. Feeds the `/embed` CSP frame-ancestors at **build** time (safe to pass as a Docker build-arg); preferred over deriving hosts from `DIGICHAT_EMBED_TENANTS` when both are set (#1360). | Optional |
 | `DIGICHAT_CHAT_RATE_LIMIT_MAX` / `_WINDOW_MS` | Shared per-`{tenantSlug}:{ownerUserSub}` chat rate limit (default 30/60000ms) | Optional |
 | `DIGICHAT_EMBED_IP_RATE_LIMIT_MAX` / `_WINDOW_MS` | Per-IP chat rate limit for anonymous `/embed` requests, in front of the shared bucket above (default 10/60000ms — must stay below `DIGICHAT_CHAT_RATE_LIMIT_MAX`) | Optional |
 | `DIGICHAT_POSTGRES_PASSWORD` | Postgres password (Compose default: `digichat`) | Change in production |

--- a/frontend/digichat/Dockerfile
+++ b/frontend/digichat/Dockerfile
@@ -14,12 +14,16 @@ RUN npm ci --workspace frontend/digichat --include-workspace-root
 FROM node:22-alpine AS builder
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
-# next.config.ts imports security-headers.ts, which reads DIGICHAT_EMBED_TENANTS
+# next.config.ts imports security-headers.ts, which reads DIGICHAT_EMBED_HOSTS
 # once at import time to compute the embed CSP frame-ancestors list — Next.js
 # evaluates this during `next build` and bakes it into the routes manifest, so
 # it must be passed as a build arg, not just a runtime container env var.
-ARG DIGICHAT_EMBED_TENANTS=""
-ENV DIGICHAT_EMBED_TENANTS=$DIGICHAT_EMBED_TENANTS
+# Deliberately DIGICHAT_EMBED_HOSTS (plain hostnames), not DIGICHAT_EMBED_TENANTS
+# (which also carries each tenant's secret token) — build-args persist in image
+# layer history and cloud-build logs (az acr build etc.), and the CSP computation
+# never reads the token anyway. DIGICHAT_EMBED_TENANTS stays runtime-only.
+ARG DIGICHAT_EMBED_HOSTS=""
+ENV DIGICHAT_EMBED_HOSTS=$DIGICHAT_EMBED_HOSTS
 COPY --from=deps /app ./
 COPY frontend/design ./frontend/design
 COPY frontend/digichat ./frontend/digichat

--- a/frontend/digichat/src/lib/security-headers.test.ts
+++ b/frontend/digichat/src/lib/security-headers.test.ts
@@ -75,3 +75,54 @@ describe("registry-derived frame-ancestors", () => {
     expect(embedFrameAncestors()).not.toContain("http://localhost:*");
   });
 });
+
+describe("DIGICHAT_EMBED_HOSTS (build-time CSP without the secret registry)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetEmbedTenantRegistryForTests();
+  });
+
+  it("derives frame-ancestors from DIGICHAT_EMBED_HOSTS without DIGICHAT_EMBED_TENANTS set", () => {
+    vi.stubEnv("DIGICHAT_EMBED_HOSTS", "dev.datatapstream.com, dev.datatap.stream");
+    resetEmbedTenantRegistryForTests();
+    const list = embedFrameAncestors();
+    expect(list).toContain("https://dev.datatapstream.com");
+    expect(list).toContain("https://dev.datatap.stream");
+  });
+
+  it("prefers DIGICHAT_EMBED_HOSTS over the registry when both are set", () => {
+    vi.stubEnv("DIGICHAT_EMBED_HOSTS", "hosts-var.example.com");
+    vi.stubEnv(
+      "DIGICHAT_EMBED_TENANTS",
+      JSON.stringify({
+        "registry-var.example.com": {
+          slug: "registryvar",
+          backend: { type: "external-relay", url: "https://relay.example.com/api/x" },
+          gateMode: "ungated",
+          token: "secret",
+        },
+      })
+    );
+    resetEmbedTenantRegistryForTests();
+    const list = embedFrameAncestors();
+    expect(list).toContain("https://hosts-var.example.com");
+    expect(list).not.toContain("https://registry-var.example.com");
+  });
+
+  it("falls back to the registry when DIGICHAT_EMBED_HOSTS is unset", () => {
+    vi.stubEnv(
+      "DIGICHAT_EMBED_TENANTS",
+      JSON.stringify({
+        "registry-var.example.com": {
+          slug: "registryvar",
+          backend: { type: "external-relay", url: "https://relay.example.com/api/x" },
+          gateMode: "ungated",
+          token: "secret",
+        },
+      })
+    );
+    resetEmbedTenantRegistryForTests();
+    const list = embedFrameAncestors();
+    expect(list).toContain("https://registry-var.example.com");
+  });
+});

--- a/frontend/digichat/src/lib/security-headers.ts
+++ b/frontend/digichat/src/lib/security-headers.ts
@@ -26,17 +26,33 @@ export const DIGICHAT_APP_CSP = [
   "object-src 'none'",
 ].join("; ");
 
+/** Plain comma-separated hostnames — no secrets, safe to pass as a build arg. */
+function embedHostsFromEnv(): string[] | null {
+  const raw = process.env.DIGICHAT_EMBED_HOSTS?.trim();
+  if (!raw) return null;
+  return raw
+    .split(",")
+    .map((h) => h.trim())
+    .filter(Boolean);
+}
+
 /**
  * First-party origins + one https origin per registered embed-tenant host.
  * Dev/test additionally allow localhost so a local page can iframe /embed.
- * Evaluated when next.config.ts imports this module — DIGICHAT_EMBED_TENANTS
- * must be set at build time for external hosts to appear in the CSP.
+ * Evaluated when next.config.ts imports this module — some source of embed
+ * hosts must be set at build time for external hosts to appear in the CSP.
+ * Prefers the non-secret DIGICHAT_EMBED_HOSTS (just hostnames) over the full
+ * DIGICHAT_EMBED_TENANTS registry (hostname + per-tenant token), since a
+ * Docker build-arg persists in image layer history and cloud-build logs —
+ * the token was never actually read here, only the registry's keys were.
  */
 export function embedFrameAncestors(): string[] {
-  const registryHosts = [...getEmbedTenantRegistry().keys()].map((h) => `https://${h}`);
+  const envHosts = embedHostsFromEnv();
+  const hosts = envHosts ?? [...getEmbedTenantRegistry().keys()];
+  const hostOrigins = hosts.map((h) => `https://${h}`);
   const dev =
     process.env.NODE_ENV !== "production" ? ["http://localhost:*", "http://127.0.0.1:*"] : [];
-  return [...FIRST_PARTY_FRAME_ANCESTORS, ...registryHosts, ...dev];
+  return [...FIRST_PARTY_FRAME_ANCESTORS, ...hostOrigins, ...dev];
 }
 
 export function embedFrameAncestorsCsp(): string {


### PR DESCRIPTION
Promotes #1360/#1361 (DIGICHAT_EMBED_HOSTS split — fixes a per-tenant token leak into Docker build-arg/image-history and cloud-build logs) to main.